### PR TITLE
mllJ (METEA): enrich review with falcon deep research evidence

### DIFF
--- a/genes/METEA/mllJ/mllJ-ai-review.yaml
+++ b/genes/METEA/mllJ/mllJ-ai-review.yaml
@@ -5,43 +5,151 @@ product_type: PROTEIN
 taxon:
   id: NCBITaxon:272630
   label: Methylorubrum extorquens AM1
-description: DUF4142 domain-containing protein (mllJ) with TAT (twin-arginine translocation)
-  signal peptide for export to periplasm. Contains ferritin-like domain. Part of mll
-  gene cluster (META1p4129-4138) showing 32-fold upregulation with poorly soluble
-  lanthanides. Likely involved in periplasmic processing or transport of metallophore.
+description: >-
+  mllJ (locus MexAM1_META1p4138; UniProt C5B1J0) is a ferritin-like DUF4142
+  domain-containing protein encoded within the methylolanthanin (mll)
+  biosynthetic gene cluster (META1p4129-META1p4138) of Methylorubrum extorquens
+  AM1. The mll cluster produces methylolanthanin, a secreted small-molecule
+  lanthanide chelator (a "lanthanophore", NOT an iron siderophore) that
+  facilitates acquisition of poorly bioavailable lanthanides. mllJ carries an
+  N-terminal twin-arginine (TAT) signal peptide (residues 1-25, UniProt) and is
+  putatively exported to the periplasm. The whole cluster, including mllJ, is
+  strongly upregulated (~32-fold on average) during growth on poorly soluble
+  Nd2O3 versus soluble NdCl3. No mllJ-specific biochemical reaction, substrate
+  specificity, or mutant phenotype has been established; its role is currently
+  inferred from cluster co-localization and co-regulation plus domain
+  architecture, with a probable accessory function in periplasmic lanthanide
+  handling/trafficking rather than core small-molecule biosynthesis.
+references:
+  - id: file:METEA/mllJ/mllJ-deep-research-falcon.md
+    title: "Falcon deep research: functional annotation of mllJ (C5B1J0) in Methylorubrum extorquens AM1"
+    findings:
+      - supporting_text: >-
+          In the retrieved primary source, **META1p4138 is explicitly named
+          mllJ**, and it lies within the methylolanthanin biosynthetic gene
+          cluster (META1p4129–META1p4138) in *Methylorubrum extorquens* AM1
+        reference_section_type: OTHER
+      - supporting_text: >-
+          part of a lanthanide-responsive biosynthetic gene cluster implicated
+          in producing **methylolanthanin**, a secreted small-molecule
+          lanthanide chelator
+        reference_section_type: OTHER
+      - supporting_text: >-
+          Zytnick et al. describe mllJ (META1p4138) as belonging to a
+          **ferritin-like DUF4142** group and as **putatively exported into the
+          periplasm**
+        reference_section_type: OTHER
+      - supporting_text: >-
+          The methylolanthanin biosynthetic locus (META1p4129–META1p4138;
+          includes mllJ/META1p4138) averaged **~32-fold upregulation** in Nd2O3
+          vs NdCl3
+        reference_section_type: OTHER
+      - supporting_text: >-
+          there is **no gene-specific biochemical reaction, substrate
+          specificity, or phenotype** reported for mllJ alone; functional
+          linkage is currently **inferred from co-localization and
+          co-regulation** with the methylolanthanin (mll) cluster
+        reference_section_type: OTHER
+      - supporting_text: >-
+          a conservative annotation is: **“periplasmic DUF4142/ferritin-like
+          protein associated with the methylolanthanin lanthanophore gene
+          cluster; probable role in lanthanide homeostasis or trafficking.”**
+        reference_section_type: OTHER
 existing_annotations:
   - term:
       id: GO:0003674
       label: molecular_function
     evidence_type: NAS
     review:
-      summary: Added to align core_functions with existing annotations.
+      summary: >-
+        The specific molecular function of mllJ is genuinely unknown. mllJ is a
+        ferritin-like DUF4142 protein with no demonstrated catalytic reaction,
+        substrate specificity, or metal-binding/iron-storage activity in the
+        obtainable literature; falcon explicitly cautions against asserting that
+        it is a biosynthetic enzyme, the transporter, or that it has ferritin-like
+        iron storage activity. The root molecular_function term is retained as a
+        placeholder reflecting this uncertainty.
       action: NEW
-      reason: Core function term not present in existing_annotations.
+      reason: >-
+        No specific MF term can be confidently assigned; the root term keeps the
+        core_functions molecular_function aligned with existing_annotations while
+        honestly reflecting that mllJ's biochemical activity is uncharacterized.
+      supported_by:
+        - reference_id: file:METEA/mllJ/mllJ-deep-research-falcon.md
+          supporting_text: >-
+            there is **no gene-specific biochemical reaction, substrate
+            specificity, or phenotype** reported for mllJ alone; functional
+            linkage is currently **inferred from co-localization and
+            co-regulation** with the methylolanthanin (mll) cluster
   - term:
       id: GO:0042597
       label: periplasmic space
     evidence_type: NAS
     review:
-      summary: Added to align core_functions with existing annotations.
+      summary: >-
+        mllJ carries an N-terminal twin-arginine (TAT) signal peptide
+        (residues 1-25, UniProt PROSITE TAT) and is described in the literature
+        as putatively exported into the periplasm. Localization is inferred from
+        the signal peptide and the authors' annotation rather than from direct
+        subcellular fractionation, so this is a confident-but-predicted cellular
+        component assignment.
       action: NEW
-      reason: Core function term not present in existing_annotations.
+      reason: >-
+        Periplasmic localization is the best-supported component annotation:
+        UniProt records a TAT signal peptide and the primary source reports the
+        protein as putatively periplasm-exported. Retained as a core localization.
+      supported_by:
+        - reference_id: file:METEA/mllJ/mllJ-deep-research-falcon.md
+          supporting_text: >-
+            Zytnick et al. describe mllJ (META1p4138) as belonging to a
+            **ferritin-like DUF4142** group and as **putatively exported into the
+            periplasm**
 core_functions:
-  - description: Periplasmic function in metallophore biosynthesis or transport
+  - description: >-
+      Accessory component of the methylolanthanin (lanthanophore) system,
+      putatively exported to the periplasm via a TAT signal peptide, with a
+      probable role in periplasmic lanthanide handling/trafficking rather than
+      core small-molecule biosynthesis. The precise molecular activity is
+      uncharacterized.
+    molecular_function:
+      id: GO:0003674
+      label: molecular_function
     locations:
       - id: GO:0042597
         label: periplasmic space
     supported_by:
-      - reference_id: file:METEA/mllJ/mllJ-deep-research-perplexity.md
-        supporting_text: Contains TAT signal peptide (residues 1-25) for export to
-          periplasm. Part of mll cluster for lanthanophore biosynthesis
-references:
-  - id: file:METEA/mllJ/mllJ-deep-research-perplexity.md
-    title: Deep research on mllJ periplasmic protein in lanthanophore system
-    findings:
-      - statement: META1p4138 encodes protein with TAT signal peptide for periplasmic
-          export
-      - statement: Contains DUF4142 domain and ferritin-like fold
-      - statement: Part of mll cluster showing 32-fold upregulation with poorly soluble
-          lanthanides
+      - reference_id: file:METEA/mllJ/mllJ-deep-research-falcon.md
+        supporting_text: >-
+          a conservative annotation is: **“periplasmic DUF4142/ferritin-like
+          protein associated with the methylolanthanin lanthanophore gene
+          cluster; probable role in lanthanide homeostasis or trafficking.”**
+      - reference_id: file:METEA/mllJ/mllJ-deep-research-falcon.md
+        supporting_text: >-
+          part of a lanthanide-responsive biosynthetic gene cluster implicated
+          in producing **methylolanthanin**, a secreted small-molecule
+          lanthanide chelator
+suggested_questions:
+  - question: >-
+      Does mllJ bind lanthanide ions (and/or lanthanide-methylolanthanin
+      complexes) directly, and does its ferritin-like fold confer metal storage
+      or sequestration activity in the periplasm?
+  - question: >-
+      Is a clean in-frame deletion of mllJ alone (without removing the rest of
+      the mll cluster) defective in methylolanthanin biosynthesis, secretion,
+      lanthanide uptake, or intracellular lanthanide trafficking?
+suggested_experiments:
+  - description: >-
+      Construct a markerless ΔmllJ mutant that leaves the remaining mll cluster
+      intact and compare growth on poorly soluble Nd2O3 vs soluble NdCl3,
+      methylolanthanin secretion (LC-MS for the m/z 799.4232/797.4092 features),
+      and intracellular Nd bioaccumulation against the parent strain.
+  - description: >-
+      Express and purify recombinant MllJ (mature chain, residues 26-225) and
+      test lanthanide vs iron binding by ITC/competition assays and determine
+      whether the ferritin-like fold mediates metal sequestration; solve the
+      structure to confirm the predicted fold.
+  - description: >-
+      Verify subcellular localization and the export route (TAT vs Sec) by
+      subcellular fractionation and by mutating the twin-arginine motif of the
+      predicted signal peptide.
 status: INITIALIZED

--- a/genes/METEA/mllJ/mllJ-deep-research-falcon.md
+++ b/genes/METEA/mllJ/mllJ-deep-research-falcon.md
@@ -1,0 +1,279 @@
+---
+provider: falcon
+model: Edison Scientific Literature
+cached: false
+start_time: '2026-06-03T08:31:34.339363'
+end_time: '2026-06-03T08:37:34.329388'
+duration_seconds: 359.99
+template_file: templates/gene_research_go_focused.md
+template_variables:
+  organism: METEA
+  gene_id: mllJ
+  gene_symbol: mllJ
+  uniprot_accession: C5B1J0
+  protein_description: 'RecName: Full=DUF4142 domain-containing protein {ECO:0000259|Pfam:PF13628};'
+  gene_info: OrderedLocusNames=MexAM1_META1p4138 {ECO:0000313|EMBL:ACS41791.1};
+  organism_full: Methylorubrum extorquens (strain ATCC 14718 / DSM 1338 / JCM 2805
+    / NCIMB 9133 / AM1) (Methylobacterium extorquens).
+  protein_family: Not specified in UniProt
+  protein_domains: DUF4142. (IPR025419); Ferritin-like. (IPR012347); TAT_signal. (IPR006311);
+    DUF4142 (PF13628)
+provider_config:
+  timeout: null
+  max_retries: 3
+  parameters:
+    allowed_domains: []
+    temperature: 0.1
+    max_embedded_images: 8
+citation_count: 6
+artifact_count: 1
+artifact_sources:
+  edison_answer_artifacts: 1
+artifacts:
+- filename: artifact-00.md
+  path: mllJ-deep-research-falcon_artifacts/artifact-00.md
+  media_type: text/markdown
+  source: edison_answer_artifacts
+  data_storage_id: null
+  description: Edison artifact artifact-00
+---
+
+## Question
+
+# Gene Research for Functional Annotation
+
+## ⚠️ CRITICAL: Gene/Protein Identification Context
+
+**BEFORE YOU BEGIN RESEARCH:** You MUST verify you are researching the CORRECT gene/protein. Gene symbols can be ambiguous, especially for less well-characterized genes from non-model organisms.
+
+### Target Gene/Protein Identity (from UniProt):
+- **UniProt Accession:** C5B1J0
+- **Protein Description:** RecName: Full=DUF4142 domain-containing protein {ECO:0000259|Pfam:PF13628};
+- **Gene Information:** OrderedLocusNames=MexAM1_META1p4138 {ECO:0000313|EMBL:ACS41791.1};
+- **Organism (full):** Methylorubrum extorquens (strain ATCC 14718 / DSM 1338 / JCM 2805 / NCIMB 9133 / AM1) (Methylobacterium extorquens).
+- **Protein Family:** Not specified in UniProt
+- **Key Domains:** DUF4142. (IPR025419); Ferritin-like. (IPR012347); TAT_signal. (IPR006311); DUF4142 (PF13628)
+
+### MANDATORY VERIFICATION STEPS:
+
+1. **Check if the gene symbol "mllJ" matches the protein description above**
+2. **Verify the organism is correct:** Methylorubrum extorquens (strain ATCC 14718 / DSM 1338 / JCM 2805 / NCIMB 9133 / AM1) (Methylobacterium extorquens).
+3. **Check if protein family/domains align with what you find in literature**
+4. **If you find literature for a DIFFERENT gene with the same or similar symbol, STOP**
+
+### If Gene Symbol is Ambiguous or You Cannot Find Relevant Literature:
+
+**DO NOT PROCEED WITH RESEARCH ON A DIFFERENT GENE.** Instead:
+- State clearly: "The gene symbol 'mllJ' is ambiguous or literature is limited for this specific protein"
+- Explain what you found (e.g., "Found extensive literature on a different gene with the same symbol in a different organism")
+- Describe the protein based ONLY on the UniProt information provided above
+- Suggest that the protein function can be inferred from domain/family information
+
+### Research Target:
+
+Please provide a comprehensive research report on the gene **mllJ** (gene ID: mllJ, UniProt: C5B1J0) in METEA.
+
+The research report should be a detailed narrative explaining the function, biological processes, and localization of the gene product. Citations should be given for all claims.
+
+You should prioritize authoritative reviews and primary scientific literature when conducting research. You can supplement
+this with annotations you find in gene/protein databases, but these can be outdated or inaccurate.
+
+We are specifically interested in the primary function of the gene - for enzymes, what reaction is catalyzed, and what is the substrate specificity? For transporters, what is the substrate? For structural proteins or adapters, what is the broader structural role? For signaling molecules, what is the role in the pathway.
+
+We are interested in where in or outside the cell the gene product carries out its function.
+
+We are also interested in the signaling or biochemical pathways in which the gene functions. We are less interested in broad pleiotropic effects, except where these elucidate the precise role.
+
+Include evidence where possible. We are interested in both experimental evidence as well as inference from structure, evolution, or bioinformatic analysis. Precise studies should be prioritized over high-throughput, where available.
+
+## Output
+
+Question: You are an expert researcher providing comprehensive, well-cited information.
+
+Provide detailed information focusing on:
+1. Key concepts and definitions with current understanding
+2. Recent developments and latest research (prioritize 2023-2024 sources)
+3. Current applications and real-world implementations
+4. Expert opinions and analysis from authoritative sources
+5. Relevant statistics and data from recent studies
+
+Format as a comprehensive research report with proper citations. Include URLs and publication dates where available.
+Always prioritize recent, authoritative sources and provide specific citations for all major claims.
+
+# Gene Research for Functional Annotation
+
+## ⚠️ CRITICAL: Gene/Protein Identification Context
+
+**BEFORE YOU BEGIN RESEARCH:** You MUST verify you are researching the CORRECT gene/protein. Gene symbols can be ambiguous, especially for less well-characterized genes from non-model organisms.
+
+### Target Gene/Protein Identity (from UniProt):
+- **UniProt Accession:** C5B1J0
+- **Protein Description:** RecName: Full=DUF4142 domain-containing protein {ECO:0000259|Pfam:PF13628};
+- **Gene Information:** OrderedLocusNames=MexAM1_META1p4138 {ECO:0000313|EMBL:ACS41791.1};
+- **Organism (full):** Methylorubrum extorquens (strain ATCC 14718 / DSM 1338 / JCM 2805 / NCIMB 9133 / AM1) (Methylobacterium extorquens).
+- **Protein Family:** Not specified in UniProt
+- **Key Domains:** DUF4142. (IPR025419); Ferritin-like. (IPR012347); TAT_signal. (IPR006311); DUF4142 (PF13628)
+
+### MANDATORY VERIFICATION STEPS:
+
+1. **Check if the gene symbol "mllJ" matches the protein description above**
+2. **Verify the organism is correct:** Methylorubrum extorquens (strain ATCC 14718 / DSM 1338 / JCM 2805 / NCIMB 9133 / AM1) (Methylobacterium extorquens).
+3. **Check if protein family/domains align with what you find in literature**
+4. **If you find literature for a DIFFERENT gene with the same or similar symbol, STOP**
+
+### If Gene Symbol is Ambiguous or You Cannot Find Relevant Literature:
+
+**DO NOT PROCEED WITH RESEARCH ON A DIFFERENT GENE.** Instead:
+- State clearly: "The gene symbol 'mllJ' is ambiguous or literature is limited for this specific protein"
+- Explain what you found (e.g., "Found extensive literature on a different gene with the same symbol in a different organism")
+- Describe the protein based ONLY on the UniProt information provided above
+- Suggest that the protein function can be inferred from domain/family information
+
+### Research Target:
+
+Please provide a comprehensive research report on the gene **mllJ** (gene ID: mllJ, UniProt: C5B1J0) in METEA.
+
+The research report should be a detailed narrative explaining the function, biological processes, and localization of the gene product. Citations should be given for all claims.
+
+You should prioritize authoritative reviews and primary scientific literature when conducting research. You can supplement
+this with annotations you find in gene/protein databases, but these can be outdated or inaccurate.
+
+We are specifically interested in the primary function of the gene - for enzymes, what reaction is catalyzed, and what is the substrate specificity? For transporters, what is the substrate? For structural proteins or adapters, what is the broader structural role? For signaling molecules, what is the role in the pathway.
+
+We are interested in where in or outside the cell the gene product carries out its function.
+
+We are also interested in the signaling or biochemical pathways in which the gene functions. We are less interested in broad pleiotropic effects, except where these elucidate the precise role.
+
+Include evidence where possible. We are interested in both experimental evidence as well as inference from structure, evolution, or bioinformatic analysis. Precise studies should be prioritized over high-throughput, where available.
+
+## Research report: functional annotation of **mllJ** (UniProt **C5B1J0**; locus **MexAM1_META1p4138/META1p4138**) in *Methylorubrum extorquens* AM1
+
+### Executive summary
+The gene **mllJ** (META1p4138; UniProt C5B1J0) from *Methylorubrum extorquens* AM1 is part of a lanthanide-responsive biosynthetic gene cluster implicated in producing **methylolanthanin**, a secreted small-molecule lanthanide chelator (“lanthanophore”). In the only directly retrievable full-text source in this tool environment, **mllJ** is annotated as a **ferritin-like DUF4142** protein and is **putatively exported to the periplasm**, but there is **no gene-specific biochemical reaction, substrate specificity, or phenotype** reported for mllJ alone; functional linkage is currently **inferred from co-localization and co-regulation** with the methylolanthanin (mll) cluster. (zytnick2022discoveryandcharacterization pages 3-5, zytnick2022discoveryandcharacterization pages 8-10)
+
+| Locus / gene | Organism | Genomic context | Induction condition and RNA-seq signal | Predicted domain / family | Predicted localization | What is not known | Supporting citation |
+|---|---|---|---|---|---|---|---|
+| META1p4138 / **mllJ** | *Methylorubrum extorquens* AM1 (formerly *Methylobacterium extorquens* AM1) | Part of the **methylolanthanin (mll) biosynthetic gene cluster**, spanning META1p4129–META1p4138 | The full cluster, including **mllJ**, was reported as highly upregulated during growth with poorly soluble **Nd2O3** versus soluble **NdCl3**, with an average induction of about **32-fold** across the cluster | Annotated as **DUF4142**; described as **ferritin-like** | Reported as **putatively exported into the periplasm** | No direct biochemical activity, substrate specificity, catalytic reaction, or mutant phenotype has been specifically established for **mllJ** in the cited study; its role is inferred from cluster membership and domain architecture rather than direct assay | (zytnick2022discoveryandcharacterization pages 3-5) |
+
+
+*Table: This table summarizes the verified identity and currently available literature evidence for META1p4138 (mllJ) in *Methylorubrum extorquens* AM1. It highlights what is supported by experimental transcriptomics and bioinformatic annotation, while clearly separating unresolved functional questions.*
+
+### 1) Key concepts and definitions (current understanding)
+
+#### 1.1. Lanthanide-dependent methylotrophy and lanthanophore concept
+Lanthanides (Ln) can act as essential cofactors for certain methanol/ethanol oxidation enzymes in methylotrophs; accordingly, Ln uptake and storage systems are transcriptionally regulated by Ln availability and (critically) by Ln **bioavailability/solubility** in the environment. In *M. extorquens* AM1, growth with poorly soluble **Nd2O3** versus soluble **NdCl3** triggers broad transcriptional remodeling, including very strong induction of the **methylolanthanin biosynthetic locus** containing **mllJ**. (zytnick2022discoveryandcharacterization pages 3-5)
+
+A **lanthanophore** is a secreted low-molecular-weight chelator that binds lanthanides and facilitates their acquisition; Zytnick et al. report discovery of **methylolanthanin** as such a molecule and connect it genetically to the **mll** cluster. (zytnick2022discoveryandcharacterization pages 5-8, zytnick2022discoveryandcharacterization pages 8-10)
+
+#### 1.2. Gene/protein identity verification (critical)
+In the retrieved primary source, **META1p4138 is explicitly named mllJ**, and it lies within the methylolanthanin biosynthetic gene cluster (META1p4129–META1p4138) in *Methylorubrum extorquens* AM1 (synonym *Methylobacterium extorquens* AM1). This directly matches the user-provided locus mapping (MexAM1_META1p4138). (zytnick2022discoveryandcharacterization pages 3-5)
+
+#### 1.3. DUF4142 / ferritin-like annotation
+Zytnick et al. describe mllJ (META1p4138) as belonging to a **ferritin-like DUF4142** group and as **putatively exported into the periplasm**. This implies a non-cytosolic role and suggests the protein may participate in metal handling (binding/sequestration) or periplasm-associated steps that support lanthanide acquisition, though the specific activity is not established in this report. (zytnick2022discoveryandcharacterization pages 3-5)
+
+### 2) Recent developments and latest research (prioritizing 2023–2024)
+
+#### 2.1. Evidence available in this tool environment and its limitations
+Within the tool-accessible corpus, the only obtainable full text directly linking **mllJ/META1p4138** to a defined biological context is a **bioRxiv preprint (Jan 2022)** that reports methylolanthanin discovery and functional genetics at the **cluster** level. (zytnick2022discoveryandcharacterization pages 3-5, zytnick2022discoveryandcharacterization pages 5-8)
+
+A closely related **2024 PNAS article** (“Identification and characterization of a small-molecule metallophore involved in lanthanide metabolism”; DOI: **10.1073/pnas.2322096121**, July 2024) was surfaced by the search tool but marked **unobtainable** here, preventing extraction of updated 2023–2024 evidence regarding whether mllJ has since been dissected experimentally. Therefore, statements below about mllJ are constrained to what is explicitly supported by the obtainable 2022 full text. (zytnick2022discoveryandcharacterization pages 3-5)
+
+**Primary obtainable source**
+- Zytnick AM et al. *Discovery and characterization of the first known biological lanthanide chelator*. **bioRxiv** (posted Jan 2022). URL: https://doi.org/10.1101/2022.01.19.476857 (zytnick2022discoveryandcharacterization pages 3-5)
+
+### 3) Current applications and real-world implementations
+
+#### 3.1. Engineering lanthanide bioaccumulation via the mll locus (cluster-level)
+Although not mllJ-specific, Zytnick et al. report that manipulating the **mll biosynthetic genes** in trans can substantially change **growth** under low-bioavailability lanthanide conditions and **intracellular lanthanide accumulation**, supporting practical strategies for:
+- Increasing microbial Ln uptake/bioaccumulation (bioremediation/biorecovery concepts).
+- Improving growth robustness of lanthanide-dependent methylotroph strains in process conditions where lanthanides are poorly soluble.
+
+Specifically, **overexpression** of the mll cluster increased growth rate on poorly bioavailable Nd2O3 (0.026 hr−1; nearly 50% increase vs control, per the excerpt) and increased Nd bioaccumulation by ~3.5-fold on average; deletion reduced bioaccumulation (e.g., 1.8-fold reduction in NdCl3 condition, and ~30% lower bioaccumulation in another comparison). These are **cluster-level** effects and cannot be attributed uniquely to mllJ. (zytnick2022discoveryandcharacterization pages 8-10, zytnick2022discoveryandcharacterization pages 10-12)
+
+#### 3.2. Use of exogenous methylolanthanin to rescue phenotypes (cluster-level)
+Addition of purified methylolanthanin (50 nM) significantly increased growth yield (max OD) in strains grown with lanthanide supplementation (reported p-values ~0.036–0.037 in the excerpt). This provides a direct “real-world” handle: supplementing cultures with the chelator can improve performance, indicating that chelation/solubilization/shuttling is a limiting step under some conditions. Again, this is not specific to mllJ. (zytnick2022discoveryandcharacterization pages 8-10)
+
+### 4) Expert opinions and analysis from authoritative sources (evidence-based interpretation)
+
+#### 4.1. What can be stated confidently about mllJ
+Based on direct textual evidence, mllJ is:
+- **Co-regulated** with the methylolanthanin biosynthetic locus and strongly induced under low Ln bioavailability (Nd2O3 vs NdCl3). (zytnick2022discoveryandcharacterization pages 3-5)
+- Bioinformatically annotated as **ferritin-like DUF4142** and predicted/per the authors “putatively” **periplasm-exported**. (zytnick2022discoveryandcharacterization pages 3-5)
+
+These facts support the interpretation that mllJ likely acts in **lanthanide handling** in a compartment outside the cytosol (periplasm), potentially:
+- buffering/temporary storage of lanthanides,
+- binding lanthanide–methylolanthanin complexes,
+- supporting transport handoff steps at the cell envelope.
+
+However, these roles are **hypotheses**; the obtainable source does not provide a dedicated mllJ mutant, purified protein biochemistry, or structural analysis. (zytnick2022discoveryandcharacterization pages 3-5, zytnick2022discoveryandcharacterization pages 5-8)
+
+#### 4.2. What should *not* be claimed (to avoid symbol/domain overreach)
+No obtainable evidence here supports that mllJ:
+- directly synthesizes methylolanthanin (i.e., is a biosynthetic enzyme),
+- is the transporter itself,
+- has demonstrated ferritin-like iron storage activity,
+- has experimentally verified Tat-dependent export (even though UniProt notes Tat-signal; the obtainable paper only states periplasm export without specifying Tat).
+
+Accordingly, a conservative annotation is: **“periplasmic DUF4142/ferritin-like protein associated with the methylolanthanin lanthanophore gene cluster; probable role in lanthanide homeostasis or trafficking.”** (zytnick2022discoveryandcharacterization pages 3-5)
+
+### 5) Relevant statistics and data from recent studies (quantitative evidence)
+
+All quantitative values below derive from Zytnick et al. (bioRxiv 2022) and are **cluster-level** unless otherwise indicated.
+
+#### 5.1. Transcriptomics (RNA-seq)
+- Differential expression between NdCl3 and Nd2O3 conditions: **1,468 DEGs** reported. (zytnick2022discoveryandcharacterization pages 3-5)
+- The methylolanthanin biosynthetic locus (META1p4129–META1p4138; includes mllJ/META1p4138) averaged **~32-fold upregulation** in Nd2O3 vs NdCl3. (zytnick2022discoveryandcharacterization pages 3-5)
+
+#### 5.2. Metabolomics: methylolanthanin-associated mass features
+- m/z features associated with methylolanthanin production included **m/z 799.4232 (positive mode)** and **m/z 797.4092 (negative mode)**; these were present in supernatants when the cluster was intact/overexpressed but absent upon mll locus deletion, supporting that the **mll region is necessary** for production. (zytnick2022discoveryandcharacterization pages 5-8)
+- Statistical analysis details in the excerpt include **Kruskal–Wallis** with pairwise **Wilcoxon** tests and BH correction (n=20 per group for boxplots; volcano plot n=5 per group; thresholds indicated at fold-change 0.5 and p<0.01; significance marks include p<0.001 and p<0.05). (zytnick2022discoveryandcharacterization pages 5-8)
+
+#### 5.3. Growth and lanthanide accumulation phenotypes
+- Overexpression increased growth rate on Nd2O3 to **0.026 hr−1** and is described as nearly a **50% increase** vs control; ΔmxaF growth rate on soluble NdCl3 reported as **0.037 hr−1**. (zytnick2022discoveryandcharacterization pages 8-10)
+- Exogenous methylolanthanin addition at **50 nM** improved growth yield with significance reported as **p=0.036** and **p=0.037** for two strain comparisons. (zytnick2022discoveryandcharacterization pages 8-10)
+- Deletion and overexpression of the mll locus altered intracellular Nd bioaccumulation (e.g., **1.8-fold reduction** in a deletion condition; **~3.5-fold increase** with overexpression; also described as **~30% decrease** in another comparison). (zytnick2022discoveryandcharacterization pages 8-10, zytnick2022discoveryandcharacterization pages 10-12)
+
+### Functional annotation (best-supported, conservative)
+
+**Gene:** mllJ (META1p4138; UniProt C5B1J0)
+
+**Proposed biological role (inferred):** accessory component of the methylolanthanin/lanthanophore system, likely involved in lanthanide handling at the cell envelope/periplasm rather than core small-molecule synthesis. (zytnick2022discoveryandcharacterization pages 3-5)
+
+**Primary biochemical function:** **unknown** (no enzyme reaction or substrate specificity demonstrated for mllJ alone in obtainable text). (zytnick2022discoveryandcharacterization pages 5-8)
+
+**Localization:** predicted/putative **periplasm-exported** protein. (zytnick2022discoveryandcharacterization pages 3-5)
+
+**Pathway context:** co-expressed with and encoded within the methylolanthanin biosynthetic gene cluster required for production of a lanthanide-chelating metabolite and for optimal lanthanide bioaccumulation, particularly under low-bioavailability conditions. (zytnick2022discoveryandcharacterization pages 3-5, zytnick2022discoveryandcharacterization pages 8-10)
+
+### Evidence gaps and recommendations for definitive annotation
+1. **mllJ-specific genetics**: a clean ΔmllJ mutant (without deleting the full cluster) would distinguish whether mllJ is required for methylolanthanin biosynthesis, secretion, uptake, or intracellular trafficking. (zytnick2022discoveryandcharacterization pages 5-8)
+2. **Protein biochemistry/structure**: purified MllJ metal-binding assays (lanthanides vs iron), and structural determination could validate whether the “ferritin-like” annotation corresponds to a true metal-storage fold/function in the periplasm. (zytnick2022discoveryandcharacterization pages 3-5)
+3. **Export mechanism**: direct experimental verification of signal peptide usage (Tat vs Sec) and subcellular fractionation would confirm localization and inform mechanistic models. (zytnick2022discoveryandcharacterization pages 3-5)
+
+### URLs and publication dates (obtainable sources)
+- Zytnick AM et al. **bioRxiv**, posted **Jan 2022**. “Discovery and characterization of the first known biological lanthanide chelator.” https://doi.org/10.1101/2022.01.19.476857 (zytnick2022discoveryandcharacterization pages 3-5)
+
+
+
+References
+
+1. (zytnick2022discoveryandcharacterization pages 3-5): Alexa M. Zytnick, Sophie M. Gutenthaler-Tietze, Allegra T. Aron, Zachary L. Reitz, Manh Tri Phi, Nathan M. Good, Daniel Petras, Lena J. Daumann, and N. Cecilia Martinez-Gomez. Discovery and characterization of the first known biological lanthanide chelator. bioRxiv, Jan 2022. URL: https://doi.org/10.1101/2022.01.19.476857, doi:10.1101/2022.01.19.476857. This article has 20 citations.
+
+2. (zytnick2022discoveryandcharacterization pages 8-10): Alexa M. Zytnick, Sophie M. Gutenthaler-Tietze, Allegra T. Aron, Zachary L. Reitz, Manh Tri Phi, Nathan M. Good, Daniel Petras, Lena J. Daumann, and N. Cecilia Martinez-Gomez. Discovery and characterization of the first known biological lanthanide chelator. bioRxiv, Jan 2022. URL: https://doi.org/10.1101/2022.01.19.476857, doi:10.1101/2022.01.19.476857. This article has 20 citations.
+
+3. (zytnick2022discoveryandcharacterization pages 5-8): Alexa M. Zytnick, Sophie M. Gutenthaler-Tietze, Allegra T. Aron, Zachary L. Reitz, Manh Tri Phi, Nathan M. Good, Daniel Petras, Lena J. Daumann, and N. Cecilia Martinez-Gomez. Discovery and characterization of the first known biological lanthanide chelator. bioRxiv, Jan 2022. URL: https://doi.org/10.1101/2022.01.19.476857, doi:10.1101/2022.01.19.476857. This article has 20 citations.
+
+4. (zytnick2022discoveryandcharacterization pages 10-12): Alexa M. Zytnick, Sophie M. Gutenthaler-Tietze, Allegra T. Aron, Zachary L. Reitz, Manh Tri Phi, Nathan M. Good, Daniel Petras, Lena J. Daumann, and N. Cecilia Martinez-Gomez. Discovery and characterization of the first known biological lanthanide chelator. bioRxiv, Jan 2022. URL: https://doi.org/10.1101/2022.01.19.476857, doi:10.1101/2022.01.19.476857. This article has 20 citations.
+
+## Artifacts
+
+- [Edison artifact artifact-00](mllJ-deep-research-falcon_artifacts/artifact-00.md)
+
+## Citations
+
+1. zytnick2022discoveryandcharacterization pages 3-5
+2. zytnick2022discoveryandcharacterization pages 8-10
+3. zytnick2022discoveryandcharacterization pages 5-8
+4. zytnick2022discoveryandcharacterization pages 10-12
+5. https://doi.org/10.1101/2022.01.19.476857
+6. https://doi.org/10.1101/2022.01.19.476857,

--- a/genes/METEA/mllJ/mllJ-deep-research-falcon_artifacts/artifact-00.md
+++ b/genes/METEA/mllJ/mllJ-deep-research-falcon_artifacts/artifact-00.md
@@ -1,0 +1,6 @@
+| Locus / gene | Organism | Genomic context | Induction condition and RNA-seq signal | Predicted domain / family | Predicted localization | What is not known | Supporting citation |
+|---|---|---|---|---|---|---|---|
+| META1p4138 / **mllJ** | *Methylorubrum extorquens* AM1 (formerly *Methylobacterium extorquens* AM1) | Part of the **methylolanthanin (mll) biosynthetic gene cluster**, spanning META1p4129–META1p4138 | The full cluster, including **mllJ**, was reported as highly upregulated during growth with poorly soluble **Nd2O3** versus soluble **NdCl3**, with an average induction of about **32-fold** across the cluster | Annotated as **DUF4142**; described as **ferritin-like** | Reported as **putatively exported into the periplasm** | No direct biochemical activity, substrate specificity, catalytic reaction, or mutant phenotype has been specifically established for **mllJ** in the cited study; its role is inferred from cluster membership and domain architecture rather than direct assay | (pqac-00000000) |
+
+
+*Table: This table summarizes the verified identity and currently available literature evidence for META1p4138 (mllJ) in *Methylorubrum extorquens* AM1. It highlights what is supported by experimental transcriptomics and bioinformatic annotation, while clearly separating unresolved functional questions.*


### PR DESCRIPTION
## Summary

Enriches the GO annotation review for **mllJ** (UniProt **C5B1J0**, locus **MexAM1_META1p4138**) in *Methylorubrum extorquens* AM1 with the falcon deep research report, and rebuilds the review around conservative, verbatim-cited evidence.

**Verified identity** (review / UniProt / falcon header all agree): C5B1J0 = mllJ = META1p4138, taxon 272630. UniProt confirms a DUF4142 domain, ferritin-like fold, and a TAT signal peptide (residues 1-25). The GOA file has no curated annotations.

**Biology:** mllJ is a ferritin-like DUF4142 protein in the **methylolanthanin (mll) biosynthetic gene cluster** (META1p4129–4138), a **lanthanide chelator / lanthanophore** system — NOT an iron siderophore. It is putatively periplasm-exported. No mllJ-specific biochemistry, substrate, or mutant phenotype exists; its role is inferred from cluster co-regulation (~32-fold upregulation on poorly soluble Nd2O3 vs soluble NdCl3) and domain architecture.

## Changes
- Added `file:METEA/mllJ/mllJ-deep-research-falcon.md` reference with **six verbatim `supporting_text` findings** (`reference_section_type: OTHER`).
- **Replaced fabricated/paraphrased pre-existing `file:` quotes.** All five pre-existing perplexity `file:` supporting texts/statements failed verbatim `grep -F` against their source; they were removed and replaced with verbatim falcon quotes.
- Converted references `findings` from `statement`-only to validated `supporting_text`.
- Attached falcon `supported_by` to both NEW annotations (GO:0003674 root MF; GO:0042597 periplasmic space) and to `core_functions`.
- **Fixed Bug #947 MF symptom:** added `molecular_function: GO:0003674` to the core_function entry, honestly reflecting that mllJ's activity is uncharacterized while keeping it aligned with `existing_annotations`.
- Stayed conservative per falcon's explicit cautions: did **not** assert biosynthetic-enzyme, transporter, or metal-binding/iron-storage activity. GO:0044550 was intentionally not added because falcon states mllJ is not shown to be a biosynthetic enzyme.

## Validation
- `just validate METEA mllJ` passes cleanly (schema, term, reference quote-matching, best practices).
- OLS-verified every GO id (GO:0003674, GO:0042597).
- No IDA evidence paired with `file:` references (all evidence is NAS).

🤖 Generated with [Claude Code](https://claude.com/claude-code)