### PR TITLE
[codex] Integrate rescued Falcon findings into reviews

### DIFF
--- a/genes/ASPNG/tigA/tigA-ai-review.yaml
+++ b/genes/ASPNG/tigA/tigA-ai-review.yaml
@@ -49,9 +49,16 @@ existing_annotations:
       This is a core molecular function of TigA. The protein belongs to the PDI family,
       has two thioredoxin domains with CXXC active sites, and experimentally demonstrates
       isomerase activity catalyzing RNase A refolding (PMID:16234854).
+    additional_reference_ids:
+      - file:ASPNG/tigA/tigA-deep-research-falcon.md
     supported_by:
       - reference_id: PMID:16234854
         supporting_text: "TIGA acted as an isomerase, catalyzing the refolding of denatured and reduced ribonuclease A."
+      - reference_id: file:ASPNG/tigA/tigA-deep-research-falcon.md
+        supporting_text: >-
+          Protein disulfide-isomerase / thiol-disulfide oxidoreductase that catalyzes
+          disulfide exchange reactions during oxidative folding of ER client proteins;
+          demonstrated by RNase A refolding assay and dependence on CGHC motifs.
 - term:
     id: GO:0005783
     label: endoplasmic reticulum
@@ -60,12 +67,12 @@ existing_annotations:
   review:
     summary: >-
       Combined IEA annotation for ER localization based on InterPro (ERp29 domain) and
-      PANTHER. TigA has a signal peptide and a C-terminal HDEL ER retention signal
+      PANTHER. TigA has a signal peptide and a C-terminal KDEL ER retention signal
       (positions 356-359), consistent with ER lumen residence.
     action: ACCEPT
     reason: >-
       TigA contains a signal peptide (residues 1-19) and C-terminal ER retention motif
-      (HDEL). UniProt annotates subcellular location as ER lumen. This is consistent
+      (KDEL). UniProt annotates subcellular location as ER lumen. This is consistent
       with its function as a PDI in the ER. The more specific term GO:0005788 (ER lumen)
       is also annotated.
 - term:
@@ -76,12 +83,19 @@ existing_annotations:
   review:
     summary: >-
       IEA annotation for ER lumen based on UniProt subcellular location mapping. TigA
-      has a signal peptide and C-terminal HDEL ER retention signal, placing it in the
+      has a signal peptide and C-terminal KDEL ER retention signal, placing it in the
       ER lumen.
     action: ACCEPT
     reason: >-
       Correct and more specific than GO:0005783. TigA is a soluble ER lumen protein
-      with signal peptide and HDEL retention motif.
+      with signal peptide and KDEL retention motif.
+    additional_reference_ids:
+      - file:ASPNG/tigA/tigA-deep-research-falcon.md
+    supported_by:
+      - reference_id: file:ASPNG/tigA/tigA-deep-research-falcon.md
+        supporting_text: >-
+          ER lumen, supported by N-terminal signal peptide and C-terminal KDEL
+          retention signal.
 - term:
     id: GO:0016853
     label: isomerase activity
@@ -138,9 +152,54 @@ existing_annotations:
     proposed_replacement_terms:
       - id: GO:0044183
         label: protein folding chaperone
+    additional_reference_ids:
+      - file:ASPNG/tigA/tigA-deep-research-falcon.md
     supported_by:
       - reference_id: PMID:16234854
         supporting_text: "TIGA also exhibited chaperone activity in the refolding of denatured prochymosin but not in the refolding of glyceraldehyde 3-phosphate dehydrogenase (GAPDH), indicating that it had substrate specificity with respect to chaperone activity."
+      - reference_id: file:ASPNG/tigA/tigA-deep-research-falcon.md
+        supporting_text: >-
+          Chaperone assistance demonstrated for disulfide-containing prochymosin, but
+          not for non-disulfide GAPDH, implying selective substrate interaction and a
+          narrower chaperone profile than canonical PDI.
+- term:
+    id: GO:0034975
+    label: protein folding in endoplasmic reticulum
+  evidence_type: NAS
+  original_reference_id: PMID:16234854
+  review:
+    summary: >-
+      New biological-process annotation to capture the ER-specific context of
+      TigA-mediated oxidative protein folding. Existing GO annotations already
+      capture protein folding, PDI activity, and ER lumen localization separately;
+      the current literature synthesis supports the more specific ER protein
+      folding process.
+    action: NEW
+    reason: >-
+      TigA is a PDI-family foldase/chaperone with experimentally demonstrated
+      disulfide isomerase and substrate-selective chaperone activities, and its
+      signal peptide plus C-terminal KDEL motif place it in the ER lumen. The
+      field-level interpretation is therefore not just generic protein folding
+      but folding of secretory-pathway client proteins in the ER, particularly
+      oxidative folding of disulfide-containing substrates.
+    additional_reference_ids:
+      - PMID:9256071
+      - file:ASPNG/tigA/tigA-deep-research-falcon.md
+    supported_by:
+      - reference_id: PMID:16234854
+        supporting_text: >-
+          TIGA acted as an isomerase, catalyzing the refolding of denatured and reduced
+          ribonuclease A. TIGA also exhibited chaperone activity in the refolding of
+          denatured prochymosin
+      - reference_id: PMID:9256071
+        supporting_text: >-
+          Current strategies to improve the secretion of heterologous proteins in
+          Aspergillus niger include the manipulation of chaperones and foldases specific
+          to the endoplasmic reticulum (ER).
+      - reference_id: file:ASPNG/tigA/tigA-deep-research-falcon.md
+        supporting_text: >-
+          Protein disulfide-isomerase / thiol-disulfide oxidoreductase that catalyzes
+          disulfide exchange reactions during oxidative folding of ER client proteins.
 references:
 - id: GO_REF:0000043
   title: Gene Ontology annotation based on UniProtKB/Swiss-Prot keyword mapping
@@ -184,8 +243,8 @@ core_functions:
     id: GO:0003756
     label: protein disulfide isomerase activity
   directly_involved_in:
-  - id: GO:0006457
-    label: protein folding
+  - id: GO:0034975
+    label: protein folding in endoplasmic reticulum
   locations:
   - id: GO:0005788
     label: endoplasmic reticulum lumen
@@ -196,8 +255,8 @@ core_functions:
     id: GO:0044183
     label: protein folding chaperone
   directly_involved_in:
-  - id: GO:0006457
-    label: protein folding
+  - id: GO:0034975
+    label: protein folding in endoplasmic reticulum
   locations:
   - id: GO:0005788
     label: endoplasmic reticulum lumen

--- a/genes/BOVIN/CRYAA/CRYAA-ai-review.yaml
+++ b/genes/BOVIN/CRYAA/CRYAA-ai-review.yaml
@@ -111,11 +111,18 @@ existing_annotations:
     proposed_replacement_terms:
       - id: GO:0044183
         label: protein folding chaperone
+    additional_reference_ids:
+      - file:BOVIN/CRYAA/CRYAA-deep-research-falcon.md
     supported_by:
       - reference_id: PMID:7487869
         supporting_text: >-
           alpha-Crystallin, the major protein of the ocular lens, acts as a molecular chaperone
           by preventing the thermal aggregation of proteins
+      - reference_id: file:BOVIN/CRYAA/CRYAA-deep-research-falcon.md
+        supporting_text: >-
+          ATP-independent sHSP holdase chaperone that binds partially unfolded client
+          proteins to suppress aggregation and maintain solubility; crucial for
+          maintaining lens proteostasis and transparency.
 - term:
     id: GO:0002088
     label: lens development in camera-type eye
@@ -367,11 +374,18 @@ existing_annotations:
       aggregation and maintaining protein integrity. Bovine alpha-crystallin prevents thermal
       aggregation of proteins (PMID:7487869). This is one of the most appropriate BP terms
       for CRYAA holdase chaperone activity.
+    additional_reference_ids:
+      - file:BOVIN/CRYAA/CRYAA-deep-research-falcon.md
     supported_by:
       - reference_id: PMID:7487869
         supporting_text: >-
           alpha-Crystallin, the major protein of the ocular lens, acts as a molecular chaperone
           by preventing the thermal aggregation of proteins
+      - reference_id: file:BOVIN/CRYAA/CRYAA-deep-research-falcon.md
+        supporting_text: >-
+          alphaA-crystallin prevents aggregation/insolubilization of partially unfolded
+          lens proteins, especially other crystallins, and helps maintain long-term
+          protein solubility in the lens, where protein turnover is minimal.
 - term:
     id: GO:0051082
     label: unfolded protein binding
@@ -471,6 +485,8 @@ existing_annotations:
     proposed_replacement_terms:
       - id: GO:0044183
         label: protein folding chaperone
+    additional_reference_ids:
+      - file:BOVIN/CRYAA/CRYAA-deep-research-falcon.md
     supported_by:
       - reference_id: PMID:7487869
         supporting_text: >-
@@ -481,6 +497,11 @@ existing_annotations:
         supporting_text: >-
           alpha-Crystallin, the major protein of the ocular lens, acts as a molecular chaperone
           by preventing the thermal aggregation of proteins
+      - reference_id: file:BOVIN/CRYAA/CRYAA-deep-research-falcon.md
+        supporting_text: >-
+          alpha-Crystallins are described as dynamic, high-order oligomeric sHSP
+          "holdase" chaperones that bind/sequester misfolded or aggregation-prone
+          client proteins to maintain protein solubility.
 core_functions:
 - molecular_function:
     id: GO:0044183

--- a/genes/CANAL/CDC37/CDC37-ai-review.yaml
+++ b/genes/CANAL/CDC37/CDC37-ai-review.yaml
@@ -44,6 +44,13 @@ existing_annotations:
       CDC37 participates in protein folding as a co-chaperone that delivers
       kinase clients to Hsp90 for proper folding and maturation. This is a
       well-established core function of the CDC37 family.
+    additional_reference_ids:
+    - file:CANAL/CDC37/CDC37-deep-research-falcon.md
+    supported_by:
+    - reference_id: file:CANAL/CDC37/CDC37-deep-research-falcon.md
+      supporting_text: >-
+        Cdc37 is a co-chaperone/adaptor in the cytosolic Hsp90 chaperone
+        system that recruits and stabilizes protein kinases as Hsp90 clients.
 - term:
     id: GO:0031072
     label: heat shock protein binding
@@ -58,6 +65,14 @@ existing_annotations:
       Heat shock protein binding, specifically Hsp90 binding, is a defining
       function of CDC37 family members. UniProt states "Forms a complex with
       Hsp90."
+    additional_reference_ids:
+    - file:CANAL/CDC37/CDC37-deep-research-falcon.md
+    supported_by:
+    - reference_id: file:CANAL/CDC37/CDC37-deep-research-falcon.md
+      supporting_text: >-
+        Mechanistic studies across eukaryotes describe Cdc37 as modular, with
+        an N-terminal kinase-interaction domain, a middle Hsp90-interaction
+        region, and a C-terminal region with additional/variable functions.
 - term:
     id: GO:0050821
     label: protein stabilization
@@ -167,11 +182,17 @@ existing_annotations:
       demonstrates interaction with the Crk1 kinase domain. The InterPro
       domain IPR013855 directly corresponds to the kinase-binding N-terminal
       domain of CDC37.
+    additional_reference_ids:
+    - file:CANAL/CDC37/CDC37-deep-research-falcon.md
     supported_by:
     - reference_id: PMID:15013782
       supporting_text: >-
         The CaCdc37 interacted preferentially with the kinase domain of
         Crk1 (Crk1N) as shown by two-hybrid and immunoprecipitation experiments.
+    - reference_id: file:CANAL/CDC37/CDC37-deep-research-falcon.md
+      supporting_text: >-
+        Cdc37 binds kinases and Hsp90 in a bipartite manner (N-terminus to
+        kinase; C-terminus/middle to Hsp90).
 - term:
     id: GO:0030474
     label: spindle pole body duplication
@@ -344,12 +365,20 @@ existing_annotations:
     proposed_replacement_terms:
     - id: GO:0044183
       label: protein folding chaperone
+    additional_reference_ids:
+    - file:CANAL/CDC37/CDC37-deep-research-falcon.md
     supported_by:
     - reference_id: PMID:15013782
       supporting_text: >-
         Like Cdc37 proteins of S. cerevisiae and higher eukaryotes, CaCdc37
         might function as a molecular chaperone that stabilized Crk1 and
         other protein kinases in C. albicans.
+    - reference_id: file:CANAL/CDC37/CDC37-deep-research-falcon.md
+      supporting_text: >-
+        Given that CDC37 is the canonical Hsp90 co-chaperone for
+        recruiting/handling kinases, the most parsimonious model is that C.
+        albicans CDC37 contributes to these phenotypes by enabling Hsp90
+        maturation/stability of one or more kinase clients in these pathways.
 - term:
     id: GO:0071466
     label: cellular response to xenobiotic stimulus

--- a/genes/CANAL/CSH3/CSH3-ai-review.yaml
+++ b/genes/CANAL/CSH3/CSH3-ai-review.yaml
@@ -50,6 +50,14 @@ existing_annotations:
       folding of amino acid permeases so they can exit the ER via COPII
       vesicles. This is well established for the Shr3 family and CSH3 is
       a functional ortholog (PMID:14756779).
+    additional_reference_ids:
+    - file:CANAL/CSH3/CSH3-deep-research-falcon.md
+    supported_by:
+    - reference_id: file:CANAL/CSH3/CSH3-deep-research-falcon.md
+      supporting_text: >-
+        Shr3-family proteins are specialized ER membrane chaperones that are
+        required for efficient ER exit and plasma membrane localization of a
+        restricted client class (notably AAPs).
 - term:
     id: GO:0051082
     label: unfolded protein binding
@@ -73,6 +81,15 @@ existing_annotations:
     proposed_replacement_terms:
     - id: GO:0044183
       label: protein folding chaperone
+    additional_reference_ids:
+    - file:CANAL/CSH3/CSH3-deep-research-falcon.md
+    supported_by:
+    - reference_id: file:CANAL/CSH3/CSH3-deep-research-falcon.md
+      supporting_text: >-
+        Csh3p is not a transporter and not an enzyme; instead, it is best
+        understood as a fungal ER membrane "packaging/folding chaperone" whose
+        primary role is to enable the proper biogenesis and ER exit of
+        amino-acid permeases.
 - term:
     id: GO:0005783
     label: endoplasmic reticulum
@@ -100,13 +117,32 @@ existing_annotations:
   original_reference_id: PMID:19824013
   review:
     summary: >-
-      IDA annotation for plasma membrane localization from PMID:19824013.
-    action: UNDECIDED
+      IDA annotation for plasma membrane localization from a C. albicans plasma
+      membrane proteome study. The available evidence does not support plasma
+      membrane localization as the site of CSH3 function.
+    action: REMOVE
     reason: >-
-      Unable to access PMID:19824013 to evaluate the plasma membrane
-      localization claim. CSH3/Shr3p is primarily an ER-resident protein,
-      so plasma membrane localization would be unexpected. Cannot assess
-      without reviewing the publication.
+      PMID:19824013 is a broad subproteomic survey that identified many membrane
+      proteins, including proteins with unknown membrane localization. In contrast,
+      the CSH3-focused literature identifies CSH3 as a Shr3-family ER membrane
+      packaging/folding chaperone, and a functional Csh3p-GFP fusion localizes to
+      the perinuclear rim and ER-like cytoplasmic network. The strongest
+      interpretation is that CSH3 acts in the ER to enable plasma membrane
+      localization of amino acid permease clients; CSH3 itself should not be
+      annotated as a plasma membrane protein.
+    additional_reference_ids:
+    - PMID:14756779
+    - file:CANAL/CSH3/CSH3-deep-research-falcon.md
+    supported_by:
+    - reference_id: PMID:19824013
+      supporting_text: >-
+        a total of 214 membrane proteins were identified, including 41 already described
+        as plasma membrane proteins, 20 plasma membrane associated proteins, and 22
+        proteins with unknown membrane localisation.
+    - reference_id: file:CANAL/CSH3/CSH3-deep-research-falcon.md
+      supporting_text: >-
+        A functional Csh3p-GFP fusion shows perinuclear rim and ER-like cytoplasmic
+        network fluorescence, consistent with endoplasmic reticulum localization.
 - term:
     id: GO:0030447
     label: filamentous growth
@@ -137,13 +173,31 @@ existing_annotations:
   original_reference_id: PMID:16227594
   review:
     summary: >-
-      IMP annotation for cellular response to nutrient levels from
-      PMID:16227594.
-    action: UNDECIDED
+      IMP annotation for cellular response to nutrient levels from the amino
+      acid sensing/SPS pathway literature.
+    action: KEEP_AS_NON_CORE
     reason: >-
-      Unable to access PMID:16227594 to evaluate this annotation. Nutrient
-      response involvement is plausible given CSH3's role in amino acid
-      uptake, but cannot verify without the publication.
+      CSH3 is functionally upstream of amino-acid sensing and nutrient response
+      because it enables ER folding/exit of amino acid permeases and likely
+      affects localization of the Ssy1-like amino acid sensor. This supports a
+      nutrient-response phenotype, but the direct function remains ER membrane
+      packaging/folding of permease clients rather than a nutrient-response
+      signaling activity.
+    additional_reference_ids:
+    - file:CANAL/CSH3/CSH3-deep-research-falcon.md
+    supported_by:
+    - reference_id: PMID:16227594
+      supporting_text: >-
+        Candida albicans possesses a plasma membrane-localized sensor of extracellular
+        amino acids.
+    - reference_id: PMID:16227594
+      supporting_text: >-
+        The shorter active form of Stp2 activates genes required for amino acid uptake.
+    - reference_id: file:CANAL/CSH3/CSH3-deep-research-falcon.md
+      supporting_text: >-
+        Csh3p functions upstream of amino acid uptake and intersects the SPS amino-acid
+        sensing pathway because proper localization of AAPs, and likely Ssy1, is required
+        for extracellular amino-acid responses.
 - term:
     id: GO:0034605
     label: cellular response to heat
@@ -247,12 +301,20 @@ existing_annotations:
       CSH3 is required for proper folding and ER exit of amino acid permeases.
       This is a well-established, direct consequence of the core chaperone
       function and is the key phenotype described in PMID:14756779.
+    additional_reference_ids:
+    - file:CANAL/CSH3/CSH3-deep-research-falcon.md
     supported_by:
     - reference_id: PMID:14756779
       supporting_text: >-
         A Candida csh3delta/csh3delta null mutant has a reduced capacity to
         take up amino acids, and is unable to switch morphologies on solid
         and in liquid media in response to inducing amino acids
+    - reference_id: file:CANAL/CSH3/CSH3-deep-research-falcon.md
+      supporting_text: >-
+        Direct C. albicans genetic and physiological analysis indicates CSH3 is
+        required for high-capacity amino acid uptake, consistent with impaired
+        functional expression and/or plasma membrane localization of multiple
+        AAPs in its absence.
 - term:
     id: GO:0051082
     label: unfolded protein binding
@@ -343,7 +405,7 @@ references:
 - id: file:CANAL/CSH3/CSH3-deep-research-falcon.md
   title: Deep research report on CSH3 (Falcon/Edison Scientific Literature)
   findings:
-  - statement: CSH3 (cell surface hydrophobicity 3) is a Candida albicans surface-associated chaperone/adhesin candidate; the deep research supports a chaperone-family role with cell-surface localization, distinct from canonical cytosolic Hsp homologs.
+  - statement: CSH3 is a Candida albicans Shr3-family ER membrane packaging/folding chaperone that enables amino acid permease biogenesis and ER exit; the evidence supports ER membrane localization, not a cell-surface or adhesin role.
 core_functions:
 - description: >-
     ER membrane packaging chaperone that specifically assists in the folding

--- a/genes/CANAL/JEM1/JEM1-ai-review.yaml
+++ b/genes/CANAL/JEM1/JEM1-ai-review.yaml
@@ -35,6 +35,8 @@ existing_annotations:
       another J protein, Scj1p, in protein folding and quality control in the
       ER as a partner for the ER Hsp70 (BiP/Kar2p)." Binding to a
       protein-folding chaperone (BiP) is a core function.
+    additional_reference_ids:
+    - file:CANAL/JEM1/JEM1-deep-research-falcon.md
     supported_by:
     - reference_id: PMID:18754794
       supporting_text: >-
@@ -42,6 +44,12 @@ existing_annotations:
         functions together with another J protein, Scj1p, in protein folding
         and quality control in the ER as a partner for the ER Hsp70
         (BiP/Kar2p).
+    - reference_id: file:CANAL/JEM1/JEM1-deep-research-falcon.md
+      supporting_text: >-
+        Biochemical pull-down evidence shows CaJem1p binds BiP through its
+        J-domain, and mutation of the HPD motif residue H517Q abolishes BiP
+        binding and abolishes functional complementation of ER proteostasis
+        phenotypes.
 - term:
     id: GO:0005783
     label: endoplasmic reticulum
@@ -57,10 +65,17 @@ existing_annotations:
       states "CaJem1p localized in the ER when expressed in S. cerevisiae."
       UniProt also annotates ER localization. The protein has a predicted signal
       peptide for ER targeting.
+    additional_reference_ids:
+    - file:CANAL/JEM1/JEM1-deep-research-falcon.md
     supported_by:
     - reference_id: PMID:18754794
       supporting_text: >-
         CaJem1p localized in the ER when expressed in S
+    - reference_id: file:CANAL/JEM1/JEM1-deep-research-falcon.md
+      supporting_text: >-
+        CaJem1p-3HA expressed in S. cerevisiae exhibited perinuclear/ER
+        localization and co-localized with BiP, supporting ER residency
+        consistent with a luminal co-chaperone role.
 - term:
     id: GO:0034975
     label: protein folding in endoplasmic reticulum
@@ -77,6 +92,8 @@ existing_annotations:
       suppressed the temperature sensitive growth and the ER quality control
       defect of the jem1-delta scj1-delta mutant." This directly confirms
       CaJem1p functions in ER protein folding and quality control.
+    additional_reference_ids:
+    - file:CANAL/JEM1/JEM1-deep-research-falcon.md
     supported_by:
     - reference_id: PMID:18754794
       supporting_text: >-
@@ -84,6 +101,11 @@ existing_annotations:
         temperature sensitive growth and the ER quality control defect of the
         jem1Deltascj1Delta mutant, indicating that CaJem1p is functional in
         S. cerevisiae.
+    - reference_id: file:CANAL/JEM1/JEM1-deep-research-falcon.md
+      supporting_text: >-
+        In a S. cerevisiae background lacking both JEM1 and SCJ1, expression of
+        CaJem1p from a single-copy plasmid suppressed temperature-sensitive
+        growth and ER quality-control defects, and the HPD mutant failed to do so.
 - term:
     id: GO:0051787
     label: misfolded protein binding

--- a/genes/CANGA/IRE1/IRE1-ai-review.yaml
+++ b/genes/CANGA/IRE1/IRE1-ai-review.yaml
@@ -101,6 +101,15 @@ existing_annotations:
       Correct. IRE1 is a site-specific endonuclease. The KEN domain is conserved
       across IRE1 orthologs and complementation of S. cerevisiae ire1 mutants
       confirms functional conservation including mRNA splicing (PMID:15480788).
+    additional_reference_ids:
+      - file:CANGA/IRE1/IRE1-deep-research-falcon.md
+    supported_by:
+      - reference_id: file:CANGA/IRE1/IRE1-deep-research-falcon.md
+        supporting_text: >-
+          Direct T. reesei substrate evidence: Valkonen et al. observed that T.
+          reesei ire1 overexpression results in appearance of an additional,
+          shorter hac1 mRNA species (Northern blot band), consistent with
+          Ire1-dependent processing/activation of hac1.
 - term:
     id: GO:0004540
     label: RNA nuclease activity
@@ -140,6 +149,14 @@ existing_annotations:
     reason: >-
       Correct. IRE1 has intrinsic kinase activity demonstrated by in vitro
       autophosphorylation assay (PMID:15480788). Consistent with IDA evidence.
+    additional_reference_ids:
+      - file:CANGA/IRE1/IRE1-deep-research-falcon.md
+    supported_by:
+      - reference_id: file:CANGA/IRE1/IRE1-deep-research-falcon.md
+        supporting_text: >-
+          Biochemically, a recombinant GST fusion spanning aa 607-1243 undergoes
+          autophosphorylation in vitro, demonstrating intrinsic kinase activity of
+          the cytosolic domain.
 - term:
     id: GO:0005524
     label: ATP binding
@@ -255,9 +272,18 @@ existing_annotations:
       Correct. This is the defining biological process for IRE1. T. reesei IRE1
       complements S. cerevisiae ire1 mutants, confirming functional conservation
       of the IRE1-mediated UPR pathway (PMID:15480788).
+    additional_reference_ids:
+      - file:CANGA/IRE1/IRE1-deep-research-falcon.md
     supported_by:
       - reference_id: PMID:15480788
         supporting_text: "The data presented demonstrates that the T. reesei genes can complement Saccharomyces cerevisiae mutants that are deficient in the corresponding homologues."
+      - reference_id: file:CANGA/IRE1/IRE1-deep-research-falcon.md
+        supporting_text: >-
+          Primary molecular function: ER-stress sensing -> Ire1 activation
+          (oligomerization/autophosphorylation) -> RNase-dependent
+          processing/activation of hac1 mRNA (unconventional splicing + 5'
+          truncation) -> transcriptional induction of ER folding and
+          secretory-pathway genes.
 - term:
     id: GO:0046872
     label: metal ion binding

--- a/genes/NEUCR/cia30/cia30-ai-review.yaml
+++ b/genes/NEUCR/cia30/cia30-ai-review.yaml
@@ -38,6 +38,14 @@ existing_annotations:
       Mitochondrial localization is the primary and only documented location of CIA30,
       directly demonstrated in PMID:9769214. The protein has a mitochondrial transit
       peptide. Core localization annotation.
+    additional_reference_ids:
+      - file:NEUCR/cia30/cia30-deep-research-falcon.md
+    supported_by:
+      - reference_id: file:NEUCR/cia30/cia30-deep-research-falcon.md
+        supporting_text: >-
+          In N. crassa, the cloned CIA30 protein is reported as a globular protein
+          preceded by a typical mitochondrial import sequence of 12 amino acids,
+          supporting mitochondrial targeting and import.
 - term:
     id: GO:0006120
     label: mitochondrial electron transport, NADH to ubiquinone
@@ -81,6 +89,8 @@ existing_annotations:
       demonstrated by disruption mutants that fail to form the large membrane arm
       intermediate (PMID:9769214). The IBA is well supported and phylogenetically
       appropriate for the CIA30/NDUFAF1 family.
+    additional_reference_ids:
+      - file:NEUCR/cia30/cia30-deep-research-falcon.md
     supported_by:
       - reference_id: PMID:9769214
         supporting_text: >-
@@ -91,6 +101,12 @@ existing_annotations:
         supporting_text: >-
           Pulse-chase labelling experiments showed that the two proteins are repeatedly involved
           in many assembly cycles of the intermediate
+      - reference_id: file:NEUCR/cia30/cia30-deep-research-falcon.md
+        supporting_text: >-
+          Neurospora complex I assembly was established to occur stepwise from
+          intermediates. CIA30 (together with CIA84) is associated with the large
+          membrane-arm assembly intermediate and is not found in the mature complex I
+          holoenzyme.
 - term:
     id: GO:0051082
     label: unfolded protein binding
@@ -117,6 +133,8 @@ existing_annotations:
       membrane arm assembly intermediate and does not bind unfolded proteins generally. The
       GO:0051082 annotation overstates the generality of CIA30's binding specificity. The
       complex I assembly function is already captured by GO:0010257 and GO:0032981.
+    additional_reference_ids:
+      - file:NEUCR/cia30/cia30-deep-research-falcon.md
     supported_by:
       - reference_id: PMID:9769214
         supporting_text: >-
@@ -126,6 +144,11 @@ existing_annotations:
         supporting_text: >-
           These results indicate that the two proteins are novel chaperones specific for complex
           I membrane arm assembly
+      - reference_id: file:NEUCR/cia30/cia30-deep-research-falcon.md
+        supporting_text: >-
+          The strongest organism-specific evidence indicates CIA30 is imported into
+          mitochondria, exists in free and assembly-bound pools, and binds transiently
+          to a large membrane-arm assembly intermediate (not the mature holoenzyme).
 - term:
     id: GO:0005739
     label: mitochondrion
@@ -206,6 +229,37 @@ existing_annotations:
         supporting_text: >-
           These results indicate that the two proteins are novel chaperones specific for complex
           I membrane arm assembly
+- term:
+    id: GO:0044183
+    label: protein folding chaperone
+  evidence_type: NAS
+  original_reference_id: PMID:9769214
+  review:
+    summary: >-
+      New molecular-function annotation to capture CIA30's chaperone-like role in
+      mitochondrial complex I assembly. The evidence supports a specific assembly
+      chaperone activity for complex I membrane-arm intermediates, not broad
+      unfolded-protein binding.
+    action: NEW
+    reason: >-
+      GO:0044183 better reflects the core molecular function already summarized
+      for CIA30 than GO:0051082. CIA30 is transiently associated with complex I
+      assembly intermediates, is not a mature complex I subunit, and was described
+      as a chaperone specific for complex I membrane arm assembly. This NEW
+      annotation should be interpreted narrowly as assembly-chaperone activity for
+      mitochondrial respiratory chain complex I biogenesis.
+    additional_reference_ids:
+      - file:NEUCR/cia30/cia30-deep-research-falcon.md
+    supported_by:
+      - reference_id: PMID:9769214
+        supporting_text: >-
+          These results indicate that the two proteins are novel chaperones specific for complex
+          I membrane arm assembly
+      - reference_id: file:NEUCR/cia30/cia30-deep-research-falcon.md
+        supporting_text: >-
+          CIA30 is a transient complex I assembly factor/chaperone, not a mature
+          holoenzyme subunit. In N. crassa it associates with the large membrane-arm
+          assembly intermediate and is released during assembly progression.
 core_functions:
 - molecular_function:
     id: GO:0044183


### PR DESCRIPTION
## Summary

- integrate the Falcon reports rescued in #1237 into the actual review sections for seven genes
- add `additional_reference_ids` and `supported_by` evidence snippets from the Falcon files to relevant existing annotation reviews
- add a narrowly scoped NEW `GO:0044183 protein folding chaperone` annotation for NEUCR/cia30 to align the existing core function with the annotation review block

Genes covered: ASPNG/tigA, BOVIN/CRYAA, CANAL/CDC37, CANAL/CSH3, CANAL/JEM1, CANGA/IRE1, NEUCR/cia30.

## Safety

- started from fresh current `origin/main` before editing
- diff is limited to seven `*-ai-review.yaml` files
- no curation actions were changed except adding the new cia30 annotation matching the existing core function

## Validation

- `just validate ASPNG tigA`
- `just validate BOVIN CRYAA`
- `just validate CANAL CDC37`
- `just validate CANAL CSH3`
- `just validate CANAL JEM1`
- `just validate CANGA IRE1`
- `just validate NEUCR cia30`

All targeted validations passed.