### PR TITLE
[codex] Review human ABRAXAS1 PN context

### DIFF
--- a/genes/human/ABRAXAS1/ABRAXAS1-ai-review.html
+++ b/genes/human/ABRAXAS1/ABRAXAS1-ai-review.html
@@ -1,0 +1,7391 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>ABRAXAS1 - AI Gene Review</title>
+    <style>
+        :root {
+            --color-accept: #22c55e;
+            --color-remove: #ef4444;
+            --color-modify: #f97316;
+            --color-keep-non-core: #3b82f6;
+            --color-undecided: #6b7280;
+            --color-new: #8b5cf6;
+            --color-mark-over: #eab308;
+            --bg-light: #f9fafb;
+            --border-color: #e5e7eb;
+            --text-muted: #6b7280;
+            --text-primary: #111827;
+        }
+
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+            line-height: 1.6;
+            color: var(--text-primary);
+            background-color: #ffffff;
+            padding: 2rem;
+            max-width: 1400px;
+            margin: 0 auto;
+        }
+
+        .header {
+            border-bottom: 2px solid var(--border-color);
+            padding-bottom: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        h1 {
+            font-size: 2.5rem;
+            font-weight: 700;
+            margin-bottom: 0.5rem;
+            color: #1f2937;
+        }
+
+        .gene-info {
+            display: flex;
+            gap: 2rem;
+            flex-wrap: wrap;
+            margin-top: 1rem;
+        }
+
+        .info-item {
+            display: flex;
+            gap: 0.5rem;
+        }
+
+        .info-label {
+            font-weight: 600;
+            color: var(--text-muted);
+        }
+
+        .aliases {
+            display: flex;
+            gap: 0.5rem;
+            flex-wrap: wrap;
+        }
+
+        .badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.875rem;
+            font-weight: 500;
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+        }
+
+        .status-badge {
+            padding: 0.375rem 0.875rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .status-initialized {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fde68a;
+        }
+
+        .status-in-progress {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+        }
+
+        .status-draft {
+            background-color: #fce7f3;
+            color: #831843;
+            border: 1px solid #fbcfe8;
+        }
+
+        .status-complete {
+            background-color: #d1fae5;
+            color: #065f46;
+            border: 1px solid #a7f3d0;
+        }
+
+        .description-card {
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        .description-card h2 {
+            font-size: 1.25rem;
+            margin-bottom: 1rem;
+            color: #374151;
+        }
+
+        .section {
+            margin-bottom: 2.5rem;
+        }
+
+        .section-title {
+            font-size: 1.5rem;
+            font-weight: 600;
+            margin-bottom: 1.5rem;
+            color: #1f2937;
+            border-bottom: 1px solid var(--border-color);
+            padding-bottom: 0.5rem;
+        }
+
+        .annotations-table {
+            width: 100%;
+            border-collapse: collapse;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            overflow: hidden;
+        }
+
+        .annotations-table thead {
+            background-color: var(--bg-light);
+        }
+
+        .annotations-table th {
+            text-align: left;
+            padding: 1rem;
+            font-weight: 600;
+            border-bottom: 2px solid var(--border-color);
+            font-size: 0.875rem;
+            text-transform: uppercase;
+            letter-spacing: 0.05em;
+            color: var(--text-muted);
+        }
+
+        .annotations-table td {
+            padding: 1rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .annotations-table tbody tr:hover {
+            background-color: #f9fafb;
+        }
+
+        .action-badge {
+            display: inline-block;
+            padding: 0.375rem 0.75rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .action-accept {
+            background-color: var(--color-accept);
+            color: white;
+        }
+
+        .action-remove {
+            background-color: var(--color-remove);
+            color: white;
+        }
+
+        .action-modify {
+            background-color: var(--color-modify);
+            color: white;
+        }
+
+        .action-keep_as_non_core {
+            background-color: var(--color-keep-non-core);
+            color: white;
+        }
+
+        .action-undecided {
+            background-color: var(--color-undecided);
+            color: white;
+        }
+
+        .action-new {
+            background-color: var(--color-new);
+            color: white;
+        }
+
+        .action-mark_as_over_annotated {
+            background-color: var(--color-mark-over);
+            color: white;
+        }
+
+        .term-info {
+            display: flex;
+            flex-direction: column;
+            gap: 0.25rem;
+        }
+
+        .term-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .term-label {
+            font-weight: 500;
+        }
+
+        .evidence-code {
+            font-family: monospace;
+            background-color: var(--bg-light);
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .not-badge {
+            display: inline-block;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-weight: 600;
+            margin-left: 0.25rem;
+        }
+
+        .isoform-badge {
+            display: inline-block;
+            background-color: #eff6ff;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            margin-top: 0.25rem;
+        }
+
+        .core-function-card {
+            background-color: white;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 1rem;
+        }
+
+        .core-function-card h3 {
+            font-size: 1.125rem;
+            margin-bottom: 1rem;
+            color: #1f2937;
+        }
+
+        .core-function-statement {
+            margin-bottom: 1rem;
+            padding: 0.75rem;
+            background-color: var(--bg-light);
+            border-left: 4px solid var(--color-accept);
+            border-radius: 0.25rem;
+        }
+
+        .function-annotations {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin-top: 1rem;
+        }
+
+        .reference-item {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+        }
+
+        .reference-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: start;
+            margin-bottom: 0.75rem;
+        }
+
+        .reference-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #2563eb;
+        }
+
+        .supported-by {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f3f4f6;
+            border-left: 3px solid #3b82f6;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .supported-by-title {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .support-item {
+            margin-bottom: 0.5rem;
+        }
+
+        .support-ref {
+            font-weight: 500;
+            color: #2563eb;
+        }
+
+        .support-text {
+            color: #6b7280;
+            font-style: italic;
+            margin-left: 1rem;
+        }
+
+        a.term-link {
+            color: #2563eb;
+            text-decoration: none;
+        }
+
+        a.term-link:hover {
+            text-decoration: underline;
+        }
+
+        .core-function-terms {
+            margin-top: 1rem;
+        }
+
+        .function-term-group {
+            margin-bottom: 1rem;
+        }
+
+        .function-term-label {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .reference-title {
+            font-weight: 500;
+            margin-bottom: 0.5rem;
+        }
+
+        .findings-list {
+            margin-top: 1rem;
+            padding-left: 1.5rem;
+        }
+
+        .finding-item {
+            margin-bottom: 0.75rem;
+        }
+
+        .finding-statement {
+            font-weight: 500;
+            margin-bottom: 0.25rem;
+        }
+
+        .finding-text {
+            color: var(--text-muted);
+            font-size: 0.95rem;
+            font-style: italic;
+        }
+
+        .proposed-term {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #fef3c7;
+        }
+
+        .question-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #dbeafe;
+        }
+
+        .experiment-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #f3e8ff;
+        }
+
+        .prediction-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: white;
+        }
+
+        .prediction-card .prediction-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+        }
+
+        .prediction-source {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+        }
+
+        .assessment-badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.8rem;
+            font-weight: 600;
+            text-transform: uppercase;
+        }
+
+        .assessment-cor { background-color: #dcfce7; color: #166534; }
+        .assessment-cnn { background-color: #dbeafe; color: #1e40af; }
+        .assessment-lsp { background-color: #fef9c3; color: #854d0e; }
+        .assessment-unc { background-color: #f3f4f6; color: #374151; }
+        .assessment-pli { background-color: #fee2e2; color: #991b1b; }
+        .assessment-npi { background-color: #fecaca; color: #7f1d1d; }
+        .assessment-rep { background-color: #fde68a; color: #92400e; }
+
+        .confidence-score {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+            margin-left: 0.5rem;
+        }
+
+        .error-type-badge {
+            font-size: 0.75rem;
+            padding: 0.125rem 0.5rem;
+            border-radius: 0.25rem;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+        }
+
+        .isoforms-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fill, minmax(400px, 1fr));
+            gap: 1rem;
+        }
+
+        .isoform-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            background-color: white;
+            transition: box-shadow 0.2s;
+        }
+
+        .isoform-card:hover {
+            box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+        }
+
+        .functional-isoform-type {
+            display: inline-block;
+            padding: 0.2rem 0.5rem;
+            border-radius: 0.25rem;
+            font-size: 0.7rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.03em;
+        }
+
+        .type-SPLICE_VARIANT, .type-SPLICE_CLASS {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #93c5fd;
+        }
+
+        .type-CLEAVAGE_PRODUCT {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fcd34d;
+        }
+
+        .type-MODIFICATION_STATE {
+            background-color: #f3e8ff;
+            color: #6b21a8;
+            border: 1px solid #c4b5fd;
+        }
+
+        .type-CONFORMATIONAL_STATE {
+            background-color: #dcfce7;
+            color: #166534;
+            border: 1px solid #86efac;
+        }
+
+        .functional-isoform-mappings {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+            font-size: 0.85rem;
+        }
+
+        .functional-isoform-mappings .mapping-type {
+            font-weight: 600;
+            color: var(--text-muted);
+            font-size: 0.75rem;
+        }
+
+        .functional-isoform-go {
+            margin-top: 0.5rem;
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.25rem;
+        }
+
+        .go-chip {
+            display: inline-block;
+            padding: 0.15rem 0.4rem;
+            background-color: #ecfdf5;
+            color: #047857;
+            border: 1px solid #a7f3d0;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-family: monospace;
+        }
+
+        .isoform-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+            padding-bottom: 0.5rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .isoform-name {
+            font-weight: 600;
+            font-size: 1.1rem;
+            color: #1f2937;
+        }
+
+        .isoform-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .isoform-sequence-note {
+            font-size: 0.875rem;
+            color: var(--text-muted);
+            margin-bottom: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+        }
+
+        .isoform-description {
+            font-size: 0.95rem;
+            line-height: 1.5;
+        }
+
+        .collapsible {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .collapsible:after {
+            content: ' ▼';
+            font-size: 0.75rem;
+        }
+
+        .collapsible.collapsed:after {
+            content: ' ►';
+        }
+
+        .collapse-content {
+            transition: max-height 0.3s ease;
+            overflow: hidden;
+        }
+
+        .collapsed + .collapse-content {
+            max-height: 0;
+        }
+
+        .no-data {
+            color: var(--text-muted);
+            font-style: italic;
+            padding: 1rem;
+            text-align: center;
+            background-color: var(--bg-light);
+            border-radius: 0.5rem;
+        }
+
+        /* Styling for markdown section summaries with voting */
+        .markdown-section summary {
+            padding: 0.75rem;
+            background: var(--bg-light);
+            border-radius: 0.5rem;
+            margin-bottom: 0.5rem;
+        }
+
+        .markdown-section summary:hover {
+            background: #e5e7eb;
+        }
+
+        .markdown-section summary .vote-buttons {
+            margin-left: auto;
+        }
+
+        .deep-research-section {
+            margin-bottom: 1rem;
+            border: 1px solid #c7d2fe;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8faff;
+        }
+
+        .deep-research-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .deep-research-section summary h3 {
+            margin: 0;
+            color: #3730a3;
+            font-size: 1.1rem;
+        }
+
+        .report-meta {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin: 0.75rem 0 1rem;
+            align-items: center;
+        }
+
+        .report-badge {
+            display: inline-flex;
+            align-items: center;
+            border: 1px solid #c7d2fe;
+            border-radius: 999px;
+            background: #eef2ff;
+            color: #4338ca;
+            font-size: 0.78rem;
+            font-weight: 600;
+            padding: 0.2rem 0.6rem;
+        }
+
+        .report-meta-text {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+        }
+
+        .artifact-list {
+            display: grid;
+            gap: 0.75rem;
+            margin: 0.75rem 0 1rem;
+        }
+
+        .artifact-link {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+            margin-top: 0.5rem;
+            word-break: break-word;
+        }
+
+        @media print {
+            body {
+                padding: 1rem;
+            }
+
+            .collapsible:after {
+                display: none;
+            }
+
+            .collapsed + .collapse-content {
+                max-height: none !important;
+            }
+        }
+
+        @media (max-width: 768px) {
+            body {
+                padding: 1rem;
+            }
+
+            h1 {
+                font-size: 2rem;
+            }
+
+            .annotations-table {
+                font-size: 0.875rem;
+            }
+
+            .annotations-table th,
+            .annotations-table td {
+                padding: 0.5rem;
+            }
+        }
+    </style>
+</head>
+<body>
+    <div class="header">
+        <h1>ABRAXAS1</h1>
+        <div class="gene-info">
+            
+            <div class="info-item">
+                
+                <span class="info-label">UniProt ID:</span>
+                <span>
+                    <a href="https://www.uniprot.org/uniprotkb/Q6UWZ7" target="_blank" class="term-link">
+                        Q6UWZ7
+                    </a>
+                </span>
+                
+            </div>
+            
+            
+            <div class="info-item">
+                <span class="info-label">Organism:</span>
+                <span>Homo sapiens</span>
+            </div>
+            
+            
+            <div class="info-item">
+                <span class="info-label">Review Status:</span>
+                <span class="status-badge status-draft">
+                    DRAFT
+                </span>
+            </div>
+            
+            
+        </div>
+        <div style="margin-top: 1rem; text-align: center;">
+            <a id="feedback-form-link"
+               href="#"
+               target="_blank"
+               style="display: inline-block; padding: 10px 20px; background-color: #4CAF50; color: white; text-decoration: none; border-radius: 5px; font-weight: 600;">
+                📝 Provide Detailed Feedback
+            </a>
+            <script>
+                // Construct the form URL with proper encoding
+                // Extract organism code from the current page path (e.g., /genes/ARATH/APO1/ -> ARATH)
+                const pathParts = window.location.pathname.split('/');
+                const genesIndex = pathParts.indexOf('genes');
+                let organism = '';
+                if (genesIndex !== -1 && pathParts[genesIndex + 1]) {
+                    organism = pathParts[genesIndex + 1].toUpperCase();
+                }
+                const geneSymbol = "ABRAXAS1";
+                const speciesGene = organism + ' ' + geneSymbol;
+                const formBaseUrl = 'https://docs.google.com/forms/d/e/1FAIpQLSdTot9L6GVkkZYgLQT0E8ZdAJv8RiN5ZgOVkgWNcKSbYvxxzQ/viewform';
+                const entryId = '1226477767'; // Correct entry ID for Species/Gene field
+                const formUrl = formBaseUrl + '?entry.' + entryId + '=' + encodeURIComponent(speciesGene);
+                const feedbackLink = document.getElementById('feedback-form-link');
+                feedbackLink.href = formUrl;
+                // Add tooltip showing the pre-filled value
+                feedbackLink.title = 'Opens form with pre-filled: ' + speciesGene;
+            </script>
+        </div>
+    </div>
+
+    
+    <div class="description-card">
+        <div style="display: flex; justify-content: space-between; align-items: center;">
+            <h2>Gene Description</h2>
+            <span class="vote-buttons" data-g="Q6UWZ7" data-a="DESCRIPTION: ABRAXAS1 encodes a nuclear BRCA1-A complex subunit..." data-r="" data-act="DESCRIPTION">
+                <button class="vote-btn" data-v="up" title="Agree with this description">👍</button>
+                <button class="vote-btn" data-v="down" title="Disagree with this description">👎</button>
+            </span>
+        </div>
+        <p>ABRAXAS1 encodes a nuclear BRCA1-A complex subunit that acts as a scaffold linking BRCA1, UIMC1/RAP80, BRCC3/BRCC36, BABAM proteins, and ubiquitin-dependent DNA damage-site signaling. The protein contains an MPN-like domain, binds polyubiquitin as part of the BRCA1-A/RAP80 complex, and supports BRCA1 recruitment, DNA double-strand break repair, K63-ubiquitin signal editing by BRCC36, and G2/M DNA damage checkpoint responses.</p>
+    </div>
+    
+
+    
+
+    
+
+    
+    <div class="section">
+        <h2 class="section-title">Existing Annotations Review</h2>
+        <table class="annotations-table">
+            <thead>
+                <tr>
+                    <th>GO Term</th>
+                    <th>Evidence</th>
+                    <th>Action</th>
+                    <th>Reason</th>
+                </tr>
+            </thead>
+            <tbody>
+                
+                <tr>
+                    <td>
+                        <div class="term-info">
+                            
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005634" target="_blank" class="term-link">
+                                    GO:0005634
+                                </a>
+                            </span>
+                            <span class="term-label">nucleus</span>
+                            
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+                        
+                        
+                        
+                        <br>
+                        <span style="font-size: 0.75rem;">
+                            
+                            GO_REF:0000033
+                            
+                        </span>
+                        
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q6UWZ7" data-a="GO:0005634" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+                        
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Supported nuclear localization. ABRAXAS1 acts in the nuclear DNA damage response and localizes to DNA damage sites within the nucleus.
+                        </div>
+                        
+                        
+                        <div>
+                            <strong>Reason:</strong> The UniProt record and the original BRCA1-A studies place ABRAXAS1 in the nucleus, where it recruits/organizes BRCA1-A complex activity at DNA double-strand breaks.
+                        </div>
+                        
+                        
+                        
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+                            
+                            <div class="support-item">
+                                <span class="support-ref">
+                                    
+                                    file:human/ABRAXAS1/ABRAXAS1-uniprot.txt
+                                    
+                                </span>
+                                
+                                <div class="support-text">Nucleus {ECO:0000269|PubMed:17525340, ECO:0000269|PubMed:17643121, ECO:0000269|PubMed:17643122}.</div>
+                                
+                            </div>
+                            
+                            <div class="support-item">
+                                <span class="support-ref">
+                                    
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/17525340" target="_blank" class="term-link">
+                                        PMID:17525340
+                                    </a>
+                                    
+                                </span>
+                                
+                                <div class="support-text">RAP80 was required for optimal accumulation of BRCA1 on damaged DNA (foci) in response to ionizing radiation</div>
+                                
+                            </div>
+                            
+                        </div>
+                        
+                    </td>
+                </tr>
+                
+                <tr>
+                    <td>
+                        <div class="term-info">
+                            
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0008017" target="_blank" class="term-link">
+                                    GO:0008017
+                                </a>
+                            </span>
+                            <span class="term-label">microtubule binding</span>
+                            
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+                        
+                        
+                        
+                        <br>
+                        <span style="font-size: 0.75rem;">
+                            
+                            GO_REF:0000033
+                            
+                        </span>
+                        
+                    </td>
+                    <td>
+                        <span class="action-badge action-remove">
+                            REMOVE
+                        </span>
+                        <span class="vote-buttons" data-g="Q6UWZ7" data-a="GO:0008017" data-r="GO_REF:0000033" data-act="REMOVE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+                        
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Likely paralog/family over-propagation. The IBA trace for this microtubule-binding term cites ABRAXAS2 rather than ABRAXAS1-specific evidence.
+                        </div>
+                        
+                        
+                        <div>
+                            <strong>Reason:</strong> ABRAXAS1 literature, UniProt, Reactome, and PN context support a nuclear BRCA1-A DNA damage-response scaffold, not microtubule binding. No ABRAXAS1-specific microtubule-binding evidence was found in the cached evidence set.
+                        </div>
+                        
+                        
+                        
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+                            
+                            <div class="support-item">
+                                <span class="support-ref">
+                                    
+                                    file:human/ABRAXAS1/ABRAXAS1-uniprot.txt
+                                    
+                                </span>
+                                
+                                <div class="support-text">Involved in DNA damage response and double-strand break (DSB) repair.</div>
+                                
+                            </div>
+                            
+                            <div class="support-item">
+                                <span class="support-ref">
+                                    
+                                    file:human/ABRAXAS1/ABRAXAS1-notes.md
+                                    
+                                </span>
+                                
+                                <div class="support-text">The IBA microtubule/spindle annotations are projected through a PANTHER node supported by ABRAXAS2</div>
+                                
+                            </div>
+                            
+                        </div>
+                        
+                    </td>
+                </tr>
+                
+                <tr>
+                    <td>
+                        <div class="term-info">
+                            
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0008608" target="_blank" class="term-link">
+                                    GO:0008608
+                                </a>
+                            </span>
+                            <span class="term-label">attachment of spindle microtubules to kinetochore</span>
+                            
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+                        
+                        
+                        
+                        <br>
+                        <span style="font-size: 0.75rem;">
+                            
+                            GO_REF:0000033
+                            
+                        </span>
+                        
+                    </td>
+                    <td>
+                        <span class="action-badge action-remove">
+                            REMOVE
+                        </span>
+                        <span class="vote-buttons" data-g="Q6UWZ7" data-a="GO:0008608" data-r="GO_REF:0000033" data-act="REMOVE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+                        
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Likely paralog/family over-propagation. The kinetochore-microtubule attachment IBA is not supported by ABRAXAS1-specific DNA damage literature.
+                        </div>
+                        
+                        
+                        <div>
+                            <strong>Reason:</strong> The with/from metadata points to ABRAXAS2 for the spindle branch, while ABRAXAS1 evidence supports BRCA1-A complex-mediated DNA damage signaling. This process would overstate ABRAXAS1 biology.
+                        </div>
+                        
+                        
+                        
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+                            
+                            <div class="support-item">
+                                <span class="support-ref">
+                                    
+                                    file:human/ABRAXAS1/ABRAXAS1-uniprot.txt
+                                    
+                                </span>
+                                
+                                <div class="support-text">Involved in DNA damage response and double-strand break (DSB) repair.</div>
+                                
+                            </div>
+                            
+                            <div class="support-item">
+                                <span class="support-ref">
+                                    
+                                    file:human/ABRAXAS1/ABRAXAS1-notes.md
+                                    
+                                </span>
+                                
+                                <div class="support-text">I marked `microtubule binding`, `attachment of spindle microtubules to kinetochore`, and `mitotic spindle assembly` for removal for ABRAXAS1.</div>
+                                
+                            </div>
+                            
+                        </div>
+                        
+                    </td>
+                </tr>
+                
+                <tr>
+                    <td>
+                        <div class="term-info">
+                            
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0031593" target="_blank" class="term-link">
+                                    GO:0031593
+                                </a>
+                            </span>
+                            <span class="term-label">polyubiquitin modification-dependent protein binding</span>
+                            
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+                        
+                        
+                        
+                        <br>
+                        <span style="font-size: 0.75rem;">
+                            
+                            GO_REF:0000033
+                            
+                        </span>
+                        
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q6UWZ7" data-a="GO:0031593" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+                        
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Core molecular function. ABRAXAS1 is part of a BRCA1-A/RAP80 complex that recognizes ubiquitinated damage-site chromatin and has polyubiquitin-binding capacity.
+                        </div>
+                        
+                        
+                        <div>
+                            <strong>Reason:</strong> The term captures the ubiquitin-recognition side of ABRAXAS1 biology better than generic protein binding. It should be retained for both direct IDA and IBA evidence.
+                        </div>
+                        
+                        
+                        
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+                            
+                            <div class="support-item">
+                                <span class="support-ref">
+                                    
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/19261749" target="_blank" class="term-link">
+                                        PMID:19261749
+                                    </a>
+                                    
+                                </span>
+                                
+                                <div class="support-text">four members of the BRCA1-A complex possess a polyubiquitin chain-binding capability</div>
+                                
+                            </div>
+                            
+                            <div class="support-item">
+                                <span class="support-ref">
+                                    
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/20656689" target="_blank" class="term-link">
+                                        PMID:20656689
+                                    </a>
+                                    
+                                </span>
+                                
+                                <div class="support-text">RAP80, in turn, is recruited to DSBs through its tandem ubiquitin-interacting motifs (UIMs) ( 6 , 14 – 16 ), which specifically recognize K63-Ub chains</div>
+                                
+                            </div>
+                            
+                        </div>
+                        
+                    </td>
+                </tr>
+                
+                <tr>
+                    <td>
+                        <div class="term-info">
+                            
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0090307" target="_blank" class="term-link">
+                                    GO:0090307
+                                </a>
+                            </span>
+                            <span class="term-label">mitotic spindle assembly</span>
+                            
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+                        
+                        
+                        
+                        <br>
+                        <span style="font-size: 0.75rem;">
+                            
+                            GO_REF:0000033
+                            
+                        </span>
+                        
+                    </td>
+                    <td>
+                        <span class="action-badge action-remove">
+                            REMOVE
+                        </span>
+                        <span class="vote-buttons" data-g="Q6UWZ7" data-a="GO:0090307" data-r="GO_REF:0000033" data-act="REMOVE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+                        
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Likely paralog/family over-propagation. The mitotic-spindle-assembly IBA is not supported for ABRAXAS1 by the reviewed evidence.
+                        </div>
+                        
+                        
+                        <div>
+                            <strong>Reason:</strong> ABRAXAS1 participates in nuclear DNA damage repair/checkpoint signaling. The PANTHER IBA spindle call is traceable to ABRAXAS2 and should not be propagated to ABRAXAS1 without gene-specific evidence.
+                        </div>
+                        
+                        
+                        
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+                            
+                            <div class="support-item">
+                                <span class="support-ref">
+                                    
+                                    file:human/ABRAXAS1/ABRAXAS1-uniprot.txt
+                                    
+                                </span>
+                                
+                                <div class="support-text">Involved in DNA damage response and double-strand break (DSB) repair.</div>
+                                
+                            </div>
+                            
+                            <div class="support-item">
+                                <span class="support-ref">
+                                    
+                                    file:human/ABRAXAS1/ABRAXAS1-notes.md
+                                    
+                                </span>
+                                
+                                <div class="support-text">I marked `microtubule binding`, `attachment of spindle microtubules to kinetochore`, and `mitotic spindle assembly` for removal for ABRAXAS1.</div>
+                                
+                            </div>
+                            
+                        </div>
+                        
+                    </td>
+                </tr>
+                
+                <tr>
+                    <td>
+                        <div class="term-info">
+                            
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005634" target="_blank" class="term-link">
+                                    GO:0005634
+                                </a>
+                            </span>
+                            <span class="term-label">nucleus</span>
+                            
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+                        
+                        
+                        
+                        <br>
+                        <span style="font-size: 0.75rem;">
+                            
+                            GO_REF:0000044
+                            
+                        </span>
+                        
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q6UWZ7" data-a="GO:0005634" data-r="GO_REF:0000044" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+                        
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Supported nuclear localization. ABRAXAS1 acts in the nuclear DNA damage response and localizes to DNA damage sites within the nucleus.
+                        </div>
+                        
+                        
+                        <div>
+                            <strong>Reason:</strong> The UniProt record and the original BRCA1-A studies place ABRAXAS1 in the nucleus, where it recruits/organizes BRCA1-A complex activity at DNA double-strand breaks.
+                        </div>
+                        
+                        
+                        
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+                            
+                            <div class="support-item">
+                                <span class="support-ref">
+                                    
+                                    file:human/ABRAXAS1/ABRAXAS1-uniprot.txt
+                                    
+                                </span>
+                                
+                                <div class="support-text">Nucleus {ECO:0000269|PubMed:17525340, ECO:0000269|PubMed:17643121, ECO:0000269|PubMed:17643122}.</div>
+                                
+                            </div>
+                            
+                            <div class="support-item">
+                                <span class="support-ref">
+                                    
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/17525340" target="_blank" class="term-link">
+                                        PMID:17525340
+                                    </a>
+                                    
+                                </span>
+                                
+                                <div class="support-text">RAP80 was required for optimal accumulation of BRCA1 on damaged DNA (foci) in response to ionizing radiation</div>
+                                
+                            </div>
+                            
+                        </div>
+                        
+                    </td>
+                </tr>
+                
+                <tr>
+                    <td>
+                        <div class="term-info">
+                            
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
+                                    GO:0005515
+                                </a>
+                            </span>
+                            <span class="term-label">protein binding</span>
+                            
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+                        
+                        
+                        
+                        <br>
+                        <span style="font-size: 0.75rem;">
+                            
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/17525340" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:17525340
+                            </a>
+                            
+                                
+                                
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Abraxas and RAP80 form a BRCA1 protein complex required for ...
+                                </span>
+                                
+                            
+                            
+                        </span>
+                        
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="Q6UWZ7" data-a="GO:0005515" data-r="PMID:17525340" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+                        
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Interaction evidence is real, but the GO term protein binding is too generic to describe ABRAXAS1 function.
+                        </div>
+                        
+                        
+                        <div>
+                            <strong>Reason:</strong> These IPI rows should not be treated as core molecular-function annotations. The informative biology is BRCA1-A complex assembly, RAP80/BRCA1/BRCC36 interactions, and polyubiquitin-dependent recruitment; broad interactome rows are even less suitable as function claims.
+                        </div>
+                        
+                        
+                        
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+                            
+                            <div class="support-item">
+                                <span class="support-ref">
+                                    
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/17525340" target="_blank" class="term-link">
+                                        PMID:17525340
+                                    </a>
+                                    
+                                </span>
+                                
+                                <div class="support-text">identified a protein, Abraxas, that directly binds the BRCA1 BRCT repeats</div>
+                                
+                            </div>
+                            
+                            <div class="support-item">
+                                <span class="support-ref">
+                                    
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/20656689" target="_blank" class="term-link">
+                                        PMID:20656689
+                                    </a>
+                                    
+                                </span>
+                                
+                                <div class="support-text">The RAP80 complex is a five-member stoichiometric complex consisting of RAP80, BRCC36, BRCC45, Abraxas, and MERIT40</div>
+                                
+                            </div>
+                            
+                        </div>
+                        
+                    </td>
+                </tr>
+                
+                <tr>
+                    <td>
+                        <div class="term-info">
+                            
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
+                                    GO:0005515
+                                </a>
+                            </span>
+                            <span class="term-label">protein binding</span>
+                            
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+                        
+                        
+                        
+                        <br>
+                        <span style="font-size: 0.75rem;">
+                            
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/17643121" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:17643121
+                            </a>
+                            
+                                
+                                
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    CCDC98 targets BRCA1 to DNA damage sites.
+                                </span>
+                                
+                            
+                            
+                        </span>
+                        
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="Q6UWZ7" data-a="GO:0005515" data-r="PMID:17643121" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+                        
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Interaction evidence is real, but the GO term protein binding is too generic to describe ABRAXAS1 function.
+                        </div>
+                        
+                        
+                        <div>
+                            <strong>Reason:</strong> These IPI rows should not be treated as core molecular-function annotations. The informative biology is BRCA1-A complex assembly, RAP80/BRCA1/BRCC36 interactions, and polyubiquitin-dependent recruitment; broad interactome rows are even less suitable as function claims.
+                        </div>
+                        
+                        
+                        
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+                            
+                            <div class="support-item">
+                                <span class="support-ref">
+                                    
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/17643121" target="_blank" class="term-link">
+                                        PMID:17643121
+                                    </a>
+                                    
+                                </span>
+                                
+                                <div class="support-text">CCDC98 is a BRCA1 binding partner that mediates BRCA1 function in response to DNA damage.</div>
+                                
+                            </div>
+                            
+                            <div class="support-item">
+                                <span class="support-ref">
+                                    
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/20656689" target="_blank" class="term-link">
+                                        PMID:20656689
+                                    </a>
+                                    
+                                </span>
+                                
+                                <div class="support-text">The RAP80 complex is a five-member stoichiometric complex consisting of RAP80, BRCC36, BRCC45, Abraxas, and MERIT40</div>
+                                
+                            </div>
+                            
+                        </div>
+                        
+                    </td>
+                </tr>
+                
+                <tr>
+                    <td>
+                        <div class="term-info">
+                            
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
+                                    GO:0005515
+                                </a>
+                            </span>
+                            <span class="term-label">protein binding</span>
+                            
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+                        
+                        
+                        
+                        <br>
+                        <span style="font-size: 0.75rem;">
+                            
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/18077395" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:18077395
+                            </a>
+                            
+                                
+                                
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Ubc13/Rnf8 ubiquitin ligases control foci formation of the R...
+                                </span>
+                                
+                            
+                            
+                        </span>
+                        
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="Q6UWZ7" data-a="GO:0005515" data-r="PMID:18077395" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+                        
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Interaction evidence is real, but the GO term protein binding is too generic to describe ABRAXAS1 function.
+                        </div>
+                        
+                        
+                        <div>
+                            <strong>Reason:</strong> These IPI rows should not be treated as core molecular-function annotations. The informative biology is BRCA1-A complex assembly, RAP80/BRCA1/BRCC36 interactions, and polyubiquitin-dependent recruitment; broad interactome rows are even less suitable as function claims.
+                        </div>
+                        
+                        
+                        
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+                            
+                            <div class="support-item">
+                                <span class="support-ref">
+                                    
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/18077395" target="_blank" class="term-link">
+                                        PMID:18077395
+                                    </a>
+                                    
+                                </span>
+                                
+                                <div class="support-text">Rap80 contains an Abraxas interaction domain</div>
+                                
+                            </div>
+                            
+                            <div class="support-item">
+                                <span class="support-ref">
+                                    
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/20656689" target="_blank" class="term-link">
+                                        PMID:20656689
+                                    </a>
+                                    
+                                </span>
+                                
+                                <div class="support-text">The RAP80 complex is a five-member stoichiometric complex consisting of RAP80, BRCC36, BRCC45, Abraxas, and MERIT40</div>
+                                
+                            </div>
+                            
+                        </div>
+                        
+                    </td>
+                </tr>
+                
+                <tr>
+                    <td>
+                        <div class="term-info">
+                            
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
+                                    GO:0005515
+                                </a>
+                            </span>
+                            <span class="term-label">protein binding</span>
+                            
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+                        
+                        
+                        
+                        <br>
+                        <span style="font-size: 0.75rem;">
+                            
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/19615732" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:19615732
+                            </a>
+                            
+                                
+                                
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Defining the human deubiquitinating enzyme interaction lands...
+                                </span>
+                                
+                            
+                            
+                        </span>
+                        
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="Q6UWZ7" data-a="GO:0005515" data-r="PMID:19615732" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+                        
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Interaction evidence is real, but the GO term protein binding is too generic to describe ABRAXAS1 function.
+                        </div>
+                        
+                        
+                        <div>
+                            <strong>Reason:</strong> These IPI rows should not be treated as core molecular-function annotations. The informative biology is BRCA1-A complex assembly, RAP80/BRCA1/BRCC36 interactions, and polyubiquitin-dependent recruitment; broad interactome rows are even less suitable as function claims.
+                        </div>
+                        
+                        
+                        
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+                            
+                            <div class="support-item">
+                                <span class="support-ref">
+                                    
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/19615732" target="_blank" class="term-link">
+                                        PMID:19615732
+                                    </a>
+                                    
+                                </span>
+                                
+                                <div class="support-text">We identified 774 candidate interacting proteins associated with 75 Dubs.</div>
+                                
+                            </div>
+                            
+                        </div>
+                        
+                    </td>
+                </tr>
+                
+                <tr>
+                    <td>
+                        <div class="term-info">
+                            
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
+                                    GO:0005515
+                                </a>
+                            </span>
+                            <span class="term-label">protein binding</span>
+                            
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+                        
+                        
+                        
+                        <br>
+                        <span style="font-size: 0.75rem;">
+                            
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/29656893" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:29656893
+                            </a>
+                            
+                                
+                                
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    DNA Repair Network Analysis Reveals Shieldin as a Key Regula...
+                                </span>
+                                
+                            
+                            
+                        </span>
+                        
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="Q6UWZ7" data-a="GO:0005515" data-r="PMID:29656893" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+                        
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Interaction evidence is real, but the GO term protein binding is too generic to describe ABRAXAS1 function.
+                        </div>
+                        
+                        
+                        <div>
+                            <strong>Reason:</strong> These IPI rows should not be treated as core molecular-function annotations. The informative biology is BRCA1-A complex assembly, RAP80/BRCA1/BRCC36 interactions, and polyubiquitin-dependent recruitment; broad interactome rows are even less suitable as function claims.
+                        </div>
+                        
+                        
+                        
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+                            
+                            <div class="support-item">
+                                <span class="support-ref">
+                                    
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/29656893" target="_blank" class="term-link">
+                                        PMID:29656893
+                                    </a>
+                                    
+                                </span>
+                                
+                                <div class="support-text">we generated high-resolution interaction neighborhood maps of the endogenously expressed DNA repair factors 53BP1, BRCA1, and MDC1</div>
+                                
+                            </div>
+                            
+                        </div>
+                        
+                    </td>
+                </tr>
+                
+                <tr>
+                    <td>
+                        <div class="term-info">
+                            
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
+                                    GO:0005515
+                                </a>
+                            </span>
+                            <span class="term-label">protein binding</span>
+                            
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+                        
+                        
+                        
+                        <br>
+                        <span style="font-size: 0.75rem;">
+                            
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/34591612" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:34591612
+                            </a>
+                            
+                                
+                                
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    A protein interaction landscape of breast cancer.
+                                </span>
+                                
+                            
+                            
+                        </span>
+                        
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="Q6UWZ7" data-a="GO:0005515" data-r="PMID:34591612" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+                        
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Interaction evidence is real, but the GO term protein binding is too generic to describe ABRAXAS1 function.
+                        </div>
+                        
+                        
+                        <div>
+                            <strong>Reason:</strong> These IPI rows should not be treated as core molecular-function annotations. The informative biology is BRCA1-A complex assembly, RAP80/BRCA1/BRCC36 interactions, and polyubiquitin-dependent recruitment; broad interactome rows are even less suitable as function claims.
+                        </div>
+                        
+                        
+                        
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+                            
+                            <div class="support-item">
+                                <span class="support-ref">
+                                    
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/34591612" target="_blank" class="term-link">
+                                        PMID:34591612
+                                    </a>
+                                    
+                                </span>
+                                
+                                <div class="support-text">we generated comprehensive interaction maps for 40 frequently altered BC proteins</div>
+                                
+                            </div>
+                            
+                        </div>
+                        
+                    </td>
+                </tr>
+                
+                <tr>
+                    <td>
+                        <div class="term-info">
+                            
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
+                                    GO:0005515
+                                </a>
+                            </span>
+                            <span class="term-label">protein binding</span>
+                            
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+                        
+                        
+                        
+                        <br>
+                        <span style="font-size: 0.75rem;">
+                            
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/35156780" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:35156780
+                            </a>
+                            
+                                
+                                
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    CFTR interactome mapping using the mammalian membrane two-hy...
+                                </span>
+                                
+                            
+                            
+                        </span>
+                        
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="Q6UWZ7" data-a="GO:0005515" data-r="PMID:35156780" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+                        
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Interaction evidence is real, but the GO term protein binding is too generic to describe ABRAXAS1 function.
+                        </div>
+                        
+                        
+                        <div>
+                            <strong>Reason:</strong> These IPI rows should not be treated as core molecular-function annotations. The informative biology is BRCA1-A complex assembly, RAP80/BRCA1/BRCC36 interactions, and polyubiquitin-dependent recruitment; broad interactome rows are even less suitable as function claims.
+                        </div>
+                        
+                        
+                        
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+                            
+                            <div class="support-item">
+                                <span class="support-ref">
+                                    
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/35156780" target="_blank" class="term-link">
+                                        PMID:35156780
+                                    </a>
+                                    
+                                </span>
+                                
+                                <div class="support-text">high-throughput screening variant of the Mammalian Membrane Two-Hybrid</div>
+                                
+                            </div>
+                            
+                        </div>
+                        
+                    </td>
+                </tr>
+                
+                <tr>
+                    <td>
+                        <div class="term-info">
+                            
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
+                                    GO:0005515
+                                </a>
+                            </span>
+                            <span class="term-label">protein binding</span>
+                            
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+                        
+                        
+                        
+                        <br>
+                        <span style="font-size: 0.75rem;">
+                            
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/36012204" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:36012204
+                            </a>
+                            
+                                
+                                
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Differential CFTR-Interactome Proximity Labeling Procedures ...
+                                </span>
+                                
+                            
+                            
+                        </span>
+                        
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="Q6UWZ7" data-a="GO:0005515" data-r="PMID:36012204" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+                        
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Interaction evidence is real, but the GO term protein binding is too generic to describe ABRAXAS1 function.
+                        </div>
+                        
+                        
+                        <div>
+                            <strong>Reason:</strong> These IPI rows should not be treated as core molecular-function annotations. The informative biology is BRCA1-A complex assembly, RAP80/BRCA1/BRCC36 interactions, and polyubiquitin-dependent recruitment; broad interactome rows are even less suitable as function claims.
+                        </div>
+                        
+                        
+                        
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+                            
+                            <div class="support-item">
+                                <span class="support-ref">
+                                    
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/36012204" target="_blank" class="term-link">
+                                        PMID:36012204
+                                    </a>
+                                    
+                                </span>
+                                
+                                <div class="support-text">proximity labeling approaches identified both known and additional CFTR protein partners</div>
+                                
+                            </div>
+                            
+                        </div>
+                        
+                    </td>
+                </tr>
+                
+                <tr>
+                    <td>
+                        <div class="term-info">
+                            
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
+                                    GO:0005515
+                                </a>
+                            </span>
+                            <span class="term-label">protein binding</span>
+                            
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+                        
+                        
+                        
+                        <br>
+                        <span style="font-size: 0.75rem;">
+                            
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/39009827" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:39009827
+                            </a>
+                            
+                                
+                                
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Proteome-scale characterisation of motif-based interactome r...
+                                </span>
+                                
+                            
+                            
+                        </span>
+                        
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="Q6UWZ7" data-a="GO:0005515" data-r="PMID:39009827" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+                        
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Interaction evidence is real, but the GO term protein binding is too generic to describe ABRAXAS1 function.
+                        </div>
+                        
+                        
+                        <div>
+                            <strong>Reason:</strong> These IPI rows should not be treated as core molecular-function annotations. The informative biology is BRCA1-A complex assembly, RAP80/BRCA1/BRCC36 interactions, and polyubiquitin-dependent recruitment; broad interactome rows are even less suitable as function claims.
+                        </div>
+                        
+                        
+                        
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+                            
+                            <div class="support-item">
+                                <span class="support-ref">
+                                    
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/39009827" target="_blank" class="term-link">
+                                        PMID:39009827
+                                    </a>
+                                    
+                                </span>
+                                
+                                <div class="support-text">we identified 366 mutation-modulated interactions</div>
+                                
+                            </div>
+                            
+                        </div>
+                        
+                    </td>
+                </tr>
+                
+                <tr>
+                    <td>
+                        <div class="term-info">
+                            
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016604" target="_blank" class="term-link">
+                                    GO:0016604
+                                </a>
+                            </span>
+                            <span class="term-label">nuclear body</span>
+                            
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+                        
+                        
+                        
+                        <br>
+                        <span style="font-size: 0.75rem;">
+                            
+                            GO_REF:0000052
+                            
+                        </span>
+                        
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="Q6UWZ7" data-a="GO:0016604" data-r="GO_REF:0000052" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+                        
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Non-core localization. HPA reports nuclear-body staining, while mechanistic ABRAXAS1 biology centers on DNA damage foci/BRCA1-A complex recruitment.
+                        </div>
+                        
+                        
+                        <div>
+                            <strong>Reason:</strong> This cellular component is plausible as a localization observation, but it is less informative than nucleus/nucleoplasm and BRCA1-A complex membership for the gene product function.
+                        </div>
+                        
+                        
+                        
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+                            
+                            <div class="support-item">
+                                <span class="support-ref">
+                                    
+                                    file:human/ABRAXAS1/ABRAXAS1-uniprot.txt
+                                    
+                                </span>
+                                
+                                <div class="support-text">Localizes at sites of DNA damage at double-strand breaks (DSBs).</div>
+                                
+                            </div>
+                            
+                        </div>
+                        
+                    </td>
+                </tr>
+                
+                <tr>
+                    <td>
+                        <div class="term-info">
+                            
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005634" target="_blank" class="term-link">
+                                    GO:0005634
+                                </a>
+                            </span>
+                            <span class="term-label">nucleus</span>
+                            
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">NAS</span>
+                        
+                        
+                        
+                        <br>
+                        <span style="font-size: 0.75rem;">
+                            
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/20656689" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:20656689
+                            </a>
+                            
+                                
+                                
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Differential regulation of JAMM domain deubiquitinating enzy...
+                                </span>
+                                
+                            
+                            
+                        </span>
+                        
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q6UWZ7" data-a="GO:0005634" data-r="PMID:20656689" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+                        
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Supported nuclear localization. ABRAXAS1 acts in the nuclear DNA damage response and localizes to DNA damage sites within the nucleus.
+                        </div>
+                        
+                        
+                        <div>
+                            <strong>Reason:</strong> The UniProt record and the original BRCA1-A studies place ABRAXAS1 in the nucleus, where it recruits/organizes BRCA1-A complex activity at DNA double-strand breaks.
+                        </div>
+                        
+                        
+                        
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+                            
+                            <div class="support-item">
+                                <span class="support-ref">
+                                    
+                                    file:human/ABRAXAS1/ABRAXAS1-uniprot.txt
+                                    
+                                </span>
+                                
+                                <div class="support-text">Nucleus {ECO:0000269|PubMed:17525340, ECO:0000269|PubMed:17643121, ECO:0000269|PubMed:17643122}.</div>
+                                
+                            </div>
+                            
+                            <div class="support-item">
+                                <span class="support-ref">
+                                    
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/17525340" target="_blank" class="term-link">
+                                        PMID:17525340
+                                    </a>
+                                    
+                                </span>
+                                
+                                <div class="support-text">RAP80 was required for optimal accumulation of BRCA1 on damaged DNA (foci) in response to ionizing radiation</div>
+                                
+                            </div>
+                            
+                        </div>
+                        
+                    </td>
+                </tr>
+                
+                <tr>
+                    <td>
+                        <div class="term-info">
+                            
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006282" target="_blank" class="term-link">
+                                    GO:0006282
+                                </a>
+                            </span>
+                            <span class="term-label">regulation of DNA repair</span>
+                            
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">NAS</span>
+                        
+                        
+                        
+                        <br>
+                        <span style="font-size: 0.75rem;">
+                            
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/20656689" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:20656689
+                            </a>
+                            
+                                
+                                
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Differential regulation of JAMM domain deubiquitinating enzy...
+                                </span>
+                                
+                            
+                            
+                        </span>
+                        
+                    </td>
+                    <td>
+                        <span class="action-badge action-modify">
+                            MODIFY
+                        </span>
+                        <span class="vote-buttons" data-g="Q6UWZ7" data-a="GO:0006282" data-r="PMID:20656689" data-act="MODIFY">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+                        
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> The broad regulation-of-DNA-repair annotation is directionally correct but less precise than positive regulation of DNA repair for ABRAXAS1.
+                        </div>
+                        
+                        
+                        <div>
+                            <strong>Reason:</strong> ABRAXAS1 promotes BRCA1-A complex recruitment/stability and DNA repair after damage; the reviewed IMP annotations already use the more informative positive-regulation term.
+                        </div>
+                        
+                        
+                        <div style="margin-top: 0.5rem;">
+                            <strong>Proposed replacements:</strong>
+                            
+                            <span class="badge">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0045739" target="_blank" class="term-link">
+                                    positive regulation of DNA repair
+                                </a>
+                            </span>
+                            
+                        </div>
+                        
+                        
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+                            
+                            <div class="support-item">
+                                <span class="support-ref">
+                                    
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/17525340" target="_blank" class="term-link">
+                                        PMID:17525340
+                                    </a>
+                                    
+                                </span>
+                                
+                                <div class="support-text">Both Abraxas and RAP80 were required for DNA damage resistance, G(2)-M checkpoint control, and DNA repair.</div>
+                                
+                            </div>
+                            
+                            <div class="support-item">
+                                <span class="support-ref">
+                                    
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/19261748" target="_blank" class="term-link">
+                                        PMID:19261748
+                                    </a>
+                                    
+                                </span>
+                                
+                                <div class="support-text">a stable complex containing MERIT40 acts early in DNA damage response and regulates damage-dependent BRCA1 localization</div>
+                                
+                            </div>
+                            
+                        </div>
+                        
+                    </td>
+                </tr>
+                
+                <tr>
+                    <td>
+                        <div class="term-info">
+                            
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0044818" target="_blank" class="term-link">
+                                    GO:0044818
+                                </a>
+                            </span>
+                            <span class="term-label">mitotic G2/M transition checkpoint</span>
+                            
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">NAS</span>
+                        
+                        
+                        
+                        <br>
+                        <span style="font-size: 0.75rem;">
+                            
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/22369660" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:22369660
+                            </a>
+                            
+                                
+                                
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    BRCA1 tumor suppressor network: focusing on its tail.
+                                </span>
+                                
+                            
+                            
+                        </span>
+                        
+                    </td>
+                    <td>
+                        <span class="action-badge action-modify">
+                            MODIFY
+                        </span>
+                        <span class="vote-buttons" data-g="Q6UWZ7" data-a="GO:0044818" data-r="PMID:22369660" data-act="MODIFY">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+                        
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> The ComplexPortal/NAS checkpoint annotation is real but should be represented using the more specific DNA-damage checkpoint signaling term.
+                        </div>
+                        
+                        
+                        <div>
+                            <strong>Reason:</strong> ABRAXAS1 evidence concerns BRCA1-dependent G2/M checkpoint activation in response to DNA damage, not the generic mitotic G2/M transition checkpoint.
+                        </div>
+                        
+                        
+                        <div style="margin-top: 0.5rem;">
+                            <strong>Proposed replacements:</strong>
+                            
+                            <span class="badge">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0007095" target="_blank" class="term-link">
+                                    mitotic G2 DNA damage checkpoint signaling
+                                </a>
+                            </span>
+                            
+                        </div>
+                        
+                        
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+                            
+                            <div class="support-item">
+                                <span class="support-ref">
+                                    
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/17643121" target="_blank" class="term-link">
+                                        PMID:17643121
+                                    </a>
+                                    
+                                </span>
+                                
+                                <div class="support-text">CCDC98 controls both DNA damage-induced formation of BRCA1 foci and BRCA1-dependent G2/M checkpoint activation</div>
+                                
+                            </div>
+                            
+                            <div class="support-item">
+                                <span class="support-ref">
+                                    
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/22369660" target="_blank" class="term-link">
+                                        PMID:22369660
+                                    </a>
+                                    
+                                </span>
+                                
+                                <div class="support-text">Studies on A, B and C complexes of BRCA1 indicate that these complexes carry out functions of BRCA1 in cell cycle checkpoint control.</div>
+                                
+                            </div>
+                            
+                        </div>
+                        
+                    </td>
+                </tr>
+                
+                <tr>
+                    <td>
+                        <div class="term-info">
+                            
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0070531" target="_blank" class="term-link">
+                                    GO:0070531
+                                </a>
+                            </span>
+                            <span class="term-label">BRCA1-A complex</span>
+                            
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">NAS</span>
+                        
+                        
+                        
+                        <br>
+                        <span style="font-size: 0.75rem;">
+                            
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/20656689" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:20656689
+                            </a>
+                            
+                                
+                                
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Differential regulation of JAMM domain deubiquitinating enzy...
+                                </span>
+                                
+                            
+                            
+                        </span>
+                        
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q6UWZ7" data-a="GO:0070531" data-r="PMID:20656689" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+                        
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Core complex membership. ABRAXAS1 is a BRCA1-A complex subunit that organizes BRCA1, UIMC1/RAP80, BRCC3/BRCC36, BABAM proteins, and related DDR functions.
+                        </div>
+                        
+                        
+                        <div>
+                            <strong>Reason:</strong> Multiple primary studies and Reactome support ABRAXAS1/FAM175A as a BRCA1-A complex component. This is more precise than the PN-projected generic ubiquitin-ligase-complex bucket.
+                        </div>
+                        
+                        
+                        
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+                            
+                            <div class="support-item">
+                                <span class="support-ref">
+                                    
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/19261749" target="_blank" class="term-link">
+                                        PMID:19261749
+                                    </a>
+                                    
+                                </span>
+                                
+                                <div class="support-text">Proteomic analysis revealed that NBA1 is a component of the BRCA1 A complex, which also contains Brca1/Bard1, Abra1, RAP80, BRCC36, and BRE.</div>
+                                
+                            </div>
+                            
+                            <div class="support-item">
+                                <span class="support-ref">
+                                    
+                                    Reactome:R-HSA-5683385
+                                    
+                                </span>
+                                
+                                <div class="support-text">Together, BRCA1, BARD1, UIMC1, FAM175A, BRCC36, BRE and BABAM1 form the so-called BRCA1-A complex at DNA DSBs</div>
+                                
+                            </div>
+                            
+                        </div>
+                        
+                    </td>
+                </tr>
+                
+                <tr>
+                    <td>
+                        <div class="term-info">
+                            
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0007095" target="_blank" class="term-link">
+                                    GO:0007095
+                                </a>
+                            </span>
+                            <span class="term-label">mitotic G2 DNA damage checkpoint signaling</span>
+                            
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IMP</span>
+                        
+                        
+                        
+                        <br>
+                        <span style="font-size: 0.75rem;">
+                            
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/17525340" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:17525340
+                            </a>
+                            
+                                
+                                
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Abraxas and RAP80 form a BRCA1 protein complex required for ...
+                                </span>
+                                
+                            
+                            
+                        </span>
+                        
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q6UWZ7" data-a="GO:0007095" data-r="PMID:17525340" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+                        
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Core checkpoint process. ABRAXAS1/CCDC98 is required for BRCA1-dependent G2/M checkpoint signaling after DNA damage.
+                        </div>
+                        
+                        
+                        <div>
+                            <strong>Reason:</strong> The original ABRAXAS1/CCDC98 work and later BRCA1-A review evidence support a G2 DNA damage checkpoint role. This is part of the DNA damage response function rather than a general mitotic-spindle role.
+                        </div>
+                        
+                        
+                        
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+                            
+                            <div class="support-item">
+                                <span class="support-ref">
+                                    
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/17643121" target="_blank" class="term-link">
+                                        PMID:17643121
+                                    </a>
+                                    
+                                </span>
+                                
+                                <div class="support-text">CCDC98 controls both DNA damage-induced formation of BRCA1 foci and BRCA1-dependent G2/M checkpoint activation</div>
+                                
+                            </div>
+                            
+                            <div class="support-item">
+                                <span class="support-ref">
+                                    
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/22369660" target="_blank" class="term-link">
+                                        PMID:22369660
+                                    </a>
+                                    
+                                </span>
+                                
+                                <div class="support-text">Studies on A, B and C complexes of BRCA1 indicate that these complexes carry out functions of BRCA1 in cell cycle checkpoint control.</div>
+                                
+                            </div>
+                            
+                        </div>
+                        
+                    </td>
+                </tr>
+                
+                <tr>
+                    <td>
+                        <div class="term-info">
+                            
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0007095" target="_blank" class="term-link">
+                                    GO:0007095
+                                </a>
+                            </span>
+                            <span class="term-label">mitotic G2 DNA damage checkpoint signaling</span>
+                            
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IMP</span>
+                        
+                        
+                        
+                        <br>
+                        <span style="font-size: 0.75rem;">
+                            
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/17643121" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:17643121
+                            </a>
+                            
+                                
+                                
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    CCDC98 targets BRCA1 to DNA damage sites.
+                                </span>
+                                
+                            
+                            
+                        </span>
+                        
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q6UWZ7" data-a="GO:0007095" data-r="PMID:17643121" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+                        
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Core checkpoint process. ABRAXAS1/CCDC98 is required for BRCA1-dependent G2/M checkpoint signaling after DNA damage.
+                        </div>
+                        
+                        
+                        <div>
+                            <strong>Reason:</strong> The original ABRAXAS1/CCDC98 work and later BRCA1-A review evidence support a G2 DNA damage checkpoint role. This is part of the DNA damage response function rather than a general mitotic-spindle role.
+                        </div>
+                        
+                        
+                        
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+                            
+                            <div class="support-item">
+                                <span class="support-ref">
+                                    
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/17643121" target="_blank" class="term-link">
+                                        PMID:17643121
+                                    </a>
+                                    
+                                </span>
+                                
+                                <div class="support-text">CCDC98 controls both DNA damage-induced formation of BRCA1 foci and BRCA1-dependent G2/M checkpoint activation</div>
+                                
+                            </div>
+                            
+                            <div class="support-item">
+                                <span class="support-ref">
+                                    
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/22369660" target="_blank" class="term-link">
+                                        PMID:22369660
+                                    </a>
+                                    
+                                </span>
+                                
+                                <div class="support-text">Studies on A, B and C complexes of BRCA1 indicate that these complexes carry out functions of BRCA1 in cell cycle checkpoint control.</div>
+                                
+                            </div>
+                            
+                        </div>
+                        
+                    </td>
+                </tr>
+                
+                <tr>
+                    <td>
+                        <div class="term-info">
+                            
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0007095" target="_blank" class="term-link">
+                                    GO:0007095
+                                </a>
+                            </span>
+                            <span class="term-label">mitotic G2 DNA damage checkpoint signaling</span>
+                            
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IMP</span>
+                        
+                        
+                        
+                        <br>
+                        <span style="font-size: 0.75rem;">
+                            
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/19261748" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:19261748
+                            </a>
+                            
+                                
+                                
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    MERIT40 facilitates BRCA1 localization and DNA damage repair...
+                                </span>
+                                
+                            
+                            
+                        </span>
+                        
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q6UWZ7" data-a="GO:0007095" data-r="PMID:19261748" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+                        
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Core checkpoint process. ABRAXAS1/CCDC98 is required for BRCA1-dependent G2/M checkpoint signaling after DNA damage.
+                        </div>
+                        
+                        
+                        <div>
+                            <strong>Reason:</strong> The original ABRAXAS1/CCDC98 work and later BRCA1-A review evidence support a G2 DNA damage checkpoint role. This is part of the DNA damage response function rather than a general mitotic-spindle role.
+                        </div>
+                        
+                        
+                        
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+                            
+                            <div class="support-item">
+                                <span class="support-ref">
+                                    
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/17643121" target="_blank" class="term-link">
+                                        PMID:17643121
+                                    </a>
+                                    
+                                </span>
+                                
+                                <div class="support-text">CCDC98 controls both DNA damage-induced formation of BRCA1 foci and BRCA1-dependent G2/M checkpoint activation</div>
+                                
+                            </div>
+                            
+                            <div class="support-item">
+                                <span class="support-ref">
+                                    
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/22369660" target="_blank" class="term-link">
+                                        PMID:22369660
+                                    </a>
+                                    
+                                </span>
+                                
+                                <div class="support-text">Studies on A, B and C complexes of BRCA1 indicate that these complexes carry out functions of BRCA1 in cell cycle checkpoint control.</div>
+                                
+                            </div>
+                            
+                        </div>
+                        
+                    </td>
+                </tr>
+                
+                <tr>
+                    <td>
+                        <div class="term-info">
+                            
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005654" target="_blank" class="term-link">
+                                    GO:0005654
+                                </a>
+                            </span>
+                            <span class="term-label">nucleoplasm</span>
+                            
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+                        
+                        
+                        
+                        <br>
+                        <span style="font-size: 0.75rem;">
+                            
+                            Reactome:R-HSA-5683384
+                            
+                        </span>
+                        
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q6UWZ7" data-a="GO:0005654" data-r="Reactome:R-HSA-5683384" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+                        
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Supported Reactome-derived nuclear compartment annotation. The BRCA1-A complex events involving FAM175A/ABRAXAS1 are modeled at nuclear DNA double-strand breaks.
+                        </div>
+                        
+                        
+                        <div>
+                            <strong>Reason:</strong> The nucleoplasm location is consistent with ABRAXAS1 nuclear localization and Reactome DNA double-strand break events. These duplicate TAS rows reflect pathway-event participation rather than distinct localizations.
+                        </div>
+                        
+                        
+                        
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+                            
+                            <div class="support-item">
+                                <span class="support-ref">
+                                    
+                                    Reactome:R-HSA-5683385
+                                    
+                                </span>
+                                
+                                <div class="support-text">Together, BRCA1, BARD1, UIMC1, FAM175A, BRCC36, BRE and BABAM1 form the so-called BRCA1-A complex at DNA DSBs</div>
+                                
+                            </div>
+                            
+                        </div>
+                        
+                    </td>
+                </tr>
+                
+                <tr>
+                    <td>
+                        <div class="term-info">
+                            
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005654" target="_blank" class="term-link">
+                                    GO:0005654
+                                </a>
+                            </span>
+                            <span class="term-label">nucleoplasm</span>
+                            
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+                        
+                        
+                        
+                        <br>
+                        <span style="font-size: 0.75rem;">
+                            
+                            Reactome:R-HSA-5683385
+                            
+                        </span>
+                        
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q6UWZ7" data-a="GO:0005654" data-r="Reactome:R-HSA-5683385" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+                        
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Supported Reactome-derived nuclear compartment annotation. The BRCA1-A complex events involving FAM175A/ABRAXAS1 are modeled at nuclear DNA double-strand breaks.
+                        </div>
+                        
+                        
+                        <div>
+                            <strong>Reason:</strong> The nucleoplasm location is consistent with ABRAXAS1 nuclear localization and Reactome DNA double-strand break events. These duplicate TAS rows reflect pathway-event participation rather than distinct localizations.
+                        </div>
+                        
+                        
+                        
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+                            
+                            <div class="support-item">
+                                <span class="support-ref">
+                                    
+                                    Reactome:R-HSA-5683385
+                                    
+                                </span>
+                                
+                                <div class="support-text">Together, BRCA1, BARD1, UIMC1, FAM175A, BRCC36, BRE and BABAM1 form the so-called BRCA1-A complex at DNA DSBs</div>
+                                
+                            </div>
+                            
+                        </div>
+                        
+                    </td>
+                </tr>
+                
+                <tr>
+                    <td>
+                        <div class="term-info">
+                            
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005654" target="_blank" class="term-link">
+                                    GO:0005654
+                                </a>
+                            </span>
+                            <span class="term-label">nucleoplasm</span>
+                            
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+                        
+                        
+                        
+                        <br>
+                        <span style="font-size: 0.75rem;">
+                            
+                            Reactome:R-HSA-5683735
+                            
+                        </span>
+                        
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q6UWZ7" data-a="GO:0005654" data-r="Reactome:R-HSA-5683735" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+                        
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Supported Reactome-derived nuclear compartment annotation. The BRCA1-A complex events involving FAM175A/ABRAXAS1 are modeled at nuclear DNA double-strand breaks.
+                        </div>
+                        
+                        
+                        <div>
+                            <strong>Reason:</strong> The nucleoplasm location is consistent with ABRAXAS1 nuclear localization and Reactome DNA double-strand break events. These duplicate TAS rows reflect pathway-event participation rather than distinct localizations.
+                        </div>
+                        
+                        
+                        
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+                            
+                            <div class="support-item">
+                                <span class="support-ref">
+                                    
+                                    Reactome:R-HSA-5683385
+                                    
+                                </span>
+                                
+                                <div class="support-text">Together, BRCA1, BARD1, UIMC1, FAM175A, BRCC36, BRE and BABAM1 form the so-called BRCA1-A complex at DNA DSBs</div>
+                                
+                            </div>
+                            
+                        </div>
+                        
+                    </td>
+                </tr>
+                
+                <tr>
+                    <td>
+                        <div class="term-info">
+                            
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005654" target="_blank" class="term-link">
+                                    GO:0005654
+                                </a>
+                            </span>
+                            <span class="term-label">nucleoplasm</span>
+                            
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+                        
+                        
+                        
+                        <br>
+                        <span style="font-size: 0.75rem;">
+                            
+                            Reactome:R-HSA-5683801
+                            
+                        </span>
+                        
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q6UWZ7" data-a="GO:0005654" data-r="Reactome:R-HSA-5683801" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+                        
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Supported Reactome-derived nuclear compartment annotation. The BRCA1-A complex events involving FAM175A/ABRAXAS1 are modeled at nuclear DNA double-strand breaks.
+                        </div>
+                        
+                        
+                        <div>
+                            <strong>Reason:</strong> The nucleoplasm location is consistent with ABRAXAS1 nuclear localization and Reactome DNA double-strand break events. These duplicate TAS rows reflect pathway-event participation rather than distinct localizations.
+                        </div>
+                        
+                        
+                        
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+                            
+                            <div class="support-item">
+                                <span class="support-ref">
+                                    
+                                    Reactome:R-HSA-5683385
+                                    
+                                </span>
+                                
+                                <div class="support-text">Together, BRCA1, BARD1, UIMC1, FAM175A, BRCC36, BRE and BABAM1 form the so-called BRCA1-A complex at DNA DSBs</div>
+                                
+                            </div>
+                            
+                        </div>
+                        
+                    </td>
+                </tr>
+                
+                <tr>
+                    <td>
+                        <div class="term-info">
+                            
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005654" target="_blank" class="term-link">
+                                    GO:0005654
+                                </a>
+                            </span>
+                            <span class="term-label">nucleoplasm</span>
+                            
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+                        
+                        
+                        
+                        <br>
+                        <span style="font-size: 0.75rem;">
+                            
+                            Reactome:R-HSA-5684052
+                            
+                        </span>
+                        
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q6UWZ7" data-a="GO:0005654" data-r="Reactome:R-HSA-5684052" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+                        
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Supported Reactome-derived nuclear compartment annotation. The BRCA1-A complex events involving FAM175A/ABRAXAS1 are modeled at nuclear DNA double-strand breaks.
+                        </div>
+                        
+                        
+                        <div>
+                            <strong>Reason:</strong> The nucleoplasm location is consistent with ABRAXAS1 nuclear localization and Reactome DNA double-strand break events. These duplicate TAS rows reflect pathway-event participation rather than distinct localizations.
+                        </div>
+                        
+                        
+                        
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+                            
+                            <div class="support-item">
+                                <span class="support-ref">
+                                    
+                                    Reactome:R-HSA-5683385
+                                    
+                                </span>
+                                
+                                <div class="support-text">Together, BRCA1, BARD1, UIMC1, FAM175A, BRCC36, BRE and BABAM1 form the so-called BRCA1-A complex at DNA DSBs</div>
+                                
+                            </div>
+                            
+                        </div>
+                        
+                    </td>
+                </tr>
+                
+                <tr>
+                    <td>
+                        <div class="term-info">
+                            
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005654" target="_blank" class="term-link">
+                                    GO:0005654
+                                </a>
+                            </span>
+                            <span class="term-label">nucleoplasm</span>
+                            
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+                        
+                        
+                        
+                        <br>
+                        <span style="font-size: 0.75rem;">
+                            
+                            Reactome:R-HSA-5684071
+                            
+                        </span>
+                        
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q6UWZ7" data-a="GO:0005654" data-r="Reactome:R-HSA-5684071" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+                        
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Supported Reactome-derived nuclear compartment annotation. The BRCA1-A complex events involving FAM175A/ABRAXAS1 are modeled at nuclear DNA double-strand breaks.
+                        </div>
+                        
+                        
+                        <div>
+                            <strong>Reason:</strong> The nucleoplasm location is consistent with ABRAXAS1 nuclear localization and Reactome DNA double-strand break events. These duplicate TAS rows reflect pathway-event participation rather than distinct localizations.
+                        </div>
+                        
+                        
+                        
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+                            
+                            <div class="support-item">
+                                <span class="support-ref">
+                                    
+                                    Reactome:R-HSA-5683385
+                                    
+                                </span>
+                                
+                                <div class="support-text">Together, BRCA1, BARD1, UIMC1, FAM175A, BRCC36, BRE and BABAM1 form the so-called BRCA1-A complex at DNA DSBs</div>
+                                
+                            </div>
+                            
+                        </div>
+                        
+                    </td>
+                </tr>
+                
+                <tr>
+                    <td>
+                        <div class="term-info">
+                            
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005654" target="_blank" class="term-link">
+                                    GO:0005654
+                                </a>
+                            </span>
+                            <span class="term-label">nucleoplasm</span>
+                            
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+                        
+                        
+                        
+                        <br>
+                        <span style="font-size: 0.75rem;">
+                            
+                            Reactome:R-HSA-5686685
+                            
+                        </span>
+                        
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q6UWZ7" data-a="GO:0005654" data-r="Reactome:R-HSA-5686685" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+                        
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Supported Reactome-derived nuclear compartment annotation. The BRCA1-A complex events involving FAM175A/ABRAXAS1 are modeled at nuclear DNA double-strand breaks.
+                        </div>
+                        
+                        
+                        <div>
+                            <strong>Reason:</strong> The nucleoplasm location is consistent with ABRAXAS1 nuclear localization and Reactome DNA double-strand break events. These duplicate TAS rows reflect pathway-event participation rather than distinct localizations.
+                        </div>
+                        
+                        
+                        
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+                            
+                            <div class="support-item">
+                                <span class="support-ref">
+                                    
+                                    Reactome:R-HSA-5683385
+                                    
+                                </span>
+                                
+                                <div class="support-text">Together, BRCA1, BARD1, UIMC1, FAM175A, BRCC36, BRE and BABAM1 form the so-called BRCA1-A complex at DNA DSBs</div>
+                                
+                            </div>
+                            
+                        </div>
+                        
+                    </td>
+                </tr>
+                
+                <tr>
+                    <td>
+                        <div class="term-info">
+                            
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005654" target="_blank" class="term-link">
+                                    GO:0005654
+                                </a>
+                            </span>
+                            <span class="term-label">nucleoplasm</span>
+                            
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+                        
+                        
+                        
+                        <br>
+                        <span style="font-size: 0.75rem;">
+                            
+                            Reactome:R-HSA-5691411
+                            
+                        </span>
+                        
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q6UWZ7" data-a="GO:0005654" data-r="Reactome:R-HSA-5691411" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+                        
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Supported Reactome-derived nuclear compartment annotation. The BRCA1-A complex events involving FAM175A/ABRAXAS1 are modeled at nuclear DNA double-strand breaks.
+                        </div>
+                        
+                        
+                        <div>
+                            <strong>Reason:</strong> The nucleoplasm location is consistent with ABRAXAS1 nuclear localization and Reactome DNA double-strand break events. These duplicate TAS rows reflect pathway-event participation rather than distinct localizations.
+                        </div>
+                        
+                        
+                        
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+                            
+                            <div class="support-item">
+                                <span class="support-ref">
+                                    
+                                    Reactome:R-HSA-5683385
+                                    
+                                </span>
+                                
+                                <div class="support-text">Together, BRCA1, BARD1, UIMC1, FAM175A, BRCC36, BRE and BABAM1 form the so-called BRCA1-A complex at DNA DSBs</div>
+                                
+                            </div>
+                            
+                        </div>
+                        
+                    </td>
+                </tr>
+                
+                <tr>
+                    <td>
+                        <div class="term-info">
+                            
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005654" target="_blank" class="term-link">
+                                    GO:0005654
+                                </a>
+                            </span>
+                            <span class="term-label">nucleoplasm</span>
+                            
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+                        
+                        
+                        
+                        <br>
+                        <span style="font-size: 0.75rem;">
+                            
+                            Reactome:R-HSA-5693551
+                            
+                        </span>
+                        
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q6UWZ7" data-a="GO:0005654" data-r="Reactome:R-HSA-5693551" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+                        
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Supported Reactome-derived nuclear compartment annotation. The BRCA1-A complex events involving FAM175A/ABRAXAS1 are modeled at nuclear DNA double-strand breaks.
+                        </div>
+                        
+                        
+                        <div>
+                            <strong>Reason:</strong> The nucleoplasm location is consistent with ABRAXAS1 nuclear localization and Reactome DNA double-strand break events. These duplicate TAS rows reflect pathway-event participation rather than distinct localizations.
+                        </div>
+                        
+                        
+                        
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+                            
+                            <div class="support-item">
+                                <span class="support-ref">
+                                    
+                                    Reactome:R-HSA-5683385
+                                    
+                                </span>
+                                
+                                <div class="support-text">Together, BRCA1, BARD1, UIMC1, FAM175A, BRCC36, BRE and BABAM1 form the so-called BRCA1-A complex at DNA DSBs</div>
+                                
+                            </div>
+                            
+                        </div>
+                        
+                    </td>
+                </tr>
+                
+                <tr>
+                    <td>
+                        <div class="term-info">
+                            
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005654" target="_blank" class="term-link">
+                                    GO:0005654
+                                </a>
+                            </span>
+                            <span class="term-label">nucleoplasm</span>
+                            
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+                        
+                        
+                        
+                        <br>
+                        <span style="font-size: 0.75rem;">
+                            
+                            Reactome:R-HSA-69891
+                            
+                        </span>
+                        
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q6UWZ7" data-a="GO:0005654" data-r="Reactome:R-HSA-69891" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+                        
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Supported Reactome-derived nuclear compartment annotation. The BRCA1-A complex events involving FAM175A/ABRAXAS1 are modeled at nuclear DNA double-strand breaks.
+                        </div>
+                        
+                        
+                        <div>
+                            <strong>Reason:</strong> The nucleoplasm location is consistent with ABRAXAS1 nuclear localization and Reactome DNA double-strand break events. These duplicate TAS rows reflect pathway-event participation rather than distinct localizations.
+                        </div>
+                        
+                        
+                        
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+                            
+                            <div class="support-item">
+                                <span class="support-ref">
+                                    
+                                    Reactome:R-HSA-5683385
+                                    
+                                </span>
+                                
+                                <div class="support-text">Together, BRCA1, BARD1, UIMC1, FAM175A, BRCC36, BRE and BABAM1 form the so-called BRCA1-A complex at DNA DSBs</div>
+                                
+                            </div>
+                            
+                        </div>
+                        
+                    </td>
+                </tr>
+                
+                <tr>
+                    <td>
+                        <div class="term-info">
+                            
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
+                                    GO:0005515
+                                </a>
+                            </span>
+                            <span class="term-label">protein binding</span>
+                            
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+                        
+                        
+                        
+                        <br>
+                        <span style="font-size: 0.75rem;">
+                            
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/19261748" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:19261748
+                            </a>
+                            
+                                
+                                
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    MERIT40 facilitates BRCA1 localization and DNA damage repair...
+                                </span>
+                                
+                            
+                            
+                        </span>
+                        
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="Q6UWZ7" data-a="GO:0005515" data-r="PMID:19261748" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+                        
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Interaction evidence is real, but the GO term protein binding is too generic to describe ABRAXAS1 function.
+                        </div>
+                        
+                        
+                        <div>
+                            <strong>Reason:</strong> These IPI rows should not be treated as core molecular-function annotations. The informative biology is BRCA1-A complex assembly, RAP80/BRCA1/BRCC36 interactions, and polyubiquitin-dependent recruitment; broad interactome rows are even less suitable as function claims.
+                        </div>
+                        
+                        
+                        
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+                            
+                            <div class="support-item">
+                                <span class="support-ref">
+                                    
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/19261748" target="_blank" class="term-link">
+                                        PMID:19261748
+                                    </a>
+                                    
+                                </span>
+                                
+                                <div class="support-text">CCDC98 binds to RAP80 via a large N-terminal region</div>
+                                
+                            </div>
+                            
+                            <div class="support-item">
+                                <span class="support-ref">
+                                    
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/20656689" target="_blank" class="term-link">
+                                        PMID:20656689
+                                    </a>
+                                    
+                                </span>
+                                
+                                <div class="support-text">The RAP80 complex is a five-member stoichiometric complex consisting of RAP80, BRCC36, BRCC45, Abraxas, and MERIT40</div>
+                                
+                            </div>
+                            
+                        </div>
+                        
+                    </td>
+                </tr>
+                
+                <tr>
+                    <td>
+                        <div class="term-info">
+                            
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
+                                    GO:0005515
+                                </a>
+                            </span>
+                            <span class="term-label">protein binding</span>
+                            
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+                        
+                        
+                        
+                        <br>
+                        <span style="font-size: 0.75rem;">
+                            
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/19261749" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:19261749
+                            </a>
+                            
+                                
+                                
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    NBA1, a new player in the Brca1 A complex, is required for D...
+                                </span>
+                                
+                            
+                            
+                        </span>
+                        
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="Q6UWZ7" data-a="GO:0005515" data-r="PMID:19261749" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+                        
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Interaction evidence is real, but the GO term protein binding is too generic to describe ABRAXAS1 function.
+                        </div>
+                        
+                        
+                        <div>
+                            <strong>Reason:</strong> These IPI rows should not be treated as core molecular-function annotations. The informative biology is BRCA1-A complex assembly, RAP80/BRCA1/BRCC36 interactions, and polyubiquitin-dependent recruitment; broad interactome rows are even less suitable as function claims.
+                        </div>
+                        
+                        
+                        
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+                            
+                            <div class="support-item">
+                                <span class="support-ref">
+                                    
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/19261749" target="_blank" class="term-link">
+                                        PMID:19261749
+                                    </a>
+                                    
+                                </span>
+                                
+                                <div class="support-text">four members of the BRCA1-A complex possess a polyubiquitin chain-binding capability</div>
+                                
+                            </div>
+                            
+                            <div class="support-item">
+                                <span class="support-ref">
+                                    
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/20656689" target="_blank" class="term-link">
+                                        PMID:20656689
+                                    </a>
+                                    
+                                </span>
+                                
+                                <div class="support-text">The RAP80 complex is a five-member stoichiometric complex consisting of RAP80, BRCC36, BRCC45, Abraxas, and MERIT40</div>
+                                
+                            </div>
+                            
+                        </div>
+                        
+                    </td>
+                </tr>
+                
+                <tr>
+                    <td>
+                        <div class="term-info">
+                            
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005634" target="_blank" class="term-link">
+                                    GO:0005634
+                                </a>
+                            </span>
+                            <span class="term-label">nucleus</span>
+                            
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+                        
+                        
+                        
+                        <br>
+                        <span style="font-size: 0.75rem;">
+                            
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/17525340" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:17525340
+                            </a>
+                            
+                                
+                                
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Abraxas and RAP80 form a BRCA1 protein complex required for ...
+                                </span>
+                                
+                            
+                            
+                        </span>
+                        
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q6UWZ7" data-a="GO:0005634" data-r="PMID:17525340" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+                        
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Supported nuclear localization. ABRAXAS1 acts in the nuclear DNA damage response and localizes to DNA damage sites within the nucleus.
+                        </div>
+                        
+                        
+                        <div>
+                            <strong>Reason:</strong> The UniProt record and the original BRCA1-A studies place ABRAXAS1 in the nucleus, where it recruits/organizes BRCA1-A complex activity at DNA double-strand breaks.
+                        </div>
+                        
+                        
+                        
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+                            
+                            <div class="support-item">
+                                <span class="support-ref">
+                                    
+                                    file:human/ABRAXAS1/ABRAXAS1-uniprot.txt
+                                    
+                                </span>
+                                
+                                <div class="support-text">Nucleus {ECO:0000269|PubMed:17525340, ECO:0000269|PubMed:17643121, ECO:0000269|PubMed:17643122}.</div>
+                                
+                            </div>
+                            
+                            <div class="support-item">
+                                <span class="support-ref">
+                                    
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/17525340" target="_blank" class="term-link">
+                                        PMID:17525340
+                                    </a>
+                                    
+                                </span>
+                                
+                                <div class="support-text">RAP80 was required for optimal accumulation of BRCA1 on damaged DNA (foci) in response to ionizing radiation</div>
+                                
+                            </div>
+                            
+                        </div>
+                        
+                    </td>
+                </tr>
+                
+                <tr>
+                    <td>
+                        <div class="term-info">
+                            
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005634" target="_blank" class="term-link">
+                                    GO:0005634
+                                </a>
+                            </span>
+                            <span class="term-label">nucleus</span>
+                            
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+                        
+                        
+                        
+                        <br>
+                        <span style="font-size: 0.75rem;">
+                            
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/17643121" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:17643121
+                            </a>
+                            
+                                
+                                
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    CCDC98 targets BRCA1 to DNA damage sites.
+                                </span>
+                                
+                            
+                            
+                        </span>
+                        
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q6UWZ7" data-a="GO:0005634" data-r="PMID:17643121" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+                        
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Supported nuclear localization. ABRAXAS1 acts in the nuclear DNA damage response and localizes to DNA damage sites within the nucleus.
+                        </div>
+                        
+                        
+                        <div>
+                            <strong>Reason:</strong> The UniProt record and the original BRCA1-A studies place ABRAXAS1 in the nucleus, where it recruits/organizes BRCA1-A complex activity at DNA double-strand breaks.
+                        </div>
+                        
+                        
+                        
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+                            
+                            <div class="support-item">
+                                <span class="support-ref">
+                                    
+                                    file:human/ABRAXAS1/ABRAXAS1-uniprot.txt
+                                    
+                                </span>
+                                
+                                <div class="support-text">Nucleus {ECO:0000269|PubMed:17525340, ECO:0000269|PubMed:17643121, ECO:0000269|PubMed:17643122}.</div>
+                                
+                            </div>
+                            
+                            <div class="support-item">
+                                <span class="support-ref">
+                                    
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/17525340" target="_blank" class="term-link">
+                                        PMID:17525340
+                                    </a>
+                                    
+                                </span>
+                                
+                                <div class="support-text">RAP80 was required for optimal accumulation of BRCA1 on damaged DNA (foci) in response to ionizing radiation</div>
+                                
+                            </div>
+                            
+                        </div>
+                        
+                    </td>
+                </tr>
+                
+                <tr>
+                    <td>
+                        <div class="term-info">
+                            
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006302" target="_blank" class="term-link">
+                                    GO:0006302
+                                </a>
+                            </span>
+                            <span class="term-label">double-strand break repair</span>
+                            
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IMP</span>
+                        
+                        
+                        
+                        <br>
+                        <span style="font-size: 0.75rem;">
+                            
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/17525340" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:17525340
+                            </a>
+                            
+                                
+                                
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Abraxas and RAP80 form a BRCA1 protein complex required for ...
+                                </span>
+                                
+                            
+                            
+                        </span>
+                        
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q6UWZ7" data-a="GO:0006302" data-r="PMID:17525340" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+                        
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Core biological process. ABRAXAS1 is required for efficient DNA double-strand break repair through BRCA1-A recruitment and ubiquitin-dependent damage-site signaling.
+                        </div>
+                        
+                        
+                        <div>
+                            <strong>Reason:</strong> Loss/depletion experiments in the original ABRAXAS1/CCDC98 papers support DNA repair and DNA damage resistance. The PN-projected broader DNA repair term is already entailed by this annotation.
+                        </div>
+                        
+                        
+                        
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+                            
+                            <div class="support-item">
+                                <span class="support-ref">
+                                    
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/17525340" target="_blank" class="term-link">
+                                        PMID:17525340
+                                    </a>
+                                    
+                                </span>
+                                
+                                <div class="support-text">Both Abraxas and RAP80 were required for DNA damage resistance, G(2)-M checkpoint control, and DNA repair.</div>
+                                
+                            </div>
+                            
+                            <div class="support-item">
+                                <span class="support-ref">
+                                    
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/19261748" target="_blank" class="term-link">
+                                        PMID:19261748
+                                    </a>
+                                    
+                                </span>
+                                
+                                <div class="support-text">a stable complex containing MERIT40 acts early in DNA damage response and regulates damage-dependent BRCA1 localization</div>
+                                
+                            </div>
+                            
+                        </div>
+                        
+                    </td>
+                </tr>
+                
+                <tr>
+                    <td>
+                        <div class="term-info">
+                            
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006302" target="_blank" class="term-link">
+                                    GO:0006302
+                                </a>
+                            </span>
+                            <span class="term-label">double-strand break repair</span>
+                            
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IMP</span>
+                        
+                        
+                        
+                        <br>
+                        <span style="font-size: 0.75rem;">
+                            
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/17643121" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:17643121
+                            </a>
+                            
+                                
+                                
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    CCDC98 targets BRCA1 to DNA damage sites.
+                                </span>
+                                
+                            
+                            
+                        </span>
+                        
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q6UWZ7" data-a="GO:0006302" data-r="PMID:17643121" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+                        
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Core biological process. ABRAXAS1 is required for efficient DNA double-strand break repair through BRCA1-A recruitment and ubiquitin-dependent damage-site signaling.
+                        </div>
+                        
+                        
+                        <div>
+                            <strong>Reason:</strong> Loss/depletion experiments in the original ABRAXAS1/CCDC98 papers support DNA repair and DNA damage resistance. The PN-projected broader DNA repair term is already entailed by this annotation.
+                        </div>
+                        
+                        
+                        
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+                            
+                            <div class="support-item">
+                                <span class="support-ref">
+                                    
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/17525340" target="_blank" class="term-link">
+                                        PMID:17525340
+                                    </a>
+                                    
+                                </span>
+                                
+                                <div class="support-text">Both Abraxas and RAP80 were required for DNA damage resistance, G(2)-M checkpoint control, and DNA repair.</div>
+                                
+                            </div>
+                            
+                            <div class="support-item">
+                                <span class="support-ref">
+                                    
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/19261748" target="_blank" class="term-link">
+                                        PMID:19261748
+                                    </a>
+                                    
+                                </span>
+                                
+                                <div class="support-text">a stable complex containing MERIT40 acts early in DNA damage response and regulates damage-dependent BRCA1 localization</div>
+                                
+                            </div>
+                            
+                        </div>
+                        
+                    </td>
+                </tr>
+                
+                <tr>
+                    <td>
+                        <div class="term-info">
+                            
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006302" target="_blank" class="term-link">
+                                    GO:0006302
+                                </a>
+                            </span>
+                            <span class="term-label">double-strand break repair</span>
+                            
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IMP</span>
+                        
+                        
+                        
+                        <br>
+                        <span style="font-size: 0.75rem;">
+                            
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/19261748" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:19261748
+                            </a>
+                            
+                                
+                                
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    MERIT40 facilitates BRCA1 localization and DNA damage repair...
+                                </span>
+                                
+                            
+                            
+                        </span>
+                        
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q6UWZ7" data-a="GO:0006302" data-r="PMID:19261748" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+                        
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Core biological process. ABRAXAS1 is required for efficient DNA double-strand break repair through BRCA1-A recruitment and ubiquitin-dependent damage-site signaling.
+                        </div>
+                        
+                        
+                        <div>
+                            <strong>Reason:</strong> Loss/depletion experiments in the original ABRAXAS1/CCDC98 papers support DNA repair and DNA damage resistance. The PN-projected broader DNA repair term is already entailed by this annotation.
+                        </div>
+                        
+                        
+                        
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+                            
+                            <div class="support-item">
+                                <span class="support-ref">
+                                    
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/17525340" target="_blank" class="term-link">
+                                        PMID:17525340
+                                    </a>
+                                    
+                                </span>
+                                
+                                <div class="support-text">Both Abraxas and RAP80 were required for DNA damage resistance, G(2)-M checkpoint control, and DNA repair.</div>
+                                
+                            </div>
+                            
+                            <div class="support-item">
+                                <span class="support-ref">
+                                    
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/19261748" target="_blank" class="term-link">
+                                        PMID:19261748
+                                    </a>
+                                    
+                                </span>
+                                
+                                <div class="support-text">a stable complex containing MERIT40 acts early in DNA damage response and regulates damage-dependent BRCA1 localization</div>
+                                
+                            </div>
+                            
+                        </div>
+                        
+                    </td>
+                </tr>
+                
+                <tr>
+                    <td>
+                        <div class="term-info">
+                            
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0010212" target="_blank" class="term-link">
+                                    GO:0010212
+                                </a>
+                            </span>
+                            <span class="term-label">response to ionizing radiation</span>
+                            
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IMP</span>
+                        
+                        
+                        
+                        <br>
+                        <span style="font-size: 0.75rem;">
+                            
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/17525340" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:17525340
+                            </a>
+                            
+                                
+                                
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Abraxas and RAP80 form a BRCA1 protein complex required for ...
+                                </span>
+                                
+                            
+                            
+                        </span>
+                        
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="Q6UWZ7" data-a="GO:0010212" data-r="PMID:17525340" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+                        
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Supported but non-core phenotype/context annotation. Ionizing radiation is the experimental damage stimulus used to reveal ABRAXAS1 DNA damage-response function.
+                        </div>
+                        
+                        
+                        <div>
+                            <strong>Reason:</strong> The IR response annotations should be retained as useful experimental context, but the core process is DNA double-strand break repair/checkpoint signaling through BRCA1-A.
+                        </div>
+                        
+                        
+                        
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+                            
+                            <div class="support-item">
+                                <span class="support-ref">
+                                    
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/18077395" target="_blank" class="term-link">
+                                        PMID:18077395
+                                    </a>
+                                    
+                                </span>
+                                
+                                <div class="support-text">the entire Brca1 A complex to DNA-damage foci</div>
+                                
+                            </div>
+                            
+                            <div class="support-item">
+                                <span class="support-ref">
+                                    
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/19261749" target="_blank" class="term-link">
+                                        PMID:19261749
+                                    </a>
+                                    
+                                </span>
+                                
+                                <div class="support-text">required for resistance to ionizing radiation</div>
+                                
+                            </div>
+                            
+                        </div>
+                        
+                    </td>
+                </tr>
+                
+                <tr>
+                    <td>
+                        <div class="term-info">
+                            
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0010212" target="_blank" class="term-link">
+                                    GO:0010212
+                                </a>
+                            </span>
+                            <span class="term-label">response to ionizing radiation</span>
+                            
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IMP</span>
+                        
+                        
+                        
+                        <br>
+                        <span style="font-size: 0.75rem;">
+                            
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/17643121" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:17643121
+                            </a>
+                            
+                                
+                                
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    CCDC98 targets BRCA1 to DNA damage sites.
+                                </span>
+                                
+                            
+                            
+                        </span>
+                        
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="Q6UWZ7" data-a="GO:0010212" data-r="PMID:17643121" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+                        
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Supported but non-core phenotype/context annotation. Ionizing radiation is the experimental damage stimulus used to reveal ABRAXAS1 DNA damage-response function.
+                        </div>
+                        
+                        
+                        <div>
+                            <strong>Reason:</strong> The IR response annotations should be retained as useful experimental context, but the core process is DNA double-strand break repair/checkpoint signaling through BRCA1-A.
+                        </div>
+                        
+                        
+                        
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+                            
+                            <div class="support-item">
+                                <span class="support-ref">
+                                    
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/18077395" target="_blank" class="term-link">
+                                        PMID:18077395
+                                    </a>
+                                    
+                                </span>
+                                
+                                <div class="support-text">the entire Brca1 A complex to DNA-damage foci</div>
+                                
+                            </div>
+                            
+                            <div class="support-item">
+                                <span class="support-ref">
+                                    
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/19261749" target="_blank" class="term-link">
+                                        PMID:19261749
+                                    </a>
+                                    
+                                </span>
+                                
+                                <div class="support-text">required for resistance to ionizing radiation</div>
+                                
+                            </div>
+                            
+                        </div>
+                        
+                    </td>
+                </tr>
+                
+                <tr>
+                    <td>
+                        <div class="term-info">
+                            
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0010212" target="_blank" class="term-link">
+                                    GO:0010212
+                                </a>
+                            </span>
+                            <span class="term-label">response to ionizing radiation</span>
+                            
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IMP</span>
+                        
+                        
+                        
+                        <br>
+                        <span style="font-size: 0.75rem;">
+                            
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/19261748" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:19261748
+                            </a>
+                            
+                                
+                                
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    MERIT40 facilitates BRCA1 localization and DNA damage repair...
+                                </span>
+                                
+                            
+                            
+                        </span>
+                        
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="Q6UWZ7" data-a="GO:0010212" data-r="PMID:19261748" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+                        
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Supported but non-core phenotype/context annotation. Ionizing radiation is the experimental damage stimulus used to reveal ABRAXAS1 DNA damage-response function.
+                        </div>
+                        
+                        
+                        <div>
+                            <strong>Reason:</strong> The IR response annotations should be retained as useful experimental context, but the core process is DNA double-strand break repair/checkpoint signaling through BRCA1-A.
+                        </div>
+                        
+                        
+                        
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+                            
+                            <div class="support-item">
+                                <span class="support-ref">
+                                    
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/18077395" target="_blank" class="term-link">
+                                        PMID:18077395
+                                    </a>
+                                    
+                                </span>
+                                
+                                <div class="support-text">the entire Brca1 A complex to DNA-damage foci</div>
+                                
+                            </div>
+                            
+                            <div class="support-item">
+                                <span class="support-ref">
+                                    
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/19261749" target="_blank" class="term-link">
+                                        PMID:19261749
+                                    </a>
+                                    
+                                </span>
+                                
+                                <div class="support-text">required for resistance to ionizing radiation</div>
+                                
+                            </div>
+                            
+                        </div>
+                        
+                    </td>
+                </tr>
+                
+                <tr>
+                    <td>
+                        <div class="term-info">
+                            
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0031593" target="_blank" class="term-link">
+                                    GO:0031593
+                                </a>
+                            </span>
+                            <span class="term-label">polyubiquitin modification-dependent protein binding</span>
+                            
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+                        
+                        
+                        
+                        <br>
+                        <span style="font-size: 0.75rem;">
+                            
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/19261749" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:19261749
+                            </a>
+                            
+                                
+                                
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    NBA1, a new player in the Brca1 A complex, is required for D...
+                                </span>
+                                
+                            
+                            
+                        </span>
+                        
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q6UWZ7" data-a="GO:0031593" data-r="PMID:19261749" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+                        
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Core molecular function. ABRAXAS1 is part of a BRCA1-A/RAP80 complex that recognizes ubiquitinated damage-site chromatin and has polyubiquitin-binding capacity.
+                        </div>
+                        
+                        
+                        <div>
+                            <strong>Reason:</strong> The term captures the ubiquitin-recognition side of ABRAXAS1 biology better than generic protein binding. It should be retained for both direct IDA and IBA evidence.
+                        </div>
+                        
+                        
+                        
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+                            
+                            <div class="support-item">
+                                <span class="support-ref">
+                                    
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/19261749" target="_blank" class="term-link">
+                                        PMID:19261749
+                                    </a>
+                                    
+                                </span>
+                                
+                                <div class="support-text">four members of the BRCA1-A complex possess a polyubiquitin chain-binding capability</div>
+                                
+                            </div>
+                            
+                            <div class="support-item">
+                                <span class="support-ref">
+                                    
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/20656689" target="_blank" class="term-link">
+                                        PMID:20656689
+                                    </a>
+                                    
+                                </span>
+                                
+                                <div class="support-text">RAP80, in turn, is recruited to DSBs through its tandem ubiquitin-interacting motifs (UIMs) ( 6 , 14 – 16 ), which specifically recognize K63-Ub chains</div>
+                                
+                            </div>
+                            
+                        </div>
+                        
+                    </td>
+                </tr>
+                
+                <tr>
+                    <td>
+                        <div class="term-info">
+                            
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0045739" target="_blank" class="term-link">
+                                    GO:0045739
+                                </a>
+                            </span>
+                            <span class="term-label">positive regulation of DNA repair</span>
+                            
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IMP</span>
+                        
+                        
+                        
+                        <br>
+                        <span style="font-size: 0.75rem;">
+                            
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/17525340" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:17525340
+                            </a>
+                            
+                                
+                                
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Abraxas and RAP80 form a BRCA1 protein complex required for ...
+                                </span>
+                                
+                            
+                            
+                        </span>
+                        
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q6UWZ7" data-a="GO:0045739" data-r="PMID:17525340" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+                        
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Core regulatory process. ABRAXAS1 positively supports DNA repair by assembling/stabilizing the RAP80-BRCA1-A complex at DNA damage sites.
+                        </div>
+                        
+                        
+                        <div>
+                            <strong>Reason:</strong> The evidence supports a positive role in DNA repair through BRCA1 localization, complex integrity, and BRCC36-associated ubiquitin editing rather than direct DNA repair catalysis.
+                        </div>
+                        
+                        
+                        
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+                            
+                            <div class="support-item">
+                                <span class="support-ref">
+                                    
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/17525340" target="_blank" class="term-link">
+                                        PMID:17525340
+                                    </a>
+                                    
+                                </span>
+                                
+                                <div class="support-text">Both Abraxas and RAP80 were required for DNA damage resistance, G(2)-M checkpoint control, and DNA repair.</div>
+                                
+                            </div>
+                            
+                            <div class="support-item">
+                                <span class="support-ref">
+                                    
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/19261748" target="_blank" class="term-link">
+                                        PMID:19261748
+                                    </a>
+                                    
+                                </span>
+                                
+                                <div class="support-text">a stable complex containing MERIT40 acts early in DNA damage response and regulates damage-dependent BRCA1 localization</div>
+                                
+                            </div>
+                            
+                            <div class="support-item">
+                                <span class="support-ref">
+                                    
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/20656689" target="_blank" class="term-link">
+                                        PMID:20656689
+                                    </a>
+                                    
+                                </span>
+                                
+                                <div class="support-text">Abraxas and BRCC45 were essential for BRCC36 DUB activity within the RAP80 complex</div>
+                                
+                            </div>
+                            
+                        </div>
+                        
+                    </td>
+                </tr>
+                
+                <tr>
+                    <td>
+                        <div class="term-info">
+                            
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0045739" target="_blank" class="term-link">
+                                    GO:0045739
+                                </a>
+                            </span>
+                            <span class="term-label">positive regulation of DNA repair</span>
+                            
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IMP</span>
+                        
+                        
+                        
+                        <br>
+                        <span style="font-size: 0.75rem;">
+                            
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/19261748" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:19261748
+                            </a>
+                            
+                                
+                                
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    MERIT40 facilitates BRCA1 localization and DNA damage repair...
+                                </span>
+                                
+                            
+                            
+                        </span>
+                        
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q6UWZ7" data-a="GO:0045739" data-r="PMID:19261748" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+                        
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Core regulatory process. ABRAXAS1 positively supports DNA repair by assembling/stabilizing the RAP80-BRCA1-A complex at DNA damage sites.
+                        </div>
+                        
+                        
+                        <div>
+                            <strong>Reason:</strong> The evidence supports a positive role in DNA repair through BRCA1 localization, complex integrity, and BRCC36-associated ubiquitin editing rather than direct DNA repair catalysis.
+                        </div>
+                        
+                        
+                        
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+                            
+                            <div class="support-item">
+                                <span class="support-ref">
+                                    
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/17525340" target="_blank" class="term-link">
+                                        PMID:17525340
+                                    </a>
+                                    
+                                </span>
+                                
+                                <div class="support-text">Both Abraxas and RAP80 were required for DNA damage resistance, G(2)-M checkpoint control, and DNA repair.</div>
+                                
+                            </div>
+                            
+                            <div class="support-item">
+                                <span class="support-ref">
+                                    
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/19261748" target="_blank" class="term-link">
+                                        PMID:19261748
+                                    </a>
+                                    
+                                </span>
+                                
+                                <div class="support-text">a stable complex containing MERIT40 acts early in DNA damage response and regulates damage-dependent BRCA1 localization</div>
+                                
+                            </div>
+                            
+                            <div class="support-item">
+                                <span class="support-ref">
+                                    
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/20656689" target="_blank" class="term-link">
+                                        PMID:20656689
+                                    </a>
+                                    
+                                </span>
+                                
+                                <div class="support-text">Abraxas and BRCC45 were essential for BRCC36 DUB activity within the RAP80 complex</div>
+                                
+                            </div>
+                            
+                        </div>
+                        
+                    </td>
+                </tr>
+                
+                <tr>
+                    <td>
+                        <div class="term-info">
+                            
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0070531" target="_blank" class="term-link">
+                                    GO:0070531
+                                </a>
+                            </span>
+                            <span class="term-label">BRCA1-A complex</span>
+                            
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+                        
+                        
+                        
+                        <br>
+                        <span style="font-size: 0.75rem;">
+                            
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/17525340" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:17525340
+                            </a>
+                            
+                                
+                                
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Abraxas and RAP80 form a BRCA1 protein complex required for ...
+                                </span>
+                                
+                            
+                            
+                        </span>
+                        
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q6UWZ7" data-a="GO:0070531" data-r="PMID:17525340" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+                        
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Core complex membership. ABRAXAS1 is a BRCA1-A complex subunit that organizes BRCA1, UIMC1/RAP80, BRCC3/BRCC36, BABAM proteins, and related DDR functions.
+                        </div>
+                        
+                        
+                        <div>
+                            <strong>Reason:</strong> Multiple primary studies and Reactome support ABRAXAS1/FAM175A as a BRCA1-A complex component. This is more precise than the PN-projected generic ubiquitin-ligase-complex bucket.
+                        </div>
+                        
+                        
+                        
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+                            
+                            <div class="support-item">
+                                <span class="support-ref">
+                                    
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/19261749" target="_blank" class="term-link">
+                                        PMID:19261749
+                                    </a>
+                                    
+                                </span>
+                                
+                                <div class="support-text">Proteomic analysis revealed that NBA1 is a component of the BRCA1 A complex, which also contains Brca1/Bard1, Abra1, RAP80, BRCC36, and BRE.</div>
+                                
+                            </div>
+                            
+                            <div class="support-item">
+                                <span class="support-ref">
+                                    
+                                    Reactome:R-HSA-5683385
+                                    
+                                </span>
+                                
+                                <div class="support-text">Together, BRCA1, BARD1, UIMC1, FAM175A, BRCC36, BRE and BABAM1 form the so-called BRCA1-A complex at DNA DSBs</div>
+                                
+                            </div>
+                            
+                        </div>
+                        
+                    </td>
+                </tr>
+                
+                <tr>
+                    <td>
+                        <div class="term-info">
+                            
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0070531" target="_blank" class="term-link">
+                                    GO:0070531
+                                </a>
+                            </span>
+                            <span class="term-label">BRCA1-A complex</span>
+                            
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+                        
+                        
+                        
+                        <br>
+                        <span style="font-size: 0.75rem;">
+                            
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/19261746" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:19261746
+                            </a>
+                            
+                                
+                                
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    MERIT40 controls BRCA1-Rap80 complex integrity and recruitme...
+                                </span>
+                                
+                            
+                            
+                        </span>
+                        
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q6UWZ7" data-a="GO:0070531" data-r="PMID:19261746" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+                        
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Core complex membership. ABRAXAS1 is a BRCA1-A complex subunit that organizes BRCA1, UIMC1/RAP80, BRCC3/BRCC36, BABAM proteins, and related DDR functions.
+                        </div>
+                        
+                        
+                        <div>
+                            <strong>Reason:</strong> Multiple primary studies and Reactome support ABRAXAS1/FAM175A as a BRCA1-A complex component. This is more precise than the PN-projected generic ubiquitin-ligase-complex bucket.
+                        </div>
+                        
+                        
+                        
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+                            
+                            <div class="support-item">
+                                <span class="support-ref">
+                                    
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/19261749" target="_blank" class="term-link">
+                                        PMID:19261749
+                                    </a>
+                                    
+                                </span>
+                                
+                                <div class="support-text">Proteomic analysis revealed that NBA1 is a component of the BRCA1 A complex, which also contains Brca1/Bard1, Abra1, RAP80, BRCC36, and BRE.</div>
+                                
+                            </div>
+                            
+                            <div class="support-item">
+                                <span class="support-ref">
+                                    
+                                    Reactome:R-HSA-5683385
+                                    
+                                </span>
+                                
+                                <div class="support-text">Together, BRCA1, BARD1, UIMC1, FAM175A, BRCC36, BRE and BABAM1 form the so-called BRCA1-A complex at DNA DSBs</div>
+                                
+                            </div>
+                            
+                        </div>
+                        
+                    </td>
+                </tr>
+                
+                <tr>
+                    <td>
+                        <div class="term-info">
+                            
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0070531" target="_blank" class="term-link">
+                                    GO:0070531
+                                </a>
+                            </span>
+                            <span class="term-label">BRCA1-A complex</span>
+                            
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+                        
+                        
+                        
+                        <br>
+                        <span style="font-size: 0.75rem;">
+                            
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/19261748" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:19261748
+                            </a>
+                            
+                                
+                                
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    MERIT40 facilitates BRCA1 localization and DNA damage repair...
+                                </span>
+                                
+                            
+                            
+                        </span>
+                        
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q6UWZ7" data-a="GO:0070531" data-r="PMID:19261748" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+                        
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Core complex membership. ABRAXAS1 is a BRCA1-A complex subunit that organizes BRCA1, UIMC1/RAP80, BRCC3/BRCC36, BABAM proteins, and related DDR functions.
+                        </div>
+                        
+                        
+                        <div>
+                            <strong>Reason:</strong> Multiple primary studies and Reactome support ABRAXAS1/FAM175A as a BRCA1-A complex component. This is more precise than the PN-projected generic ubiquitin-ligase-complex bucket.
+                        </div>
+                        
+                        
+                        
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+                            
+                            <div class="support-item">
+                                <span class="support-ref">
+                                    
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/19261749" target="_blank" class="term-link">
+                                        PMID:19261749
+                                    </a>
+                                    
+                                </span>
+                                
+                                <div class="support-text">Proteomic analysis revealed that NBA1 is a component of the BRCA1 A complex, which also contains Brca1/Bard1, Abra1, RAP80, BRCC36, and BRE.</div>
+                                
+                            </div>
+                            
+                            <div class="support-item">
+                                <span class="support-ref">
+                                    
+                                    Reactome:R-HSA-5683385
+                                    
+                                </span>
+                                
+                                <div class="support-text">Together, BRCA1, BARD1, UIMC1, FAM175A, BRCC36, BRE and BABAM1 form the so-called BRCA1-A complex at DNA DSBs</div>
+                                
+                            </div>
+                            
+                        </div>
+                        
+                    </td>
+                </tr>
+                
+                <tr>
+                    <td>
+                        <div class="term-info">
+                            
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0070531" target="_blank" class="term-link">
+                                    GO:0070531
+                                </a>
+                            </span>
+                            <span class="term-label">BRCA1-A complex</span>
+                            
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+                        
+                        
+                        
+                        <br>
+                        <span style="font-size: 0.75rem;">
+                            
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/19261749" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:19261749
+                            </a>
+                            
+                                
+                                
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    NBA1, a new player in the Brca1 A complex, is required for D...
+                                </span>
+                                
+                            
+                            
+                        </span>
+                        
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q6UWZ7" data-a="GO:0070531" data-r="PMID:19261749" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+                        
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Core complex membership. ABRAXAS1 is a BRCA1-A complex subunit that organizes BRCA1, UIMC1/RAP80, BRCC3/BRCC36, BABAM proteins, and related DDR functions.
+                        </div>
+                        
+                        
+                        <div>
+                            <strong>Reason:</strong> Multiple primary studies and Reactome support ABRAXAS1/FAM175A as a BRCA1-A complex component. This is more precise than the PN-projected generic ubiquitin-ligase-complex bucket.
+                        </div>
+                        
+                        
+                        
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+                            
+                            <div class="support-item">
+                                <span class="support-ref">
+                                    
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/19261749" target="_blank" class="term-link">
+                                        PMID:19261749
+                                    </a>
+                                    
+                                </span>
+                                
+                                <div class="support-text">Proteomic analysis revealed that NBA1 is a component of the BRCA1 A complex, which also contains Brca1/Bard1, Abra1, RAP80, BRCC36, and BRE.</div>
+                                
+                            </div>
+                            
+                            <div class="support-item">
+                                <span class="support-ref">
+                                    
+                                    Reactome:R-HSA-5683385
+                                    
+                                </span>
+                                
+                                <div class="support-text">Together, BRCA1, BARD1, UIMC1, FAM175A, BRCC36, BRE and BABAM1 form the so-called BRCA1-A complex at DNA DSBs</div>
+                                
+                            </div>
+                            
+                        </div>
+                        
+                    </td>
+                </tr>
+                
+            </tbody>
+        </table>
+    </div>
+    
+
+    
+    <div class="section">
+        <h2 class="section-title">Core Functions</h2>
+        
+        <div class="core-function-card">
+            
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+                <h3>ABRAXAS1 is a scaffold and ubiquitin-recognition subunit of the nuclear BRCA1-A/RAP80 complex. It helps assemble BRCA1, UIMC1/RAP80, BRCC3/BRCC36, BABAM proteins, and related partners at ubiquitinated DNA double-strand break sites, thereby supporting BRCA1 recruitment, BRCC36-dependent K63-ubiquitin signal editing, DNA repair, and G2/M DNA damage checkpoint signaling.</h3>
+                <span class="vote-buttons" data-g="Q6UWZ7" data-a="FUNCTION: ABRAXAS1 is a scaffold and ubiquitin-recognition s..." data-r="" data-act="CORE_FUNCTION">
+                    <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
+                    <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
+                </span>
+            </div>
+            
+
+            <div class="core-function-terms">
+                
+                <div class="function-term-group">
+                    <div class="function-term-label">Molecular Function:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0031593" target="_blank" class="term-link">
+                            polyubiquitin modification-dependent protein binding
+                        </a>
+                    </span>
+                </div>
+                
+
+                
+                <div class="function-term-group">
+                    <div class="function-term-label">Directly Involved In:</div>
+                    <div class="function-annotations">
+                        
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006302" target="_blank" class="term-link">
+                                double-strand break repair
+                            </a>
+                        </span>
+                        
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0045739" target="_blank" class="term-link">
+                                positive regulation of DNA repair
+                            </a>
+                        </span>
+                        
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0007095" target="_blank" class="term-link">
+                                mitotic G2 DNA damage checkpoint signaling
+                            </a>
+                        </span>
+                        
+                    </div>
+                </div>
+                
+
+                
+                <div class="function-term-group">
+                    <div class="function-term-label">Cellular Locations:</div>
+                    <div class="function-annotations">
+                        
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005634" target="_blank" class="term-link">
+                                nucleus
+                            </a>
+                        </span>
+                        
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005654" target="_blank" class="term-link">
+                                nucleoplasm
+                            </a>
+                        </span>
+                        
+                    </div>
+                </div>
+                
+
+                
+                <div class="function-term-group">
+                    <div class="function-term-label">In Complex:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0070531" target="_blank" class="term-link">
+                            BRCA1-A complex
+                        </a>
+                    </span>
+                </div>
+                
+
+                
+            </div>
+
+            
+            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
+                <strong>Supporting Evidence:</strong>
+                <ul class="findings-list">
+                    
+                    <li class="finding-item">
+                        <span class="reference-id">
+                            
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/17525340" target="_blank" class="term-link">
+                                PMID:17525340
+                            </a>
+                            
+                        </span>
+                        
+                        <div class="finding-text">Abraxas and RAP80 were required for DNA damage resistance, G(2)-M checkpoint control, and DNA repair.</div>
+                        
+                    </li>
+                    
+                    <li class="finding-item">
+                        <span class="reference-id">
+                            
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/19261748" target="_blank" class="term-link">
+                                PMID:19261748
+                            </a>
+                            
+                        </span>
+                        
+                        <div class="finding-text">CCDC98 as the central component that facilitates the assembly of this protein complex</div>
+                        
+                    </li>
+                    
+                    <li class="finding-item">
+                        <span class="reference-id">
+                            
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/19261749" target="_blank" class="term-link">
+                                PMID:19261749
+                            </a>
+                            
+                        </span>
+                        
+                        <div class="finding-text">four members of the BRCA1-A complex possess a polyubiquitin chain-binding capability</div>
+                        
+                    </li>
+                    
+                    <li class="finding-item">
+                        <span class="reference-id">
+                            
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/20656689" target="_blank" class="term-link">
+                                PMID:20656689
+                            </a>
+                            
+                        </span>
+                        
+                        <div class="finding-text">Abraxas and BRCC45 were essential for BRCC36 DUB activity within the RAP80 complex</div>
+                        
+                    </li>
+                    
+                    <li class="finding-item">
+                        <span class="reference-id">
+                            
+                            Reactome:R-HSA-5683385
+                            
+                        </span>
+                        
+                        <div class="finding-text">Together, BRCA1, BARD1, UIMC1, FAM175A, BRCC36, BRE and BABAM1 form the so-called BRCA1-A complex at DNA DSBs</div>
+                        
+                    </li>
+                    
+                    <li class="finding-item">
+                        <span class="reference-id">
+                            
+                            file:human/ABRAXAS1/ABRAXAS1-uniprot.txt
+                            
+                        </span>
+                        
+                        <div class="finding-text">Involved in DNA damage response and double-strand break (DSB) repair.</div>
+                        
+                    </li>
+                    
+                </ul>
+            </div>
+            
+        </div>
+        
+    </div>
+    
+
+    
+    <div class="section">
+        <h2 class="section-title collapsible">References</h2>
+        <div class="collapse-content">
+            
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+                        
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000033.md" target="_blank" class="term-link">
+                            GO_REF:0000033
+                        </a>
+                        
+                    </span>
+                </div>
+                
+                <div class="reference-title">Annotation inferences using phylogenetic trees</div>
+                
+                
+            </div>
+            
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+                        
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000044.md" target="_blank" class="term-link">
+                            GO_REF:0000044
+                        </a>
+                        
+                    </span>
+                </div>
+                
+                <div class="reference-title">Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location vocabulary mapping, accompanied by conservative changes to GO terms applied by UniProt</div>
+                
+                
+            </div>
+            
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+                        
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000052.md" target="_blank" class="term-link">
+                            GO_REF:0000052
+                        </a>
+                        
+                    </span>
+                </div>
+                
+                <div class="reference-title">Gene Ontology annotation based on curation of immunofluorescence data</div>
+                
+                
+            </div>
+            
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+                        
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/17525340" target="_blank" class="term-link">
+                            PMID:17525340
+                        </a>
+                        
+                    </span>
+                </div>
+                
+                <div class="reference-title">Abraxas and RAP80 form a BRCA1 protein complex required for the DNA damage response.</div>
+                
+                
+                <ul class="findings-list">
+                    
+                    <li class="finding-item">
+                        <div class="finding-statement">ABRAXAS1/Abraxas binds BRCA1 BRCT repeats and RAP80, and is required for DNA damage resistance, G2/M checkpoint control, and DNA repair.</div>
+                        
+                        <div class="finding-text">"Abraxas and RAP80 were required for DNA damage resistance, G(2)-M checkpoint control, and DNA repair."</div>
+                        
+                    </li>
+                    
+                </ul>
+                
+            </div>
+            
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+                        
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/17643121" target="_blank" class="term-link">
+                            PMID:17643121
+                        </a>
+                        
+                    </span>
+                </div>
+                
+                <div class="reference-title">CCDC98 targets BRCA1 to DNA damage sites.</div>
+                
+                
+            </div>
+            
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+                        
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/18077395" target="_blank" class="term-link">
+                            PMID:18077395
+                        </a>
+                        
+                    </span>
+                </div>
+                
+                <div class="reference-title">Ubc13/Rnf8 ubiquitin ligases control foci formation of the Rap80/Abraxas/Brca1/Brcc36 complex in response to DNA damage.</div>
+                
+                
+            </div>
+            
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+                        
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/19261746" target="_blank" class="term-link">
+                            PMID:19261746
+                        </a>
+                        
+                    </span>
+                </div>
+                
+                <div class="reference-title">MERIT40 controls BRCA1-Rap80 complex integrity and recruitment to DNA double-strand breaks.</div>
+                
+                
+            </div>
+            
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+                        
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/19261748" target="_blank" class="term-link">
+                            PMID:19261748
+                        </a>
+                        
+                    </span>
+                </div>
+                
+                <div class="reference-title">MERIT40 facilitates BRCA1 localization and DNA damage repair.</div>
+                
+                
+                <ul class="findings-list">
+                    
+                    <li class="finding-item">
+                        <div class="finding-statement">CCDC98/ABRAXAS1 is a central component for assembly of the RAP80-containing BRCA1-A complex at DNA damage sites.</div>
+                        
+                        <div class="finding-text">"CCDC98 as the central component that facilitates the assembly of this protein complex"</div>
+                        
+                    </li>
+                    
+                </ul>
+                
+            </div>
+            
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+                        
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/19261749" target="_blank" class="term-link">
+                            PMID:19261749
+                        </a>
+                        
+                    </span>
+                </div>
+                
+                <div class="reference-title">NBA1, a new player in the Brca1 A complex, is required for DNA damage resistance and checkpoint control.</div>
+                
+                
+            </div>
+            
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+                        
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/19615732" target="_blank" class="term-link">
+                            PMID:19615732
+                        </a>
+                        
+                    </span>
+                </div>
+                
+                <div class="reference-title">Defining the human deubiquitinating enzyme interaction landscape.</div>
+                
+                
+            </div>
+            
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+                        
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/20656689" target="_blank" class="term-link">
+                            PMID:20656689
+                        </a>
+                        
+                    </span>
+                </div>
+                
+                <div class="reference-title">Differential regulation of JAMM domain deubiquitinating enzyme activity within the RAP80 complex.</div>
+                
+                
+                <ul class="findings-list">
+                    
+                    <li class="finding-item">
+                        <div class="finding-statement">ABRAXAS1 is required for BRCC36 DUB activity in the RAP80/BRCA1-A complex context, but is not itself the catalytic DUB.</div>
+                        
+                        <div class="finding-text">"Abraxas and BRCC45 were essential for BRCC36 DUB activity within the RAP80 complex"</div>
+                        
+                    </li>
+                    
+                </ul>
+                
+            </div>
+            
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+                        
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/22369660" target="_blank" class="term-link">
+                            PMID:22369660
+                        </a>
+                        
+                    </span>
+                </div>
+                
+                <div class="reference-title">BRCA1 tumor suppressor network: focusing on its tail.</div>
+                
+                
+            </div>
+            
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+                        
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/29656893" target="_blank" class="term-link">
+                            PMID:29656893
+                        </a>
+                        
+                    </span>
+                </div>
+                
+                <div class="reference-title">DNA Repair Network Analysis Reveals Shieldin as a Key Regulator of NHEJ and PARP Inhibitor Sensitivity.</div>
+                
+                
+            </div>
+            
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+                        
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/34591612" target="_blank" class="term-link">
+                            PMID:34591612
+                        </a>
+                        
+                    </span>
+                </div>
+                
+                <div class="reference-title">A protein interaction landscape of breast cancer.</div>
+                
+                
+            </div>
+            
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+                        
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/35156780" target="_blank" class="term-link">
+                            PMID:35156780
+                        </a>
+                        
+                    </span>
+                </div>
+                
+                <div class="reference-title">CFTR interactome mapping using the mammalian membrane two-hybrid high-throughput screening system.</div>
+                
+                
+            </div>
+            
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+                        
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/36012204" target="_blank" class="term-link">
+                            PMID:36012204
+                        </a>
+                        
+                    </span>
+                </div>
+                
+                <div class="reference-title">Differential CFTR-Interactome Proximity Labeling Procedures Identify Enrichment in Multiple SLC Transporters.</div>
+                
+                
+            </div>
+            
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+                        
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/39009827" target="_blank" class="term-link">
+                            PMID:39009827
+                        </a>
+                        
+                    </span>
+                </div>
+                
+                <div class="reference-title">Proteome-scale characterisation of motif-based interactome rewiring by disease mutations.</div>
+                
+                
+            </div>
+            
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+                        
+                        Reactome:R-HSA-5683384
+                        
+                    </span>
+                </div>
+                
+                <div class="reference-title">UIMC1 and FAM175A bind DNA DSBs</div>
+                
+                
+            </div>
+            
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+                        
+                        Reactome:R-HSA-5683385
+                        
+                    </span>
+                </div>
+                
+                <div class="reference-title">Formation of BRCA1-A complex at DNA DSBs</div>
+                
+                
+            </div>
+            
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+                        
+                        Reactome:R-HSA-5683735
+                        
+                    </span>
+                </div>
+                
+                <div class="reference-title">CHEK2 is recruited to DNA DSBs</div>
+                
+                
+            </div>
+            
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+                        
+                        Reactome:R-HSA-5683801
+                        
+                    </span>
+                </div>
+                
+                <div class="reference-title">CHEK2 phosphorylates BRCA1</div>
+                
+                
+            </div>
+            
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+                        
+                        Reactome:R-HSA-5684052
+                        
+                    </span>
+                </div>
+                
+                <div class="reference-title">PIAS4 SUMOylates MDC1</div>
+                
+                
+            </div>
+            
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+                        
+                        Reactome:R-HSA-5684071
+                        
+                    </span>
+                </div>
+                
+                <div class="reference-title">RNF4 ubiquitinates MDC1</div>
+                
+                
+            </div>
+            
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+                        
+                        Reactome:R-HSA-5686685
+                        
+                    </span>
+                </div>
+                
+                <div class="reference-title">RIF1 and PAX1IP bind TP53BP1 at DNA DSBs</div>
+                
+                
+            </div>
+            
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+                        
+                        Reactome:R-HSA-5691411
+                        
+                    </span>
+                </div>
+                
+                <div class="reference-title">BRCA1-A complex deubiquitinates K63polyUb-histone H2A</div>
+                
+                
+            </div>
+            
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+                        
+                        Reactome:R-HSA-5693551
+                        
+                    </span>
+                </div>
+                
+                <div class="reference-title">Phosphorylation of BRCA1-A complex at multiple sites by ATM</div>
+                
+                
+            </div>
+            
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+                        
+                        Reactome:R-HSA-69891
+                        
+                    </span>
+                </div>
+                
+                <div class="reference-title">Phosphorylation and activation of CHEK2 by ATM</div>
+                
+                
+            </div>
+            
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+                        
+                        file:human/ABRAXAS1/ABRAXAS1-uniprot.txt
+                        
+                    </span>
+                </div>
+                
+                <div class="reference-title">ABRAXAS1 UniProtKB record</div>
+                
+                
+            </div>
+            
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+                        
+                        file:human/ABRAXAS1/ABRAXAS1-notes.md
+                        
+                    </span>
+                </div>
+                
+                <div class="reference-title">ABRAXAS1 manual review notes and failed deep-research provenance</div>
+                
+                
+            </div>
+            
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+                        
+                        file:projects/PROTEOSTASIS/reports/pn_projection/pn_projected_gene_go_summary.tsv
+                        
+                    </span>
+                </div>
+                
+                <div class="reference-title">Proteostasis PN projected GO summary for ABRAXAS1</div>
+                
+                
+            </div>
+            
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+                        
+                        file:projects/PROTEOSTASIS/mappings/ubiquitin_proteasome_system.yaml
+                        
+                    </span>
+                </div>
+                
+                <div class="reference-title">Proteostasis ubiquitin proteasome system mapping file</div>
+                
+                
+            </div>
+            
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+                        
+                        file:interpro/panther/PTHR31728/PTHR31728-entries.csv
+                        
+                    </span>
+                </div>
+                
+                <div class="reference-title">PANTHER PTHR31728 reviewed protein members</div>
+                
+                
+            </div>
+            
+        </div>
+    </div>
+    
+
+
+    
+    <div class="section">
+        <h2 class="section-title">Suggested Questions for Experts</h2>
+        
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> Should GO curation represent ABRAXAS1 only as part of the BRCA1-A complex, or is there enough evidence to annotate ABRAXAS1 to a broader ubiquitin ligase complex term despite its scaffold/DUB-support role?</p>
+                    
+                    <p style="margin-top: 0.5rem;"><em>Suggested experts: Wang B, Greenberg RA, Elledge SJ</em></p>
+                    
+                </div>
+                <span class="vote-buttons" data-g="Q6UWZ7" data-a="Q: Should GO curation represent ABRAXAS1 only as part..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+        
+    </div>
+    
+
+    
+    <div class="section">
+        <h2 class="section-title">Suggested Experiments</h2>
+        
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    
+                    <p><strong>Experiment:</strong> Compare ABRAXAS1 and ABRAXAS2 depletion or rescue in synchronized human cells using spindle assembly, kinetochore-microtubule attachment, and DNA damage-response readouts in the same experimental system.</p>
+                    
+                    
+                    <p style="margin-top: 0.5rem;"><em>Hypothesis: The PANTHER-derived spindle and microtubule annotations are ABRAXAS2/paralog-specific and do not apply to ABRAXAS1.</em></p>
+                    
+                    
+                    <p style="margin-top: 0.5rem;">Type: comparative cell biology</p>
+                    
+                </div>
+                <span class="vote-buttons" data-g="Q6UWZ7" data-a="EXPERIMENT: Compare ABRAXAS1 and ABRAXAS2 depletion or rescue ..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+        
+    </div>
+    
+
+    
+
+    <!-- Computational Predictions Section -->
+    
+
+    <!-- Deep Research Sections -->
+    
+
+    <!-- Additional Documentation Sections -->
+    
+    <div class="section">
+        <h2 class="section-title">📚 Additional Documentation</h2>
+        
+        <details class="markdown-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; cursor: pointer;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Notes</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(ABRAXAS1-notes.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="Q6UWZ7" data-a="DOC: Notes" data-r="" data-act="DOCUMENTATION" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This documentation is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This documentation needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+                <h1 id="abraxas1-review-notes">ABRAXAS1 review notes</h1>
+<h2 id="evidence-setup">Evidence setup</h2>
+<ul>
+<li><code>just fetch-gene human ABRAXAS1</code> seeded the UniProt, GOA, Reactome, PANTHER family, and review stub files on 2026-06-03.</li>
+<li>Falcon deep research was attempted with <code>just deep-research-falcon human ABRAXAS1 --fallback perplexity-lite</code>. Falcon timed out after 600 seconds; the <code>perplexity-lite</code> fallback then failed with a Perplexity API 401 quota error. No provider deep-research file was produced, so this review uses cached publications, UniProt, Reactome, PANTHER, and PN projection files directly.</li>
+</ul>
+<h2 id="functional-synthesis">Functional synthesis</h2>
+<p>ABRAXAS1/FAM175A/CCDC98 is a nuclear BRCA1-A complex scaffold and ubiquitin-recognition subunit. The primary literature identifies Abraxas as a BRCA1 BRCT-binding phosphoprotein and RAP80 partner: <a href="https://pubmed.ncbi.nlm.nih.gov/17525340" title="identified a protein, Abraxas, that directly binds the BRCA1 BRCT repeats through a phospho-Ser-X-X-Phe motif">PMID:17525340</a> and <a href="https://pubmed.ncbi.nlm.nih.gov/17525340" title="Abraxas recruits the ubiquitin-interacting motif (UIM)-containing protein RAP80 to BRCA1">PMID:17525340</a>.</p>
+<p>The supported biological role is DNA double-strand break response and checkpoint/repair signaling, not a standalone catalytic activity. The key experimental summary is that <a href="https://pubmed.ncbi.nlm.nih.gov/17525340" title="Abraxas and RAP80 were required for DNA damage resistance, G(2)-M checkpoint control, and DNA repair">PMID:17525340</a>. A second study frames CCDC98 as the factor that mediates BRCA1-RAP80 association and BRCA1-dependent G2/M checkpoint activation <a href="https://pubmed.ncbi.nlm.nih.gov/17643121" title="CCDC98 controls both DNA damage-induced formation of BRCA1 foci and BRCA1-dependent G2/M checkpoint activation">PMID:17643121</a>.</p>
+<p>ABRAXAS1 is also an organizer of the RAP80/BRCA1-A complex. Feng et al. describe CCDC98 as central to assembly: <a href="https://pubmed.ncbi.nlm.nih.gov/19261748" title="CCDC98 as the central component that facilitates the assembly of this protein complex">PMID:19261748</a>. The BRCA1-A/RAP80 complex has BRCC36 K63-linked deubiquitinase activity, but the catalytic subunit is BRCC36, while Abraxas is required for that activity in the RAP80 complex context <a href="https://pubmed.ncbi.nlm.nih.gov/20656689" title="Abraxas and BRCC45 were essential for BRCC36 DUB activity within the RAP80 complex">PMID:20656689</a>.</p>
+<h2 id="pn-projection-decision">PN projection decision</h2>
+<p>The PN projection has three ABRAXAS1 rows:</p>
+<ul>
+<li><code>GO:0070531 BRCA1-A complex</code>: already exact in GOA and accepted.</li>
+<li><code>GO:0006281 DNA repair</code>: already entailed by GOA via <code>GO:0006302 double-strand break repair</code>, so no new annotation is needed.</li>
+<li><code>GO:0000151 ubiquitin ligase complex</code>: new to GOA from the PN group <code>Ubiquitin Proteasome System|E3 ubiquitin and UBL ligases|idiosyncratic RING complex</code>. I did not add this as a proposed annotation. ABRAXAS1 is part of BRCA1-A, but the gene-level evidence supports scaffold/polyubiquitin-binding and BRCC36 DUB support rather than direct membership in a generic ubiquitin ligase complex. The PN mapping itself says this is a shared E3-complex bucket and warns against assigning catalytic activity to every subunit.</li>
+</ul>
+<h2 id="annotation-cautions">Annotation cautions</h2>
+<ul>
+<li><code>protein binding</code> rows are real interaction evidence but too uninformative for core molecular function. Mechanistic papers should be interpreted as BRCA1-A complex assembly, RAP80/BRCA1/BRCC36 interaction, and polyubiquitin-dependent recruitment rather than retained as generic protein binding.</li>
+<li>The IBA microtubule/spindle annotations are projected through a PANTHER node supported by ABRAXAS2 (<code>WITH/FROM: UniProtKB:Q15018</code>) rather than ABRAXAS1-specific evidence. I marked <code>microtubule binding</code>, <code>attachment of spindle microtubules to kinetochore</code>, and <code>mitotic spindle assembly</code> for removal for ABRAXAS1.</li>
+</ul>
+            </div>
+        </details>
+        
+    </div>
+    
+
+    <!-- YAML Preview Section -->
+    <div class="section">
+        <details class="yaml-preview">
+            <summary>
+                <h2 style="display: inline;">📄 View Raw YAML</h2>
+            </summary>
+            <div class="yaml-content">
+                <pre><code>id: Q6UWZ7
+gene_symbol: ABRAXAS1
+product_type: PROTEIN
+status: DRAFT
+taxon:
+  id: NCBITaxon:9606
+  label: Homo sapiens
+description: &gt;-
+  ABRAXAS1 encodes a nuclear BRCA1-A complex subunit that acts as a scaffold linking BRCA1, UIMC1/RAP80, BRCC3/BRCC36,
+  BABAM proteins, and ubiquitin-dependent DNA damage-site signaling. The protein contains an MPN-like domain, binds
+  polyubiquitin as part of the BRCA1-A/RAP80 complex, and supports BRCA1 recruitment, DNA double-strand break repair,
+  K63-ubiquitin signal editing by BRCC36, and G2/M DNA damage checkpoint responses.
+alternative_products:
+- name: &#39;1&#39;
+  id: Q6UWZ7-1
+- name: &#39;2&#39;
+  id: Q6UWZ7-2
+  sequence_note: VSP_058196
+existing_annotations:
+- term:
+    id: GO:0005634
+    label: nucleus
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: is_active_in
+  review:
+    summary: &gt;-
+      Supported nuclear localization. ABRAXAS1 acts in the nuclear DNA damage response and localizes to DNA damage
+      sites within the nucleus.
+    action: ACCEPT
+    reason: &gt;-
+      The UniProt record and the original BRCA1-A studies place ABRAXAS1 in the nucleus, where it recruits/organizes
+      BRCA1-A complex activity at DNA double-strand breaks.
+    supported_by:
+    - reference_id: file:human/ABRAXAS1/ABRAXAS1-uniprot.txt
+      supporting_text: Nucleus {ECO:0000269|PubMed:17525340, ECO:0000269|PubMed:17643121,
+        ECO:0000269|PubMed:17643122}.
+    - reference_id: PMID:17525340
+      supporting_text: RAP80 was required for optimal accumulation of BRCA1 on damaged DNA (foci) in response
+        to ionizing radiation
+- term:
+    id: GO:0008017
+    label: microtubule binding
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Likely paralog/family over-propagation. The IBA trace for this microtubule-binding term cites ABRAXAS2 rather
+      than ABRAXAS1-specific evidence.
+    action: REMOVE
+    reason: &gt;-
+      ABRAXAS1 literature, UniProt, Reactome, and PN context support a nuclear BRCA1-A DNA damage-response scaffold,
+      not microtubule binding. No ABRAXAS1-specific microtubule-binding evidence was found in the cached evidence
+      set.
+    additional_reference_ids:
+    - file:interpro/panther/PTHR31728/PTHR31728-entries.csv
+    supported_by:
+    - reference_id: file:human/ABRAXAS1/ABRAXAS1-uniprot.txt
+      supporting_text: Involved in DNA damage response and double-strand break (DSB) repair.
+    - reference_id: file:human/ABRAXAS1/ABRAXAS1-notes.md
+      supporting_text: The IBA microtubule/spindle annotations are projected through a PANTHER node supported
+        by ABRAXAS2
+- term:
+    id: GO:0008608
+    label: attachment of spindle microtubules to kinetochore
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Likely paralog/family over-propagation. The kinetochore-microtubule attachment IBA is not supported by ABRAXAS1-specific
+      DNA damage literature.
+    action: REMOVE
+    reason: &gt;-
+      The with/from metadata points to ABRAXAS2 for the spindle branch, while ABRAXAS1 evidence supports BRCA1-A
+      complex-mediated DNA damage signaling. This process would overstate ABRAXAS1 biology.
+    additional_reference_ids:
+    - file:interpro/panther/PTHR31728/PTHR31728-entries.csv
+    supported_by:
+    - reference_id: file:human/ABRAXAS1/ABRAXAS1-uniprot.txt
+      supporting_text: Involved in DNA damage response and double-strand break (DSB) repair.
+    - reference_id: file:human/ABRAXAS1/ABRAXAS1-notes.md
+      supporting_text: I marked `microtubule binding`, `attachment of spindle microtubules to kinetochore`,
+        and `mitotic spindle assembly` for removal for ABRAXAS1.
+- term:
+    id: GO:0031593
+    label: polyubiquitin modification-dependent protein binding
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Core molecular function. ABRAXAS1 is part of a BRCA1-A/RAP80 complex that recognizes ubiquitinated damage-site
+      chromatin and has polyubiquitin-binding capacity.
+    action: ACCEPT
+    reason: &gt;-
+      The term captures the ubiquitin-recognition side of ABRAXAS1 biology better than generic protein binding.
+      It should be retained for both direct IDA and IBA evidence.
+    supported_by:
+    - reference_id: PMID:19261749
+      supporting_text: four members of the BRCA1-A complex possess a polyubiquitin chain-binding capability
+    - reference_id: PMID:20656689
+      supporting_text: RAP80, in turn, is recruited to DSBs through its tandem ubiquitin-interacting motifs
+        (UIMs) ( 6 , 14 – 16 ), which specifically recognize K63-Ub chains
+- term:
+    id: GO:0090307
+    label: mitotic spindle assembly
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Likely paralog/family over-propagation. The mitotic-spindle-assembly IBA is not supported for ABRAXAS1 by
+      the reviewed evidence.
+    action: REMOVE
+    reason: &gt;-
+      ABRAXAS1 participates in nuclear DNA damage repair/checkpoint signaling. The PANTHER IBA spindle call is traceable
+      to ABRAXAS2 and should not be propagated to ABRAXAS1 without gene-specific evidence.
+    additional_reference_ids:
+    - file:interpro/panther/PTHR31728/PTHR31728-entries.csv
+    supported_by:
+    - reference_id: file:human/ABRAXAS1/ABRAXAS1-uniprot.txt
+      supporting_text: Involved in DNA damage response and double-strand break (DSB) repair.
+    - reference_id: file:human/ABRAXAS1/ABRAXAS1-notes.md
+      supporting_text: I marked `microtubule binding`, `attachment of spindle microtubules to kinetochore`,
+        and `mitotic spindle assembly` for removal for ABRAXAS1.
+- term:
+    id: GO:0005634
+    label: nucleus
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000044
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      Supported nuclear localization. ABRAXAS1 acts in the nuclear DNA damage response and localizes to DNA damage
+      sites within the nucleus.
+    action: ACCEPT
+    reason: &gt;-
+      The UniProt record and the original BRCA1-A studies place ABRAXAS1 in the nucleus, where it recruits/organizes
+      BRCA1-A complex activity at DNA double-strand breaks.
+    supported_by:
+    - reference_id: file:human/ABRAXAS1/ABRAXAS1-uniprot.txt
+      supporting_text: Nucleus {ECO:0000269|PubMed:17525340, ECO:0000269|PubMed:17643121,
+        ECO:0000269|PubMed:17643122}.
+    - reference_id: PMID:17525340
+      supporting_text: RAP80 was required for optimal accumulation of BRCA1 on damaged DNA (foci) in response
+        to ionizing radiation
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:17525340
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Interaction evidence is real, but the GO term protein binding is too generic to describe ABRAXAS1 function.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: &gt;-
+      These IPI rows should not be treated as core molecular-function annotations. The informative biology is BRCA1-A
+      complex assembly, RAP80/BRCA1/BRCC36 interactions, and polyubiquitin-dependent recruitment; broad interactome
+      rows are even less suitable as function claims.
+    supported_by:
+    - reference_id: PMID:17525340
+      supporting_text: identified a protein, Abraxas, that directly binds the BRCA1 BRCT repeats
+    - reference_id: PMID:20656689
+      supporting_text: The RAP80 complex is a five-member stoichiometric complex consisting of RAP80, BRCC36,
+        BRCC45, Abraxas, and MERIT40
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:17643121
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Interaction evidence is real, but the GO term protein binding is too generic to describe ABRAXAS1 function.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: &gt;-
+      These IPI rows should not be treated as core molecular-function annotations. The informative biology is BRCA1-A
+      complex assembly, RAP80/BRCA1/BRCC36 interactions, and polyubiquitin-dependent recruitment; broad interactome
+      rows are even less suitable as function claims.
+    supported_by:
+    - reference_id: PMID:17643121
+      supporting_text: CCDC98 is a BRCA1 binding partner that mediates BRCA1 function in response to DNA
+        damage.
+    - reference_id: PMID:20656689
+      supporting_text: The RAP80 complex is a five-member stoichiometric complex consisting of RAP80, BRCC36,
+        BRCC45, Abraxas, and MERIT40
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:18077395
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Interaction evidence is real, but the GO term protein binding is too generic to describe ABRAXAS1 function.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: &gt;-
+      These IPI rows should not be treated as core molecular-function annotations. The informative biology is BRCA1-A
+      complex assembly, RAP80/BRCA1/BRCC36 interactions, and polyubiquitin-dependent recruitment; broad interactome
+      rows are even less suitable as function claims.
+    supported_by:
+    - reference_id: PMID:18077395
+      supporting_text: Rap80 contains an Abraxas interaction domain
+    - reference_id: PMID:20656689
+      supporting_text: The RAP80 complex is a five-member stoichiometric complex consisting of RAP80, BRCC36,
+        BRCC45, Abraxas, and MERIT40
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:19615732
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Interaction evidence is real, but the GO term protein binding is too generic to describe ABRAXAS1 function.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: &gt;-
+      These IPI rows should not be treated as core molecular-function annotations. The informative biology is BRCA1-A
+      complex assembly, RAP80/BRCA1/BRCC36 interactions, and polyubiquitin-dependent recruitment; broad interactome
+      rows are even less suitable as function claims.
+    supported_by:
+    - reference_id: PMID:19615732
+      supporting_text: We identified 774 candidate interacting proteins associated with 75 Dubs.
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:29656893
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Interaction evidence is real, but the GO term protein binding is too generic to describe ABRAXAS1 function.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: &gt;-
+      These IPI rows should not be treated as core molecular-function annotations. The informative biology is BRCA1-A
+      complex assembly, RAP80/BRCA1/BRCC36 interactions, and polyubiquitin-dependent recruitment; broad interactome
+      rows are even less suitable as function claims.
+    supported_by:
+    - reference_id: PMID:29656893
+      supporting_text: we generated high-resolution interaction neighborhood maps of the endogenously
+        expressed DNA repair factors 53BP1, BRCA1, and MDC1
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:34591612
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Interaction evidence is real, but the GO term protein binding is too generic to describe ABRAXAS1 function.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: &gt;-
+      These IPI rows should not be treated as core molecular-function annotations. The informative biology is BRCA1-A
+      complex assembly, RAP80/BRCA1/BRCC36 interactions, and polyubiquitin-dependent recruitment; broad interactome
+      rows are even less suitable as function claims.
+    supported_by:
+    - reference_id: PMID:34591612
+      supporting_text: we generated comprehensive interaction maps for 40 frequently altered BC proteins
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:35156780
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Interaction evidence is real, but the GO term protein binding is too generic to describe ABRAXAS1 function.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: &gt;-
+      These IPI rows should not be treated as core molecular-function annotations. The informative biology is BRCA1-A
+      complex assembly, RAP80/BRCA1/BRCC36 interactions, and polyubiquitin-dependent recruitment; broad interactome
+      rows are even less suitable as function claims.
+    supported_by:
+    - reference_id: PMID:35156780
+      supporting_text: high-throughput screening variant of the Mammalian Membrane Two-Hybrid
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:36012204
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Interaction evidence is real, but the GO term protein binding is too generic to describe ABRAXAS1 function.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: &gt;-
+      These IPI rows should not be treated as core molecular-function annotations. The informative biology is BRCA1-A
+      complex assembly, RAP80/BRCA1/BRCC36 interactions, and polyubiquitin-dependent recruitment; broad interactome
+      rows are even less suitable as function claims.
+    supported_by:
+    - reference_id: PMID:36012204
+      supporting_text: proximity labeling approaches identified both known and additional CFTR protein
+        partners
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:39009827
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Interaction evidence is real, but the GO term protein binding is too generic to describe ABRAXAS1 function.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: &gt;-
+      These IPI rows should not be treated as core molecular-function annotations. The informative biology is BRCA1-A
+      complex assembly, RAP80/BRCA1/BRCC36 interactions, and polyubiquitin-dependent recruitment; broad interactome
+      rows are even less suitable as function claims.
+    supported_by:
+    - reference_id: PMID:39009827
+      supporting_text: we identified 366 mutation-modulated interactions
+- term:
+    id: GO:0016604
+    label: nuclear body
+  evidence_type: IDA
+  original_reference_id: GO_REF:0000052
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      Non-core localization. HPA reports nuclear-body staining, while mechanistic ABRAXAS1 biology centers on DNA
+      damage foci/BRCA1-A complex recruitment.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      This cellular component is plausible as a localization observation, but it is less informative than nucleus/nucleoplasm
+      and BRCA1-A complex membership for the gene product function.
+    supported_by:
+    - reference_id: file:human/ABRAXAS1/ABRAXAS1-uniprot.txt
+      supporting_text: Localizes at sites of DNA damage at double-strand breaks (DSBs).
+- term:
+    id: GO:0005634
+    label: nucleus
+  evidence_type: NAS
+  original_reference_id: PMID:20656689
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      Supported nuclear localization. ABRAXAS1 acts in the nuclear DNA damage response and localizes to DNA damage
+      sites within the nucleus.
+    action: ACCEPT
+    reason: &gt;-
+      The UniProt record and the original BRCA1-A studies place ABRAXAS1 in the nucleus, where it recruits/organizes
+      BRCA1-A complex activity at DNA double-strand breaks.
+    supported_by:
+    - reference_id: file:human/ABRAXAS1/ABRAXAS1-uniprot.txt
+      supporting_text: Nucleus {ECO:0000269|PubMed:17525340, ECO:0000269|PubMed:17643121,
+        ECO:0000269|PubMed:17643122}.
+    - reference_id: PMID:17525340
+      supporting_text: RAP80 was required for optimal accumulation of BRCA1 on damaged DNA (foci) in response
+        to ionizing radiation
+- term:
+    id: GO:0006282
+    label: regulation of DNA repair
+  evidence_type: NAS
+  original_reference_id: PMID:20656689
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      The broad regulation-of-DNA-repair annotation is directionally correct but less precise than positive regulation
+      of DNA repair for ABRAXAS1.
+    action: MODIFY
+    reason: &gt;-
+      ABRAXAS1 promotes BRCA1-A complex recruitment/stability and DNA repair after damage; the reviewed IMP annotations
+      already use the more informative positive-regulation term.
+    proposed_replacement_terms:
+    - id: GO:0045739
+      label: positive regulation of DNA repair
+    supported_by:
+    - reference_id: PMID:17525340
+      supporting_text: Both Abraxas and RAP80 were required for DNA damage resistance, G(2)-M checkpoint
+        control, and DNA repair.
+    - reference_id: PMID:19261748
+      supporting_text: a stable complex containing MERIT40 acts early in DNA damage response and regulates
+        damage-dependent BRCA1 localization
+- term:
+    id: GO:0044818
+    label: mitotic G2/M transition checkpoint
+  evidence_type: NAS
+  original_reference_id: PMID:22369660
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      The ComplexPortal/NAS checkpoint annotation is real but should be represented using the more specific DNA-damage
+      checkpoint signaling term.
+    action: MODIFY
+    reason: &gt;-
+      ABRAXAS1 evidence concerns BRCA1-dependent G2/M checkpoint activation in response to DNA damage, not the generic
+      mitotic G2/M transition checkpoint.
+    proposed_replacement_terms:
+    - id: GO:0007095
+      label: mitotic G2 DNA damage checkpoint signaling
+    supported_by:
+    - reference_id: PMID:17643121
+      supporting_text: CCDC98 controls both DNA damage-induced formation of BRCA1 foci and BRCA1-dependent
+        G2/M checkpoint activation
+    - reference_id: PMID:22369660
+      supporting_text: Studies on A, B and C complexes of BRCA1 indicate that these complexes carry out
+        functions of BRCA1 in cell cycle checkpoint control.
+- term:
+    id: GO:0070531
+    label: BRCA1-A complex
+  evidence_type: NAS
+  original_reference_id: PMID:20656689
+  qualifier: part_of
+  review:
+    summary: &gt;-
+      Core complex membership. ABRAXAS1 is a BRCA1-A complex subunit that organizes BRCA1, UIMC1/RAP80, BRCC3/BRCC36,
+      BABAM proteins, and related DDR functions.
+    action: ACCEPT
+    reason: &gt;-
+      Multiple primary studies and Reactome support ABRAXAS1/FAM175A as a BRCA1-A complex component. This is more
+      precise than the PN-projected generic ubiquitin-ligase-complex bucket.
+    additional_reference_ids:
+    - file:projects/PROTEOSTASIS/reports/pn_projection/pn_projected_gene_go_summary.tsv
+    - file:projects/PROTEOSTASIS/mappings/ubiquitin_proteasome_system.yaml
+    supported_by:
+    - reference_id: PMID:19261749
+      supporting_text: Proteomic analysis revealed that NBA1 is a component of the BRCA1 A complex, which also
+        contains Brca1/Bard1, Abra1, RAP80, BRCC36, and BRE.
+    - reference_id: Reactome:R-HSA-5683385
+      supporting_text: Together, BRCA1, BARD1, UIMC1, FAM175A, BRCC36, BRE and BABAM1 form the so-called
+        BRCA1-A complex at DNA DSBs
+- term:
+    id: GO:0007095
+    label: mitotic G2 DNA damage checkpoint signaling
+  evidence_type: IMP
+  original_reference_id: PMID:17525340
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Core checkpoint process. ABRAXAS1/CCDC98 is required for BRCA1-dependent G2/M checkpoint signaling after DNA
+      damage.
+    action: ACCEPT
+    reason: &gt;-
+      The original ABRAXAS1/CCDC98 work and later BRCA1-A review evidence support a G2 DNA damage checkpoint role.
+      This is part of the DNA damage response function rather than a general mitotic-spindle role.
+    supported_by:
+    - reference_id: PMID:17643121
+      supporting_text: CCDC98 controls both DNA damage-induced formation of BRCA1 foci and BRCA1-dependent
+        G2/M checkpoint activation
+    - reference_id: PMID:22369660
+      supporting_text: Studies on A, B and C complexes of BRCA1 indicate that these complexes carry out
+        functions of BRCA1 in cell cycle checkpoint control.
+- term:
+    id: GO:0007095
+    label: mitotic G2 DNA damage checkpoint signaling
+  evidence_type: IMP
+  original_reference_id: PMID:17643121
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Core checkpoint process. ABRAXAS1/CCDC98 is required for BRCA1-dependent G2/M checkpoint signaling after DNA
+      damage.
+    action: ACCEPT
+    reason: &gt;-
+      The original ABRAXAS1/CCDC98 work and later BRCA1-A review evidence support a G2 DNA damage checkpoint role.
+      This is part of the DNA damage response function rather than a general mitotic-spindle role.
+    supported_by:
+    - reference_id: PMID:17643121
+      supporting_text: CCDC98 controls both DNA damage-induced formation of BRCA1 foci and BRCA1-dependent
+        G2/M checkpoint activation
+    - reference_id: PMID:22369660
+      supporting_text: Studies on A, B and C complexes of BRCA1 indicate that these complexes carry out
+        functions of BRCA1 in cell cycle checkpoint control.
+- term:
+    id: GO:0007095
+    label: mitotic G2 DNA damage checkpoint signaling
+  evidence_type: IMP
+  original_reference_id: PMID:19261748
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Core checkpoint process. ABRAXAS1/CCDC98 is required for BRCA1-dependent G2/M checkpoint signaling after DNA
+      damage.
+    action: ACCEPT
+    reason: &gt;-
+      The original ABRAXAS1/CCDC98 work and later BRCA1-A review evidence support a G2 DNA damage checkpoint role.
+      This is part of the DNA damage response function rather than a general mitotic-spindle role.
+    supported_by:
+    - reference_id: PMID:17643121
+      supporting_text: CCDC98 controls both DNA damage-induced formation of BRCA1 foci and BRCA1-dependent
+        G2/M checkpoint activation
+    - reference_id: PMID:22369660
+      supporting_text: Studies on A, B and C complexes of BRCA1 indicate that these complexes carry out
+        functions of BRCA1 in cell cycle checkpoint control.
+- term:
+    id: GO:0005654
+    label: nucleoplasm
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-5683384
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      Supported Reactome-derived nuclear compartment annotation. The BRCA1-A complex events involving FAM175A/ABRAXAS1
+      are modeled at nuclear DNA double-strand breaks.
+    action: ACCEPT
+    reason: &gt;-
+      The nucleoplasm location is consistent with ABRAXAS1 nuclear localization and Reactome DNA double-strand break
+      events. These duplicate TAS rows reflect pathway-event participation rather than distinct localizations.
+    supported_by:
+    - reference_id: Reactome:R-HSA-5683385
+      supporting_text: Together, BRCA1, BARD1, UIMC1, FAM175A, BRCC36, BRE and BABAM1 form the so-called
+        BRCA1-A complex at DNA DSBs
+- term:
+    id: GO:0005654
+    label: nucleoplasm
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-5683385
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      Supported Reactome-derived nuclear compartment annotation. The BRCA1-A complex events involving FAM175A/ABRAXAS1
+      are modeled at nuclear DNA double-strand breaks.
+    action: ACCEPT
+    reason: &gt;-
+      The nucleoplasm location is consistent with ABRAXAS1 nuclear localization and Reactome DNA double-strand break
+      events. These duplicate TAS rows reflect pathway-event participation rather than distinct localizations.
+    supported_by:
+    - reference_id: Reactome:R-HSA-5683385
+      supporting_text: Together, BRCA1, BARD1, UIMC1, FAM175A, BRCC36, BRE and BABAM1 form the so-called
+        BRCA1-A complex at DNA DSBs
+- term:
+    id: GO:0005654
+    label: nucleoplasm
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-5683735
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      Supported Reactome-derived nuclear compartment annotation. The BRCA1-A complex events involving FAM175A/ABRAXAS1
+      are modeled at nuclear DNA double-strand breaks.
+    action: ACCEPT
+    reason: &gt;-
+      The nucleoplasm location is consistent with ABRAXAS1 nuclear localization and Reactome DNA double-strand break
+      events. These duplicate TAS rows reflect pathway-event participation rather than distinct localizations.
+    supported_by:
+    - reference_id: Reactome:R-HSA-5683385
+      supporting_text: Together, BRCA1, BARD1, UIMC1, FAM175A, BRCC36, BRE and BABAM1 form the so-called
+        BRCA1-A complex at DNA DSBs
+- term:
+    id: GO:0005654
+    label: nucleoplasm
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-5683801
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      Supported Reactome-derived nuclear compartment annotation. The BRCA1-A complex events involving FAM175A/ABRAXAS1
+      are modeled at nuclear DNA double-strand breaks.
+    action: ACCEPT
+    reason: &gt;-
+      The nucleoplasm location is consistent with ABRAXAS1 nuclear localization and Reactome DNA double-strand break
+      events. These duplicate TAS rows reflect pathway-event participation rather than distinct localizations.
+    supported_by:
+    - reference_id: Reactome:R-HSA-5683385
+      supporting_text: Together, BRCA1, BARD1, UIMC1, FAM175A, BRCC36, BRE and BABAM1 form the so-called
+        BRCA1-A complex at DNA DSBs
+- term:
+    id: GO:0005654
+    label: nucleoplasm
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-5684052
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      Supported Reactome-derived nuclear compartment annotation. The BRCA1-A complex events involving FAM175A/ABRAXAS1
+      are modeled at nuclear DNA double-strand breaks.
+    action: ACCEPT
+    reason: &gt;-
+      The nucleoplasm location is consistent with ABRAXAS1 nuclear localization and Reactome DNA double-strand break
+      events. These duplicate TAS rows reflect pathway-event participation rather than distinct localizations.
+    supported_by:
+    - reference_id: Reactome:R-HSA-5683385
+      supporting_text: Together, BRCA1, BARD1, UIMC1, FAM175A, BRCC36, BRE and BABAM1 form the so-called
+        BRCA1-A complex at DNA DSBs
+- term:
+    id: GO:0005654
+    label: nucleoplasm
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-5684071
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      Supported Reactome-derived nuclear compartment annotation. The BRCA1-A complex events involving FAM175A/ABRAXAS1
+      are modeled at nuclear DNA double-strand breaks.
+    action: ACCEPT
+    reason: &gt;-
+      The nucleoplasm location is consistent with ABRAXAS1 nuclear localization and Reactome DNA double-strand break
+      events. These duplicate TAS rows reflect pathway-event participation rather than distinct localizations.
+    supported_by:
+    - reference_id: Reactome:R-HSA-5683385
+      supporting_text: Together, BRCA1, BARD1, UIMC1, FAM175A, BRCC36, BRE and BABAM1 form the so-called
+        BRCA1-A complex at DNA DSBs
+- term:
+    id: GO:0005654
+    label: nucleoplasm
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-5686685
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      Supported Reactome-derived nuclear compartment annotation. The BRCA1-A complex events involving FAM175A/ABRAXAS1
+      are modeled at nuclear DNA double-strand breaks.
+    action: ACCEPT
+    reason: &gt;-
+      The nucleoplasm location is consistent with ABRAXAS1 nuclear localization and Reactome DNA double-strand break
+      events. These duplicate TAS rows reflect pathway-event participation rather than distinct localizations.
+    supported_by:
+    - reference_id: Reactome:R-HSA-5683385
+      supporting_text: Together, BRCA1, BARD1, UIMC1, FAM175A, BRCC36, BRE and BABAM1 form the so-called
+        BRCA1-A complex at DNA DSBs
+- term:
+    id: GO:0005654
+    label: nucleoplasm
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-5691411
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      Supported Reactome-derived nuclear compartment annotation. The BRCA1-A complex events involving FAM175A/ABRAXAS1
+      are modeled at nuclear DNA double-strand breaks.
+    action: ACCEPT
+    reason: &gt;-
+      The nucleoplasm location is consistent with ABRAXAS1 nuclear localization and Reactome DNA double-strand break
+      events. These duplicate TAS rows reflect pathway-event participation rather than distinct localizations.
+    supported_by:
+    - reference_id: Reactome:R-HSA-5683385
+      supporting_text: Together, BRCA1, BARD1, UIMC1, FAM175A, BRCC36, BRE and BABAM1 form the so-called
+        BRCA1-A complex at DNA DSBs
+- term:
+    id: GO:0005654
+    label: nucleoplasm
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-5693551
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      Supported Reactome-derived nuclear compartment annotation. The BRCA1-A complex events involving FAM175A/ABRAXAS1
+      are modeled at nuclear DNA double-strand breaks.
+    action: ACCEPT
+    reason: &gt;-
+      The nucleoplasm location is consistent with ABRAXAS1 nuclear localization and Reactome DNA double-strand break
+      events. These duplicate TAS rows reflect pathway-event participation rather than distinct localizations.
+    supported_by:
+    - reference_id: Reactome:R-HSA-5683385
+      supporting_text: Together, BRCA1, BARD1, UIMC1, FAM175A, BRCC36, BRE and BABAM1 form the so-called
+        BRCA1-A complex at DNA DSBs
+- term:
+    id: GO:0005654
+    label: nucleoplasm
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-69891
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      Supported Reactome-derived nuclear compartment annotation. The BRCA1-A complex events involving FAM175A/ABRAXAS1
+      are modeled at nuclear DNA double-strand breaks.
+    action: ACCEPT
+    reason: &gt;-
+      The nucleoplasm location is consistent with ABRAXAS1 nuclear localization and Reactome DNA double-strand break
+      events. These duplicate TAS rows reflect pathway-event participation rather than distinct localizations.
+    supported_by:
+    - reference_id: Reactome:R-HSA-5683385
+      supporting_text: Together, BRCA1, BARD1, UIMC1, FAM175A, BRCC36, BRE and BABAM1 form the so-called
+        BRCA1-A complex at DNA DSBs
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:19261748
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Interaction evidence is real, but the GO term protein binding is too generic to describe ABRAXAS1 function.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: &gt;-
+      These IPI rows should not be treated as core molecular-function annotations. The informative biology is BRCA1-A
+      complex assembly, RAP80/BRCA1/BRCC36 interactions, and polyubiquitin-dependent recruitment; broad interactome
+      rows are even less suitable as function claims.
+    supported_by:
+    - reference_id: PMID:19261748
+      supporting_text: CCDC98 binds to RAP80 via a large N-terminal region
+    - reference_id: PMID:20656689
+      supporting_text: The RAP80 complex is a five-member stoichiometric complex consisting of RAP80, BRCC36,
+        BRCC45, Abraxas, and MERIT40
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:19261749
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Interaction evidence is real, but the GO term protein binding is too generic to describe ABRAXAS1 function.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: &gt;-
+      These IPI rows should not be treated as core molecular-function annotations. The informative biology is BRCA1-A
+      complex assembly, RAP80/BRCA1/BRCC36 interactions, and polyubiquitin-dependent recruitment; broad interactome
+      rows are even less suitable as function claims.
+    supported_by:
+    - reference_id: PMID:19261749
+      supporting_text: four members of the BRCA1-A complex possess a polyubiquitin chain-binding capability
+    - reference_id: PMID:20656689
+      supporting_text: The RAP80 complex is a five-member stoichiometric complex consisting of RAP80, BRCC36,
+        BRCC45, Abraxas, and MERIT40
+- term:
+    id: GO:0005634
+    label: nucleus
+  evidence_type: IDA
+  original_reference_id: PMID:17525340
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      Supported nuclear localization. ABRAXAS1 acts in the nuclear DNA damage response and localizes to DNA damage
+      sites within the nucleus.
+    action: ACCEPT
+    reason: &gt;-
+      The UniProt record and the original BRCA1-A studies place ABRAXAS1 in the nucleus, where it recruits/organizes
+      BRCA1-A complex activity at DNA double-strand breaks.
+    supported_by:
+    - reference_id: file:human/ABRAXAS1/ABRAXAS1-uniprot.txt
+      supporting_text: Nucleus {ECO:0000269|PubMed:17525340, ECO:0000269|PubMed:17643121,
+        ECO:0000269|PubMed:17643122}.
+    - reference_id: PMID:17525340
+      supporting_text: RAP80 was required for optimal accumulation of BRCA1 on damaged DNA (foci) in response
+        to ionizing radiation
+- term:
+    id: GO:0005634
+    label: nucleus
+  evidence_type: IDA
+  original_reference_id: PMID:17643121
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      Supported nuclear localization. ABRAXAS1 acts in the nuclear DNA damage response and localizes to DNA damage
+      sites within the nucleus.
+    action: ACCEPT
+    reason: &gt;-
+      The UniProt record and the original BRCA1-A studies place ABRAXAS1 in the nucleus, where it recruits/organizes
+      BRCA1-A complex activity at DNA double-strand breaks.
+    supported_by:
+    - reference_id: file:human/ABRAXAS1/ABRAXAS1-uniprot.txt
+      supporting_text: Nucleus {ECO:0000269|PubMed:17525340, ECO:0000269|PubMed:17643121,
+        ECO:0000269|PubMed:17643122}.
+    - reference_id: PMID:17525340
+      supporting_text: RAP80 was required for optimal accumulation of BRCA1 on damaged DNA (foci) in response
+        to ionizing radiation
+- term:
+    id: GO:0006302
+    label: double-strand break repair
+  evidence_type: IMP
+  original_reference_id: PMID:17525340
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Core biological process. ABRAXAS1 is required for efficient DNA double-strand break repair through BRCA1-A
+      recruitment and ubiquitin-dependent damage-site signaling.
+    action: ACCEPT
+    reason: &gt;-
+      Loss/depletion experiments in the original ABRAXAS1/CCDC98 papers support DNA repair and DNA damage resistance.
+      The PN-projected broader DNA repair term is already entailed by this annotation.
+    additional_reference_ids:
+    - file:projects/PROTEOSTASIS/reports/pn_projection/pn_projected_gene_go_summary.tsv
+    supported_by:
+    - reference_id: PMID:17525340
+      supporting_text: Both Abraxas and RAP80 were required for DNA damage resistance, G(2)-M checkpoint
+        control, and DNA repair.
+    - reference_id: PMID:19261748
+      supporting_text: a stable complex containing MERIT40 acts early in DNA damage response and regulates
+        damage-dependent BRCA1 localization
+- term:
+    id: GO:0006302
+    label: double-strand break repair
+  evidence_type: IMP
+  original_reference_id: PMID:17643121
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Core biological process. ABRAXAS1 is required for efficient DNA double-strand break repair through BRCA1-A
+      recruitment and ubiquitin-dependent damage-site signaling.
+    action: ACCEPT
+    reason: &gt;-
+      Loss/depletion experiments in the original ABRAXAS1/CCDC98 papers support DNA repair and DNA damage resistance.
+      The PN-projected broader DNA repair term is already entailed by this annotation.
+    additional_reference_ids:
+    - file:projects/PROTEOSTASIS/reports/pn_projection/pn_projected_gene_go_summary.tsv
+    supported_by:
+    - reference_id: PMID:17525340
+      supporting_text: Both Abraxas and RAP80 were required for DNA damage resistance, G(2)-M checkpoint
+        control, and DNA repair.
+    - reference_id: PMID:19261748
+      supporting_text: a stable complex containing MERIT40 acts early in DNA damage response and regulates
+        damage-dependent BRCA1 localization
+- term:
+    id: GO:0006302
+    label: double-strand break repair
+  evidence_type: IMP
+  original_reference_id: PMID:19261748
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Core biological process. ABRAXAS1 is required for efficient DNA double-strand break repair through BRCA1-A
+      recruitment and ubiquitin-dependent damage-site signaling.
+    action: ACCEPT
+    reason: &gt;-
+      Loss/depletion experiments in the original ABRAXAS1/CCDC98 papers support DNA repair and DNA damage resistance.
+      The PN-projected broader DNA repair term is already entailed by this annotation.
+    additional_reference_ids:
+    - file:projects/PROTEOSTASIS/reports/pn_projection/pn_projected_gene_go_summary.tsv
+    supported_by:
+    - reference_id: PMID:17525340
+      supporting_text: Both Abraxas and RAP80 were required for DNA damage resistance, G(2)-M checkpoint
+        control, and DNA repair.
+    - reference_id: PMID:19261748
+      supporting_text: a stable complex containing MERIT40 acts early in DNA damage response and regulates
+        damage-dependent BRCA1 localization
+- term:
+    id: GO:0010212
+    label: response to ionizing radiation
+  evidence_type: IMP
+  original_reference_id: PMID:17525340
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Supported but non-core phenotype/context annotation. Ionizing radiation is the experimental damage stimulus
+      used to reveal ABRAXAS1 DNA damage-response function.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      The IR response annotations should be retained as useful experimental context, but the core process is DNA
+      double-strand break repair/checkpoint signaling through BRCA1-A.
+    supported_by:
+    - reference_id: PMID:18077395
+      supporting_text: the entire Brca1 A complex to DNA-damage foci
+    - reference_id: PMID:19261749
+      supporting_text: required for resistance to ionizing radiation
+- term:
+    id: GO:0010212
+    label: response to ionizing radiation
+  evidence_type: IMP
+  original_reference_id: PMID:17643121
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Supported but non-core phenotype/context annotation. Ionizing radiation is the experimental damage stimulus
+      used to reveal ABRAXAS1 DNA damage-response function.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      The IR response annotations should be retained as useful experimental context, but the core process is DNA
+      double-strand break repair/checkpoint signaling through BRCA1-A.
+    supported_by:
+    - reference_id: PMID:18077395
+      supporting_text: the entire Brca1 A complex to DNA-damage foci
+    - reference_id: PMID:19261749
+      supporting_text: required for resistance to ionizing radiation
+- term:
+    id: GO:0010212
+    label: response to ionizing radiation
+  evidence_type: IMP
+  original_reference_id: PMID:19261748
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Supported but non-core phenotype/context annotation. Ionizing radiation is the experimental damage stimulus
+      used to reveal ABRAXAS1 DNA damage-response function.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      The IR response annotations should be retained as useful experimental context, but the core process is DNA
+      double-strand break repair/checkpoint signaling through BRCA1-A.
+    supported_by:
+    - reference_id: PMID:18077395
+      supporting_text: the entire Brca1 A complex to DNA-damage foci
+    - reference_id: PMID:19261749
+      supporting_text: required for resistance to ionizing radiation
+- term:
+    id: GO:0031593
+    label: polyubiquitin modification-dependent protein binding
+  evidence_type: IDA
+  original_reference_id: PMID:19261749
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Core molecular function. ABRAXAS1 is part of a BRCA1-A/RAP80 complex that recognizes ubiquitinated damage-site
+      chromatin and has polyubiquitin-binding capacity.
+    action: ACCEPT
+    reason: &gt;-
+      The term captures the ubiquitin-recognition side of ABRAXAS1 biology better than generic protein binding.
+      It should be retained for both direct IDA and IBA evidence.
+    supported_by:
+    - reference_id: PMID:19261749
+      supporting_text: four members of the BRCA1-A complex possess a polyubiquitin chain-binding capability
+    - reference_id: PMID:20656689
+      supporting_text: RAP80, in turn, is recruited to DSBs through its tandem ubiquitin-interacting motifs
+        (UIMs) ( 6 , 14 – 16 ), which specifically recognize K63-Ub chains
+- term:
+    id: GO:0045739
+    label: positive regulation of DNA repair
+  evidence_type: IMP
+  original_reference_id: PMID:17525340
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Core regulatory process. ABRAXAS1 positively supports DNA repair by assembling/stabilizing the RAP80-BRCA1-A
+      complex at DNA damage sites.
+    action: ACCEPT
+    reason: &gt;-
+      The evidence supports a positive role in DNA repair through BRCA1 localization, complex integrity, and BRCC36-associated
+      ubiquitin editing rather than direct DNA repair catalysis.
+    supported_by:
+    - reference_id: PMID:17525340
+      supporting_text: Both Abraxas and RAP80 were required for DNA damage resistance, G(2)-M checkpoint
+        control, and DNA repair.
+    - reference_id: PMID:19261748
+      supporting_text: a stable complex containing MERIT40 acts early in DNA damage response and regulates
+        damage-dependent BRCA1 localization
+    - reference_id: PMID:20656689
+      supporting_text: Abraxas and BRCC45 were essential for BRCC36 DUB activity within the RAP80 complex
+- term:
+    id: GO:0045739
+    label: positive regulation of DNA repair
+  evidence_type: IMP
+  original_reference_id: PMID:19261748
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Core regulatory process. ABRAXAS1 positively supports DNA repair by assembling/stabilizing the RAP80-BRCA1-A
+      complex at DNA damage sites.
+    action: ACCEPT
+    reason: &gt;-
+      The evidence supports a positive role in DNA repair through BRCA1 localization, complex integrity, and BRCC36-associated
+      ubiquitin editing rather than direct DNA repair catalysis.
+    supported_by:
+    - reference_id: PMID:17525340
+      supporting_text: Both Abraxas and RAP80 were required for DNA damage resistance, G(2)-M checkpoint
+        control, and DNA repair.
+    - reference_id: PMID:19261748
+      supporting_text: a stable complex containing MERIT40 acts early in DNA damage response and regulates
+        damage-dependent BRCA1 localization
+    - reference_id: PMID:20656689
+      supporting_text: Abraxas and BRCC45 were essential for BRCC36 DUB activity within the RAP80 complex
+- term:
+    id: GO:0070531
+    label: BRCA1-A complex
+  evidence_type: IDA
+  original_reference_id: PMID:17525340
+  qualifier: part_of
+  review:
+    summary: &gt;-
+      Core complex membership. ABRAXAS1 is a BRCA1-A complex subunit that organizes BRCA1, UIMC1/RAP80, BRCC3/BRCC36,
+      BABAM proteins, and related DDR functions.
+    action: ACCEPT
+    reason: &gt;-
+      Multiple primary studies and Reactome support ABRAXAS1/FAM175A as a BRCA1-A complex component. This is more
+      precise than the PN-projected generic ubiquitin-ligase-complex bucket.
+    additional_reference_ids:
+    - file:projects/PROTEOSTASIS/reports/pn_projection/pn_projected_gene_go_summary.tsv
+    - file:projects/PROTEOSTASIS/mappings/ubiquitin_proteasome_system.yaml
+    supported_by:
+    - reference_id: PMID:19261749
+      supporting_text: Proteomic analysis revealed that NBA1 is a component of the BRCA1 A complex, which also
+        contains Brca1/Bard1, Abra1, RAP80, BRCC36, and BRE.
+    - reference_id: Reactome:R-HSA-5683385
+      supporting_text: Together, BRCA1, BARD1, UIMC1, FAM175A, BRCC36, BRE and BABAM1 form the so-called
+        BRCA1-A complex at DNA DSBs
+- term:
+    id: GO:0070531
+    label: BRCA1-A complex
+  evidence_type: IDA
+  original_reference_id: PMID:19261746
+  qualifier: part_of
+  review:
+    summary: &gt;-
+      Core complex membership. ABRAXAS1 is a BRCA1-A complex subunit that organizes BRCA1, UIMC1/RAP80, BRCC3/BRCC36,
+      BABAM proteins, and related DDR functions.
+    action: ACCEPT
+    reason: &gt;-
+      Multiple primary studies and Reactome support ABRAXAS1/FAM175A as a BRCA1-A complex component. This is more
+      precise than the PN-projected generic ubiquitin-ligase-complex bucket.
+    additional_reference_ids:
+    - file:projects/PROTEOSTASIS/reports/pn_projection/pn_projected_gene_go_summary.tsv
+    - file:projects/PROTEOSTASIS/mappings/ubiquitin_proteasome_system.yaml
+    supported_by:
+    - reference_id: PMID:19261749
+      supporting_text: Proteomic analysis revealed that NBA1 is a component of the BRCA1 A complex, which also
+        contains Brca1/Bard1, Abra1, RAP80, BRCC36, and BRE.
+    - reference_id: Reactome:R-HSA-5683385
+      supporting_text: Together, BRCA1, BARD1, UIMC1, FAM175A, BRCC36, BRE and BABAM1 form the so-called
+        BRCA1-A complex at DNA DSBs
+- term:
+    id: GO:0070531
+    label: BRCA1-A complex
+  evidence_type: IDA
+  original_reference_id: PMID:19261748
+  qualifier: part_of
+  review:
+    summary: &gt;-
+      Core complex membership. ABRAXAS1 is a BRCA1-A complex subunit that organizes BRCA1, UIMC1/RAP80, BRCC3/BRCC36,
+      BABAM proteins, and related DDR functions.
+    action: ACCEPT
+    reason: &gt;-
+      Multiple primary studies and Reactome support ABRAXAS1/FAM175A as a BRCA1-A complex component. This is more
+      precise than the PN-projected generic ubiquitin-ligase-complex bucket.
+    additional_reference_ids:
+    - file:projects/PROTEOSTASIS/reports/pn_projection/pn_projected_gene_go_summary.tsv
+    - file:projects/PROTEOSTASIS/mappings/ubiquitin_proteasome_system.yaml
+    supported_by:
+    - reference_id: PMID:19261749
+      supporting_text: Proteomic analysis revealed that NBA1 is a component of the BRCA1 A complex, which also
+        contains Brca1/Bard1, Abra1, RAP80, BRCC36, and BRE.
+    - reference_id: Reactome:R-HSA-5683385
+      supporting_text: Together, BRCA1, BARD1, UIMC1, FAM175A, BRCC36, BRE and BABAM1 form the so-called
+        BRCA1-A complex at DNA DSBs
+- term:
+    id: GO:0070531
+    label: BRCA1-A complex
+  evidence_type: IDA
+  original_reference_id: PMID:19261749
+  qualifier: part_of
+  review:
+    summary: &gt;-
+      Core complex membership. ABRAXAS1 is a BRCA1-A complex subunit that organizes BRCA1, UIMC1/RAP80, BRCC3/BRCC36,
+      BABAM proteins, and related DDR functions.
+    action: ACCEPT
+    reason: &gt;-
+      Multiple primary studies and Reactome support ABRAXAS1/FAM175A as a BRCA1-A complex component. This is more
+      precise than the PN-projected generic ubiquitin-ligase-complex bucket.
+    additional_reference_ids:
+    - file:projects/PROTEOSTASIS/reports/pn_projection/pn_projected_gene_go_summary.tsv
+    - file:projects/PROTEOSTASIS/mappings/ubiquitin_proteasome_system.yaml
+    supported_by:
+    - reference_id: PMID:19261749
+      supporting_text: Proteomic analysis revealed that NBA1 is a component of the BRCA1 A complex, which also
+        contains Brca1/Bard1, Abra1, RAP80, BRCC36, and BRE.
+    - reference_id: Reactome:R-HSA-5683385
+      supporting_text: Together, BRCA1, BARD1, UIMC1, FAM175A, BRCC36, BRE and BABAM1 form the so-called
+        BRCA1-A complex at DNA DSBs
+references:
+- id: GO_REF:0000033
+  title: Annotation inferences using phylogenetic trees
+  findings: []
+- id: GO_REF:0000044
+  title: Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location vocabulary mapping,
+    accompanied by conservative changes to GO terms applied by UniProt
+  findings: []
+- id: GO_REF:0000052
+  title: Gene Ontology annotation based on curation of immunofluorescence data
+  findings: []
+- id: PMID:17525340
+  title: Abraxas and RAP80 form a BRCA1 protein complex required for the DNA damage response.
+  findings:
+  - statement: ABRAXAS1/Abraxas binds BRCA1 BRCT repeats and RAP80, and is required for DNA damage resistance,
+      G2/M checkpoint control, and DNA repair.
+    supporting_text: Abraxas and RAP80 were required for DNA damage resistance, G(2)-M checkpoint control, and
+      DNA repair.
+    reference_section_type: ABSTRACT
+- id: PMID:17643121
+  title: CCDC98 targets BRCA1 to DNA damage sites.
+  findings: []
+- id: PMID:18077395
+  title: Ubc13/Rnf8 ubiquitin ligases control foci formation of the Rap80/Abraxas/Brca1/Brcc36 complex in
+    response to DNA damage.
+  findings: []
+- id: PMID:19261746
+  title: MERIT40 controls BRCA1-Rap80 complex integrity and recruitment to DNA double-strand breaks.
+  findings: []
+- id: PMID:19261748
+  title: MERIT40 facilitates BRCA1 localization and DNA damage repair.
+  findings:
+  - statement: CCDC98/ABRAXAS1 is a central component for assembly of the RAP80-containing BRCA1-A complex at
+      DNA damage sites.
+    supporting_text: CCDC98 as the central component that facilitates the assembly of this protein complex
+    reference_section_type: DISCUSSION
+- id: PMID:19261749
+  title: NBA1, a new player in the Brca1 A complex, is required for DNA damage resistance and checkpoint
+    control.
+  findings: []
+- id: PMID:19615732
+  title: Defining the human deubiquitinating enzyme interaction landscape.
+  findings: []
+- id: PMID:20656689
+  title: Differential regulation of JAMM domain deubiquitinating enzyme activity within the RAP80 complex.
+  findings:
+  - statement: ABRAXAS1 is required for BRCC36 DUB activity in the RAP80/BRCA1-A complex context, but is not
+      itself the catalytic DUB.
+    supporting_text: Abraxas and BRCC45 were essential for BRCC36 DUB activity within the RAP80 complex
+    reference_section_type: ABSTRACT
+- id: PMID:22369660
+  title: &#39;BRCA1 tumor suppressor network: focusing on its tail.&#39;
+  findings: []
+- id: PMID:29656893
+  title: DNA Repair Network Analysis Reveals Shieldin as a Key Regulator of NHEJ and PARP Inhibitor
+    Sensitivity.
+  findings: []
+- id: PMID:34591612
+  title: A protein interaction landscape of breast cancer.
+  findings: []
+- id: PMID:35156780
+  title: CFTR interactome mapping using the mammalian membrane two-hybrid high-throughput screening system.
+  findings: []
+- id: PMID:36012204
+  title: Differential CFTR-Interactome Proximity Labeling Procedures Identify Enrichment in Multiple SLC
+    Transporters.
+  findings: []
+- id: PMID:39009827
+  title: Proteome-scale characterisation of motif-based interactome rewiring by disease mutations.
+  findings: []
+- id: Reactome:R-HSA-5683384
+  title: UIMC1 and FAM175A bind DNA DSBs
+  findings: []
+- id: Reactome:R-HSA-5683385
+  title: Formation of BRCA1-A complex at DNA DSBs
+  findings: []
+- id: Reactome:R-HSA-5683735
+  title: CHEK2 is recruited to DNA DSBs
+  findings: []
+- id: Reactome:R-HSA-5683801
+  title: CHEK2 phosphorylates BRCA1
+  findings: []
+- id: Reactome:R-HSA-5684052
+  title: PIAS4 SUMOylates MDC1
+  findings: []
+- id: Reactome:R-HSA-5684071
+  title: RNF4 ubiquitinates MDC1
+  findings: []
+- id: Reactome:R-HSA-5686685
+  title: RIF1 and PAX1IP bind TP53BP1 at DNA DSBs
+  findings: []
+- id: Reactome:R-HSA-5691411
+  title: BRCA1-A complex deubiquitinates K63polyUb-histone H2A
+  findings: []
+- id: Reactome:R-HSA-5693551
+  title: Phosphorylation of BRCA1-A complex at multiple sites by ATM
+  findings: []
+- id: Reactome:R-HSA-69891
+  title: Phosphorylation and activation of CHEK2 by ATM
+  findings: []
+- id: file:human/ABRAXAS1/ABRAXAS1-uniprot.txt
+  title: ABRAXAS1 UniProtKB record
+  findings: []
+- id: file:human/ABRAXAS1/ABRAXAS1-notes.md
+  title: ABRAXAS1 manual review notes and failed deep-research provenance
+  findings: []
+- id: file:projects/PROTEOSTASIS/reports/pn_projection/pn_projected_gene_go_summary.tsv
+  title: Proteostasis PN projected GO summary for ABRAXAS1
+  findings: []
+- id: file:projects/PROTEOSTASIS/mappings/ubiquitin_proteasome_system.yaml
+  title: Proteostasis ubiquitin proteasome system mapping file
+  findings: []
+- id: file:interpro/panther/PTHR31728/PTHR31728-entries.csv
+  title: PANTHER PTHR31728 reviewed protein members
+  findings: []
+core_functions:
+- molecular_function:
+    id: GO:0031593
+    label: polyubiquitin modification-dependent protein binding
+  description: &gt;-
+    ABRAXAS1 is a scaffold and ubiquitin-recognition subunit of the nuclear BRCA1-A/RAP80 complex. It helps assemble
+    BRCA1, UIMC1/RAP80, BRCC3/BRCC36, BABAM proteins, and related partners at ubiquitinated DNA double-strand break
+    sites, thereby supporting BRCA1 recruitment, BRCC36-dependent K63-ubiquitin signal editing, DNA repair, and
+    G2/M DNA damage checkpoint signaling.
+  directly_involved_in:
+  - id: GO:0006302
+    label: double-strand break repair
+  - id: GO:0045739
+    label: positive regulation of DNA repair
+  - id: GO:0007095
+    label: mitotic G2 DNA damage checkpoint signaling
+  locations:
+  - id: GO:0005634
+    label: nucleus
+  - id: GO:0005654
+    label: nucleoplasm
+  in_complex:
+    id: GO:0070531
+    label: BRCA1-A complex
+  supported_by:
+  - reference_id: PMID:17525340
+    supporting_text: Abraxas and RAP80 were required for DNA damage resistance, G(2)-M checkpoint control, and
+      DNA repair.
+  - reference_id: PMID:19261748
+    supporting_text: CCDC98 as the central component that facilitates the assembly of this protein complex
+  - reference_id: PMID:19261749
+    supporting_text: four members of the BRCA1-A complex possess a polyubiquitin chain-binding capability
+  - reference_id: PMID:20656689
+    supporting_text: Abraxas and BRCC45 were essential for BRCC36 DUB activity within the RAP80 complex
+  - reference_id: Reactome:R-HSA-5683385
+    supporting_text: Together, BRCA1, BARD1, UIMC1, FAM175A, BRCC36, BRE and BABAM1 form the so-called BRCA1-A
+      complex at DNA DSBs
+  - reference_id: file:human/ABRAXAS1/ABRAXAS1-uniprot.txt
+    supporting_text: Involved in DNA damage response and double-strand break (DSB) repair.
+proposed_new_terms: []
+suggested_questions:
+- question: Should GO curation represent ABRAXAS1 only as part of the BRCA1-A complex, or is there enough
+    evidence to annotate ABRAXAS1 to a broader ubiquitin ligase complex term despite its scaffold/DUB-support
+    role?
+  experts:
+  - Wang B
+  - Greenberg RA
+  - Elledge SJ
+suggested_experiments:
+- hypothesis: The PANTHER-derived spindle and microtubule annotations are ABRAXAS2/paralog-specific and do not
+    apply to ABRAXAS1.
+  description: Compare ABRAXAS1 and ABRAXAS2 depletion or rescue in synchronized human cells using spindle
+    assembly, kinetochore-microtubule attachment, and DNA damage-response readouts in the same experimental
+    system.
+  experiment_type: comparative cell biology
+</code></pre>
+            </div>
+        </details>
+    </div>
+
+    <!-- Pathway Visualization Link -->
+    
+
+    <style>
+        /* Markdown Section Styles */
+        .markdown-section {
+            margin-bottom: 1rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .markdown-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .markdown-section summary h3 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.1rem;
+        }
+
+        .markdown-section summary:hover h3 {
+            color: #007bff;
+        }
+
+        .markdown-section[open] {
+            background-color: #fff;
+        }
+
+        .markdown-content {
+            margin-top: 1rem;
+            padding: 1rem;
+            border-top: 1px solid #dee2e6;
+        }
+
+        /* Markdown content styling */
+        .markdown-content h1 { font-size: 1.5rem; margin-top: 1.5rem; }
+        .markdown-content h2 { font-size: 1.3rem; margin-top: 1.3rem; }
+        .markdown-content h3 { font-size: 1.1rem; margin-top: 1.1rem; }
+        .markdown-content h4 { font-size: 1rem; margin-top: 1rem; }
+
+        .markdown-content pre {
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .markdown-content code {
+            background-color: #f8f9fa;
+            padding: 0.2rem 0.4rem;
+            border-radius: 3px;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+        }
+
+        .markdown-content pre code {
+            background: none;
+            padding: 0;
+        }
+
+        .markdown-content table {
+            border-collapse: collapse;
+            width: 100%;
+            margin: 1rem 0;
+        }
+
+        .markdown-content table th,
+        .markdown-content table td {
+            border: 1px solid #dee2e6;
+            padding: 0.5rem;
+            text-align: left;
+        }
+
+        .markdown-content table th {
+            background-color: #f8f9fa;
+            font-weight: bold;
+        }
+
+        .markdown-content blockquote {
+            border-left: 4px solid #007bff;
+            padding-left: 1rem;
+            margin-left: 0;
+            color: #666;
+        }
+
+        /* YAML Preview Styles */
+        .yaml-preview {
+            margin-top: 2rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .yaml-preview summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .yaml-preview summary h2 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.3rem;
+        }
+
+        .yaml-preview summary:hover h2 {
+            color: #007bff;
+        }
+
+        .yaml-preview[open] {
+            background-color: #fff;
+        }
+
+        .yaml-content {
+            margin-top: 1rem;
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .yaml-content pre {
+            margin: 0;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+            line-height: 1.4;
+        }
+
+        .yaml-content code {
+            color: #333;
+            background: none;
+            padding: 0;
+        }
+
+        /* Pathway Link Styles */
+        .pathway-link {
+            margin: 1rem 0;
+        }
+
+        .btn-link {
+            display: inline-block;
+            padding: 0.5rem 1rem;
+            background-color: #007bff;
+            color: white !important;
+            text-decoration: none;
+            border-radius: 4px;
+            font-weight: 500;
+            transition: background-color 0.2s;
+        }
+
+        .btn-link:hover {
+            background-color: #0056b3;
+            text-decoration: none;
+        }
+
+        /* Voting buttons */
+        .vote-buttons {
+            display: inline-block;
+            margin-left: 0.5rem;
+        }
+
+        .vote-btn {
+            background: none;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 2px 6px;
+            margin: 0 2px;
+            cursor: pointer;
+            font-size: 0.9rem;
+            transition: all 0.2s;
+            opacity: 0.6;
+        }
+
+        .vote-btn:hover {
+            opacity: 1;
+            transform: scale(1.1);
+        }
+
+        .vote-btn.voted {
+            opacity: 1;
+            border-color: #28a745;
+            background-color: #d4edda;
+        }
+
+        .vote-btn.voted-down {
+            border-color: #dc3545;
+            background-color: #f8d7da;
+        }
+
+        .vote-btn-small {
+            font-size: 0.7rem;
+            padding: 1px 4px;
+            margin: 0 1px;
+        }
+    </style>
+
+    <script>
+        // Add collapsible functionality
+        document.querySelectorAll('.collapsible').forEach(element => {
+            element.addEventListener('click', function() {
+                this.classList.toggle('collapsed');
+            });
+        });
+
+        // Voting functionality
+        const VOTE_URL = 'https://script.google.com/macros/s/AKfycbwPKH7d3seuPNBtB0ugVjqGeTiByyOGD5vkqB_Ck6K8eOcPQYbJqBOuz6GFgXHKBNWK/exec';
+
+        // Get or create session ID
+        let sessionId = localStorage.getItem('review_session_id');
+        if (!sessionId) {
+            sessionId = 's' + Date.now() + '_' + Math.random().toString(36).substr(2, 9);
+            localStorage.setItem('review_session_id', sessionId);
+        }
+
+        // Show previous votes on page load
+        document.addEventListener('DOMContentLoaded', function() {
+            document.querySelectorAll('.vote-buttons').forEach(container => {
+                const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+                const previousVote = localStorage.getItem(key);
+                if (previousVote) {
+                    const btn = container.querySelector(`[data-v="${previousVote}"]`);
+                    if (btn) btn.classList.add(previousVote === 'up' ? 'voted' : 'voted-down');
+                }
+            });
+        });
+
+        // Handle vote clicks - Simple image beacon approach
+        document.addEventListener('click', function(e) {
+            if (!e.target.classList.contains('vote-btn')) return;
+
+            // Prevent the click from bubbling to parent elements (like summary)
+            e.preventDefault();
+            e.stopPropagation();
+
+            const btn = e.target;
+            const container = btn.closest('.vote-buttons');
+            if (!container) return;
+
+            const voteType = btn.dataset.v;
+
+            // Check if already voted (locally)
+            const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+            const previousVote = localStorage.getItem(key);
+
+            if (previousVote === voteType) {
+                // Same vote - do nothing
+                btn.style.animation = 'shake 0.5s';
+                setTimeout(() => btn.style.animation = '', 500);
+                return;
+            }
+
+            // Build URL
+            const params = new URLSearchParams({
+                gene_id: container.dataset.g,
+                annotation_id: container.dataset.a,
+                ref_id: container.dataset.r || '',
+                action: container.dataset.act,
+                vote: voteType,
+                session_id: sessionId,
+                ua: navigator.userAgent.substring(0, 100)
+            });
+
+            // Clear previous vote styling
+            container.querySelectorAll('.vote-btn').forEach(b => {
+                b.classList.remove('voted', 'voted-down');
+            });
+
+            // Apply new vote styling immediately (optimistic UI)
+            btn.classList.add(voteType === 'up' ? 'voted' : 'voted-down');
+
+            // Store locally
+            localStorage.setItem(key, voteType);
+
+            // Send vote using fetch with no-cors mode (fire and forget)
+            const fullUrl = VOTE_URL + '?' + params;
+            console.log('Sending vote to:', fullUrl);
+
+            // Use fetch in no-cors mode - we won't get a response but the request will be sent
+            fetch(fullUrl, {
+                mode: 'no-cors',
+                method: 'GET'
+            }).then(() => {
+                console.log('Vote request sent (no response due to no-cors mode)');
+            }).catch(err => {
+                console.warn('Vote may not have been recorded, but saved locally:', err);
+
+                // Fallback: try image beacon as well
+                const img = new Image();
+                img.src = fullUrl;
+            });
+        });
+
+        // Optional: Add shake animation for feedback
+        const style = document.createElement('style');
+        style.textContent = `
+            @keyframes shake {
+                0%, 100% { transform: translateX(0); }
+                25% { transform: translateX(-5px); }
+                75% { transform: translateX(5px); }
+            }
+        `;
+        document.head.appendChild(style);
+    </script>
+</body>
+</html>

--- a/genes/human/ABRAXAS1/ABRAXAS1-ai-review.yaml
+++ b/genes/human/ABRAXAS1/ABRAXAS1-ai-review.yaml
@@ -1,0 +1,1206 @@
+id: Q6UWZ7
+gene_symbol: ABRAXAS1
+product_type: PROTEIN
+status: DRAFT
+taxon:
+  id: NCBITaxon:9606
+  label: Homo sapiens
+description: >-
+  ABRAXAS1 encodes a nuclear BRCA1-A complex subunit that acts as a scaffold linking BRCA1, UIMC1/RAP80, BRCC3/BRCC36,
+  BABAM proteins, and ubiquitin-dependent DNA damage-site signaling. The protein contains an MPN-like domain, binds
+  polyubiquitin as part of the BRCA1-A/RAP80 complex, and supports BRCA1 recruitment, DNA double-strand break repair,
+  K63-ubiquitin signal editing by BRCC36, and G2/M DNA damage checkpoint responses.
+alternative_products:
+- name: '1'
+  id: Q6UWZ7-1
+- name: '2'
+  id: Q6UWZ7-2
+  sequence_note: VSP_058196
+existing_annotations:
+- term:
+    id: GO:0005634
+    label: nucleus
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: is_active_in
+  review:
+    summary: >-
+      Supported nuclear localization. ABRAXAS1 acts in the nuclear DNA damage response and localizes to DNA damage
+      sites within the nucleus.
+    action: ACCEPT
+    reason: >-
+      The UniProt record and the original BRCA1-A studies place ABRAXAS1 in the nucleus, where it recruits/organizes
+      BRCA1-A complex activity at DNA double-strand breaks.
+    supported_by:
+    - reference_id: file:human/ABRAXAS1/ABRAXAS1-uniprot.txt
+      supporting_text: Nucleus {ECO:0000269|PubMed:17525340, ECO:0000269|PubMed:17643121,
+        ECO:0000269|PubMed:17643122}.
+    - reference_id: PMID:17525340
+      supporting_text: RAP80 was required for optimal accumulation of BRCA1 on damaged DNA (foci) in response
+        to ionizing radiation
+- term:
+    id: GO:0008017
+    label: microtubule binding
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: enables
+  review:
+    summary: >-
+      Likely paralog/family over-propagation. The IBA trace for this microtubule-binding term cites ABRAXAS2 rather
+      than ABRAXAS1-specific evidence.
+    action: REMOVE
+    reason: >-
+      ABRAXAS1 literature, UniProt, Reactome, and PN context support a nuclear BRCA1-A DNA damage-response scaffold,
+      not microtubule binding. No ABRAXAS1-specific microtubule-binding evidence was found in the cached evidence
+      set.
+    additional_reference_ids:
+    - file:interpro/panther/PTHR31728/PTHR31728-entries.csv
+    supported_by:
+    - reference_id: file:human/ABRAXAS1/ABRAXAS1-uniprot.txt
+      supporting_text: Involved in DNA damage response and double-strand break (DSB) repair.
+    - reference_id: file:human/ABRAXAS1/ABRAXAS1-notes.md
+      supporting_text: The IBA microtubule/spindle annotations are projected through a PANTHER node supported
+        by ABRAXAS2
+- term:
+    id: GO:0008608
+    label: attachment of spindle microtubules to kinetochore
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: involved_in
+  review:
+    summary: >-
+      Likely paralog/family over-propagation. The kinetochore-microtubule attachment IBA is not supported by ABRAXAS1-specific
+      DNA damage literature.
+    action: REMOVE
+    reason: >-
+      The with/from metadata points to ABRAXAS2 for the spindle branch, while ABRAXAS1 evidence supports BRCA1-A
+      complex-mediated DNA damage signaling. This process would overstate ABRAXAS1 biology.
+    additional_reference_ids:
+    - file:interpro/panther/PTHR31728/PTHR31728-entries.csv
+    supported_by:
+    - reference_id: file:human/ABRAXAS1/ABRAXAS1-uniprot.txt
+      supporting_text: Involved in DNA damage response and double-strand break (DSB) repair.
+    - reference_id: file:human/ABRAXAS1/ABRAXAS1-notes.md
+      supporting_text: I marked `microtubule binding`, `attachment of spindle microtubules to kinetochore`,
+        and `mitotic spindle assembly` for removal for ABRAXAS1.
+- term:
+    id: GO:0031593
+    label: polyubiquitin modification-dependent protein binding
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: enables
+  review:
+    summary: >-
+      Core molecular function. ABRAXAS1 is part of a BRCA1-A/RAP80 complex that recognizes ubiquitinated damage-site
+      chromatin and has polyubiquitin-binding capacity.
+    action: ACCEPT
+    reason: >-
+      The term captures the ubiquitin-recognition side of ABRAXAS1 biology better than generic protein binding.
+      It should be retained for both direct IDA and IBA evidence.
+    supported_by:
+    - reference_id: PMID:19261749
+      supporting_text: four members of the BRCA1-A complex possess a polyubiquitin chain-binding capability
+    - reference_id: PMID:20656689
+      supporting_text: RAP80, in turn, is recruited to DSBs through its tandem ubiquitin-interacting motifs
+        (UIMs) ( 6 , 14 – 16 ), which specifically recognize K63-Ub chains
+- term:
+    id: GO:0090307
+    label: mitotic spindle assembly
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: involved_in
+  review:
+    summary: >-
+      Likely paralog/family over-propagation. The mitotic-spindle-assembly IBA is not supported for ABRAXAS1 by
+      the reviewed evidence.
+    action: REMOVE
+    reason: >-
+      ABRAXAS1 participates in nuclear DNA damage repair/checkpoint signaling. The PANTHER IBA spindle call is traceable
+      to ABRAXAS2 and should not be propagated to ABRAXAS1 without gene-specific evidence.
+    additional_reference_ids:
+    - file:interpro/panther/PTHR31728/PTHR31728-entries.csv
+    supported_by:
+    - reference_id: file:human/ABRAXAS1/ABRAXAS1-uniprot.txt
+      supporting_text: Involved in DNA damage response and double-strand break (DSB) repair.
+    - reference_id: file:human/ABRAXAS1/ABRAXAS1-notes.md
+      supporting_text: I marked `microtubule binding`, `attachment of spindle microtubules to kinetochore`,
+        and `mitotic spindle assembly` for removal for ABRAXAS1.
+- term:
+    id: GO:0005634
+    label: nucleus
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000044
+  qualifier: located_in
+  review:
+    summary: >-
+      Supported nuclear localization. ABRAXAS1 acts in the nuclear DNA damage response and localizes to DNA damage
+      sites within the nucleus.
+    action: ACCEPT
+    reason: >-
+      The UniProt record and the original BRCA1-A studies place ABRAXAS1 in the nucleus, where it recruits/organizes
+      BRCA1-A complex activity at DNA double-strand breaks.
+    supported_by:
+    - reference_id: file:human/ABRAXAS1/ABRAXAS1-uniprot.txt
+      supporting_text: Nucleus {ECO:0000269|PubMed:17525340, ECO:0000269|PubMed:17643121,
+        ECO:0000269|PubMed:17643122}.
+    - reference_id: PMID:17525340
+      supporting_text: RAP80 was required for optimal accumulation of BRCA1 on damaged DNA (foci) in response
+        to ionizing radiation
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:17525340
+  qualifier: enables
+  review:
+    summary: >-
+      Interaction evidence is real, but the GO term protein binding is too generic to describe ABRAXAS1 function.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: >-
+      These IPI rows should not be treated as core molecular-function annotations. The informative biology is BRCA1-A
+      complex assembly, RAP80/BRCA1/BRCC36 interactions, and polyubiquitin-dependent recruitment; broad interactome
+      rows are even less suitable as function claims.
+    supported_by:
+    - reference_id: PMID:17525340
+      supporting_text: identified a protein, Abraxas, that directly binds the BRCA1 BRCT repeats
+    - reference_id: PMID:20656689
+      supporting_text: The RAP80 complex is a five-member stoichiometric complex consisting of RAP80, BRCC36,
+        BRCC45, Abraxas, and MERIT40
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:17643121
+  qualifier: enables
+  review:
+    summary: >-
+      Interaction evidence is real, but the GO term protein binding is too generic to describe ABRAXAS1 function.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: >-
+      These IPI rows should not be treated as core molecular-function annotations. The informative biology is BRCA1-A
+      complex assembly, RAP80/BRCA1/BRCC36 interactions, and polyubiquitin-dependent recruitment; broad interactome
+      rows are even less suitable as function claims.
+    supported_by:
+    - reference_id: PMID:17643121
+      supporting_text: CCDC98 is a BRCA1 binding partner that mediates BRCA1 function in response to DNA
+        damage.
+    - reference_id: PMID:20656689
+      supporting_text: The RAP80 complex is a five-member stoichiometric complex consisting of RAP80, BRCC36,
+        BRCC45, Abraxas, and MERIT40
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:18077395
+  qualifier: enables
+  review:
+    summary: >-
+      Interaction evidence is real, but the GO term protein binding is too generic to describe ABRAXAS1 function.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: >-
+      These IPI rows should not be treated as core molecular-function annotations. The informative biology is BRCA1-A
+      complex assembly, RAP80/BRCA1/BRCC36 interactions, and polyubiquitin-dependent recruitment; broad interactome
+      rows are even less suitable as function claims.
+    supported_by:
+    - reference_id: PMID:18077395
+      supporting_text: Rap80 contains an Abraxas interaction domain
+    - reference_id: PMID:20656689
+      supporting_text: The RAP80 complex is a five-member stoichiometric complex consisting of RAP80, BRCC36,
+        BRCC45, Abraxas, and MERIT40
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:19615732
+  qualifier: enables
+  review:
+    summary: >-
+      Interaction evidence is real, but the GO term protein binding is too generic to describe ABRAXAS1 function.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: >-
+      These IPI rows should not be treated as core molecular-function annotations. The informative biology is BRCA1-A
+      complex assembly, RAP80/BRCA1/BRCC36 interactions, and polyubiquitin-dependent recruitment; broad interactome
+      rows are even less suitable as function claims.
+    supported_by:
+    - reference_id: PMID:19615732
+      supporting_text: We identified 774 candidate interacting proteins associated with 75 Dubs.
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:29656893
+  qualifier: enables
+  review:
+    summary: >-
+      Interaction evidence is real, but the GO term protein binding is too generic to describe ABRAXAS1 function.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: >-
+      These IPI rows should not be treated as core molecular-function annotations. The informative biology is BRCA1-A
+      complex assembly, RAP80/BRCA1/BRCC36 interactions, and polyubiquitin-dependent recruitment; broad interactome
+      rows are even less suitable as function claims.
+    supported_by:
+    - reference_id: PMID:29656893
+      supporting_text: we generated high-resolution interaction neighborhood maps of the endogenously
+        expressed DNA repair factors 53BP1, BRCA1, and MDC1
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:34591612
+  qualifier: enables
+  review:
+    summary: >-
+      Interaction evidence is real, but the GO term protein binding is too generic to describe ABRAXAS1 function.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: >-
+      These IPI rows should not be treated as core molecular-function annotations. The informative biology is BRCA1-A
+      complex assembly, RAP80/BRCA1/BRCC36 interactions, and polyubiquitin-dependent recruitment; broad interactome
+      rows are even less suitable as function claims.
+    supported_by:
+    - reference_id: PMID:34591612
+      supporting_text: we generated comprehensive interaction maps for 40 frequently altered BC proteins
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:35156780
+  qualifier: enables
+  review:
+    summary: >-
+      Interaction evidence is real, but the GO term protein binding is too generic to describe ABRAXAS1 function.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: >-
+      These IPI rows should not be treated as core molecular-function annotations. The informative biology is BRCA1-A
+      complex assembly, RAP80/BRCA1/BRCC36 interactions, and polyubiquitin-dependent recruitment; broad interactome
+      rows are even less suitable as function claims.
+    supported_by:
+    - reference_id: PMID:35156780
+      supporting_text: high-throughput screening variant of the Mammalian Membrane Two-Hybrid
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:36012204
+  qualifier: enables
+  review:
+    summary: >-
+      Interaction evidence is real, but the GO term protein binding is too generic to describe ABRAXAS1 function.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: >-
+      These IPI rows should not be treated as core molecular-function annotations. The informative biology is BRCA1-A
+      complex assembly, RAP80/BRCA1/BRCC36 interactions, and polyubiquitin-dependent recruitment; broad interactome
+      rows are even less suitable as function claims.
+    supported_by:
+    - reference_id: PMID:36012204
+      supporting_text: proximity labeling approaches identified both known and additional CFTR protein
+        partners
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:39009827
+  qualifier: enables
+  review:
+    summary: >-
+      Interaction evidence is real, but the GO term protein binding is too generic to describe ABRAXAS1 function.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: >-
+      These IPI rows should not be treated as core molecular-function annotations. The informative biology is BRCA1-A
+      complex assembly, RAP80/BRCA1/BRCC36 interactions, and polyubiquitin-dependent recruitment; broad interactome
+      rows are even less suitable as function claims.
+    supported_by:
+    - reference_id: PMID:39009827
+      supporting_text: we identified 366 mutation-modulated interactions
+- term:
+    id: GO:0016604
+    label: nuclear body
+  evidence_type: IDA
+  original_reference_id: GO_REF:0000052
+  qualifier: located_in
+  review:
+    summary: >-
+      Non-core localization. HPA reports nuclear-body staining, while mechanistic ABRAXAS1 biology centers on DNA
+      damage foci/BRCA1-A complex recruitment.
+    action: KEEP_AS_NON_CORE
+    reason: >-
+      This cellular component is plausible as a localization observation, but it is less informative than nucleus/nucleoplasm
+      and BRCA1-A complex membership for the gene product function.
+    supported_by:
+    - reference_id: file:human/ABRAXAS1/ABRAXAS1-uniprot.txt
+      supporting_text: Localizes at sites of DNA damage at double-strand breaks (DSBs).
+- term:
+    id: GO:0005634
+    label: nucleus
+  evidence_type: NAS
+  original_reference_id: PMID:20656689
+  qualifier: located_in
+  review:
+    summary: >-
+      Supported nuclear localization. ABRAXAS1 acts in the nuclear DNA damage response and localizes to DNA damage
+      sites within the nucleus.
+    action: ACCEPT
+    reason: >-
+      The UniProt record and the original BRCA1-A studies place ABRAXAS1 in the nucleus, where it recruits/organizes
+      BRCA1-A complex activity at DNA double-strand breaks.
+    supported_by:
+    - reference_id: file:human/ABRAXAS1/ABRAXAS1-uniprot.txt
+      supporting_text: Nucleus {ECO:0000269|PubMed:17525340, ECO:0000269|PubMed:17643121,
+        ECO:0000269|PubMed:17643122}.
+    - reference_id: PMID:17525340
+      supporting_text: RAP80 was required for optimal accumulation of BRCA1 on damaged DNA (foci) in response
+        to ionizing radiation
+- term:
+    id: GO:0006282
+    label: regulation of DNA repair
+  evidence_type: NAS
+  original_reference_id: PMID:20656689
+  qualifier: involved_in
+  review:
+    summary: >-
+      The broad regulation-of-DNA-repair annotation is directionally correct but less precise than positive regulation
+      of DNA repair for ABRAXAS1.
+    action: MODIFY
+    reason: >-
+      ABRAXAS1 promotes BRCA1-A complex recruitment/stability and DNA repair after damage; the reviewed IMP annotations
+      already use the more informative positive-regulation term.
+    proposed_replacement_terms:
+    - id: GO:0045739
+      label: positive regulation of DNA repair
+    supported_by:
+    - reference_id: PMID:17525340
+      supporting_text: Both Abraxas and RAP80 were required for DNA damage resistance, G(2)-M checkpoint
+        control, and DNA repair.
+    - reference_id: PMID:19261748
+      supporting_text: a stable complex containing MERIT40 acts early in DNA damage response and regulates
+        damage-dependent BRCA1 localization
+- term:
+    id: GO:0044818
+    label: mitotic G2/M transition checkpoint
+  evidence_type: NAS
+  original_reference_id: PMID:22369660
+  qualifier: involved_in
+  review:
+    summary: >-
+      The ComplexPortal/NAS checkpoint annotation is real but should be represented using the more specific DNA-damage
+      checkpoint signaling term.
+    action: MODIFY
+    reason: >-
+      ABRAXAS1 evidence concerns BRCA1-dependent G2/M checkpoint activation in response to DNA damage, not the generic
+      mitotic G2/M transition checkpoint.
+    proposed_replacement_terms:
+    - id: GO:0007095
+      label: mitotic G2 DNA damage checkpoint signaling
+    supported_by:
+    - reference_id: PMID:17643121
+      supporting_text: CCDC98 controls both DNA damage-induced formation of BRCA1 foci and BRCA1-dependent
+        G2/M checkpoint activation
+    - reference_id: PMID:22369660
+      supporting_text: Studies on A, B and C complexes of BRCA1 indicate that these complexes carry out
+        functions of BRCA1 in cell cycle checkpoint control.
+- term:
+    id: GO:0070531
+    label: BRCA1-A complex
+  evidence_type: NAS
+  original_reference_id: PMID:20656689
+  qualifier: part_of
+  review:
+    summary: >-
+      Core complex membership. ABRAXAS1 is a BRCA1-A complex subunit that organizes BRCA1, UIMC1/RAP80, BRCC3/BRCC36,
+      BABAM proteins, and related DDR functions.
+    action: ACCEPT
+    reason: >-
+      Multiple primary studies and Reactome support ABRAXAS1/FAM175A as a BRCA1-A complex component. This is more
+      precise than the PN-projected generic ubiquitin-ligase-complex bucket.
+    additional_reference_ids:
+    - file:projects/PROTEOSTASIS/reports/pn_projection/pn_projected_gene_go_summary.tsv
+    - file:projects/PROTEOSTASIS/mappings/ubiquitin_proteasome_system.yaml
+    supported_by:
+    - reference_id: PMID:19261749
+      supporting_text: Proteomic analysis revealed that NBA1 is a component of the BRCA1 A complex, which also
+        contains Brca1/Bard1, Abra1, RAP80, BRCC36, and BRE.
+    - reference_id: Reactome:R-HSA-5683385
+      supporting_text: Together, BRCA1, BARD1, UIMC1, FAM175A, BRCC36, BRE and BABAM1 form the so-called
+        BRCA1-A complex at DNA DSBs
+- term:
+    id: GO:0007095
+    label: mitotic G2 DNA damage checkpoint signaling
+  evidence_type: IMP
+  original_reference_id: PMID:17525340
+  qualifier: involved_in
+  review:
+    summary: >-
+      Core checkpoint process. ABRAXAS1/CCDC98 is required for BRCA1-dependent G2/M checkpoint signaling after DNA
+      damage.
+    action: ACCEPT
+    reason: >-
+      The original ABRAXAS1/CCDC98 work and later BRCA1-A review evidence support a G2 DNA damage checkpoint role.
+      This is part of the DNA damage response function rather than a general mitotic-spindle role.
+    supported_by:
+    - reference_id: PMID:17643121
+      supporting_text: CCDC98 controls both DNA damage-induced formation of BRCA1 foci and BRCA1-dependent
+        G2/M checkpoint activation
+    - reference_id: PMID:22369660
+      supporting_text: Studies on A, B and C complexes of BRCA1 indicate that these complexes carry out
+        functions of BRCA1 in cell cycle checkpoint control.
+- term:
+    id: GO:0007095
+    label: mitotic G2 DNA damage checkpoint signaling
+  evidence_type: IMP
+  original_reference_id: PMID:17643121
+  qualifier: involved_in
+  review:
+    summary: >-
+      Core checkpoint process. ABRAXAS1/CCDC98 is required for BRCA1-dependent G2/M checkpoint signaling after DNA
+      damage.
+    action: ACCEPT
+    reason: >-
+      The original ABRAXAS1/CCDC98 work and later BRCA1-A review evidence support a G2 DNA damage checkpoint role.
+      This is part of the DNA damage response function rather than a general mitotic-spindle role.
+    supported_by:
+    - reference_id: PMID:17643121
+      supporting_text: CCDC98 controls both DNA damage-induced formation of BRCA1 foci and BRCA1-dependent
+        G2/M checkpoint activation
+    - reference_id: PMID:22369660
+      supporting_text: Studies on A, B and C complexes of BRCA1 indicate that these complexes carry out
+        functions of BRCA1 in cell cycle checkpoint control.
+- term:
+    id: GO:0007095
+    label: mitotic G2 DNA damage checkpoint signaling
+  evidence_type: IMP
+  original_reference_id: PMID:19261748
+  qualifier: involved_in
+  review:
+    summary: >-
+      Core checkpoint process. ABRAXAS1/CCDC98 is required for BRCA1-dependent G2/M checkpoint signaling after DNA
+      damage.
+    action: ACCEPT
+    reason: >-
+      The original ABRAXAS1/CCDC98 work and later BRCA1-A review evidence support a G2 DNA damage checkpoint role.
+      This is part of the DNA damage response function rather than a general mitotic-spindle role.
+    supported_by:
+    - reference_id: PMID:17643121
+      supporting_text: CCDC98 controls both DNA damage-induced formation of BRCA1 foci and BRCA1-dependent
+        G2/M checkpoint activation
+    - reference_id: PMID:22369660
+      supporting_text: Studies on A, B and C complexes of BRCA1 indicate that these complexes carry out
+        functions of BRCA1 in cell cycle checkpoint control.
+- term:
+    id: GO:0005654
+    label: nucleoplasm
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-5683384
+  qualifier: located_in
+  review:
+    summary: >-
+      Supported Reactome-derived nuclear compartment annotation. The BRCA1-A complex events involving FAM175A/ABRAXAS1
+      are modeled at nuclear DNA double-strand breaks.
+    action: ACCEPT
+    reason: >-
+      The nucleoplasm location is consistent with ABRAXAS1 nuclear localization and Reactome DNA double-strand break
+      events. These duplicate TAS rows reflect pathway-event participation rather than distinct localizations.
+    supported_by:
+    - reference_id: Reactome:R-HSA-5683385
+      supporting_text: Together, BRCA1, BARD1, UIMC1, FAM175A, BRCC36, BRE and BABAM1 form the so-called
+        BRCA1-A complex at DNA DSBs
+- term:
+    id: GO:0005654
+    label: nucleoplasm
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-5683385
+  qualifier: located_in
+  review:
+    summary: >-
+      Supported Reactome-derived nuclear compartment annotation. The BRCA1-A complex events involving FAM175A/ABRAXAS1
+      are modeled at nuclear DNA double-strand breaks.
+    action: ACCEPT
+    reason: >-
+      The nucleoplasm location is consistent with ABRAXAS1 nuclear localization and Reactome DNA double-strand break
+      events. These duplicate TAS rows reflect pathway-event participation rather than distinct localizations.
+    supported_by:
+    - reference_id: Reactome:R-HSA-5683385
+      supporting_text: Together, BRCA1, BARD1, UIMC1, FAM175A, BRCC36, BRE and BABAM1 form the so-called
+        BRCA1-A complex at DNA DSBs
+- term:
+    id: GO:0005654
+    label: nucleoplasm
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-5683735
+  qualifier: located_in
+  review:
+    summary: >-
+      Supported Reactome-derived nuclear compartment annotation. The BRCA1-A complex events involving FAM175A/ABRAXAS1
+      are modeled at nuclear DNA double-strand breaks.
+    action: ACCEPT
+    reason: >-
+      The nucleoplasm location is consistent with ABRAXAS1 nuclear localization and Reactome DNA double-strand break
+      events. These duplicate TAS rows reflect pathway-event participation rather than distinct localizations.
+    supported_by:
+    - reference_id: Reactome:R-HSA-5683385
+      supporting_text: Together, BRCA1, BARD1, UIMC1, FAM175A, BRCC36, BRE and BABAM1 form the so-called
+        BRCA1-A complex at DNA DSBs
+- term:
+    id: GO:0005654
+    label: nucleoplasm
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-5683801
+  qualifier: located_in
+  review:
+    summary: >-
+      Supported Reactome-derived nuclear compartment annotation. The BRCA1-A complex events involving FAM175A/ABRAXAS1
+      are modeled at nuclear DNA double-strand breaks.
+    action: ACCEPT
+    reason: >-
+      The nucleoplasm location is consistent with ABRAXAS1 nuclear localization and Reactome DNA double-strand break
+      events. These duplicate TAS rows reflect pathway-event participation rather than distinct localizations.
+    supported_by:
+    - reference_id: Reactome:R-HSA-5683385
+      supporting_text: Together, BRCA1, BARD1, UIMC1, FAM175A, BRCC36, BRE and BABAM1 form the so-called
+        BRCA1-A complex at DNA DSBs
+- term:
+    id: GO:0005654
+    label: nucleoplasm
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-5684052
+  qualifier: located_in
+  review:
+    summary: >-
+      Supported Reactome-derived nuclear compartment annotation. The BRCA1-A complex events involving FAM175A/ABRAXAS1
+      are modeled at nuclear DNA double-strand breaks.
+    action: ACCEPT
+    reason: >-
+      The nucleoplasm location is consistent with ABRAXAS1 nuclear localization and Reactome DNA double-strand break
+      events. These duplicate TAS rows reflect pathway-event participation rather than distinct localizations.
+    supported_by:
+    - reference_id: Reactome:R-HSA-5683385
+      supporting_text: Together, BRCA1, BARD1, UIMC1, FAM175A, BRCC36, BRE and BABAM1 form the so-called
+        BRCA1-A complex at DNA DSBs
+- term:
+    id: GO:0005654
+    label: nucleoplasm
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-5684071
+  qualifier: located_in
+  review:
+    summary: >-
+      Supported Reactome-derived nuclear compartment annotation. The BRCA1-A complex events involving FAM175A/ABRAXAS1
+      are modeled at nuclear DNA double-strand breaks.
+    action: ACCEPT
+    reason: >-
+      The nucleoplasm location is consistent with ABRAXAS1 nuclear localization and Reactome DNA double-strand break
+      events. These duplicate TAS rows reflect pathway-event participation rather than distinct localizations.
+    supported_by:
+    - reference_id: Reactome:R-HSA-5683385
+      supporting_text: Together, BRCA1, BARD1, UIMC1, FAM175A, BRCC36, BRE and BABAM1 form the so-called
+        BRCA1-A complex at DNA DSBs
+- term:
+    id: GO:0005654
+    label: nucleoplasm
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-5686685
+  qualifier: located_in
+  review:
+    summary: >-
+      Supported Reactome-derived nuclear compartment annotation. The BRCA1-A complex events involving FAM175A/ABRAXAS1
+      are modeled at nuclear DNA double-strand breaks.
+    action: ACCEPT
+    reason: >-
+      The nucleoplasm location is consistent with ABRAXAS1 nuclear localization and Reactome DNA double-strand break
+      events. These duplicate TAS rows reflect pathway-event participation rather than distinct localizations.
+    supported_by:
+    - reference_id: Reactome:R-HSA-5683385
+      supporting_text: Together, BRCA1, BARD1, UIMC1, FAM175A, BRCC36, BRE and BABAM1 form the so-called
+        BRCA1-A complex at DNA DSBs
+- term:
+    id: GO:0005654
+    label: nucleoplasm
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-5691411
+  qualifier: located_in
+  review:
+    summary: >-
+      Supported Reactome-derived nuclear compartment annotation. The BRCA1-A complex events involving FAM175A/ABRAXAS1
+      are modeled at nuclear DNA double-strand breaks.
+    action: ACCEPT
+    reason: >-
+      The nucleoplasm location is consistent with ABRAXAS1 nuclear localization and Reactome DNA double-strand break
+      events. These duplicate TAS rows reflect pathway-event participation rather than distinct localizations.
+    supported_by:
+    - reference_id: Reactome:R-HSA-5683385
+      supporting_text: Together, BRCA1, BARD1, UIMC1, FAM175A, BRCC36, BRE and BABAM1 form the so-called
+        BRCA1-A complex at DNA DSBs
+- term:
+    id: GO:0005654
+    label: nucleoplasm
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-5693551
+  qualifier: located_in
+  review:
+    summary: >-
+      Supported Reactome-derived nuclear compartment annotation. The BRCA1-A complex events involving FAM175A/ABRAXAS1
+      are modeled at nuclear DNA double-strand breaks.
+    action: ACCEPT
+    reason: >-
+      The nucleoplasm location is consistent with ABRAXAS1 nuclear localization and Reactome DNA double-strand break
+      events. These duplicate TAS rows reflect pathway-event participation rather than distinct localizations.
+    supported_by:
+    - reference_id: Reactome:R-HSA-5683385
+      supporting_text: Together, BRCA1, BARD1, UIMC1, FAM175A, BRCC36, BRE and BABAM1 form the so-called
+        BRCA1-A complex at DNA DSBs
+- term:
+    id: GO:0005654
+    label: nucleoplasm
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-69891
+  qualifier: located_in
+  review:
+    summary: >-
+      Supported Reactome-derived nuclear compartment annotation. The BRCA1-A complex events involving FAM175A/ABRAXAS1
+      are modeled at nuclear DNA double-strand breaks.
+    action: ACCEPT
+    reason: >-
+      The nucleoplasm location is consistent with ABRAXAS1 nuclear localization and Reactome DNA double-strand break
+      events. These duplicate TAS rows reflect pathway-event participation rather than distinct localizations.
+    supported_by:
+    - reference_id: Reactome:R-HSA-5683385
+      supporting_text: Together, BRCA1, BARD1, UIMC1, FAM175A, BRCC36, BRE and BABAM1 form the so-called
+        BRCA1-A complex at DNA DSBs
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:19261748
+  qualifier: enables
+  review:
+    summary: >-
+      Interaction evidence is real, but the GO term protein binding is too generic to describe ABRAXAS1 function.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: >-
+      These IPI rows should not be treated as core molecular-function annotations. The informative biology is BRCA1-A
+      complex assembly, RAP80/BRCA1/BRCC36 interactions, and polyubiquitin-dependent recruitment; broad interactome
+      rows are even less suitable as function claims.
+    supported_by:
+    - reference_id: PMID:19261748
+      supporting_text: CCDC98 binds to RAP80 via a large N-terminal region
+    - reference_id: PMID:20656689
+      supporting_text: The RAP80 complex is a five-member stoichiometric complex consisting of RAP80, BRCC36,
+        BRCC45, Abraxas, and MERIT40
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:19261749
+  qualifier: enables
+  review:
+    summary: >-
+      Interaction evidence is real, but the GO term protein binding is too generic to describe ABRAXAS1 function.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: >-
+      These IPI rows should not be treated as core molecular-function annotations. The informative biology is BRCA1-A
+      complex assembly, RAP80/BRCA1/BRCC36 interactions, and polyubiquitin-dependent recruitment; broad interactome
+      rows are even less suitable as function claims.
+    supported_by:
+    - reference_id: PMID:19261749
+      supporting_text: four members of the BRCA1-A complex possess a polyubiquitin chain-binding capability
+    - reference_id: PMID:20656689
+      supporting_text: The RAP80 complex is a five-member stoichiometric complex consisting of RAP80, BRCC36,
+        BRCC45, Abraxas, and MERIT40
+- term:
+    id: GO:0005634
+    label: nucleus
+  evidence_type: IDA
+  original_reference_id: PMID:17525340
+  qualifier: located_in
+  review:
+    summary: >-
+      Supported nuclear localization. ABRAXAS1 acts in the nuclear DNA damage response and localizes to DNA damage
+      sites within the nucleus.
+    action: ACCEPT
+    reason: >-
+      The UniProt record and the original BRCA1-A studies place ABRAXAS1 in the nucleus, where it recruits/organizes
+      BRCA1-A complex activity at DNA double-strand breaks.
+    supported_by:
+    - reference_id: file:human/ABRAXAS1/ABRAXAS1-uniprot.txt
+      supporting_text: Nucleus {ECO:0000269|PubMed:17525340, ECO:0000269|PubMed:17643121,
+        ECO:0000269|PubMed:17643122}.
+    - reference_id: PMID:17525340
+      supporting_text: RAP80 was required for optimal accumulation of BRCA1 on damaged DNA (foci) in response
+        to ionizing radiation
+- term:
+    id: GO:0005634
+    label: nucleus
+  evidence_type: IDA
+  original_reference_id: PMID:17643121
+  qualifier: located_in
+  review:
+    summary: >-
+      Supported nuclear localization. ABRAXAS1 acts in the nuclear DNA damage response and localizes to DNA damage
+      sites within the nucleus.
+    action: ACCEPT
+    reason: >-
+      The UniProt record and the original BRCA1-A studies place ABRAXAS1 in the nucleus, where it recruits/organizes
+      BRCA1-A complex activity at DNA double-strand breaks.
+    supported_by:
+    - reference_id: file:human/ABRAXAS1/ABRAXAS1-uniprot.txt
+      supporting_text: Nucleus {ECO:0000269|PubMed:17525340, ECO:0000269|PubMed:17643121,
+        ECO:0000269|PubMed:17643122}.
+    - reference_id: PMID:17525340
+      supporting_text: RAP80 was required for optimal accumulation of BRCA1 on damaged DNA (foci) in response
+        to ionizing radiation
+- term:
+    id: GO:0006302
+    label: double-strand break repair
+  evidence_type: IMP
+  original_reference_id: PMID:17525340
+  qualifier: involved_in
+  review:
+    summary: >-
+      Core biological process. ABRAXAS1 is required for efficient DNA double-strand break repair through BRCA1-A
+      recruitment and ubiquitin-dependent damage-site signaling.
+    action: ACCEPT
+    reason: >-
+      Loss/depletion experiments in the original ABRAXAS1/CCDC98 papers support DNA repair and DNA damage resistance.
+      The PN-projected broader DNA repair term is already entailed by this annotation.
+    additional_reference_ids:
+    - file:projects/PROTEOSTASIS/reports/pn_projection/pn_projected_gene_go_summary.tsv
+    supported_by:
+    - reference_id: PMID:17525340
+      supporting_text: Both Abraxas and RAP80 were required for DNA damage resistance, G(2)-M checkpoint
+        control, and DNA repair.
+    - reference_id: PMID:19261748
+      supporting_text: a stable complex containing MERIT40 acts early in DNA damage response and regulates
+        damage-dependent BRCA1 localization
+- term:
+    id: GO:0006302
+    label: double-strand break repair
+  evidence_type: IMP
+  original_reference_id: PMID:17643121
+  qualifier: involved_in
+  review:
+    summary: >-
+      Core biological process. ABRAXAS1 is required for efficient DNA double-strand break repair through BRCA1-A
+      recruitment and ubiquitin-dependent damage-site signaling.
+    action: ACCEPT
+    reason: >-
+      Loss/depletion experiments in the original ABRAXAS1/CCDC98 papers support DNA repair and DNA damage resistance.
+      The PN-projected broader DNA repair term is already entailed by this annotation.
+    additional_reference_ids:
+    - file:projects/PROTEOSTASIS/reports/pn_projection/pn_projected_gene_go_summary.tsv
+    supported_by:
+    - reference_id: PMID:17525340
+      supporting_text: Both Abraxas and RAP80 were required for DNA damage resistance, G(2)-M checkpoint
+        control, and DNA repair.
+    - reference_id: PMID:19261748
+      supporting_text: a stable complex containing MERIT40 acts early in DNA damage response and regulates
+        damage-dependent BRCA1 localization
+- term:
+    id: GO:0006302
+    label: double-strand break repair
+  evidence_type: IMP
+  original_reference_id: PMID:19261748
+  qualifier: involved_in
+  review:
+    summary: >-
+      Core biological process. ABRAXAS1 is required for efficient DNA double-strand break repair through BRCA1-A
+      recruitment and ubiquitin-dependent damage-site signaling.
+    action: ACCEPT
+    reason: >-
+      Loss/depletion experiments in the original ABRAXAS1/CCDC98 papers support DNA repair and DNA damage resistance.
+      The PN-projected broader DNA repair term is already entailed by this annotation.
+    additional_reference_ids:
+    - file:projects/PROTEOSTASIS/reports/pn_projection/pn_projected_gene_go_summary.tsv
+    supported_by:
+    - reference_id: PMID:17525340
+      supporting_text: Both Abraxas and RAP80 were required for DNA damage resistance, G(2)-M checkpoint
+        control, and DNA repair.
+    - reference_id: PMID:19261748
+      supporting_text: a stable complex containing MERIT40 acts early in DNA damage response and regulates
+        damage-dependent BRCA1 localization
+- term:
+    id: GO:0010212
+    label: response to ionizing radiation
+  evidence_type: IMP
+  original_reference_id: PMID:17525340
+  qualifier: involved_in
+  review:
+    summary: >-
+      Supported but non-core phenotype/context annotation. Ionizing radiation is the experimental damage stimulus
+      used to reveal ABRAXAS1 DNA damage-response function.
+    action: KEEP_AS_NON_CORE
+    reason: >-
+      The IR response annotations should be retained as useful experimental context, but the core process is DNA
+      double-strand break repair/checkpoint signaling through BRCA1-A.
+    supported_by:
+    - reference_id: PMID:18077395
+      supporting_text: the entire Brca1 A complex to DNA-damage foci
+    - reference_id: PMID:19261749
+      supporting_text: required for resistance to ionizing radiation
+- term:
+    id: GO:0010212
+    label: response to ionizing radiation
+  evidence_type: IMP
+  original_reference_id: PMID:17643121
+  qualifier: involved_in
+  review:
+    summary: >-
+      Supported but non-core phenotype/context annotation. Ionizing radiation is the experimental damage stimulus
+      used to reveal ABRAXAS1 DNA damage-response function.
+    action: KEEP_AS_NON_CORE
+    reason: >-
+      The IR response annotations should be retained as useful experimental context, but the core process is DNA
+      double-strand break repair/checkpoint signaling through BRCA1-A.
+    supported_by:
+    - reference_id: PMID:18077395
+      supporting_text: the entire Brca1 A complex to DNA-damage foci
+    - reference_id: PMID:19261749
+      supporting_text: required for resistance to ionizing radiation
+- term:
+    id: GO:0010212
+    label: response to ionizing radiation
+  evidence_type: IMP
+  original_reference_id: PMID:19261748
+  qualifier: involved_in
+  review:
+    summary: >-
+      Supported but non-core phenotype/context annotation. Ionizing radiation is the experimental damage stimulus
+      used to reveal ABRAXAS1 DNA damage-response function.
+    action: KEEP_AS_NON_CORE
+    reason: >-
+      The IR response annotations should be retained as useful experimental context, but the core process is DNA
+      double-strand break repair/checkpoint signaling through BRCA1-A.
+    supported_by:
+    - reference_id: PMID:18077395
+      supporting_text: the entire Brca1 A complex to DNA-damage foci
+    - reference_id: PMID:19261749
+      supporting_text: required for resistance to ionizing radiation
+- term:
+    id: GO:0031593
+    label: polyubiquitin modification-dependent protein binding
+  evidence_type: IDA
+  original_reference_id: PMID:19261749
+  qualifier: enables
+  review:
+    summary: >-
+      Core molecular function. ABRAXAS1 is part of a BRCA1-A/RAP80 complex that recognizes ubiquitinated damage-site
+      chromatin and has polyubiquitin-binding capacity.
+    action: ACCEPT
+    reason: >-
+      The term captures the ubiquitin-recognition side of ABRAXAS1 biology better than generic protein binding.
+      It should be retained for both direct IDA and IBA evidence.
+    supported_by:
+    - reference_id: PMID:19261749
+      supporting_text: four members of the BRCA1-A complex possess a polyubiquitin chain-binding capability
+    - reference_id: PMID:20656689
+      supporting_text: RAP80, in turn, is recruited to DSBs through its tandem ubiquitin-interacting motifs
+        (UIMs) ( 6 , 14 – 16 ), which specifically recognize K63-Ub chains
+- term:
+    id: GO:0045739
+    label: positive regulation of DNA repair
+  evidence_type: IMP
+  original_reference_id: PMID:17525340
+  qualifier: involved_in
+  review:
+    summary: >-
+      Core regulatory process. ABRAXAS1 positively supports DNA repair by assembling/stabilizing the RAP80-BRCA1-A
+      complex at DNA damage sites.
+    action: ACCEPT
+    reason: >-
+      The evidence supports a positive role in DNA repair through BRCA1 localization, complex integrity, and BRCC36-associated
+      ubiquitin editing rather than direct DNA repair catalysis.
+    supported_by:
+    - reference_id: PMID:17525340
+      supporting_text: Both Abraxas and RAP80 were required for DNA damage resistance, G(2)-M checkpoint
+        control, and DNA repair.
+    - reference_id: PMID:19261748
+      supporting_text: a stable complex containing MERIT40 acts early in DNA damage response and regulates
+        damage-dependent BRCA1 localization
+    - reference_id: PMID:20656689
+      supporting_text: Abraxas and BRCC45 were essential for BRCC36 DUB activity within the RAP80 complex
+- term:
+    id: GO:0045739
+    label: positive regulation of DNA repair
+  evidence_type: IMP
+  original_reference_id: PMID:19261748
+  qualifier: involved_in
+  review:
+    summary: >-
+      Core regulatory process. ABRAXAS1 positively supports DNA repair by assembling/stabilizing the RAP80-BRCA1-A
+      complex at DNA damage sites.
+    action: ACCEPT
+    reason: >-
+      The evidence supports a positive role in DNA repair through BRCA1 localization, complex integrity, and BRCC36-associated
+      ubiquitin editing rather than direct DNA repair catalysis.
+    supported_by:
+    - reference_id: PMID:17525340
+      supporting_text: Both Abraxas and RAP80 were required for DNA damage resistance, G(2)-M checkpoint
+        control, and DNA repair.
+    - reference_id: PMID:19261748
+      supporting_text: a stable complex containing MERIT40 acts early in DNA damage response and regulates
+        damage-dependent BRCA1 localization
+    - reference_id: PMID:20656689
+      supporting_text: Abraxas and BRCC45 were essential for BRCC36 DUB activity within the RAP80 complex
+- term:
+    id: GO:0070531
+    label: BRCA1-A complex
+  evidence_type: IDA
+  original_reference_id: PMID:17525340
+  qualifier: part_of
+  review:
+    summary: >-
+      Core complex membership. ABRAXAS1 is a BRCA1-A complex subunit that organizes BRCA1, UIMC1/RAP80, BRCC3/BRCC36,
+      BABAM proteins, and related DDR functions.
+    action: ACCEPT
+    reason: >-
+      Multiple primary studies and Reactome support ABRAXAS1/FAM175A as a BRCA1-A complex component. This is more
+      precise than the PN-projected generic ubiquitin-ligase-complex bucket.
+    additional_reference_ids:
+    - file:projects/PROTEOSTASIS/reports/pn_projection/pn_projected_gene_go_summary.tsv
+    - file:projects/PROTEOSTASIS/mappings/ubiquitin_proteasome_system.yaml
+    supported_by:
+    - reference_id: PMID:19261749
+      supporting_text: Proteomic analysis revealed that NBA1 is a component of the BRCA1 A complex, which also
+        contains Brca1/Bard1, Abra1, RAP80, BRCC36, and BRE.
+    - reference_id: Reactome:R-HSA-5683385
+      supporting_text: Together, BRCA1, BARD1, UIMC1, FAM175A, BRCC36, BRE and BABAM1 form the so-called
+        BRCA1-A complex at DNA DSBs
+- term:
+    id: GO:0070531
+    label: BRCA1-A complex
+  evidence_type: IDA
+  original_reference_id: PMID:19261746
+  qualifier: part_of
+  review:
+    summary: >-
+      Core complex membership. ABRAXAS1 is a BRCA1-A complex subunit that organizes BRCA1, UIMC1/RAP80, BRCC3/BRCC36,
+      BABAM proteins, and related DDR functions.
+    action: ACCEPT
+    reason: >-
+      Multiple primary studies and Reactome support ABRAXAS1/FAM175A as a BRCA1-A complex component. This is more
+      precise than the PN-projected generic ubiquitin-ligase-complex bucket.
+    additional_reference_ids:
+    - file:projects/PROTEOSTASIS/reports/pn_projection/pn_projected_gene_go_summary.tsv
+    - file:projects/PROTEOSTASIS/mappings/ubiquitin_proteasome_system.yaml
+    supported_by:
+    - reference_id: PMID:19261749
+      supporting_text: Proteomic analysis revealed that NBA1 is a component of the BRCA1 A complex, which also
+        contains Brca1/Bard1, Abra1, RAP80, BRCC36, and BRE.
+    - reference_id: Reactome:R-HSA-5683385
+      supporting_text: Together, BRCA1, BARD1, UIMC1, FAM175A, BRCC36, BRE and BABAM1 form the so-called
+        BRCA1-A complex at DNA DSBs
+- term:
+    id: GO:0070531
+    label: BRCA1-A complex
+  evidence_type: IDA
+  original_reference_id: PMID:19261748
+  qualifier: part_of
+  review:
+    summary: >-
+      Core complex membership. ABRAXAS1 is a BRCA1-A complex subunit that organizes BRCA1, UIMC1/RAP80, BRCC3/BRCC36,
+      BABAM proteins, and related DDR functions.
+    action: ACCEPT
+    reason: >-
+      Multiple primary studies and Reactome support ABRAXAS1/FAM175A as a BRCA1-A complex component. This is more
+      precise than the PN-projected generic ubiquitin-ligase-complex bucket.
+    additional_reference_ids:
+    - file:projects/PROTEOSTASIS/reports/pn_projection/pn_projected_gene_go_summary.tsv
+    - file:projects/PROTEOSTASIS/mappings/ubiquitin_proteasome_system.yaml
+    supported_by:
+    - reference_id: PMID:19261749
+      supporting_text: Proteomic analysis revealed that NBA1 is a component of the BRCA1 A complex, which also
+        contains Brca1/Bard1, Abra1, RAP80, BRCC36, and BRE.
+    - reference_id: Reactome:R-HSA-5683385
+      supporting_text: Together, BRCA1, BARD1, UIMC1, FAM175A, BRCC36, BRE and BABAM1 form the so-called
+        BRCA1-A complex at DNA DSBs
+- term:
+    id: GO:0070531
+    label: BRCA1-A complex
+  evidence_type: IDA
+  original_reference_id: PMID:19261749
+  qualifier: part_of
+  review:
+    summary: >-
+      Core complex membership. ABRAXAS1 is a BRCA1-A complex subunit that organizes BRCA1, UIMC1/RAP80, BRCC3/BRCC36,
+      BABAM proteins, and related DDR functions.
+    action: ACCEPT
+    reason: >-
+      Multiple primary studies and Reactome support ABRAXAS1/FAM175A as a BRCA1-A complex component. This is more
+      precise than the PN-projected generic ubiquitin-ligase-complex bucket.
+    additional_reference_ids:
+    - file:projects/PROTEOSTASIS/reports/pn_projection/pn_projected_gene_go_summary.tsv
+    - file:projects/PROTEOSTASIS/mappings/ubiquitin_proteasome_system.yaml
+    supported_by:
+    - reference_id: PMID:19261749
+      supporting_text: Proteomic analysis revealed that NBA1 is a component of the BRCA1 A complex, which also
+        contains Brca1/Bard1, Abra1, RAP80, BRCC36, and BRE.
+    - reference_id: Reactome:R-HSA-5683385
+      supporting_text: Together, BRCA1, BARD1, UIMC1, FAM175A, BRCC36, BRE and BABAM1 form the so-called
+        BRCA1-A complex at DNA DSBs
+references:
+- id: GO_REF:0000033
+  title: Annotation inferences using phylogenetic trees
+  findings: []
+- id: GO_REF:0000044
+  title: Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location vocabulary mapping,
+    accompanied by conservative changes to GO terms applied by UniProt
+  findings: []
+- id: GO_REF:0000052
+  title: Gene Ontology annotation based on curation of immunofluorescence data
+  findings: []
+- id: PMID:17525340
+  title: Abraxas and RAP80 form a BRCA1 protein complex required for the DNA damage response.
+  findings:
+  - statement: ABRAXAS1/Abraxas binds BRCA1 BRCT repeats and RAP80, and is required for DNA damage resistance,
+      G2/M checkpoint control, and DNA repair.
+    supporting_text: Abraxas and RAP80 were required for DNA damage resistance, G(2)-M checkpoint control, and
+      DNA repair.
+    reference_section_type: ABSTRACT
+- id: PMID:17643121
+  title: CCDC98 targets BRCA1 to DNA damage sites.
+  findings: []
+- id: PMID:18077395
+  title: Ubc13/Rnf8 ubiquitin ligases control foci formation of the Rap80/Abraxas/Brca1/Brcc36 complex in
+    response to DNA damage.
+  findings: []
+- id: PMID:19261746
+  title: MERIT40 controls BRCA1-Rap80 complex integrity and recruitment to DNA double-strand breaks.
+  findings: []
+- id: PMID:19261748
+  title: MERIT40 facilitates BRCA1 localization and DNA damage repair.
+  findings:
+  - statement: CCDC98/ABRAXAS1 is a central component for assembly of the RAP80-containing BRCA1-A complex at
+      DNA damage sites.
+    supporting_text: CCDC98 as the central component that facilitates the assembly of this protein complex
+    reference_section_type: DISCUSSION
+- id: PMID:19261749
+  title: NBA1, a new player in the Brca1 A complex, is required for DNA damage resistance and checkpoint
+    control.
+  findings: []
+- id: PMID:19615732
+  title: Defining the human deubiquitinating enzyme interaction landscape.
+  findings: []
+- id: PMID:20656689
+  title: Differential regulation of JAMM domain deubiquitinating enzyme activity within the RAP80 complex.
+  findings:
+  - statement: ABRAXAS1 is required for BRCC36 DUB activity in the RAP80/BRCA1-A complex context, but is not
+      itself the catalytic DUB.
+    supporting_text: Abraxas and BRCC45 were essential for BRCC36 DUB activity within the RAP80 complex
+    reference_section_type: ABSTRACT
+- id: PMID:22369660
+  title: 'BRCA1 tumor suppressor network: focusing on its tail.'
+  findings: []
+- id: PMID:29656893
+  title: DNA Repair Network Analysis Reveals Shieldin as a Key Regulator of NHEJ and PARP Inhibitor
+    Sensitivity.
+  findings: []
+- id: PMID:34591612
+  title: A protein interaction landscape of breast cancer.
+  findings: []
+- id: PMID:35156780
+  title: CFTR interactome mapping using the mammalian membrane two-hybrid high-throughput screening system.
+  findings: []
+- id: PMID:36012204
+  title: Differential CFTR-Interactome Proximity Labeling Procedures Identify Enrichment in Multiple SLC
+    Transporters.
+  findings: []
+- id: PMID:39009827
+  title: Proteome-scale characterisation of motif-based interactome rewiring by disease mutations.
+  findings: []
+- id: Reactome:R-HSA-5683384
+  title: UIMC1 and FAM175A bind DNA DSBs
+  findings: []
+- id: Reactome:R-HSA-5683385
+  title: Formation of BRCA1-A complex at DNA DSBs
+  findings: []
+- id: Reactome:R-HSA-5683735
+  title: CHEK2 is recruited to DNA DSBs
+  findings: []
+- id: Reactome:R-HSA-5683801
+  title: CHEK2 phosphorylates BRCA1
+  findings: []
+- id: Reactome:R-HSA-5684052
+  title: PIAS4 SUMOylates MDC1
+  findings: []
+- id: Reactome:R-HSA-5684071
+  title: RNF4 ubiquitinates MDC1
+  findings: []
+- id: Reactome:R-HSA-5686685
+  title: RIF1 and PAX1IP bind TP53BP1 at DNA DSBs
+  findings: []
+- id: Reactome:R-HSA-5691411
+  title: BRCA1-A complex deubiquitinates K63polyUb-histone H2A
+  findings: []
+- id: Reactome:R-HSA-5693551
+  title: Phosphorylation of BRCA1-A complex at multiple sites by ATM
+  findings: []
+- id: Reactome:R-HSA-69891
+  title: Phosphorylation and activation of CHEK2 by ATM
+  findings: []
+- id: file:human/ABRAXAS1/ABRAXAS1-uniprot.txt
+  title: ABRAXAS1 UniProtKB record
+  findings: []
+- id: file:human/ABRAXAS1/ABRAXAS1-notes.md
+  title: ABRAXAS1 manual review notes and failed deep-research provenance
+  findings: []
+- id: file:projects/PROTEOSTASIS/reports/pn_projection/pn_projected_gene_go_summary.tsv
+  title: Proteostasis PN projected GO summary for ABRAXAS1
+  findings: []
+- id: file:projects/PROTEOSTASIS/mappings/ubiquitin_proteasome_system.yaml
+  title: Proteostasis ubiquitin proteasome system mapping file
+  findings: []
+- id: file:interpro/panther/PTHR31728/PTHR31728-entries.csv
+  title: PANTHER PTHR31728 reviewed protein members
+  findings: []
+core_functions:
+- molecular_function:
+    id: GO:0031593
+    label: polyubiquitin modification-dependent protein binding
+  description: >-
+    ABRAXAS1 is a scaffold and ubiquitin-recognition subunit of the nuclear BRCA1-A/RAP80 complex. It helps assemble
+    BRCA1, UIMC1/RAP80, BRCC3/BRCC36, BABAM proteins, and related partners at ubiquitinated DNA double-strand break
+    sites, thereby supporting BRCA1 recruitment, BRCC36-dependent K63-ubiquitin signal editing, DNA repair, and
+    G2/M DNA damage checkpoint signaling.
+  directly_involved_in:
+  - id: GO:0006302
+    label: double-strand break repair
+  - id: GO:0045739
+    label: positive regulation of DNA repair
+  - id: GO:0007095
+    label: mitotic G2 DNA damage checkpoint signaling
+  locations:
+  - id: GO:0005634
+    label: nucleus
+  - id: GO:0005654
+    label: nucleoplasm
+  in_complex:
+    id: GO:0070531
+    label: BRCA1-A complex
+  supported_by:
+  - reference_id: PMID:17525340
+    supporting_text: Abraxas and RAP80 were required for DNA damage resistance, G(2)-M checkpoint control, and
+      DNA repair.
+  - reference_id: PMID:19261748
+    supporting_text: CCDC98 as the central component that facilitates the assembly of this protein complex
+  - reference_id: PMID:19261749
+    supporting_text: four members of the BRCA1-A complex possess a polyubiquitin chain-binding capability
+  - reference_id: PMID:20656689
+    supporting_text: Abraxas and BRCC45 were essential for BRCC36 DUB activity within the RAP80 complex
+  - reference_id: Reactome:R-HSA-5683385
+    supporting_text: Together, BRCA1, BARD1, UIMC1, FAM175A, BRCC36, BRE and BABAM1 form the so-called BRCA1-A
+      complex at DNA DSBs
+  - reference_id: file:human/ABRAXAS1/ABRAXAS1-uniprot.txt
+    supporting_text: Involved in DNA damage response and double-strand break (DSB) repair.
+proposed_new_terms: []
+suggested_questions:
+- question: Should GO curation represent ABRAXAS1 only as part of the BRCA1-A complex, or is there enough
+    evidence to annotate ABRAXAS1 to a broader ubiquitin ligase complex term despite its scaffold/DUB-support
+    role?
+  experts:
+  - Wang B
+  - Greenberg RA
+  - Elledge SJ
+suggested_experiments:
+- hypothesis: The PANTHER-derived spindle and microtubule annotations are ABRAXAS2/paralog-specific and do not
+    apply to ABRAXAS1.
+  description: Compare ABRAXAS1 and ABRAXAS2 depletion or rescue in synchronized human cells using spindle
+    assembly, kinetochore-microtubule attachment, and DNA damage-response readouts in the same experimental
+    system.
+  experiment_type: comparative cell biology

--- a/genes/human/ABRAXAS1/ABRAXAS1-goa.tsv
+++ b/genes/human/ABRAXAS1/ABRAXAS1-goa.tsv
@@ -1,0 +1,66 @@
+GENE PRODUCT DB	GENE PRODUCT ID	SYMBOL	QUALIFIER	GO TERM	GO NAME	GO ASPECT	ECO ID	GO EVIDENCE CODE	REFERENCE	WITH/FROM	TAXON ID	TAXON NAME	ASSIGNED BY	GENE NAME	DATE
+UniProtKB	Q6UWZ7	ABRAXAS1	is_active_in	GO:0005634	nucleus	cellular_component	ECO:0000318	IBA	GO_REF:0000033	MGI:MGI:1926116|PANTHER:PTN001272081|UniProtKB:Q15018|UniProtKB:Q6UWZ7	9606	Homo sapiens	GO_Central	BRCA1-A complex subunit Abraxas 1	20190430
+UniProtKB	Q6UWZ7	ABRAXAS1	enables	GO:0008017	microtubule binding	molecular_function	ECO:0000318	IBA	GO_REF:0000033	PANTHER:PTN001272083|UniProtKB:Q15018	9606	Homo sapiens	GO_Central	BRCA1-A complex subunit Abraxas 1	20190430
+UniProtKB	Q6UWZ7	ABRAXAS1	involved_in	GO:0008608	attachment of spindle microtubules to kinetochore	biological_process	ECO:0000318	IBA	GO_REF:0000033	PANTHER:PTN001272083|UniProtKB:Q15018	9606	Homo sapiens	GO_Central	BRCA1-A complex subunit Abraxas 1	20190430
+UniProtKB	Q6UWZ7	ABRAXAS1	enables	GO:0031593	polyubiquitin modification-dependent protein binding	molecular_function	ECO:0000318	IBA	GO_REF:0000033	PANTHER:PTN001272081|UniProtKB:Q15018|UniProtKB:Q6UWZ7	9606	Homo sapiens	GO_Central	BRCA1-A complex subunit Abraxas 1	20190430
+UniProtKB	Q6UWZ7	ABRAXAS1	involved_in	GO:0090307	mitotic spindle assembly	biological_process	ECO:0000318	IBA	GO_REF:0000033	PANTHER:PTN001272083|UniProtKB:Q15018	9606	Homo sapiens	GO_Central	BRCA1-A complex subunit Abraxas 1	20190430
+UniProtKB	Q6UWZ7	ABRAXAS1	located_in	GO:0005634	nucleus	cellular_component	ECO:0007322	IEA	GO_REF:0000044	UniProtKB-SubCell:SL-0191	9606	Homo sapiens	UniProt	BRCA1-A complex subunit Abraxas 1	20260428
+UniProtKB	Q6UWZ7	ABRAXAS1	enables	GO:0005515	protein binding	molecular_function	ECO:0000353	IPI	PMID:17525340	UniProtKB:P38398	9606	Homo sapiens	IntAct	BRCA1-A complex subunit Abraxas 1	20260425
+UniProtKB	Q6UWZ7	ABRAXAS1	enables	GO:0005515	protein binding	molecular_function	ECO:0000353	IPI	PMID:17525340	UniProtKB:Q96RL1	9606	Homo sapiens	IntAct	BRCA1-A complex subunit Abraxas 1	20260425
+UniProtKB	Q6UWZ7	ABRAXAS1	enables	GO:0005515	protein binding	molecular_function	ECO:0000353	IPI	PMID:17643121	UniProtKB:P38398	9606	Homo sapiens	IntAct	BRCA1-A complex subunit Abraxas 1	20260425
+UniProtKB	Q6UWZ7	ABRAXAS1	enables	GO:0005515	protein binding	molecular_function	ECO:0000353	IPI	PMID:17643121	UniProtKB:Q96RL1-1	9606	Homo sapiens	IntAct	BRCA1-A complex subunit Abraxas 1	20260425
+UniProtKB	Q6UWZ7	ABRAXAS1	enables	GO:0005515	protein binding	molecular_function	ECO:0000353	IPI	PMID:18077395	UniProtKB:P46736	9606	Homo sapiens	IntAct	BRCA1-A complex subunit Abraxas 1	20260425
+UniProtKB	Q6UWZ7	ABRAXAS1	enables	GO:0005515	protein binding	molecular_function	ECO:0000353	IPI	PMID:18077395	UniProtKB:Q96RL1-1	9606	Homo sapiens	IntAct	BRCA1-A complex subunit Abraxas 1	20260425
+UniProtKB	Q6UWZ7	ABRAXAS1	enables	GO:0005515	protein binding	molecular_function	ECO:0000353	IPI	PMID:19615732	UniProtKB:P46736	9606	Homo sapiens	IntAct	BRCA1-A complex subunit Abraxas 1	20260425
+UniProtKB	Q6UWZ7	ABRAXAS1	enables	GO:0005515	protein binding	molecular_function	ECO:0000353	IPI	PMID:19615732	UniProtKB:Q96RL1	9606	Homo sapiens	IntAct	BRCA1-A complex subunit Abraxas 1	20260425
+UniProtKB	Q6UWZ7	ABRAXAS1	enables	GO:0005515	protein binding	molecular_function	ECO:0000353	IPI	PMID:29656893	UniProtKB:P38398	9606	Homo sapiens	IntAct	BRCA1-A complex subunit Abraxas 1	20260425
+UniProtKB	Q6UWZ7	ABRAXAS1	enables	GO:0005515	protein binding	molecular_function	ECO:0000353	IPI	PMID:34591612	UniProtKB:P38398	9606	Homo sapiens	IntAct	BRCA1-A complex subunit Abraxas 1	20260425
+UniProtKB	Q6UWZ7	ABRAXAS1	enables	GO:0005515	protein binding	molecular_function	ECO:0000353	IPI	PMID:35156780	UniProtKB:P13569	9606	Homo sapiens	IntAct	BRCA1-A complex subunit Abraxas 1	20260425
+UniProtKB	Q6UWZ7	ABRAXAS1	enables	GO:0005515	protein binding	molecular_function	ECO:0000353	IPI	PMID:36012204	UniProtKB:P13569	9606	Homo sapiens	IntAct	BRCA1-A complex subunit Abraxas 1	20260425
+UniProtKB	Q6UWZ7	ABRAXAS1	enables	GO:0005515	protein binding	molecular_function	ECO:0000353	IPI	PMID:39009827	UniProtKB:O00629	9606	Homo sapiens	IntAct	BRCA1-A complex subunit Abraxas 1	20260425
+UniProtKB	Q6UWZ7	ABRAXAS1	located_in	GO:0016604	nuclear body	cellular_component	ECO:0000314	IDA	GO_REF:0000052		9606	Homo sapiens	HPA	BRCA1-A complex subunit Abraxas 1	20251115
+UniProtKB	Q6UWZ7	ABRAXAS1	located_in	GO:0005634	nucleus	cellular_component	ECO:0005547	NAS	PMID:20656689		9606	Homo sapiens	ComplexPortal	BRCA1-A complex subunit Abraxas 1	20250904
+UniProtKB	Q6UWZ7	ABRAXAS1	involved_in	GO:0006282	regulation of DNA repair	biological_process	ECO:0005547	NAS	PMID:20656689		9606	Homo sapiens	ComplexPortal	BRCA1-A complex subunit Abraxas 1	20250904
+UniProtKB	Q6UWZ7	ABRAXAS1	involved_in	GO:0044818	mitotic G2/M transition checkpoint	biological_process	ECO:0005547	NAS	PMID:22369660		9606	Homo sapiens	ComplexPortal	BRCA1-A complex subunit Abraxas 1	20250904
+UniProtKB	Q6UWZ7	ABRAXAS1	part_of	GO:0070531	BRCA1-A complex	cellular_component	ECO:0005547	NAS	PMID:20656689		9606	Homo sapiens	ComplexPortal	BRCA1-A complex subunit Abraxas 1	20250904
+UniProtKB	Q6UWZ7	ABRAXAS1	involved_in	GO:0007095	mitotic G2 DNA damage checkpoint signaling	biological_process	ECO:0000315	IMP	PMID:17525340		9606	Homo sapiens	UniProt	BRCA1-A complex subunit Abraxas 1	20171116
+UniProtKB	Q6UWZ7	ABRAXAS1	involved_in	GO:0007095	mitotic G2 DNA damage checkpoint signaling	biological_process	ECO:0000315	IMP	PMID:17643121		9606	Homo sapiens	UniProt	BRCA1-A complex subunit Abraxas 1	20171116
+UniProtKB	Q6UWZ7	ABRAXAS1	involved_in	GO:0007095	mitotic G2 DNA damage checkpoint signaling	biological_process	ECO:0000315	IMP	PMID:19261748		9606	Homo sapiens	UniProt	BRCA1-A complex subunit Abraxas 1	20171116
+UniProtKB	Q6UWZ7	ABRAXAS1	located_in	GO:0005654	nucleoplasm	cellular_component	ECO:0000304	TAS	Reactome:R-HSA-5683384		9606	Homo sapiens	Reactome	BRCA1-A complex subunit Abraxas 1	20150313
+UniProtKB	Q6UWZ7	ABRAXAS1	located_in	GO:0005654	nucleoplasm	cellular_component	ECO:0000304	TAS	Reactome:R-HSA-5683385		9606	Homo sapiens	Reactome	BRCA1-A complex subunit Abraxas 1	20150313
+UniProtKB	Q6UWZ7	ABRAXAS1	located_in	GO:0005654	nucleoplasm	cellular_component	ECO:0000304	TAS	Reactome:R-HSA-5683735		9606	Homo sapiens	Reactome	BRCA1-A complex subunit Abraxas 1	20150313
+UniProtKB	Q6UWZ7	ABRAXAS1	located_in	GO:0005654	nucleoplasm	cellular_component	ECO:0000304	TAS	Reactome:R-HSA-5683801		9606	Homo sapiens	Reactome	BRCA1-A complex subunit Abraxas 1	20150313
+UniProtKB	Q6UWZ7	ABRAXAS1	located_in	GO:0005654	nucleoplasm	cellular_component	ECO:0000304	TAS	Reactome:R-HSA-5684052		9606	Homo sapiens	Reactome	BRCA1-A complex subunit Abraxas 1	20150313
+UniProtKB	Q6UWZ7	ABRAXAS1	located_in	GO:0005654	nucleoplasm	cellular_component	ECO:0000304	TAS	Reactome:R-HSA-5684071		9606	Homo sapiens	Reactome	BRCA1-A complex subunit Abraxas 1	20150313
+UniProtKB	Q6UWZ7	ABRAXAS1	located_in	GO:0005654	nucleoplasm	cellular_component	ECO:0000304	TAS	Reactome:R-HSA-5686685		9606	Homo sapiens	Reactome	BRCA1-A complex subunit Abraxas 1	20150313
+UniProtKB	Q6UWZ7	ABRAXAS1	located_in	GO:0005654	nucleoplasm	cellular_component	ECO:0000304	TAS	Reactome:R-HSA-5691411		9606	Homo sapiens	Reactome	BRCA1-A complex subunit Abraxas 1	20150313
+UniProtKB	Q6UWZ7	ABRAXAS1	located_in	GO:0005654	nucleoplasm	cellular_component	ECO:0000304	TAS	Reactome:R-HSA-5693551		9606	Homo sapiens	Reactome	BRCA1-A complex subunit Abraxas 1	20150313
+UniProtKB	Q6UWZ7	ABRAXAS1	located_in	GO:0005654	nucleoplasm	cellular_component	ECO:0000304	TAS	Reactome:R-HSA-69891		9606	Homo sapiens	Reactome	BRCA1-A complex subunit Abraxas 1	20150313
+UniProtKB	Q6UWZ7	ABRAXAS1	enables	GO:0005515	protein binding	molecular_function	ECO:0000353	IPI	PMID:17525340	UniProtKB:P38398	9606	Homo sapiens	UniProt	BRCA1-A complex subunit Abraxas 1	20090528
+UniProtKB	Q6UWZ7	ABRAXAS1	enables	GO:0005515	protein binding	molecular_function	ECO:0000353	IPI	PMID:17643121	UniProtKB:P38398	9606	Homo sapiens	UniProt	BRCA1-A complex subunit Abraxas 1	20090528
+UniProtKB	Q6UWZ7	ABRAXAS1	enables	GO:0005515	protein binding	molecular_function	ECO:0000353	IPI	PMID:19261748	UniProtKB:P38398	9606	Homo sapiens	UniProt	BRCA1-A complex subunit Abraxas 1	20090528
+UniProtKB	Q6UWZ7	ABRAXAS1	enables	GO:0005515	protein binding	molecular_function	ECO:0000353	IPI	PMID:17525340	UniProtKB:Q96RL1	9606	Homo sapiens	UniProt	BRCA1-A complex subunit Abraxas 1	20090422
+UniProtKB	Q6UWZ7	ABRAXAS1	enables	GO:0005515	protein binding	molecular_function	ECO:0000353	IPI	PMID:17643121	UniProtKB:Q96RL1	9606	Homo sapiens	UniProt	BRCA1-A complex subunit Abraxas 1	20090422
+UniProtKB	Q6UWZ7	ABRAXAS1	enables	GO:0005515	protein binding	molecular_function	ECO:0000353	IPI	PMID:19261748	UniProtKB:P46736	9606	Homo sapiens	UniProt	BRCA1-A complex subunit Abraxas 1	20090422
+UniProtKB	Q6UWZ7	ABRAXAS1	enables	GO:0005515	protein binding	molecular_function	ECO:0000353	IPI	PMID:19261748	UniProtKB:Q96RL1	9606	Homo sapiens	UniProt	BRCA1-A complex subunit Abraxas 1	20090422
+UniProtKB	Q6UWZ7	ABRAXAS1	enables	GO:0005515	protein binding	molecular_function	ECO:0000353	IPI	PMID:19261748	UniProtKB:Q9NXR7	9606	Homo sapiens	UniProt	BRCA1-A complex subunit Abraxas 1	20090422
+UniProtKB	Q6UWZ7	ABRAXAS1	enables	GO:0005515	protein binding	molecular_function	ECO:0000353	IPI	PMID:19261749	UniProtKB:P38398	9606	Homo sapiens	UniProt	BRCA1-A complex subunit Abraxas 1	20090422
+UniProtKB	Q6UWZ7	ABRAXAS1	enables	GO:0005515	protein binding	molecular_function	ECO:0000353	IPI	PMID:19261749	UniProtKB:P46736	9606	Homo sapiens	UniProt	BRCA1-A complex subunit Abraxas 1	20090422
+UniProtKB	Q6UWZ7	ABRAXAS1	enables	GO:0005515	protein binding	molecular_function	ECO:0000353	IPI	PMID:19261749	UniProtKB:Q96RL1	9606	Homo sapiens	UniProt	BRCA1-A complex subunit Abraxas 1	20090422
+UniProtKB	Q6UWZ7	ABRAXAS1	enables	GO:0005515	protein binding	molecular_function	ECO:0000353	IPI	PMID:19261749	UniProtKB:Q9NWV8	9606	Homo sapiens	UniProt	BRCA1-A complex subunit Abraxas 1	20090422
+UniProtKB	Q6UWZ7	ABRAXAS1	enables	GO:0005515	protein binding	molecular_function	ECO:0000353	IPI	PMID:19261749	UniProtKB:Q9NXR7	9606	Homo sapiens	UniProt	BRCA1-A complex subunit Abraxas 1	20090422
+UniProtKB	Q6UWZ7	ABRAXAS1	located_in	GO:0005634	nucleus	cellular_component	ECO:0000314	IDA	PMID:17525340		9606	Homo sapiens	UniProt	BRCA1-A complex subunit Abraxas 1	20090422
+UniProtKB	Q6UWZ7	ABRAXAS1	located_in	GO:0005634	nucleus	cellular_component	ECO:0000314	IDA	PMID:17643121		9606	Homo sapiens	UniProt	BRCA1-A complex subunit Abraxas 1	20090422
+UniProtKB	Q6UWZ7	ABRAXAS1	involved_in	GO:0006302	double-strand break repair	biological_process	ECO:0000315	IMP	PMID:17525340		9606	Homo sapiens	UniProt	BRCA1-A complex subunit Abraxas 1	20090422
+UniProtKB	Q6UWZ7	ABRAXAS1	involved_in	GO:0006302	double-strand break repair	biological_process	ECO:0000315	IMP	PMID:17643121		9606	Homo sapiens	UniProt	BRCA1-A complex subunit Abraxas 1	20090422
+UniProtKB	Q6UWZ7	ABRAXAS1	involved_in	GO:0006302	double-strand break repair	biological_process	ECO:0000315	IMP	PMID:19261748		9606	Homo sapiens	UniProt	BRCA1-A complex subunit Abraxas 1	20090422
+UniProtKB	Q6UWZ7	ABRAXAS1	involved_in	GO:0010212	response to ionizing radiation	biological_process	ECO:0000315	IMP	PMID:17525340		9606	Homo sapiens	UniProt	BRCA1-A complex subunit Abraxas 1	20090422
+UniProtKB	Q6UWZ7	ABRAXAS1	involved_in	GO:0010212	response to ionizing radiation	biological_process	ECO:0000315	IMP	PMID:17643121		9606	Homo sapiens	UniProt	BRCA1-A complex subunit Abraxas 1	20090422
+UniProtKB	Q6UWZ7	ABRAXAS1	involved_in	GO:0010212	response to ionizing radiation	biological_process	ECO:0000315	IMP	PMID:19261748		9606	Homo sapiens	UniProt	BRCA1-A complex subunit Abraxas 1	20090422
+UniProtKB	Q6UWZ7	ABRAXAS1	enables	GO:0031593	polyubiquitin modification-dependent protein binding	molecular_function	ECO:0000314	IDA	PMID:19261749		9606	Homo sapiens	UniProt	BRCA1-A complex subunit Abraxas 1	20090422
+UniProtKB	Q6UWZ7	ABRAXAS1	involved_in	GO:0045739	positive regulation of DNA repair	biological_process	ECO:0000315	IMP	PMID:17525340		9606	Homo sapiens	UniProt	BRCA1-A complex subunit Abraxas 1	20090422
+UniProtKB	Q6UWZ7	ABRAXAS1	involved_in	GO:0045739	positive regulation of DNA repair	biological_process	ECO:0000315	IMP	PMID:19261748		9606	Homo sapiens	UniProt	BRCA1-A complex subunit Abraxas 1	20090422
+UniProtKB	Q6UWZ7	ABRAXAS1	part_of	GO:0070531	BRCA1-A complex	cellular_component	ECO:0000314	IDA	PMID:17525340		9606	Homo sapiens	UniProt	BRCA1-A complex subunit Abraxas 1	20090422
+UniProtKB	Q6UWZ7	ABRAXAS1	part_of	GO:0070531	BRCA1-A complex	cellular_component	ECO:0000314	IDA	PMID:19261746		9606	Homo sapiens	UniProt	BRCA1-A complex subunit Abraxas 1	20090422
+UniProtKB	Q6UWZ7	ABRAXAS1	part_of	GO:0070531	BRCA1-A complex	cellular_component	ECO:0000314	IDA	PMID:19261748		9606	Homo sapiens	UniProt	BRCA1-A complex subunit Abraxas 1	20090422
+UniProtKB	Q6UWZ7	ABRAXAS1	part_of	GO:0070531	BRCA1-A complex	cellular_component	ECO:0000314	IDA	PMID:19261749		9606	Homo sapiens	UniProt	BRCA1-A complex subunit Abraxas 1	20090422

--- a/genes/human/ABRAXAS1/ABRAXAS1-notes.md
+++ b/genes/human/ABRAXAS1/ABRAXAS1-notes.md
@@ -1,0 +1,27 @@
+# ABRAXAS1 review notes
+
+## Evidence setup
+
+- `just fetch-gene human ABRAXAS1` seeded the UniProt, GOA, Reactome, PANTHER family, and review stub files on 2026-06-03.
+- Falcon deep research was attempted with `just deep-research-falcon human ABRAXAS1 --fallback perplexity-lite`. Falcon timed out after 600 seconds; the `perplexity-lite` fallback then failed with a Perplexity API 401 quota error. No provider deep-research file was produced, so this review uses cached publications, UniProt, Reactome, PANTHER, and PN projection files directly.
+
+## Functional synthesis
+
+ABRAXAS1/FAM175A/CCDC98 is a nuclear BRCA1-A complex scaffold and ubiquitin-recognition subunit. The primary literature identifies Abraxas as a BRCA1 BRCT-binding phosphoprotein and RAP80 partner: [PMID:17525340 "identified a protein, Abraxas, that directly binds the BRCA1 BRCT repeats through a phospho-Ser-X-X-Phe motif"] and [PMID:17525340 "Abraxas recruits the ubiquitin-interacting motif (UIM)-containing protein RAP80 to BRCA1"].
+
+The supported biological role is DNA double-strand break response and checkpoint/repair signaling, not a standalone catalytic activity. The key experimental summary is that [PMID:17525340 "Abraxas and RAP80 were required for DNA damage resistance, G(2)-M checkpoint control, and DNA repair"]. A second study frames CCDC98 as the factor that mediates BRCA1-RAP80 association and BRCA1-dependent G2/M checkpoint activation [PMID:17643121 "CCDC98 controls both DNA damage-induced formation of BRCA1 foci and BRCA1-dependent G2/M checkpoint activation"].
+
+ABRAXAS1 is also an organizer of the RAP80/BRCA1-A complex. Feng et al. describe CCDC98 as central to assembly: [PMID:19261748 "CCDC98 as the central component that facilitates the assembly of this protein complex"]. The BRCA1-A/RAP80 complex has BRCC36 K63-linked deubiquitinase activity, but the catalytic subunit is BRCC36, while Abraxas is required for that activity in the RAP80 complex context [PMID:20656689 "Abraxas and BRCC45 were essential for BRCC36 DUB activity within the RAP80 complex"].
+
+## PN projection decision
+
+The PN projection has three ABRAXAS1 rows:
+
+- `GO:0070531 BRCA1-A complex`: already exact in GOA and accepted.
+- `GO:0006281 DNA repair`: already entailed by GOA via `GO:0006302 double-strand break repair`, so no new annotation is needed.
+- `GO:0000151 ubiquitin ligase complex`: new to GOA from the PN group `Ubiquitin Proteasome System|E3 ubiquitin and UBL ligases|idiosyncratic RING complex`. I did not add this as a proposed annotation. ABRAXAS1 is part of BRCA1-A, but the gene-level evidence supports scaffold/polyubiquitin-binding and BRCC36 DUB support rather than direct membership in a generic ubiquitin ligase complex. The PN mapping itself says this is a shared E3-complex bucket and warns against assigning catalytic activity to every subunit.
+
+## Annotation cautions
+
+- `protein binding` rows are real interaction evidence but too uninformative for core molecular function. Mechanistic papers should be interpreted as BRCA1-A complex assembly, RAP80/BRCA1/BRCC36 interaction, and polyubiquitin-dependent recruitment rather than retained as generic protein binding.
+- The IBA microtubule/spindle annotations are projected through a PANTHER node supported by ABRAXAS2 (`WITH/FROM: UniProtKB:Q15018`) rather than ABRAXAS1-specific evidence. I marked `microtubule binding`, `attachment of spindle microtubules to kinetochore`, and `mitotic spindle assembly` for removal for ABRAXAS1.

--- a/genes/human/ABRAXAS1/ABRAXAS1-uniprot.txt
+++ b/genes/human/ABRAXAS1/ABRAXAS1-uniprot.txt
@@ -1,0 +1,539 @@
+ID   ABRX1_HUMAN             Reviewed;         409 AA.
+AC   Q6UWZ7; A5JJ07; Q9H8I1; Q9H9N4;
+DT   20-FEB-2007, integrated into UniProtKB/Swiss-Prot.
+DT   20-FEB-2007, sequence version 2.
+DT   28-JAN-2026, entry version 157.
+DE   RecName: Full=BRCA1-A complex subunit Abraxas 1 {ECO:0000312|HGNC:HGNC:25829};
+DE   AltName: Full=Coiled-coil domain-containing protein 98;
+DE   AltName: Full=Protein FAM175A;
+GN   Name=ABRAXAS1 {ECO:0000312|HGNC:HGNC:25829};
+GN   Synonyms=ABRA1 {ECO:0000312|HGNC:HGNC:25829}, CCDC98, FAM175A
+GN   {ECO:0000312|HGNC:HGNC:25829}; ORFNames=UNQ496/PRO1013;
+OS   Homo sapiens (Human).
+OC   Eukaryota; Metazoa; Chordata; Craniata; Vertebrata; Euteleostomi; Mammalia;
+OC   Eutheria; Euarchontoglires; Primates; Haplorrhini; Catarrhini; Hominidae;
+OC   Homo.
+OX   NCBI_TaxID=9606;
+RN   [1]
+RP   NUCLEOTIDE SEQUENCE [MRNA] (ISOFORM 1), FUNCTION, SUBCELLULAR LOCATION,
+RP   INTERACTION WITH BRCA1 AND UIMC1, PHOSPHORYLATION AT SER-406, AND
+RP   MUTAGENESIS OF SER-406.
+RX   PubMed=17525340; DOI=10.1126/science.1139476;
+RA   Wang B., Matsuoka S., Ballif B.A., Zhang D., Smogorzewska A., Giyi S.,
+RA   Elledge S.J.;
+RT   "Abraxas and RAP80 form a BRCA1 protein complex required for the DNA damage
+RT   response.";
+RL   Science 316:1194-1198(2007).
+RN   [2]
+RP   NUCLEOTIDE SEQUENCE [LARGE SCALE MRNA] (ISOFORM 1), AND VARIANT ASN-373.
+RX   PubMed=12975309; DOI=10.1101/gr.1293003;
+RA   Clark H.F., Gurney A.L., Abaya E., Baker K., Baldwin D.T., Brush J.,
+RA   Chen J., Chow B., Chui C., Crowley C., Currell B., Deuel B., Dowd P.,
+RA   Eaton D., Foster J.S., Grimaldi C., Gu Q., Hass P.E., Heldens S., Huang A.,
+RA   Kim H.S., Klimowski L., Jin Y., Johnson S., Lee J., Lewis L., Liao D.,
+RA   Mark M.R., Robbie E., Sanchez C., Schoenfeld J., Seshagiri S., Simmons L.,
+RA   Singh J., Smith V., Stinson J., Vagts A., Vandlen R.L., Watanabe C.,
+RA   Wieand D., Woods K., Xie M.-H., Yansura D.G., Yi S., Yu G., Yuan J.,
+RA   Zhang M., Zhang Z., Goddard A.D., Wood W.I., Godowski P.J., Gray A.M.;
+RT   "The secreted protein discovery initiative (SPDI), a large-scale effort to
+RT   identify novel human secreted and transmembrane proteins: a bioinformatics
+RT   assessment.";
+RL   Genome Res. 13:2265-2270(2003).
+RN   [3]
+RP   NUCLEOTIDE SEQUENCE [LARGE SCALE GENOMIC DNA].
+RA   Mural R.J., Istrail S., Sutton G.G., Florea L., Halpern A.L., Mobarry C.M.,
+RA   Lippert R., Walenz B., Shatkay H., Dew I., Miller J.R., Flanigan M.J.,
+RA   Edwards N.J., Bolanos R., Fasulo D., Halldorsson B.V., Hannenhalli S.,
+RA   Turner R., Yooseph S., Lu F., Nusskern D.R., Shue B.C., Zheng X.H.,
+RA   Zhong F., Delcher A.L., Huson D.H., Kravitz S.A., Mouchard L., Reinert K.,
+RA   Remington K.A., Clark A.G., Waterman M.S., Eichler E.E., Adams M.D.,
+RA   Hunkapiller M.W., Myers E.W., Venter J.C.;
+RL   Submitted (JUL-2005) to the EMBL/GenBank/DDBJ databases.
+RN   [4]
+RP   NUCLEOTIDE SEQUENCE [LARGE SCALE MRNA] (ISOFORM 1).
+RC   TISSUE=Testis;
+RX   PubMed=15489334; DOI=10.1101/gr.2596504;
+RG   The MGC Project Team;
+RT   "The status, quality, and expansion of the NIH full-length cDNA project:
+RT   the Mammalian Gene Collection (MGC).";
+RL   Genome Res. 14:2121-2127(2004).
+RN   [5]
+RP   NUCLEOTIDE SEQUENCE [LARGE SCALE MRNA] (ISOFORM 2), AND VARIANT THR-348.
+RC   TISSUE=Placenta;
+RX   PubMed=14702039; DOI=10.1038/ng1285;
+RA   Ota T., Suzuki Y., Nishikawa T., Otsuki T., Sugiyama T., Irie R.,
+RA   Wakamatsu A., Hayashi K., Sato H., Nagai K., Kimura K., Makita H.,
+RA   Sekine M., Obayashi M., Nishi T., Shibahara T., Tanaka T., Ishii S.,
+RA   Yamamoto J., Saito K., Kawai Y., Isono Y., Nakamura Y., Nagahari K.,
+RA   Murakami K., Yasuda T., Iwayanagi T., Wagatsuma M., Shiratori A., Sudo H.,
+RA   Hosoiri T., Kaku Y., Kodaira H., Kondo H., Sugawara M., Takahashi M.,
+RA   Kanda K., Yokoi T., Furuya T., Kikkawa E., Omura Y., Abe K., Kamihara K.,
+RA   Katsuta N., Sato K., Tanikawa M., Yamazaki M., Ninomiya K., Ishibashi T.,
+RA   Yamashita H., Murakawa K., Fujimori K., Tanai H., Kimata M., Watanabe M.,
+RA   Hiraoka S., Chiba Y., Ishida S., Ono Y., Takiguchi S., Watanabe S.,
+RA   Yosida M., Hotuta T., Kusano J., Kanehori K., Takahashi-Fujii A., Hara H.,
+RA   Tanase T.-O., Nomura Y., Togiya S., Komai F., Hara R., Takeuchi K.,
+RA   Arita M., Imose N., Musashino K., Yuuki H., Oshima A., Sasaki N.,
+RA   Aotsuka S., Yoshikawa Y., Matsunawa H., Ichihara T., Shiohata N., Sano S.,
+RA   Moriya S., Momiyama H., Satoh N., Takami S., Terashima Y., Suzuki O.,
+RA   Nakagawa S., Senoh A., Mizoguchi H., Goto Y., Shimizu F., Wakebe H.,
+RA   Hishigaki H., Watanabe T., Sugiyama A., Takemoto M., Kawakami B.,
+RA   Yamazaki M., Watanabe K., Kumagai A., Itakura S., Fukuzumi Y., Fujimori Y.,
+RA   Komiyama M., Tashiro H., Tanigami A., Fujiwara T., Ono T., Yamada K.,
+RA   Fujii Y., Ozaki K., Hirao M., Ohmori Y., Kawabata A., Hikiji T.,
+RA   Kobatake N., Inagaki H., Ikema Y., Okamoto S., Okitani R., Kawakami T.,
+RA   Noguchi S., Itoh T., Shigeta K., Senba T., Matsumura K., Nakajima Y.,
+RA   Mizuno T., Morinaga M., Sasaki M., Togashi T., Oyama M., Hata H.,
+RA   Watanabe M., Komatsu T., Mizushima-Sugano J., Satoh T., Shirai Y.,
+RA   Takahashi Y., Nakagawa K., Okumura K., Nagase T., Nomura N., Kikuchi H.,
+RA   Masuho Y., Yamashita R., Nakai K., Yada T., Nakamura Y., Ohara O.,
+RA   Isogai T., Sugano S.;
+RT   "Complete sequencing and characterization of 21,243 full-length human
+RT   cDNAs.";
+RL   Nat. Genet. 36:40-45(2004).
+RN   [6]
+RP   FUNCTION, SUBCELLULAR LOCATION, INTERACTION WITH BRCA1 AND UIMC1,
+RP   PHOSPHORYLATION AT SER-406, AND MUTAGENESIS OF SER-406.
+RX   PubMed=17643121; DOI=10.1038/nsmb1279;
+RA   Liu Z., Wu J., Yu X.;
+RT   "CCDC98 targets BRCA1 to DNA damage sites.";
+RL   Nat. Struct. Mol. Biol. 14:716-720(2007).
+RN   [7]
+RP   FUNCTION, SUBCELLULAR LOCATION, INTERACTION WITH BRCA1 AND UIMC1,
+RP   PHOSPHORYLATION AT SER-406, AND MUTAGENESIS OF SER-406.
+RX   PubMed=17643122; DOI=10.1038/nsmb1277;
+RA   Kim H., Huang J., Chen J.;
+RT   "CCDC98 is a BRCA1-BRCT domain-binding protein involved in the DNA damage
+RT   response.";
+RL   Nat. Struct. Mol. Biol. 14:710-715(2007).
+RN   [8]
+RP   FUNCTION.
+RX   PubMed=18077395; DOI=10.1073/pnas.0710061104;
+RA   Wang B., Elledge S.J.;
+RT   "Ubc13/Rnf8 ubiquitin ligases control foci formation of the
+RT   Rap80/Abraxas/Brca1/Brcc36 complex in response to DNA damage.";
+RL   Proc. Natl. Acad. Sci. U.S.A. 104:20759-20763(2007).
+RN   [9]
+RP   PHOSPHORYLATION [LARGE SCALE ANALYSIS] AT SER-386; SER-387; THR-390 AND
+RP   SER-406, AND IDENTIFICATION BY MASS SPECTROMETRY [LARGE SCALE ANALYSIS].
+RC   TISSUE=Cervix carcinoma;
+RX   PubMed=18669648; DOI=10.1073/pnas.0805139105;
+RA   Dephoure N., Zhou C., Villen J., Beausoleil S.A., Bakalarski C.E.,
+RA   Elledge S.J., Gygi S.P.;
+RT   "A quantitative atlas of mitotic phosphorylation.";
+RL   Proc. Natl. Acad. Sci. U.S.A. 105:10762-10767(2008).
+RN   [10]
+RP   IDENTIFICATION BY MASS SPECTROMETRY [LARGE SCALE ANALYSIS].
+RX   PubMed=19413330; DOI=10.1021/ac9004309;
+RA   Gauci S., Helbig A.O., Slijper M., Krijgsveld J., Heck A.J., Mohammed S.;
+RT   "Lys-N and trypsin cover complementary parts of the phosphoproteome in a
+RT   refined SCX-based approach.";
+RL   Anal. Chem. 81:4493-4501(2009).
+RN   [11]
+RP   IDENTIFICATION IN THE BRCA1-A COMPLEX.
+RX   PubMed=19261746; DOI=10.1101/gad.1739609;
+RA   Shao G., Patterson-Fortin J., Messick T.E., Feng D., Shanbhag N., Wang Y.,
+RA   Greenberg R.A.;
+RT   "MERIT40 controls BRCA1-Rap80 complex integrity and recruitment to DNA
+RT   double-strand breaks.";
+RL   Genes Dev. 23:740-754(2009).
+RN   [12]
+RP   IDENTIFICATION IN THE BRCA1-A COMPLEX, DOMAIN MPN-LIKE, INTERACTION WITH
+RP   UIMC1; BRCC3; BABAM2; BABAM1 AND BRCA1, AND UBIQUITIN-BINDING.
+RX   PubMed=19261749; DOI=10.1101/gad.1770309;
+RA   Wang B., Hurov K., Hofmann K., Elledge S.J.;
+RT   "NBA1, a new player in the Brca1 A complex, is required for DNA damage
+RT   resistance and checkpoint control.";
+RL   Genes Dev. 23:729-739(2009).
+RN   [13]
+RP   FUNCTION, IDENTIFICATION IN THE BRCA1-A COMPLEX, AND INTERACTION WITH
+RP   UIMC1; BRCC3; BABAM2 AND BRCA1.
+RX   PubMed=19261748; DOI=10.1101/gad.1770609;
+RA   Feng L., Huang J., Chen J.;
+RT   "MERIT40 facilitates BRCA1 localization and DNA damage repair.";
+RL   Genes Dev. 23:719-728(2009).
+RN   [14]
+RP   PHOSPHORYLATION [LARGE SCALE ANALYSIS] AT THR-390 AND SER-406, AND
+RP   IDENTIFICATION BY MASS SPECTROMETRY [LARGE SCALE ANALYSIS].
+RC   TISSUE=Leukemic T-cell;
+RX   PubMed=19690332; DOI=10.1126/scisignal.2000007;
+RA   Mayya V., Lundgren D.H., Hwang S.-I., Rezaul K., Wu L., Eng J.K.,
+RA   Rodionov V., Han D.K.;
+RT   "Quantitative phosphoproteomic analysis of T cell receptor signaling
+RT   reveals system-wide modulation of protein-protein interactions.";
+RL   Sci. Signal. 2:RA46-RA46(2009).
+RN   [15]
+RP   PHOSPHORYLATION [LARGE SCALE ANALYSIS] AT SER-386; SER-387; THR-390 AND
+RP   SER-406, AND IDENTIFICATION BY MASS SPECTROMETRY [LARGE SCALE ANALYSIS].
+RC   TISSUE=Cervix carcinoma;
+RX   PubMed=20068231; DOI=10.1126/scisignal.2000475;
+RA   Olsen J.V., Vermeulen M., Santamaria A., Kumar C., Miller M.L.,
+RA   Jensen L.J., Gnad F., Cox J., Jensen T.S., Nigg E.A., Brunak S., Mann M.;
+RT   "Quantitative phosphoproteomics reveals widespread full phosphorylation
+RT   site occupancy during mitosis.";
+RL   Sci. Signal. 3:RA3-RA3(2010).
+RN   [16]
+RP   PHOSPHORYLATION [LARGE SCALE ANALYSIS] AT SER-386; SER-387 AND THR-390, AND
+RP   IDENTIFICATION BY MASS SPECTROMETRY [LARGE SCALE ANALYSIS].
+RX   PubMed=21406692; DOI=10.1126/scisignal.2001570;
+RA   Rigbolt K.T., Prokhorova T.A., Akimov V., Henningsen J., Johansen P.T.,
+RA   Kratchmarova I., Kassem M., Mann M., Olsen J.V., Blagoev B.;
+RT   "System-wide temporal characterization of the proteome and phosphoproteome
+RT   of human embryonic stem cell differentiation.";
+RL   Sci. Signal. 4:RS3-RS3(2011).
+RN   [17]
+RP   IDENTIFICATION IN THE ARISC COMPLEX, AND IDENTIFICATION BY MASS
+RP   SPECTROMETRY.
+RX   PubMed=24075985; DOI=10.1016/j.celrep.2013.08.025;
+RA   Zheng H., Gupta V., Patterson-Fortin J., Bhattacharya S., Katlinski K.,
+RA   Wu J., Varghese B., Carbone C.J., Aressy B., Fuchs S.Y., Greenberg R.A.;
+RT   "A BRISC-SHMT complex deubiquitinates IFNAR1 and regulates interferon
+RT   responses.";
+RL   Cell Rep. 5:180-193(2013).
+RN   [18]
+RP   PHOSPHORYLATION [LARGE SCALE ANALYSIS] AT THR-390 AND SER-406, AND
+RP   IDENTIFICATION BY MASS SPECTROMETRY [LARGE SCALE ANALYSIS].
+RC   TISSUE=Cervix carcinoma, and Erythroleukemia;
+RX   PubMed=23186163; DOI=10.1021/pr300630k;
+RA   Zhou H., Di Palma S., Preisinger C., Peng M., Polat A.N., Heck A.J.,
+RA   Mohammed S.;
+RT   "Toward a comprehensive characterization of a human cancer cell
+RT   phosphoproteome.";
+RL   J. Proteome Res. 12:260-271(2013).
+RN   [19]
+RP   X-RAY CRYSTALLOGRAPHY (3.50 ANGSTROMS) OF 399-409 IN COMPLEX WITH BRCA1,
+RP   AND INTERACTION WITH BRCA1.
+RX   PubMed=24316840; DOI=10.1107/s1744309113030649;
+RA   Badgujar D.C., Sawant U., Vikrant X., Yadav L., Hosur M.V., Varma A.K.;
+RT   "Preliminary crystallographic studies of BRCA1 BRCT-ABRAXAS complex.";
+RL   Acta Crystallogr. F 69:1401-1404(2013).
+RN   [20]
+RP   X-RAY CRYSTALLOGRAPHY (2.50 ANGSTROMS) OF 403-409 IN COMPLEX WITH BRCA1,
+RP   INTERACTION WITH BRCA1, SUBUNIT, FUNCTION, PHOSPHORYLATION AT SER-404 AND
+RP   SER-406, AND MUTAGENESIS OF PHE-400; GLU-402; TYR-403; SER-404 AND SER-406.
+RX   PubMed=26778126; DOI=10.1016/j.molcel.2015.12.017;
+RA   Wu Q., Paul A., Su D., Mehmood S., Foo T.K., Ochi T., Bunting E.L., Xia B.,
+RA   Robinson C.V., Wang B., Blundell T.L.;
+RT   "Structure of BRCA1-BRCT/Abraxas complex reveals phosphorylation-dependent
+RT   BRCT dimerization at DNA damage sites.";
+RL   Mol. Cell 61:434-448(2016).
+RN   [21]
+RP   VARIANTS THR-348 AND ASN-373.
+RX   PubMed=18695986; DOI=10.1007/s10549-008-0134-y;
+RA   Novak D.J., Sabbaghian N., Maillet P., Chappuis P.O., Foulkes W.D.,
+RA   Tischkowitz M.;
+RT   "Analysis of the genes coding for the BRCA1-interacting proteins, RAP80 and
+RT   Abraxas (CCDC98), in high-risk, non-BRCA1/2, multiethnic breast cancer
+RT   cases.";
+RL   Breast Cancer Res. Treat. 117:453-459(2009).
+RN   [22]
+RP   FUNCTION, VARIANTS THR-348 AND ASN-373, VARIANT BC GLN-361, AND
+RP   CHARACTERIZATION OF VARIANT BC GLN-361.
+RX   PubMed=22357538; DOI=10.1126/scitranslmed.3003223;
+RA   Solyom S., Aressy B., Pylkas K., Patterson-Fortin J., Hartikainen J.M.,
+RA   Kallioniemi A., Kauppila S., Nikkila J., Kosma V.M., Mannermaa A.,
+RA   Greenberg R.A., Winqvist R.;
+RT   "Breast cancer-associated Abraxas mutation disrupts nuclear localization
+RT   and DNA damage response functions.";
+RL   Sci. Transl. Med. 4:122ra23-122ra23(2012).
+RN   [23]
+RP   CHARACTERIZATION OF VARIANT BC GLN-361.
+RX   PubMed=25105795; DOI=10.1080/07391102.2014.945484;
+RA   Kumar R.V., Siddiqui Q., Singh N., Waghmare S.K., Varma A.K.;
+RT   "Mislocalization of BRCA1-complex due to ABRAXAS Arg361Gln mutation.";
+RL   J. Biomol. Struct. Dyn. 33:1291-1301(2015).
+CC   -!- FUNCTION: Involved in DNA damage response and double-strand break (DSB)
+CC       repair. Component of the BRCA1-A complex, acting as a central scaffold
+CC       protein that assembles the various components of the complex and
+CC       mediates the recruitment of BRCA1. The BRCA1-A complex specifically
+CC       recognizes 'Lys-63'-linked ubiquitinated histones H2A and H2AX at DNA
+CC       lesion sites, leading to target the BRCA1-BARD1 heterodimer to sites of
+CC       DNA damage at DSBs. This complex also possesses deubiquitinase activity
+CC       that specifically removes 'Lys-63'-linked ubiquitin on histones H2A and
+CC       H2AX. {ECO:0000269|PubMed:17525340, ECO:0000269|PubMed:17643121,
+CC       ECO:0000269|PubMed:17643122, ECO:0000269|PubMed:18077395,
+CC       ECO:0000269|PubMed:19261748, ECO:0000269|PubMed:22357538,
+CC       ECO:0000269|PubMed:26778126}.
+CC   -!- SUBUNIT: Component of the ARISC complex, at least composed of
+CC       UIMC1/RAP80, ABRAXAS1, BRCC3/BRCC36, BABAM2 and BABAM1/NBA1
+CC       (PubMed:24075985). Component of the BRCA1-A complex, at least composed
+CC       of BRCA1, BARD1, UIMC1/RAP80, ABRAXAS1, BRCC3/BRCC36, BABAM2 and
+CC       BABAM1/NBA1. In the complex, interacts directly with UIMC1/RAP80,
+CC       BRCC3/BRCC36 and BABAM2. Interacts directly (when phosphorylated at
+CC       Ser-406) with BRCA1. Homodimer. The homodimer interacts directly (when
+CC       phosphorylated at Ser-404 and Ser-406) with two BRCA1 chains, giving
+CC       rise to a heterotetramer. Binds polyubiquitin.
+CC       {ECO:0000269|PubMed:17525340, ECO:0000269|PubMed:17643121,
+CC       ECO:0000269|PubMed:17643122, ECO:0000269|PubMed:19261746,
+CC       ECO:0000269|PubMed:19261748, ECO:0000269|PubMed:19261749,
+CC       ECO:0000269|PubMed:24075985, ECO:0000269|PubMed:24316840,
+CC       ECO:0000269|PubMed:26778126}.
+CC   -!- INTERACTION:
+CC       Q6UWZ7; P38398: BRCA1; NbExp=16; IntAct=EBI-1263451, EBI-349905;
+CC       Q6UWZ7; P46736: BRCC3; NbExp=4; IntAct=EBI-1263451, EBI-750352;
+CC       Q6UWZ7; P13569: CFTR; NbExp=3; IntAct=EBI-1263451, EBI-349854;
+CC       Q6UWZ7; O00629: KPNA4; NbExp=2; IntAct=EBI-1263451, EBI-396343;
+CC       Q6UWZ7; Q96RL1: UIMC1; NbExp=9; IntAct=EBI-1263451, EBI-725300;
+CC       Q6UWZ7; Q96RL1-1: UIMC1; NbExp=4; IntAct=EBI-1263451, EBI-9640371;
+CC   -!- SUBCELLULAR LOCATION: Nucleus {ECO:0000269|PubMed:17525340,
+CC       ECO:0000269|PubMed:17643121, ECO:0000269|PubMed:17643122}.
+CC       Note=Localizes at sites of DNA damage at double-strand breaks (DSBs).
+CC       {ECO:0000305}.
+CC   -!- ALTERNATIVE PRODUCTS:
+CC       Event=Alternative splicing; Named isoforms=2;
+CC       Name=1;
+CC         IsoId=Q6UWZ7-1; Sequence=Displayed;
+CC       Name=2;
+CC         IsoId=Q6UWZ7-2; Sequence=VSP_058196;
+CC   -!- PTM: Phosphorylation of Ser-406 of the pSXXF motif by ATM or ATR
+CC       constitutes a specific recognition motif for the BRCT domain of BRCA1
+CC       (PubMed:17525340, PubMed:17643121, PubMed:17643122). Ionizing radiation
+CC       promotes rapid phosphorylation at Ser-404 and Ser-406 by ATM; this
+CC       promotes recruitment of BRCA1 to sites of DNA damage (PubMed:26778126).
+CC       {ECO:0000269|PubMed:17525340, ECO:0000269|PubMed:17643121,
+CC       ECO:0000269|PubMed:17643122, ECO:0000269|PubMed:26778126}.
+CC   -!- DISEASE: Breast cancer (BC) [MIM:114480]: A common malignancy
+CC       originating from breast epithelial tissue. Breast neoplasms can be
+CC       distinguished by their histologic pattern. Invasive ductal carcinoma is
+CC       by far the most common type. Breast cancer is etiologically and
+CC       genetically heterogeneous. Important genetic factors have been
+CC       indicated by familial occurrence and bilateral involvement. Mutations
+CC       at more than one locus can be involved in different families or even in
+CC       the same case. {ECO:0000269|PubMed:22357538,
+CC       ECO:0000269|PubMed:25105795}. Note=Disease susceptibility is associated
+CC       with variants affecting the gene represented in this entry.
+CC   -!- SIMILARITY: Belongs to the FAM175 family. Abraxas subfamily.
+CC       {ECO:0000305}.
+CC   -!- SEQUENCE CAUTION:
+CC       Sequence=AAH39573.1; Type=Erroneous initiation; Note=Truncated N-terminus.; Evidence={ECO:0000305};
+CC   ---------------------------------------------------------------------------
+CC   Copyrighted by the UniProt Consortium, see https://www.uniprot.org/terms
+CC   Distributed under the Creative Commons Attribution (CC BY 4.0) License
+CC   ---------------------------------------------------------------------------
+DR   EMBL; AY358576; AAQ88939.1; -; mRNA.
+DR   EMBL; EF531340; ABP87396.1; -; mRNA.
+DR   EMBL; CH471057; EAX05942.1; -; Genomic_DNA.
+DR   EMBL; BC039573; AAH39573.1; ALT_INIT; mRNA.
+DR   EMBL; AK022704; BAB14189.1; -; mRNA.
+DR   EMBL; AK023676; BAB14635.1; -; mRNA.
+DR   CCDS; CCDS3605.2; -. [Q6UWZ7-1]
+DR   RefSeq; NP_001332891.1; NM_001345962.2. [Q6UWZ7-2]
+DR   RefSeq; NP_620775.2; NM_139076.3. [Q6UWZ7-1]
+DR   PDB; 4JLU; X-ray; 3.50 A; B=399-409.
+DR   PDB; 4U4A; X-ray; 3.51 A; D/E/F=399-409.
+DR   PDB; 4Y18; X-ray; 3.50 A; I/J/K/L/M/N/O/P=399-409.
+DR   PDB; 4Y2G; X-ray; 2.50 A; B=403-409.
+DR   PDBsum; 4JLU; -.
+DR   PDBsum; 4U4A; -.
+DR   PDBsum; 4Y18; -.
+DR   PDBsum; 4Y2G; -.
+DR   AlphaFoldDB; Q6UWZ7; -.
+DR   SMR; Q6UWZ7; -.
+DR   BioGRID; 123911; 43.
+DR   ComplexPortal; CPX-4425; BRCA1-A complex.
+DR   CORUM; Q6UWZ7; -.
+DR   DIP; DIP-29615N; -.
+DR   ELM; Q6UWZ7; -.
+DR   FunCoup; Q6UWZ7; 2756.
+DR   IntAct; Q6UWZ7; 19.
+DR   MINT; Q6UWZ7; -.
+DR   STRING; 9606.ENSP00000369857; -.
+DR   GlyGen; Q6UWZ7; 1 site, 1 O-linked glycan (1 site).
+DR   iPTMnet; Q6UWZ7; -.
+DR   PhosphoSitePlus; Q6UWZ7; -.
+DR   BioMuta; ABRAXAS1; -.
+DR   DMDM; 126215684; -.
+DR   jPOST; Q6UWZ7; -.
+DR   MassIVE; Q6UWZ7; -.
+DR   PaxDb; 9606-ENSP00000369857; -.
+DR   PeptideAtlas; Q6UWZ7; -.
+DR   ProteomicsDB; 67539; -.
+DR   Pumba; Q6UWZ7; -.
+DR   Antibodypedia; 25225; 195 antibodies from 33 providers.
+DR   DNASU; 84142; -.
+DR   Ensembl; ENST00000321945.12; ENSP00000369857.3; ENSG00000163322.15. [Q6UWZ7-1]
+DR   GeneID; 84142; -.
+DR   KEGG; hsa:84142; -.
+DR   MANE-Select; ENST00000321945.12; ENSP00000369857.3; NM_139076.3; NP_620775.2.
+DR   UCSC; uc003hou.3; human. [Q6UWZ7-1]
+DR   AGR; HGNC:25829; -.
+DR   ClinPGx; PA162387308; -.
+DR   CTD; 84142; -.
+DR   DisGeNET; 84142; -.
+DR   GeneCards; ABRAXAS1; -.
+DR   HGNC; HGNC:25829; ABRAXAS1.
+DR   HPA; ENSG00000163322; Low tissue specificity.
+DR   MalaCards; ABRAXAS1; -.
+DR   MIM; 114480; phenotype.
+DR   MIM; 611143; gene.
+DR   OpenTargets; ENSG00000163322; -.
+DR   VEuPathDB; HostDB:ENSG00000163322; -.
+DR   eggNOG; ENOG502QVCD; Eukaryota.
+DR   GeneTree; ENSGT00530000063424; -.
+DR   HOGENOM; CLU_056671_0_1_1; -.
+DR   InParanoid; Q6UWZ7; -.
+DR   OrthoDB; 6358435at2759; -.
+DR   PAN-GO; Q6UWZ7; 6 GO annotations based on evolutionary models.
+DR   PhylomeDB; Q6UWZ7; -.
+DR   PathwayCommons; Q6UWZ7; -.
+DR   Reactome; R-HSA-5689901; Metalloprotease DUBs.
+DR   Reactome; R-HSA-5693565; Recruitment and ATM-mediated phosphorylation of repair and signaling proteins at DNA double strand breaks.
+DR   Reactome; R-HSA-5693571; Nonhomologous End-Joining (NHEJ).
+DR   Reactome; R-HSA-5693607; Processing of DNA double-strand break ends.
+DR   Reactome; R-HSA-69473; G2/M DNA damage checkpoint.
+DR   SignaLink; Q6UWZ7; -.
+DR   SIGNOR; Q6UWZ7; -.
+DR   Agora; ENSG00000163322; -.
+DR   BioGRID-ORCS; 84142; 56 hits in 1167 CRISPR screens.
+DR   ChiTaRS; FAM175A; human.
+DR   EvolutionaryTrace; Q6UWZ7; -.
+DR   GenomeRNAi; 84142; -.
+DR   Pharos; Q6UWZ7; Tbio.
+DR   PRO; PR:Q6UWZ7; -.
+DR   Proteomes; UP000005640; Chromosome 4.
+DR   RNAct; Q6UWZ7; protein.
+DR   Bgee; ENSG00000163322; Expressed in primordial germ cell in gonad and 185 other cell types or tissues.
+DR   ExpressionAtlas; Q6UWZ7; baseline and differential.
+DR   GO; GO:0070531; C:BRCA1-A complex; IDA:UniProtKB.
+DR   GO; GO:0016604; C:nuclear body; IDA:HPA.
+DR   GO; GO:0005654; C:nucleoplasm; TAS:Reactome.
+DR   GO; GO:0005634; C:nucleus; IDA:UniProtKB.
+DR   GO; GO:0008017; F:microtubule binding; IBA:GO_Central.
+DR   GO; GO:0031593; F:polyubiquitin modification-dependent protein binding; IDA:UniProtKB.
+DR   GO; GO:0008608; P:attachment of spindle microtubules to kinetochore; IBA:GO_Central.
+DR   GO; GO:0006325; P:chromatin organization; IEA:UniProtKB-KW.
+DR   GO; GO:0006302; P:double-strand break repair; IMP:UniProtKB.
+DR   GO; GO:0007095; P:mitotic G2 DNA damage checkpoint signaling; IMP:UniProtKB.
+DR   GO; GO:0044818; P:mitotic G2/M transition checkpoint; NAS:ComplexPortal.
+DR   GO; GO:0090307; P:mitotic spindle assembly; IBA:GO_Central.
+DR   GO; GO:0045739; P:positive regulation of DNA repair; IMP:UniProtKB.
+DR   GO; GO:0006282; P:regulation of DNA repair; NAS:ComplexPortal.
+DR   GO; GO:0010212; P:response to ionizing radiation; IMP:UniProtKB.
+DR   CDD; cd23523; Abraxas_1; 1.
+DR   InterPro; IPR023239; BRISC_Abraxas1.
+DR   InterPro; IPR023238; FAM175.
+DR   InterPro; IPR037518; MPN.
+DR   PANTHER; PTHR31728; ABRAXAS FAMILY MEMBER; 1.
+DR   PANTHER; PTHR31728:SF2; BRCA1-A COMPLEX SUBUNIT ABRAXAS 1; 1.
+DR   Pfam; PF21125; MPN_2A_DUB_like; 1.
+DR   PRINTS; PR02052; ABRAXAS.
+DR   PRINTS; PR02051; PROTEINF175.
+DR   PROSITE; PS50249; MPN; 1.
+PE   1: Evidence at protein level;
+KW   3D-structure; Alternative splicing; Chromatin regulator; Coiled coil;
+KW   Disease variant; DNA damage; DNA repair; Nucleus; Phosphoprotein;
+KW   Proteomics identification; Reference proteome.
+FT   CHAIN           1..409
+FT                   /note="BRCA1-A complex subunit Abraxas 1"
+FT                   /id="PRO_0000278575"
+FT   DOMAIN          7..160
+FT                   /note="MPN"
+FT                   /evidence="ECO:0000255|PROSITE-ProRule:PRU01182"
+FT   REGION          362..409
+FT                   /note="Disordered"
+FT                   /evidence="ECO:0000256|SAM:MobiDB-lite"
+FT   COILED          206..260
+FT                   /evidence="ECO:0000255"
+FT   MOTIF           406..409
+FT                   /note="pSXXF motif"
+FT                   /evidence="ECO:0000305"
+FT   COMPBIAS        362..372
+FT                   /note="Basic and acidic residues"
+FT                   /evidence="ECO:0000256|SAM:MobiDB-lite"
+FT   COMPBIAS        373..388
+FT                   /note="Polar residues"
+FT                   /evidence="ECO:0000256|SAM:MobiDB-lite"
+FT   MOD_RES         48
+FT                   /note="Phosphoserine"
+FT                   /evidence="ECO:0000250|UniProtKB:Q8BPZ8"
+FT   MOD_RES         386
+FT                   /note="Phosphoserine"
+FT                   /evidence="ECO:0007744|PubMed:18669648,
+FT                   ECO:0007744|PubMed:20068231, ECO:0007744|PubMed:21406692"
+FT   MOD_RES         387
+FT                   /note="Phosphoserine"
+FT                   /evidence="ECO:0007744|PubMed:18669648,
+FT                   ECO:0007744|PubMed:20068231, ECO:0007744|PubMed:21406692"
+FT   MOD_RES         390
+FT                   /note="Phosphothreonine"
+FT                   /evidence="ECO:0007744|PubMed:18669648,
+FT                   ECO:0007744|PubMed:19690332, ECO:0007744|PubMed:20068231,
+FT                   ECO:0007744|PubMed:21406692, ECO:0007744|PubMed:23186163"
+FT   MOD_RES         404
+FT                   /note="Phosphoserine"
+FT                   /evidence="ECO:0000269|PubMed:26778126"
+FT   MOD_RES         406
+FT                   /note="Phosphoserine"
+FT                   /evidence="ECO:0000269|PubMed:17525340,
+FT                   ECO:0000269|PubMed:17643121, ECO:0000269|PubMed:17643122,
+FT                   ECO:0000269|PubMed:26778126, ECO:0007744|PubMed:18669648,
+FT                   ECO:0007744|PubMed:19690332, ECO:0007744|PubMed:20068231,
+FT                   ECO:0007744|PubMed:23186163"
+FT   VAR_SEQ         1..109
+FT                   /note="Missing (in isoform 2)"
+FT                   /id="VSP_058196"
+FT   VARIANT         239
+FT                   /note="A -> T (in dbSNP:rs752929794)"
+FT                   /id="VAR_030790"
+FT   VARIANT         348
+FT                   /note="A -> T (in dbSNP:rs12642536)"
+FT                   /evidence="ECO:0000269|PubMed:14702039,
+FT                   ECO:0000269|PubMed:18695986, ECO:0000269|PubMed:22357538"
+FT                   /id="VAR_054054"
+FT   VARIANT         361
+FT                   /note="R -> Q (in BC; results in reduced DSB repair
+FT                   efficiency; primarily localizes to the cytoplasm and has
+FT                   reduced nuclear localization; does not affect interaction
+FT                   with BRCA1; results in highly reduced interaction with
+FT                   UIMC1/RAP80; dbSNP:rs201627097)"
+FT                   /evidence="ECO:0000269|PubMed:22357538,
+FT                   ECO:0000269|PubMed:25105795"
+FT                   /id="VAR_071865"
+FT   VARIANT         373
+FT                   /note="D -> N (in dbSNP:rs13125836)"
+FT                   /evidence="ECO:0000269|PubMed:12975309,
+FT                   ECO:0000269|PubMed:18695986, ECO:0000269|PubMed:22357538"
+FT                   /id="VAR_054055"
+FT   MUTAGEN         400
+FT                   /note="F->D: No effect on formation of a heterotetramer
+FT                   with BRCA1."
+FT                   /evidence="ECO:0000269|PubMed:26778126"
+FT   MUTAGEN         402
+FT                   /note="E->R: Decreases formation of a heterotetramer with
+FT                   BRCA1."
+FT                   /evidence="ECO:0000269|PubMed:26778126"
+FT   MUTAGEN         403
+FT                   /note="Y->A: No effect on formation of a heterotetramer
+FT                   with BRCA1."
+FT                   /evidence="ECO:0000269|PubMed:26778126"
+FT   MUTAGEN         404
+FT                   /note="S->A: No effect on homodimerization. Mildly
+FT                   decreased recruitment of BRCA1 to sites of DNA damage."
+FT                   /evidence="ECO:0000269|PubMed:26778126"
+FT   MUTAGEN         404
+FT                   /note="S->D: Permits formation of a heterotetramer with
+FT                   BRCA1."
+FT                   /evidence="ECO:0000269|PubMed:26778126"
+FT   MUTAGEN         404
+FT                   /note="S->P: Abolishes formation of a heterotetramer with
+FT                   BRCA1. Does not affect interaction with a first BRCA1
+FT                   chain."
+FT                   /evidence="ECO:0000269|PubMed:26778126"
+FT   MUTAGEN         406
+FT                   /note="S->A: Abolishes phosphorylation of the pSXXF motif
+FT                   and the interaction with BRCA1 but does not affect the
+FT                   interaction with UIMC1/RAP80. Strongly decreases
+FT                   recruitment of BRCA1 to sites of DNA damage. No effect on
+FT                   homodimerization."
+FT                   /evidence="ECO:0000269|PubMed:17525340,
+FT                   ECO:0000269|PubMed:17643121, ECO:0000269|PubMed:17643122,
+FT                   ECO:0000269|PubMed:26778126"
+SQ   SEQUENCE   409 AA;  46663 MW;  A1ACA4F759BD1AEE CRC64;
+     MEGESTSAVL SGFVLGALAF QHLNTDSDTE GFLLGEVKGE AKNSITDSQM DDVEVVYTID
+     IQKYIPCYQL FSFYNSSGEV NEQALKKILS NVKKNVVGWY KFRRHSDQIM TFRERLLHKN
+     LQEHFSNQDL VFLLLTPSII TESCSTHRLE HSLYKPQKGL FHRVPLVVAN LGMSEQLGYK
+     TVSGSCMSTG FSRAVQTHSS KFFEEDGSLK EVHKINEMYA SLQEELKSIC KKVEDSEQAV
+     DKLVKDVNRL KREIEKRRGA QIQAAREKNI QKDPQENIFL CQALRTFFPN SEFLHSCVMS
+     LKNRHVSKSS CNYNHHLDVV DNLTLMVEHT DIPEASPAST PQIIKHKALD LDDRWQFKRS
+     RLLDTQDKRS KADTGSSNQD KASKMSSPET DEEIEKMKGF GEYSRSPTF
+//

--- a/interpro/panther/PTHR31728/PTHR31728-entries.csv
+++ b/interpro/panther/PTHR31728/PTHR31728-entries.csv
@@ -1,0 +1,16 @@
+id,name,entry_type,source_tax_id,source_tax_name,full_tax_name,gene,length,subfamily,subfamily_name,in_alphafold
+A0A8M3AJY3,BRISC complex subunit abraxas 2,protein,7955,Danio rerio,Danio rerio (Zebrafish),abraxas2,416,PTHR31728:SF1,BRISC COMPLEX SUBUNIT ABRAXAS 2,True
+A6QLR3,BRISC complex subunit Abraxas 2,protein,9913,Bos taurus,Bos taurus (Bovine),ABRAXAS2,409,PTHR31728:SF1,BRISC COMPLEX SUBUNIT ABRAXAS 2,True
+B5X1P9,BRCA1-A complex subunit Abraxas 1,protein,8030,Salmo salar,Salmo salar (Atlantic salmon),abraxas1,404,PTHR31728:SF2,BRCA1-A COMPLEX SUBUNIT ABRAXAS 1,True
+E2AB17,BRISC complex subunit FAM175B,protein,104421,Camponotus floridanus,Camponotus floridanus (Florida carpenter ant),EAG_01033,471,PTHR31728:SF5,OS07G0540200 PROTEIN,True
+Q15018,BRISC complex subunit Abraxas 2,protein,9606,Homo sapiens,Homo sapiens (Human),ABRAXAS2,415,PTHR31728:SF1,BRISC COMPLEX SUBUNIT ABRAXAS 2,True
+Q1LVP6,BRCA1-A complex subunit Abraxas 1,protein,7955,Danio rerio,Danio rerio (Zebrafish),abraxas1,391,PTHR31728:SF2,BRCA1-A COMPLEX SUBUNIT ABRAXAS 1,True
+Q28HX0,BRCA1-A complex subunit Abraxas 1,protein,8364,Xenopus tropicalis,Xenopus tropicalis (Western clawed frog),abraxas1,408,PTHR31728:SF2,BRCA1-A COMPLEX SUBUNIT ABRAXAS 1,True
+Q3TCJ1,BRISC complex subunit Abraxas 2,protein,10090,Mus musculus,Mus musculus (Mouse),Abraxas2,415,PTHR31728:SF1,BRISC COMPLEX SUBUNIT ABRAXAS 2,True
+Q5E9P1,BRCA1-A complex subunit Abraxas 1,protein,9913,Bos taurus,Bos taurus (Bovine),ABRAXAS1,410,PTHR31728:SF2,BRCA1-A COMPLEX SUBUNIT ABRAXAS 1,True
+Q5I0F1,BRCA1-A complex subunit Abraxas 1,protein,10116,Rattus norvegicus,Rattus norvegicus (Rat),ABRAXAS1,405,PTHR31728:SF2,BRCA1-A COMPLEX SUBUNIT ABRAXAS 1,True
+Q5ZHS0,BRCA1-A complex subunit Abraxas 1,protein,9031,Gallus gallus,Gallus gallus (Chicken),ABRAXAS1,405,PTHR31728:SF2,BRCA1-A COMPLEX SUBUNIT ABRAXAS 1,True
+Q6GR31,BRCA1-A complex subunit Abraxas 1,protein,8355,Xenopus laevis,Xenopus laevis (African clawed frog),abraxas1,408,PTHR31728:SF2,BRCA1-A COMPLEX SUBUNIT ABRAXAS 1,True
+Q6P4W0,BRISC complex subunit Abraxas 2,protein,8364,Xenopus tropicalis,Xenopus tropicalis (Western clawed frog),abraxas2,390,PTHR31728:SF1,BRISC COMPLEX SUBUNIT ABRAXAS 2,True
+Q6UWZ7,BRCA1-A complex subunit Abraxas 1,protein,9606,Homo sapiens,Homo sapiens (Human),ABRAXAS1,409,PTHR31728:SF2,BRCA1-A COMPLEX SUBUNIT ABRAXAS 1,True
+Q8BPZ8,BRCA1-A complex subunit Abraxas 1,protein,10090,Mus musculus,Mus musculus (Mouse),Abraxas1,407,PTHR31728:SF2,BRCA1-A COMPLEX SUBUNIT ABRAXAS 1,True

--- a/interpro/panther/PTHR31728/PTHR31728-metadata.yaml
+++ b/interpro/panther/PTHR31728/PTHR31728-metadata.yaml
@@ -1,0 +1,44 @@
+metadata:
+  accession: PTHR31728
+  entry_id: null
+  type: family
+  go_terms: null
+  source_database: panther
+  member_databases: null
+  integrated: IPR023238
+  hierarchy: null
+  name:
+    name: ABRAXAS FAMILY MEMBER
+    short: null
+  description: null
+  wikipedia: null
+  literature: null
+  set_info: null
+  overlaps_with: null
+  counters:
+    subfamilies: 5
+    domain_architectures: 0
+    interactions: 0
+    matches: 3128
+    pathways: 0
+    proteins: 3128
+    proteomes: 1390
+    sets: 0
+    structural_models:
+      alphafold: 2847
+      bfvd: 0
+    structures: 8
+    taxa: 4592
+  entry_annotations:
+    hmm: 0
+    logo: 0
+  cross_references: {}
+  is_llm: false
+  is_reviewed_llm: false
+  is_updated_llm: false
+  representative_structure: null
+_fetch_info:
+  fetched_date: '2026-06-03T09:01:38.328015'
+  api_endpoint: https://www.ebi.ac.uk/interpro/api/entry/panther/PTHR31728/
+  database: panther
+  family_id: PTHR31728

--- a/publications/PMID_18077395.md
+++ b/publications/PMID_18077395.md
@@ -1,0 +1,62 @@
+---
+pmid: '18077395'
+title: Ubc13/Rnf8 ubiquitin ligases control foci formation of the Rap80/Abraxas/Brca1/Brcc36
+  complex in response to DNA damage.
+authors:
+- Wang B
+- Elledge SJ
+journal: Proc Natl Acad Sci U S A
+year: '2007'
+full_text_available: false
+pmcid: PMC2410075
+doi: 10.1073/pnas.0710061104
+---
+
+# Ubc13/Rnf8 ubiquitin ligases control foci formation of the Rap80/Abraxas/Brca1/Brcc36 complex in response to DNA damage.
+**Authors:** Wang B, Elledge SJ
+**Journal:** Proc Natl Acad Sci U S A (2007)
+**DOI:** [10.1073/pnas.0710061104](https://doi.org/10.1073/pnas.0710061104)
+**PMC:** [PMC2410075](https://www.ncbi.nlm.nih.gov/pmc/articles/PMC2410075/)
+
+## Abstract
+
+1. Proc Natl Acad Sci U S A. 2007 Dec 26;104(52):20759-63. doi: 
+10.1073/pnas.0710061104. Epub 2007 Dec 5.
+
+Ubc13/Rnf8 ubiquitin ligases control foci formation of the 
+Rap80/Abraxas/Brca1/Brcc36 complex in response to DNA damage.
+
+Wang B(1), Elledge SJ.
+
+Author information:
+(1)Department of Genetics, Howard Hughes Medical Institute, Center for Genetics 
+and Genomics, Brigham and Women's Hospital, Harvard University Medical School, 
+Boston, MA 02115, USA.
+
+Comment in
+    Proc Natl Acad Sci U S A. 2007 Dec 26;104(52):20645-6. doi: 
+10.1073/pnas.0710916105.
+
+The Brca1 A complex contains Brca1/Bard1, Abraxas, Rap80, and Brcc36; however, 
+with the exception of the Brca1-Abraxas interaction, how the A complex is 
+assembled is not known. The A complex is localized to sites of DNA damage 
+through the UIM domains of RAP80, which bind K63-linked polyubiquitin chains. In 
+this study, we identified an FHA domain RING finger E3 ubiquitin ligase, RNF8, 
+and an E2-conjugating enzyme known to form K63-polyubiquitin chains, Ubc13, each 
+of which is required to recruit the Brca1 A complex to sites of DNA damage. Rnf8 
+localizes to sites of DNA damage through an FHA-domain-containing region. We 
+found that Rap80 contains an Abraxas interaction domain [AIR 
+(Abraxas-interacting region)], required for association of Rap80 with Abraxas, 
+Brca1, and Brcc36. Abraxas and Brcc36 associate through coiled-coil domains on 
+each protein. These data suggest a model through which Ubc13 and Rnf8 are 
+recruited to sites of DNA damage through DNA-damage-induced phosphorylation of a 
+chromatin-associated protein and generate polyubiquitin chains that then recruit 
+Rap80 and the entire Brca1 A complex to DNA-damage foci. This sequential E3 
+ubiquitin ligase recruitment constitutes a ubiquitin ligase cascade required for 
+DNA repair and checkpoint signaling.
+
+DOI: 10.1073/pnas.0710061104
+PMCID: PMC2410075
+PMID: 18077395 [Indexed for MEDLINE]
+
+Conflict of interest statement: The authors declare no conflict of interest.

--- a/publications/PMID_19261746.md
+++ b/publications/PMID_19261746.md
@@ -1,0 +1,59 @@
+---
+pmid: '19261746'
+title: MERIT40 controls BRCA1-Rap80 complex integrity and recruitment to DNA double-strand
+  breaks.
+authors:
+- Shao G
+- Patterson-Fortin J
+- Messick TE
+- Feng D
+- Shanbhag N
+- Wang Y
+- Greenberg RA
+journal: Genes Dev
+year: '2009'
+full_text_available: false
+pmcid: PMC2661612
+doi: 10.1101/gad.1739609
+---
+
+# MERIT40 controls BRCA1-Rap80 complex integrity and recruitment to DNA double-strand breaks.
+**Authors:** Shao G, Patterson-Fortin J, Messick TE, Feng D, Shanbhag N, Wang Y, Greenberg RA
+**Journal:** Genes Dev (2009)
+**DOI:** [10.1101/gad.1739609](https://doi.org/10.1101/gad.1739609)
+**PMC:** [PMC2661612](https://www.ncbi.nlm.nih.gov/pmc/articles/PMC2661612/)
+
+## Abstract
+
+1. Genes Dev. 2009 Mar 15;23(6):740-54. doi: 10.1101/gad.1739609. Epub 2009 Mar
+4.
+
+MERIT40 controls BRCA1-Rap80 complex integrity and recruitment to DNA 
+double-strand breaks.
+
+Shao G(1), Patterson-Fortin J, Messick TE, Feng D, Shanbhag N, Wang Y, Greenberg 
+RA.
+
+Author information:
+(1)Department of Cancer Biology, Abramson Family Cancer Research Institute, 
+University of Pennsylvania School of Medicine, Philadelphia, Pennsylvania 19104, 
+USA.
+
+Rap80 targets the breast cancer suppressor protein BRCA1 along with Abraxas and 
+the BRCC36 deubiquitinating enzyme (DUB) to polyubiquitin structures at DNA 
+double-strand breaks (DSBs). These DSB targeting events are essential for 
+BRCA1-dependent DNA damage response-induced checkpoint and repair functions. 
+Here, we identify MERIT40 (Mediator of Rap80 Interactions and Targeting 40 
+kD)/(C19orf62) as a Rap80-associated protein that is essential for BRCA1-Rap80 
+complex protein interactions, stability, and DSB targeting. Moreover, MERIT40 is 
+required for Rap80-associated lysine(63)-ubiquitin DUB activity, a critical 
+component of BRCA1-Rap80 G2 checkpoint and viability responses to ionizing 
+radiation. Thus, MERIT40 represents a novel factor that links BRCA1-Rap80 
+complex integrity, DSB recognition, and ubiquitin chain hydrolytic activities to 
+the DNA damage response. These findings provide new molecular insights into how 
+BRCA1 associates with independently assembled core protein complexes to maintain 
+genome integrity.
+
+DOI: 10.1101/gad.1739609
+PMCID: PMC2661612
+PMID: 19261746 [Indexed for MEDLINE]

--- a/reactome/R-HSA-5683384.md
+++ b/reactome/R-HSA-5683384.md
@@ -1,0 +1,20 @@
+---
+stable_id: R-HSA-5683384
+display_name: UIMC1 and FAM175A bind DNA DSBs
+species: Homo sapiens
+summary: 'UIMC1 (RAP80) is recruited to DNA double-strand breaks (DSBs) through the
+  interaction of its UIM (ubiquitin interaction motif) region with H2AFX (H2AX) ubiquitinated
+  by RNF8 and RNF168 (Huen et al. 2007, Wang and Elledge 2007, Kolas et al. 2007,
+  Mailand et al. 2007). A simultaneous interaction with FAM175A (Abraxas) through
+  the AIR (Abraxas-interaction region) domain of UIMC1 facilitates UIMC1 binding to
+  DNA DSBs. The interaction between UIMC1 and FAM175A and their loading to DNA DSBs
+  is independent of BRCA1 (Wang et al. 2007, Wang and Elledge 2007). '
+---
+
+# UIMC1 and FAM175A bind DNA DSBs
+**Reactome ID:** [R-HSA-5683384](https://reactome.org/content/detail/R-HSA-5683384)
+**Species:** Homo sapiens
+
+## Summary
+
+UIMC1 (RAP80) is recruited to DNA double-strand breaks (DSBs) through the interaction of its UIM (ubiquitin interaction motif) region with H2AFX (H2AX) ubiquitinated by RNF8 and RNF168 (Huen et al. 2007, Wang and Elledge 2007, Kolas et al. 2007, Mailand et al. 2007). A simultaneous interaction with FAM175A (Abraxas) through the AIR (Abraxas-interaction region) domain of UIMC1 facilitates UIMC1 binding to DNA DSBs. The interaction between UIMC1 and FAM175A and their loading to DNA DSBs is independent of BRCA1 (Wang et al. 2007, Wang and Elledge 2007). 


### PR DESCRIPTION
## Summary
- Added the human `ABRAXAS1` review package for the Proteostasis PN batch: fetched UniProt/GOA evidence, review YAML, notes, rendered HTML, PANTHER family cache, and newly needed PMID/Reactome cache files.
- Reviewed 50 existing GO annotations conservatively: accepted the BRCA1-A/DNA damage response core, marked generic `protein binding` as over-annotated, and removed ABRAXAS2-derived spindle/microtubule IBA projections.
- Evaluated the PN projection context and did not add `GO:0000151 ubiquitin ligase complex`; ABRAXAS1 evidence supports BRCA1-A scaffold/polyubiquitin-dependent DNA damage signaling and BRCC36 DUB support, not a broad gene-level ubiquitin ligase-complex annotation.

## Deep Research
- Attempted Falcon deep research with `just deep-research-falcon human ABRAXAS1 --fallback perplexity-lite`.
- Falcon timed out after 600 seconds; the `perplexity-lite` fallback failed with a Perplexity API 401 quota error.
- No provider deep-research file was produced; this limitation and the fallback evidence sources are documented in `ABRAXAS1-notes.md`.

## Checks
- `just validate human ABRAXAS1`
- `just render human ABRAXAS1`
