### PR TITLE
[codex] Review ATP6V0B for proteostasis PN

### DIFF
--- a/genes/human/ATP6V0B/ATP6V0B-ai-review.html
+++ b/genes/human/ATP6V0B/ATP6V0B-ai-review.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Q99437 - AI Gene Review</title>
+    <title>ATP6V0B - AI Gene Review</title>
     <style>
         :root {
             --color-accept: #22c55e;
@@ -726,35 +726,35 @@
 </head>
 <body>
     <div class="header">
-        <h1>Q99437</h1>
+        <h1>ATP6V0B</h1>
         <div class="gene-info">
-            
+
             <div class="info-item">
-                
+
                 <span class="info-label">UniProt ID:</span>
                 <span>
                     <a href="https://www.uniprot.org/uniprotkb/Q99437" target="_blank" class="term-link">
                         Q99437
                     </a>
                 </span>
-                
+
             </div>
-            
-            
+
+
             <div class="info-item">
                 <span class="info-label">Organism:</span>
                 <span>Homo sapiens</span>
             </div>
-            
-            
+
+
             <div class="info-item">
                 <span class="info-label">Review Status:</span>
                 <span class="status-badge status-complete">
                     COMPLETE
                 </span>
             </div>
-            
-            
+
+
         </div>
         <div style="margin-top: 1rem; text-align: center;">
             <a id="feedback-form-link"
@@ -772,7 +772,7 @@
                 if (genesIndex !== -1 && pathParts[genesIndex + 1]) {
                     organism = pathParts[genesIndex + 1].toUpperCase();
                 }
-                const geneSymbol = "Q99437";
+                const geneSymbol = "ATP6V0B";
                 const speciesGene = organism + ' ' + geneSymbol;
                 const formBaseUrl = 'https://docs.google.com/forms/d/e/1FAIpQLSdTot9L6GVkkZYgLQT0E8ZdAJv8RiN5ZgOVkgWNcKSbYvxxzQ/viewform';
                 const entryId = '1226477767'; // Correct entry ID for Species/Gene field
@@ -785,24 +785,24 @@
         </div>
     </div>
 
-    
+
     <div class="description-card">
         <div style="display: flex; justify-content: space-between; align-items: center;">
             <h2>Gene Description</h2>
-            <span class="vote-buttons" data-g="Q99437" data-a="DESCRIPTION: TODO: Add description for Q99437..." data-r="" data-act="DESCRIPTION">
+            <span class="vote-buttons" data-g="Q99437" data-a="DESCRIPTION: ATP6V0B encodes the human V-type proton ATPase V0 ..." data-r="" data-act="DESCRIPTION">
                 <button class="vote-btn" data-v="up" title="Agree with this description">👍</button>
                 <button class="vote-btn" data-v="down" title="Disagree with this description">👎</button>
             </span>
         </div>
-        <p>TODO: Add description for Q99437</p>
+        <p>ATP6V0B encodes the human V-type proton ATPase V0 proteolipid subunit c&#39;&#39;. It is a small multi-pass membrane component of the proton-translocating V0 sector, where it forms part of the c-ring rotor/pore with an essential conserved Glu98 residue required for H+ transport. ATP6V0B-containing V-ATPase complexes acidify lysosomes, endosomes, Golgi-derived compartments and other vesicles, thereby supporting endolysosomal pH homeostasis, membrane trafficking, protein degradation, autophagic flux and lysosome-associated nutrient signaling. In specialized cell contexts, V-ATPase complexes can also function at the plasma membrane to acidify the extracellular or phagosomal environment.</p>
     </div>
-    
 
-    
 
-    
 
-    
+
+
+
+
     <div class="section">
         <h2 class="section-title">Existing Annotations Review</h2>
         <table class="annotations-table">
@@ -815,3138 +815,4950 @@
                 </tr>
             </thead>
             <tbody>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016020" target="_blank" class="term-link">
                                     GO:0016020
                                 </a>
                             </span>
                             <span class="term-label">membrane</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IBA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000033
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="Q99437" data-a="GO:0016020" data-r="GO_REF:0000033" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q99437" data-a="GO:0016020" data-r="GO_REF:0000033" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Accept membrane as a supported V-ATPase membrane localization.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> ATP6V0B is an integral membrane subunit of V-ATPase. Human V-ATPase structures and reviews support its role in organellar and vesicular proton-pump complexes; the broad membrane/localization annotation is correct, although more specific endolysosomal V-ATPase component terms are more informative.
+                        </div>
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
-                                    file:human/ATP6V0B/ATP6V0B-deep-research-falcon.md
-                                    
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/33065002" target="_blank" class="term-link">
+                                        PMID:33065002
+                                    </a>
+
                                 </span>
-                                
-                                <div class="support-text">model: Edison Scientific Literature</div>
-                                
+
+                                <div class="support-text">Vesicular- or vacuolar-type adenosine triphosphatases (V-ATPases) are ATP-driven proton pumps comprised of a cytoplasmic V1 complex for ATP hydrolysis and a membrane-embedded Vo complex for proton transfer.</div>
+
                             </div>
-                            
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/9653649" target="_blank" class="term-link">
+                                        PMID:9653649
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">The proteolipid domain of vacuolar H(+)-ATPase (V-ATPase) plays a major role in H+ transport in microvesicles and other acidic organelles.</div>
+
+                            </div>
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006811" target="_blank" class="term-link">
                                     GO:0006811
                                 </a>
                             </span>
                             <span class="term-label">monoatomic ion transport</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000043
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-modify">
+                            MODIFY
                         </span>
-                        <span class="vote-buttons" data-g="Q99437" data-a="GO:0006811" data-r="GO_REF:0000043" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q99437" data-a="GO:0006811" data-r="GO_REF:0000043" data-act="MODIFY">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> The annotation is directionally correct but too broad for ATP6V0B.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> ATP6V0B is not a generic ion-transport factor; it contributes to V-ATPase-driven proton transmembrane transport. Replace the broad monoatomic ion transport term with the established proton transport process term already supported elsewhere in GOA.
+                        </div>
+
+
+                        <div style="margin-top: 0.5rem;">
+                            <strong>Proposed replacements:</strong>
+
+                            <span class="badge">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:1902600" target="_blank" class="term-link">
+                                    proton transmembrane transport
+                                </a>
+                            </span>
+
+                        </div>
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/33065002" target="_blank" class="term-link">
+                                        PMID:33065002
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Vesicular- or vacuolar-type adenosine triphosphatases (V-ATPases) are ATP-driven proton pumps comprised of a cytoplasmic V1 complex for ATP hydrolysis and a membrane-embedded Vo complex for proton transfer.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/9653649" target="_blank" class="term-link">
+                                        PMID:9653649
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">The proteolipid domain of vacuolar H(+)-ATPase (V-ATPase) plays a major role in H+ transport in microvesicles and other acidic organelles.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0015078" target="_blank" class="term-link">
                                     GO:0015078
                                 </a>
                             </span>
                             <span class="term-label">proton transmembrane transporter activity</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000120
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-modify">
+                            MODIFY
                         </span>
-                        <span class="vote-buttons" data-g="Q99437" data-a="GO:0015078" data-r="GO_REF:0000120" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q99437" data-a="GO:0015078" data-r="GO_REF:0000120" data-act="MODIFY">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> The proton-transporter concept is correct, but the more precise complex activity is V-type ATPase rotational proton pumping.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> ATP6V0B contributes as the c&#39;&#39; proteolipid in the V0 rotor rather than acting as an independent transporter. A complex-level term, proton-transporting ATPase activity, rotational mechanism, is the better molecular-function target; in GPAD/GAF this should be treated conservatively as a contribution to the V-ATPase complex activity.
+                        </div>
+
+
+                        <div style="margin-top: 0.5rem;">
+                            <strong>Proposed replacements:</strong>
+
+                            <span class="badge">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0046961" target="_blank" class="term-link">
+                                    proton-transporting ATPase activity, rotational mechanism
+                                </a>
+                            </span>
+
+                        </div>
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/33065002" target="_blank" class="term-link">
+                                        PMID:33065002
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Vesicular- or vacuolar-type adenosine triphosphatases (V-ATPases) are ATP-driven proton pumps comprised of a cytoplasmic V1 complex for ATP hydrolysis and a membrane-embedded Vo complex for proton transfer.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/9653649" target="_blank" class="term-link">
+                                        PMID:9653649
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">hATP6F is a hydrophobic protein with five putative transmembrane segments, having 61% amino acid identity and 83% similarity to the yeast protein, except in the N-terminus, and contains a conserved glutamic acid residue (Glu98) that is essential for H(+)-transporting activity.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0030665" target="_blank" class="term-link">
                                     GO:0030665
                                 </a>
                             </span>
                             <span class="term-label">clathrin-coated vesicle membrane</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000044
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="Q99437" data-a="GO:0030665" data-r="GO_REF:0000044" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q99437" data-a="GO:0030665" data-r="GO_REF:0000044" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Accept clathrin-coated vesicle membrane as a supported V-ATPase membrane localization.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> ATP6V0B is an integral membrane subunit of V-ATPase. Human V-ATPase structures and reviews support its role in organellar and vesicular proton-pump complexes; the broad membrane/localization annotation is correct, although more specific endolysosomal V-ATPase component terms are more informative.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/33065002" target="_blank" class="term-link">
+                                        PMID:33065002
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Vesicular- or vacuolar-type adenosine triphosphatases (V-ATPases) are ATP-driven proton pumps comprised of a cytoplasmic V1 complex for ATP hydrolysis and a membrane-embedded Vo complex for proton transfer.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/9653649" target="_blank" class="term-link">
+                                        PMID:9653649
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">The proteolipid domain of vacuolar H(+)-ATPase (V-ATPase) plays a major role in H+ transport in microvesicles and other acidic organelles.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0031410" target="_blank" class="term-link">
                                     GO:0031410
                                 </a>
                             </span>
                             <span class="term-label">cytoplasmic vesicle</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000043
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
                         </span>
-                        <span class="vote-buttons" data-g="Q99437" data-a="GO:0031410" data-r="GO_REF:0000043" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q99437" data-a="GO:0031410" data-r="GO_REF:0000043" data-act="KEEP_AS_NON_CORE">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Keep this localization as a valid but non-core or context-specific site for V-ATPase complexes.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> ATP6V0B is a membrane V-ATPase subunit and V-ATPases can act in vesicular or specialized plasma/phagosomal compartments. For ATP6V0B&#39;s core annotation, however, lysosomal/endosomal/Golgi V0-domain component and acidification terms are more informative than this broad or context-specific location.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/33065002" target="_blank" class="term-link">
+                                        PMID:33065002
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Vesicular- or vacuolar-type adenosine triphosphatases (V-ATPases) are ATP-driven proton pumps comprised of a cytoplasmic V1 complex for ATP hydrolysis and a membrane-embedded Vo complex for proton transfer.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    Reactome:R-HSA-1222516
+
+                                </span>
+
+                                <div class="support-text">When pumping, ATP hydrolysis drives a 120 degree rotation of the rotor which leads to movement of three protons into the phagosome</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0033177" target="_blank" class="term-link">
                                     GO:0033177
                                 </a>
                             </span>
                             <span class="term-label">proton-transporting two-sector ATPase complex, proton-transporting domain</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000002
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="Q99437" data-a="GO:0033177" data-r="GO_REF:0000002" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q99437" data-a="GO:0033177" data-r="GO_REF:0000002" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> This component annotation is consistent with ATP6V0B being the c&#39;&#39; proteolipid subunit of the V0 proton-translocating sector of V-ATPase.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> ATP6V0B is experimentally identified as a five-transmembrane human V-ATPase proteolipid with conserved Glu98 required for H+ transport, and human V-ATPase structures place V0 subunits in the membrane-embedded proton-transfer module. The component annotation is therefore part of the core molecular role of ATP6V0B.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/33065002" target="_blank" class="term-link">
+                                        PMID:33065002
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Vesicular- or vacuolar-type adenosine triphosphatases (V-ATPases) are ATP-driven proton pumps comprised of a cytoplasmic V1 complex for ATP hydrolysis and a membrane-embedded Vo complex for proton transfer.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/9653649" target="_blank" class="term-link">
+                                        PMID:9653649
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">hATP6F is a hydrophobic protein with five putative transmembrane segments, having 61% amino acid identity and 83% similarity to the yeast protein, except in the N-terminus, and contains a conserved glutamic acid residue (Glu98) that is essential for H(+)-transporting activity.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0033179" target="_blank" class="term-link">
                                     GO:0033179
                                 </a>
                             </span>
                             <span class="term-label">proton-transporting V-type ATPase, V0 domain</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000002
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="Q99437" data-a="GO:0033179" data-r="GO_REF:0000002" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q99437" data-a="GO:0033179" data-r="GO_REF:0000002" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> This component annotation is consistent with ATP6V0B being the c&#39;&#39; proteolipid subunit of the V0 proton-translocating sector of V-ATPase.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> ATP6V0B is experimentally identified as a five-transmembrane human V-ATPase proteolipid with conserved Glu98 required for H+ transport, and human V-ATPase structures place V0 subunits in the membrane-embedded proton-transfer module. The component annotation is therefore part of the core molecular role of ATP6V0B.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/33065002" target="_blank" class="term-link">
+                                        PMID:33065002
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Vesicular- or vacuolar-type adenosine triphosphatases (V-ATPases) are ATP-driven proton pumps comprised of a cytoplasmic V1 complex for ATP hydrolysis and a membrane-embedded Vo complex for proton transfer.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/9653649" target="_blank" class="term-link">
+                                        PMID:9653649
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">hATP6F is a hydrophobic protein with five putative transmembrane segments, having 61% amino acid identity and 83% similarity to the yeast protein, except in the N-terminus, and contains a conserved glutamic acid residue (Glu98) that is essential for H(+)-transporting activity.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0046961" target="_blank" class="term-link">
                                     GO:0046961
                                 </a>
                             </span>
                             <span class="term-label">proton-transporting ATPase activity, rotational mechanism</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000002
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="Q99437" data-a="GO:0046961" data-r="GO_REF:0000002" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q99437" data-a="GO:0046961" data-r="GO_REF:0000002" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Accept the V-type ATPase rotational proton-pump activity as the complex activity to which ATP6V0B contributes.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> ATP6V0B is not the ATP-hydrolytic catalytic subunit, but it is an essential V0 c-ring proteolipid required for proton translocation by the rotary V-ATPase. This is the correct complex-level molecular function for the ATP6V0B-containing V-ATPase machinery.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/33065002" target="_blank" class="term-link">
+                                        PMID:33065002
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Vesicular- or vacuolar-type adenosine triphosphatases (V-ATPases) are ATP-driven proton pumps comprised of a cytoplasmic V1 complex for ATP hydrolysis and a membrane-embedded Vo complex for proton transfer.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/9653649" target="_blank" class="term-link">
+                                        PMID:9653649
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">hATP6F is a hydrophobic protein with five putative transmembrane segments, having 61% amino acid identity and 83% similarity to the yeast protein, except in the N-terminus, and contains a conserved glutamic acid residue (Glu98) that is essential for H(+)-transporting activity.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:1902600" target="_blank" class="term-link">
                                     GO:1902600
                                 </a>
                             </span>
                             <span class="term-label">proton transmembrane transport</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000120
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="Q99437" data-a="GO:1902600" data-r="GO_REF:0000120" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q99437" data-a="GO:1902600" data-r="GO_REF:0000120" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Accept this acidification/proton-transport process annotation for the ATP6V0B-containing V-ATPase complex.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> The ATP6V0B-containing V0 sector contributes to proton transfer by V-ATPase. Human V-ATPases maintain acidic endosomes and lysosomes and support membrane trafficking and protein degradation, so proton transport and organelle lumen acidification annotations reflect the core biological consequence of this subunit&#39;s role in the pump.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/33065002" target="_blank" class="term-link">
+                                        PMID:33065002
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Vesicular- or vacuolar-type adenosine triphosphatases (V-ATPases) are ATP-driven proton pumps comprised of a cytoplasmic V1 complex for ATP hydrolysis and a membrane-embedded Vo complex for proton transfer.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/33065002" target="_blank" class="term-link">
+                                        PMID:33065002
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Vesicular and organellar V-ATPases are essential in establishing and maintaining the pH homeostasis of endosomes and lysosomes and in supporting intracellular membrane trafficking and protein degradation</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/9653649" target="_blank" class="term-link">
+                                        PMID:9653649
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">The proteolipid domain of vacuolar H(+)-ATPase (V-ATPase) plays a major role in H+ transport in microvesicles and other acidic organelles.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/23864651" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:23864651
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     The identification of novel proteins that interact with the ...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-remove">
+                            REMOVE
                         </span>
-                        <span class="vote-buttons" data-g="Q99437" data-a="GO:0005515" data-r="PMID:23864651" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q99437" data-a="GO:0005515" data-r="PMID:23864651" data-act="REMOVE">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Remove the generic protein binding annotation from the GLP-1R interaction screen.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> GO:0005515 is uninformative for ATP6V0B and the supporting study is a receptor-interactome screen rather than evidence for ATP6V0B&#39;s core V-ATPase function. No specific ATP6V0B molecular activity should be inferred from this interaction record.
+                        </div>
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/23864651" target="_blank" class="term-link">
                                         PMID:23864651
                                     </a>
-                                    
+
                                 </span>
-                                
-                                <div class="support-text">Jul 17. The identification of novel proteins that interact with the GLP-1 receptor and restrain its activity.</div>
-                                
+
+                                <div class="support-text">A screen of a human fetal brain cDNA prey library with an unliganded human GLP-1R as bait in yeast revealed 38 novel interactor protein candidates.</div>
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/32296183" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:32296183
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     A reference map of the human binary protein interactome.
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-remove">
+                            REMOVE
                         </span>
-                        <span class="vote-buttons" data-g="Q99437" data-a="GO:0005515" data-r="PMID:32296183" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q99437" data-a="GO:0005515" data-r="PMID:32296183" data-act="REMOVE">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Remove the generic protein binding annotation from the high-throughput binary interactome map.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> GO:0005515 is deliberately avoided in this curation workflow because it does not describe ATP6V0B&#39;s mechanistic role. The HuRI study is a large-scale interaction map, useful as interaction evidence but not sufficient to replace the established V-ATPase c&#39;&#39; subunit function with a generic binding term.
+                        </div>
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/32296183" target="_blank" class="term-link">
                                         PMID:32296183
                                     </a>
-                                    
+
                                 </span>
-                                
-                                <div class="support-text">Apr 8. A reference map of the human binary protein interactome.</div>
-                                
+
+                                <div class="support-text">The dataset, versioned HI-III-20 (Human Interactome obtained from screening Space III, published in 2020), contains 52,569 verified PPIs involving 8,275 proteins</div>
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005768" target="_blank" class="term-link">
                                     GO:0005768
                                 </a>
                             </span>
                             <span class="term-label">endosome</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000107
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="Q99437" data-a="GO:0005768" data-r="GO_REF:0000107" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q99437" data-a="GO:0005768" data-r="GO_REF:0000107" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Accept endosome as a supported V-ATPase membrane localization.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> ATP6V0B is an integral membrane subunit of V-ATPase. Human V-ATPase structures and reviews support its role in organellar and vesicular proton-pump complexes; the broad membrane/localization annotation is correct, although more specific endolysosomal V-ATPase component terms are more informative.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/33065002" target="_blank" class="term-link">
+                                        PMID:33065002
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Vesicular- or vacuolar-type adenosine triphosphatases (V-ATPases) are ATP-driven proton pumps comprised of a cytoplasmic V1 complex for ATP hydrolysis and a membrane-embedded Vo complex for proton transfer.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/9653649" target="_blank" class="term-link">
+                                        PMID:9653649
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">The proteolipid domain of vacuolar H(+)-ATPase (V-ATPase) plays a major role in H+ transport in microvesicles and other acidic organelles.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016020" target="_blank" class="term-link">
                                     GO:0016020
                                 </a>
                             </span>
                             <span class="term-label">membrane</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000120
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="Q99437" data-a="GO:0016020" data-r="GO_REF:0000120" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q99437" data-a="GO:0016020" data-r="GO_REF:0000120" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Accept membrane as a supported V-ATPase membrane localization.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> ATP6V0B is an integral membrane subunit of V-ATPase. Human V-ATPase structures and reviews support its role in organellar and vesicular proton-pump complexes; the broad membrane/localization annotation is correct, although more specific endolysosomal V-ATPase component terms are more informative.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/33065002" target="_blank" class="term-link">
+                                        PMID:33065002
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Vesicular- or vacuolar-type adenosine triphosphatases (V-ATPases) are ATP-driven proton pumps comprised of a cytoplasmic V1 complex for ATP hydrolysis and a membrane-embedded Vo complex for proton transfer.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/9653649" target="_blank" class="term-link">
+                                        PMID:9653649
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">The proteolipid domain of vacuolar H(+)-ATPase (V-ATPase) plays a major role in H+ transport in microvesicles and other acidic organelles.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0033176" target="_blank" class="term-link">
                                     GO:0033176
                                 </a>
                             </span>
                             <span class="term-label">proton-transporting V-type ATPase complex</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000107
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="Q99437" data-a="GO:0033176" data-r="GO_REF:0000107" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q99437" data-a="GO:0033176" data-r="GO_REF:0000107" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> This component annotation is consistent with ATP6V0B being the c&#39;&#39; proteolipid subunit of the V0 proton-translocating sector of V-ATPase.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> ATP6V0B is experimentally identified as a five-transmembrane human V-ATPase proteolipid with conserved Glu98 required for H+ transport, and human V-ATPase structures place V0 subunits in the membrane-embedded proton-transfer module. The component annotation is therefore part of the core molecular role of ATP6V0B.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/33065002" target="_blank" class="term-link">
+                                        PMID:33065002
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Vesicular- or vacuolar-type adenosine triphosphatases (V-ATPases) are ATP-driven proton pumps comprised of a cytoplasmic V1 complex for ATP hydrolysis and a membrane-embedded Vo complex for proton transfer.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/9653649" target="_blank" class="term-link">
+                                        PMID:9653649
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">hATP6F is a hydrophobic protein with five putative transmembrane segments, having 61% amino acid identity and 83% similarity to the yeast protein, except in the N-terminus, and contains a conserved glutamic acid residue (Glu98) that is essential for H(+)-transporting activity.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0000139" target="_blank" class="term-link">
                                     GO:0000139
                                 </a>
                             </span>
                             <span class="term-label">Golgi membrane</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">NAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/32001091" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:32001091
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Structure and Roles of V-type ATPases.
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="Q99437" data-a="GO:0000139" data-r="PMID:32001091" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q99437" data-a="GO:0000139" data-r="PMID:32001091" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Accept Golgi membrane as a supported V-ATPase membrane localization.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> ATP6V0B is an integral membrane subunit of V-ATPase. Human V-ATPase structures and reviews support its role in organellar and vesicular proton-pump complexes; the broad membrane/localization annotation is correct, although more specific endolysosomal V-ATPase component terms are more informative.
+                        </div>
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
-                                    <a href="https://pubmed.ncbi.nlm.nih.gov/32001091" target="_blank" class="term-link">
-                                        PMID:32001091
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/33065002" target="_blank" class="term-link">
+                                        PMID:33065002
                                     </a>
-                                    
+
                                 </span>
-                                
-                                <div class="support-text">Epub 2020 Jan 28. Structure and Roles of V-type ATPases.</div>
-                                
+
+                                <div class="support-text">Vesicular- or vacuolar-type adenosine triphosphatases (V-ATPases) are ATP-driven proton pumps comprised of a cytoplasmic V1 complex for ATP hydrolysis and a membrane-embedded Vo complex for proton transfer.</div>
+
                             </div>
-                            
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/9653649" target="_blank" class="term-link">
+                                        PMID:9653649
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">The proteolipid domain of vacuolar H(+)-ATPase (V-ATPase) plays a major role in H+ transport in microvesicles and other acidic organelles.</div>
+
+                            </div>
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005765" target="_blank" class="term-link">
                                     GO:0005765
                                 </a>
                             </span>
                             <span class="term-label">lysosomal membrane</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">NAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/32001091" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:32001091
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Structure and Roles of V-type ATPases.
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="Q99437" data-a="GO:0005765" data-r="PMID:32001091" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q99437" data-a="GO:0005765" data-r="PMID:32001091" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Accept lysosomal membrane as a supported V-ATPase membrane localization.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> ATP6V0B is an integral membrane subunit of V-ATPase. Human V-ATPase structures and reviews support its role in organellar and vesicular proton-pump complexes; the broad membrane/localization annotation is correct, although more specific endolysosomal V-ATPase component terms are more informative.
+                        </div>
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
-                                    <a href="https://pubmed.ncbi.nlm.nih.gov/32001091" target="_blank" class="term-link">
-                                        PMID:32001091
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/33065002" target="_blank" class="term-link">
+                                        PMID:33065002
                                     </a>
-                                    
+
                                 </span>
-                                
-                                <div class="support-text">Epub 2020 Jan 28. Structure and Roles of V-type ATPases.</div>
-                                
+
+                                <div class="support-text">Vesicular- or vacuolar-type adenosine triphosphatases (V-ATPases) are ATP-driven proton pumps comprised of a cytoplasmic V1 complex for ATP hydrolysis and a membrane-embedded Vo complex for proton transfer.</div>
+
                             </div>
-                            
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/9653649" target="_blank" class="term-link">
+                                        PMID:9653649
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">The proteolipid domain of vacuolar H(+)-ATPase (V-ATPase) plays a major role in H+ transport in microvesicles and other acidic organelles.</div>
+
+                            </div>
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005886" target="_blank" class="term-link">
                                     GO:0005886
                                 </a>
                             </span>
                             <span class="term-label">plasma membrane</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">NAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/32001091" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:32001091
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Structure and Roles of V-type ATPases.
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
                         </span>
-                        <span class="vote-buttons" data-g="Q99437" data-a="GO:0005886" data-r="PMID:32001091" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q99437" data-a="GO:0005886" data-r="PMID:32001091" data-act="KEEP_AS_NON_CORE">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Keep this localization as a valid but non-core or context-specific site for V-ATPase complexes.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> ATP6V0B is a membrane V-ATPase subunit and V-ATPases can act in vesicular or specialized plasma/phagosomal compartments. For ATP6V0B&#39;s core annotation, however, lysosomal/endosomal/Golgi V0-domain component and acidification terms are more informative than this broad or context-specific location.
+                        </div>
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
-                                    <a href="https://pubmed.ncbi.nlm.nih.gov/32001091" target="_blank" class="term-link">
-                                        PMID:32001091
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/33065002" target="_blank" class="term-link">
+                                        PMID:33065002
                                     </a>
-                                    
+
                                 </span>
-                                
-                                <div class="support-text">Epub 2020 Jan 28. Structure and Roles of V-type ATPases.</div>
-                                
+
+                                <div class="support-text">Vesicular- or vacuolar-type adenosine triphosphatases (V-ATPases) are ATP-driven proton pumps comprised of a cytoplasmic V1 complex for ATP hydrolysis and a membrane-embedded Vo complex for proton transfer.</div>
+
                             </div>
-                            
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    Reactome:R-HSA-1222516
+
+                                </span>
+
+                                <div class="support-text">When pumping, ATP hydrolysis drives a 120 degree rotation of the rotor which leads to movement of three protons into the phagosome</div>
+
+                            </div>
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0007035" target="_blank" class="term-link">
                                     GO:0007035
                                 </a>
                             </span>
                             <span class="term-label">vacuolar acidification</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">NAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/32001091" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:32001091
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Structure and Roles of V-type ATPases.
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="Q99437" data-a="GO:0007035" data-r="PMID:32001091" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q99437" data-a="GO:0007035" data-r="PMID:32001091" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Accept this acidification/proton-transport process annotation for the ATP6V0B-containing V-ATPase complex.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> The ATP6V0B-containing V0 sector contributes to proton transfer by V-ATPase. Human V-ATPases maintain acidic endosomes and lysosomes and support membrane trafficking and protein degradation, so proton transport and organelle lumen acidification annotations reflect the core biological consequence of this subunit&#39;s role in the pump.
+                        </div>
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
-                                    <a href="https://pubmed.ncbi.nlm.nih.gov/32001091" target="_blank" class="term-link">
-                                        PMID:32001091
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/33065002" target="_blank" class="term-link">
+                                        PMID:33065002
                                     </a>
-                                    
+
                                 </span>
-                                
-                                <div class="support-text">Epub 2020 Jan 28. Structure and Roles of V-type ATPases.</div>
-                                
+
+                                <div class="support-text">Vesicular- or vacuolar-type adenosine triphosphatases (V-ATPases) are ATP-driven proton pumps comprised of a cytoplasmic V1 complex for ATP hydrolysis and a membrane-embedded Vo complex for proton transfer.</div>
+
                             </div>
-                            
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/33065002" target="_blank" class="term-link">
+                                        PMID:33065002
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Vesicular and organellar V-ATPases are essential in establishing and maintaining the pH homeostasis of endosomes and lysosomes and in supporting intracellular membrane trafficking and protein degradation</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/9653649" target="_blank" class="term-link">
+                                        PMID:9653649
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">The proteolipid domain of vacuolar H(+)-ATPase (V-ATPase) plays a major role in H+ transport in microvesicles and other acidic organelles.</div>
+
+                            </div>
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0007042" target="_blank" class="term-link">
                                     GO:0007042
                                 </a>
                             </span>
                             <span class="term-label">lysosomal lumen acidification</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">NAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/32001091" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:32001091
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Structure and Roles of V-type ATPases.
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="Q99437" data-a="GO:0007042" data-r="PMID:32001091" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q99437" data-a="GO:0007042" data-r="PMID:32001091" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Accept this acidification/proton-transport process annotation for the ATP6V0B-containing V-ATPase complex.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> The ATP6V0B-containing V0 sector contributes to proton transfer by V-ATPase. Human V-ATPases maintain acidic endosomes and lysosomes and support membrane trafficking and protein degradation, so proton transport and organelle lumen acidification annotations reflect the core biological consequence of this subunit&#39;s role in the pump.
+                        </div>
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
-                                    <a href="https://pubmed.ncbi.nlm.nih.gov/32001091" target="_blank" class="term-link">
-                                        PMID:32001091
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/33065002" target="_blank" class="term-link">
+                                        PMID:33065002
                                     </a>
-                                    
+
                                 </span>
-                                
-                                <div class="support-text">Epub 2020 Jan 28. Structure and Roles of V-type ATPases.</div>
-                                
+
+                                <div class="support-text">Vesicular- or vacuolar-type adenosine triphosphatases (V-ATPases) are ATP-driven proton pumps comprised of a cytoplasmic V1 complex for ATP hydrolysis and a membrane-embedded Vo complex for proton transfer.</div>
+
                             </div>
-                            
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/33065002" target="_blank" class="term-link">
+                                        PMID:33065002
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Vesicular and organellar V-ATPases are essential in establishing and maintaining the pH homeostasis of endosomes and lysosomes and in supporting intracellular membrane trafficking and protein degradation</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/9653649" target="_blank" class="term-link">
+                                        PMID:9653649
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">The proteolipid domain of vacuolar H(+)-ATPase (V-ATPase) plays a major role in H+ transport in microvesicles and other acidic organelles.</div>
+
+                            </div>
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0007042" target="_blank" class="term-link">
                                     GO:0007042
                                 </a>
                             </span>
                             <span class="term-label">lysosomal lumen acidification</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">NAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/33065002" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:33065002
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Structures of a Complete Human V-ATPase Reveal Mechanisms of...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="Q99437" data-a="GO:0007042" data-r="PMID:33065002" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q99437" data-a="GO:0007042" data-r="PMID:33065002" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Accept this acidification/proton-transport process annotation for the ATP6V0B-containing V-ATPase complex.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> The ATP6V0B-containing V0 sector contributes to proton transfer by V-ATPase. Human V-ATPases maintain acidic endosomes and lysosomes and support membrane trafficking and protein degradation, so proton transport and organelle lumen acidification annotations reflect the core biological consequence of this subunit&#39;s role in the pump.
+                        </div>
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/33065002" target="_blank" class="term-link">
                                         PMID:33065002
                                     </a>
-                                    
+
                                 </span>
-                                
-                                <div class="support-text">2020 Oct 15. Structures of a Complete Human V-ATPase Reveal Mechanisms of Its Assembly.</div>
-                                
+
+                                <div class="support-text">Vesicular- or vacuolar-type adenosine triphosphatases (V-ATPases) are ATP-driven proton pumps comprised of a cytoplasmic V1 complex for ATP hydrolysis and a membrane-embedded Vo complex for proton transfer.</div>
+
                             </div>
-                            
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/33065002" target="_blank" class="term-link">
+                                        PMID:33065002
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Vesicular and organellar V-ATPases are essential in establishing and maintaining the pH homeostasis of endosomes and lysosomes and in supporting intracellular membrane trafficking and protein degradation</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/9653649" target="_blank" class="term-link">
+                                        PMID:9653649
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">The proteolipid domain of vacuolar H(+)-ATPase (V-ATPase) plays a major role in H+ transport in microvesicles and other acidic organelles.</div>
+
+                            </div>
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0010008" target="_blank" class="term-link">
                                     GO:0010008
                                 </a>
                             </span>
                             <span class="term-label">endosome membrane</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">NAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/32001091" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:32001091
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Structure and Roles of V-type ATPases.
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="Q99437" data-a="GO:0010008" data-r="PMID:32001091" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q99437" data-a="GO:0010008" data-r="PMID:32001091" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Accept endosome membrane as a supported V-ATPase membrane localization.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> ATP6V0B is an integral membrane subunit of V-ATPase. Human V-ATPase structures and reviews support its role in organellar and vesicular proton-pump complexes; the broad membrane/localization annotation is correct, although more specific endolysosomal V-ATPase component terms are more informative.
+                        </div>
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
-                                    <a href="https://pubmed.ncbi.nlm.nih.gov/32001091" target="_blank" class="term-link">
-                                        PMID:32001091
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/33065002" target="_blank" class="term-link">
+                                        PMID:33065002
                                     </a>
-                                    
+
                                 </span>
-                                
-                                <div class="support-text">Epub 2020 Jan 28. Structure and Roles of V-type ATPases.</div>
-                                
+
+                                <div class="support-text">Vesicular- or vacuolar-type adenosine triphosphatases (V-ATPases) are ATP-driven proton pumps comprised of a cytoplasmic V1 complex for ATP hydrolysis and a membrane-embedded Vo complex for proton transfer.</div>
+
                             </div>
-                            
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/9653649" target="_blank" class="term-link">
+                                        PMID:9653649
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">The proteolipid domain of vacuolar H(+)-ATPase (V-ATPase) plays a major role in H+ transport in microvesicles and other acidic organelles.</div>
+
+                            </div>
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016020" target="_blank" class="term-link">
                                     GO:0016020
                                 </a>
                             </span>
                             <span class="term-label">membrane</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/33065002" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:33065002
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Structures of a Complete Human V-ATPase Reveal Mechanisms of...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="Q99437" data-a="GO:0016020" data-r="PMID:33065002" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q99437" data-a="GO:0016020" data-r="PMID:33065002" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Accept membrane as a supported V-ATPase membrane localization.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> ATP6V0B is an integral membrane subunit of V-ATPase. Human V-ATPase structures and reviews support its role in organellar and vesicular proton-pump complexes; the broad membrane/localization annotation is correct, although more specific endolysosomal V-ATPase component terms are more informative.
+                        </div>
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/33065002" target="_blank" class="term-link">
                                         PMID:33065002
                                     </a>
-                                    
+
                                 </span>
-                                
-                                <div class="support-text">2020 Oct 15. Structures of a Complete Human V-ATPase Reveal Mechanisms of Its Assembly.</div>
-                                
+
+                                <div class="support-text">Vesicular- or vacuolar-type adenosine triphosphatases (V-ATPases) are ATP-driven proton pumps comprised of a cytoplasmic V1 complex for ATP hydrolysis and a membrane-embedded Vo complex for proton transfer.</div>
+
                             </div>
-                            
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/9653649" target="_blank" class="term-link">
+                                        PMID:9653649
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">The proteolipid domain of vacuolar H(+)-ATPase (V-ATPase) plays a major role in H+ transport in microvesicles and other acidic organelles.</div>
+
+                            </div>
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0033176" target="_blank" class="term-link">
                                     GO:0033176
                                 </a>
                             </span>
                             <span class="term-label">proton-transporting V-type ATPase complex</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">NAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/33065002" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:33065002
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Structures of a Complete Human V-ATPase Reveal Mechanisms of...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="Q99437" data-a="GO:0033176" data-r="PMID:33065002" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q99437" data-a="GO:0033176" data-r="PMID:33065002" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> This component annotation is consistent with ATP6V0B being the c&#39;&#39; proteolipid subunit of the V0 proton-translocating sector of V-ATPase.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> ATP6V0B is experimentally identified as a five-transmembrane human V-ATPase proteolipid with conserved Glu98 required for H+ transport, and human V-ATPase structures place V0 subunits in the membrane-embedded proton-transfer module. The component annotation is therefore part of the core molecular role of ATP6V0B.
+                        </div>
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/33065002" target="_blank" class="term-link">
                                         PMID:33065002
                                     </a>
-                                    
+
                                 </span>
-                                
-                                <div class="support-text">2020 Oct 15. Structures of a Complete Human V-ATPase Reveal Mechanisms of Its Assembly.</div>
-                                
+
+                                <div class="support-text">Vesicular- or vacuolar-type adenosine triphosphatases (V-ATPases) are ATP-driven proton pumps comprised of a cytoplasmic V1 complex for ATP hydrolysis and a membrane-embedded Vo complex for proton transfer.</div>
+
                             </div>
-                            
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/9653649" target="_blank" class="term-link">
+                                        PMID:9653649
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">hATP6F is a hydrophobic protein with five putative transmembrane segments, having 61% amino acid identity and 83% similarity to the yeast protein, except in the N-terminus, and contains a conserved glutamic acid residue (Glu98) that is essential for H(+)-transporting activity.</div>
+
+                            </div>
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0048388" target="_blank" class="term-link">
                                     GO:0048388
                                 </a>
                             </span>
                             <span class="term-label">endosomal lumen acidification</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">NAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/32001091" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:32001091
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Structure and Roles of V-type ATPases.
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="Q99437" data-a="GO:0048388" data-r="PMID:32001091" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q99437" data-a="GO:0048388" data-r="PMID:32001091" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Accept this acidification/proton-transport process annotation for the ATP6V0B-containing V-ATPase complex.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> The ATP6V0B-containing V0 sector contributes to proton transfer by V-ATPase. Human V-ATPases maintain acidic endosomes and lysosomes and support membrane trafficking and protein degradation, so proton transport and organelle lumen acidification annotations reflect the core biological consequence of this subunit&#39;s role in the pump.
+                        </div>
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
-                                    <a href="https://pubmed.ncbi.nlm.nih.gov/32001091" target="_blank" class="term-link">
-                                        PMID:32001091
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/33065002" target="_blank" class="term-link">
+                                        PMID:33065002
                                     </a>
-                                    
+
                                 </span>
-                                
-                                <div class="support-text">Epub 2020 Jan 28. Structure and Roles of V-type ATPases.</div>
-                                
+
+                                <div class="support-text">Vesicular- or vacuolar-type adenosine triphosphatases (V-ATPases) are ATP-driven proton pumps comprised of a cytoplasmic V1 complex for ATP hydrolysis and a membrane-embedded Vo complex for proton transfer.</div>
+
                             </div>
-                            
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/33065002" target="_blank" class="term-link">
+                                        PMID:33065002
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Vesicular and organellar V-ATPases are essential in establishing and maintaining the pH homeostasis of endosomes and lysosomes and in supporting intracellular membrane trafficking and protein degradation</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/9653649" target="_blank" class="term-link">
+                                        PMID:9653649
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">The proteolipid domain of vacuolar H(+)-ATPase (V-ATPase) plays a major role in H+ transport in microvesicles and other acidic organelles.</div>
+
+                            </div>
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0051452" target="_blank" class="term-link">
                                     GO:0051452
                                 </a>
                             </span>
                             <span class="term-label">intracellular pH reduction</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">NAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/32001091" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:32001091
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Structure and Roles of V-type ATPases.
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="Q99437" data-a="GO:0051452" data-r="PMID:32001091" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q99437" data-a="GO:0051452" data-r="PMID:32001091" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Accept this acidification/proton-transport process annotation for the ATP6V0B-containing V-ATPase complex.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> The ATP6V0B-containing V0 sector contributes to proton transfer by V-ATPase. Human V-ATPases maintain acidic endosomes and lysosomes and support membrane trafficking and protein degradation, so proton transport and organelle lumen acidification annotations reflect the core biological consequence of this subunit&#39;s role in the pump.
+                        </div>
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
-                                    <a href="https://pubmed.ncbi.nlm.nih.gov/32001091" target="_blank" class="term-link">
-                                        PMID:32001091
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/33065002" target="_blank" class="term-link">
+                                        PMID:33065002
                                     </a>
-                                    
+
                                 </span>
-                                
-                                <div class="support-text">Epub 2020 Jan 28. Structure and Roles of V-type ATPases.</div>
-                                
+
+                                <div class="support-text">Vesicular- or vacuolar-type adenosine triphosphatases (V-ATPases) are ATP-driven proton pumps comprised of a cytoplasmic V1 complex for ATP hydrolysis and a membrane-embedded Vo complex for proton transfer.</div>
+
                             </div>
-                            
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/33065002" target="_blank" class="term-link">
+                                        PMID:33065002
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Vesicular and organellar V-ATPases are essential in establishing and maintaining the pH homeostasis of endosomes and lysosomes and in supporting intracellular membrane trafficking and protein degradation</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/9653649" target="_blank" class="term-link">
+                                        PMID:9653649
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">The proteolipid domain of vacuolar H(+)-ATPase (V-ATPase) plays a major role in H+ transport in microvesicles and other acidic organelles.</div>
+
+                            </div>
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0061795" target="_blank" class="term-link">
                                     GO:0061795
                                 </a>
                             </span>
                             <span class="term-label">Golgi lumen acidification</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">NAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/32001091" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:32001091
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Structure and Roles of V-type ATPases.
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="Q99437" data-a="GO:0061795" data-r="PMID:32001091" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q99437" data-a="GO:0061795" data-r="PMID:32001091" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Accept this acidification/proton-transport process annotation for the ATP6V0B-containing V-ATPase complex.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> The ATP6V0B-containing V0 sector contributes to proton transfer by V-ATPase. Human V-ATPases maintain acidic endosomes and lysosomes and support membrane trafficking and protein degradation, so proton transport and organelle lumen acidification annotations reflect the core biological consequence of this subunit&#39;s role in the pump.
+                        </div>
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
-                                    <a href="https://pubmed.ncbi.nlm.nih.gov/32001091" target="_blank" class="term-link">
-                                        PMID:32001091
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/33065002" target="_blank" class="term-link">
+                                        PMID:33065002
                                     </a>
-                                    
+
                                 </span>
-                                
-                                <div class="support-text">Epub 2020 Jan 28. Structure and Roles of V-type ATPases.</div>
-                                
+
+                                <div class="support-text">Vesicular- or vacuolar-type adenosine triphosphatases (V-ATPases) are ATP-driven proton pumps comprised of a cytoplasmic V1 complex for ATP hydrolysis and a membrane-embedded Vo complex for proton transfer.</div>
+
                             </div>
-                            
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/33065002" target="_blank" class="term-link">
+                                        PMID:33065002
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Vesicular and organellar V-ATPases are essential in establishing and maintaining the pH homeostasis of endosomes and lysosomes and in supporting intracellular membrane trafficking and protein degradation</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/9653649" target="_blank" class="term-link">
+                                        PMID:9653649
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">The proteolipid domain of vacuolar H(+)-ATPase (V-ATPase) plays a major role in H+ transport in microvesicles and other acidic organelles.</div>
+
+                            </div>
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:1902600" target="_blank" class="term-link">
                                     GO:1902600
                                 </a>
                             </span>
                             <span class="term-label">proton transmembrane transport</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">NAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/33065002" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:33065002
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Structures of a Complete Human V-ATPase Reveal Mechanisms of...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="Q99437" data-a="GO:1902600" data-r="PMID:33065002" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q99437" data-a="GO:1902600" data-r="PMID:33065002" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Accept this acidification/proton-transport process annotation for the ATP6V0B-containing V-ATPase complex.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> The ATP6V0B-containing V0 sector contributes to proton transfer by V-ATPase. Human V-ATPases maintain acidic endosomes and lysosomes and support membrane trafficking and protein degradation, so proton transport and organelle lumen acidification annotations reflect the core biological consequence of this subunit&#39;s role in the pump.
+                        </div>
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/33065002" target="_blank" class="term-link">
                                         PMID:33065002
                                     </a>
-                                    
+
                                 </span>
-                                
-                                <div class="support-text">2020 Oct 15. Structures of a Complete Human V-ATPase Reveal Mechanisms of Its Assembly.</div>
-                                
+
+                                <div class="support-text">Vesicular- or vacuolar-type adenosine triphosphatases (V-ATPases) are ATP-driven proton pumps comprised of a cytoplasmic V1 complex for ATP hydrolysis and a membrane-embedded Vo complex for proton transfer.</div>
+
                             </div>
-                            
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/33065002" target="_blank" class="term-link">
+                                        PMID:33065002
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Vesicular and organellar V-ATPases are essential in establishing and maintaining the pH homeostasis of endosomes and lysosomes and in supporting intracellular membrane trafficking and protein degradation</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/9653649" target="_blank" class="term-link">
+                                        PMID:9653649
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">The proteolipid domain of vacuolar H(+)-ATPase (V-ATPase) plays a major role in H+ transport in microvesicles and other acidic organelles.</div>
+
+                            </div>
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0046961" target="_blank" class="term-link">
                                     GO:0046961
                                 </a>
                             </span>
                             <span class="term-label">proton-transporting ATPase activity, rotational mechanism</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/9653649" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:9653649
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Identification and characterization of the gene encoding a s...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="Q99437" data-a="GO:0046961" data-r="PMID:9653649" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q99437" data-a="GO:0046961" data-r="PMID:9653649" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Accept the V-type ATPase rotational proton-pump activity as the complex activity to which ATP6V0B contributes.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> ATP6V0B is not the ATP-hydrolytic catalytic subunit, but it is an essential V0 c-ring proteolipid required for proton translocation by the rotary V-ATPase. This is the correct complex-level molecular function for the ATP6V0B-containing V-ATPase machinery.
+                        </div>
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/33065002" target="_blank" class="term-link">
+                                        PMID:33065002
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Vesicular- or vacuolar-type adenosine triphosphatases (V-ATPases) are ATP-driven proton pumps comprised of a cytoplasmic V1 complex for ATP hydrolysis and a membrane-embedded Vo complex for proton transfer.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/9653649" target="_blank" class="term-link">
                                         PMID:9653649
                                     </a>
-                                    
+
                                 </span>
-                                
-                                <div class="support-text">Identification and characterization of the gene encoding a second proteolipid subunit of human vacuolar H(+)-ATPase (ATP6F).</div>
-                                
+
+                                <div class="support-text">hATP6F is a hydrophobic protein with five putative transmembrane segments, having 61% amino acid identity and 83% similarity to the yeast protein, except in the N-terminus, and contains a conserved glutamic acid residue (Glu98) that is essential for H(+)-transporting activity.</div>
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0000220" target="_blank" class="term-link">
                                     GO:0000220
                                 </a>
                             </span>
                             <span class="term-label">vacuolar proton-transporting V-type ATPase, V0 domain</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">ISS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000024
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="Q99437" data-a="GO:0000220" data-r="GO_REF:0000024" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q99437" data-a="GO:0000220" data-r="GO_REF:0000024" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> This component annotation is consistent with ATP6V0B being the c&#39;&#39; proteolipid subunit of the V0 proton-translocating sector of V-ATPase.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> ATP6V0B is experimentally identified as a five-transmembrane human V-ATPase proteolipid with conserved Glu98 required for H+ transport, and human V-ATPase structures place V0 subunits in the membrane-embedded proton-transfer module. The component annotation is therefore part of the core molecular role of ATP6V0B.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/33065002" target="_blank" class="term-link">
+                                        PMID:33065002
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Vesicular- or vacuolar-type adenosine triphosphatases (V-ATPases) are ATP-driven proton pumps comprised of a cytoplasmic V1 complex for ATP hydrolysis and a membrane-embedded Vo complex for proton transfer.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/9653649" target="_blank" class="term-link">
+                                        PMID:9653649
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">hATP6F is a hydrophobic protein with five putative transmembrane segments, having 61% amino acid identity and 83% similarity to the yeast protein, except in the N-terminus, and contains a conserved glutamic acid residue (Glu98) that is essential for H(+)-transporting activity.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005765" target="_blank" class="term-link">
                                     GO:0005765
                                 </a>
                             </span>
                             <span class="term-label">lysosomal membrane</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-9639286
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="Q99437" data-a="GO:0005765" data-r="Reactome:R-HSA-9639286" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q99437" data-a="GO:0005765" data-r="Reactome:R-HSA-9639286" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Accept lysosomal membrane as a supported V-ATPase membrane localization.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> ATP6V0B is an integral membrane subunit of V-ATPase. Human V-ATPase structures and reviews support its role in organellar and vesicular proton-pump complexes; the broad membrane/localization annotation is correct, although more specific endolysosomal V-ATPase component terms are more informative.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/33065002" target="_blank" class="term-link">
+                                        PMID:33065002
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Vesicular- or vacuolar-type adenosine triphosphatases (V-ATPases) are ATP-driven proton pumps comprised of a cytoplasmic V1 complex for ATP hydrolysis and a membrane-embedded Vo complex for proton transfer.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/9653649" target="_blank" class="term-link">
+                                        PMID:9653649
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">The proteolipid domain of vacuolar H(+)-ATPase (V-ATPase) plays a major role in H+ transport in microvesicles and other acidic organelles.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005765" target="_blank" class="term-link">
                                     GO:0005765
                                 </a>
                             </span>
                             <span class="term-label">lysosomal membrane</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-9640167
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="Q99437" data-a="GO:0005765" data-r="Reactome:R-HSA-9640167" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q99437" data-a="GO:0005765" data-r="Reactome:R-HSA-9640167" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Accept lysosomal membrane as a supported V-ATPase membrane localization.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> ATP6V0B is an integral membrane subunit of V-ATPase. Human V-ATPase structures and reviews support its role in organellar and vesicular proton-pump complexes; the broad membrane/localization annotation is correct, although more specific endolysosomal V-ATPase component terms are more informative.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/33065002" target="_blank" class="term-link">
+                                        PMID:33065002
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Vesicular- or vacuolar-type adenosine triphosphatases (V-ATPases) are ATP-driven proton pumps comprised of a cytoplasmic V1 complex for ATP hydrolysis and a membrane-embedded Vo complex for proton transfer.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/9653649" target="_blank" class="term-link">
+                                        PMID:9653649
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">The proteolipid domain of vacuolar H(+)-ATPase (V-ATPase) plays a major role in H+ transport in microvesicles and other acidic organelles.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005765" target="_blank" class="term-link">
                                     GO:0005765
                                 </a>
                             </span>
                             <span class="term-label">lysosomal membrane</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-9640168
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="Q99437" data-a="GO:0005765" data-r="Reactome:R-HSA-9640168" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q99437" data-a="GO:0005765" data-r="Reactome:R-HSA-9640168" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Accept lysosomal membrane as a supported V-ATPase membrane localization.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> ATP6V0B is an integral membrane subunit of V-ATPase. Human V-ATPase structures and reviews support its role in organellar and vesicular proton-pump complexes; the broad membrane/localization annotation is correct, although more specific endolysosomal V-ATPase component terms are more informative.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/33065002" target="_blank" class="term-link">
+                                        PMID:33065002
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Vesicular- or vacuolar-type adenosine triphosphatases (V-ATPases) are ATP-driven proton pumps comprised of a cytoplasmic V1 complex for ATP hydrolysis and a membrane-embedded Vo complex for proton transfer.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/9653649" target="_blank" class="term-link">
+                                        PMID:9653649
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">The proteolipid domain of vacuolar H(+)-ATPase (V-ATPase) plays a major role in H+ transport in microvesicles and other acidic organelles.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005765" target="_blank" class="term-link">
                                     GO:0005765
                                 </a>
                             </span>
                             <span class="term-label">lysosomal membrane</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-9640175
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="Q99437" data-a="GO:0005765" data-r="Reactome:R-HSA-9640175" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q99437" data-a="GO:0005765" data-r="Reactome:R-HSA-9640175" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Accept lysosomal membrane as a supported V-ATPase membrane localization.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> ATP6V0B is an integral membrane subunit of V-ATPase. Human V-ATPase structures and reviews support its role in organellar and vesicular proton-pump complexes; the broad membrane/localization annotation is correct, although more specific endolysosomal V-ATPase component terms are more informative.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/33065002" target="_blank" class="term-link">
+                                        PMID:33065002
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Vesicular- or vacuolar-type adenosine triphosphatases (V-ATPases) are ATP-driven proton pumps comprised of a cytoplasmic V1 complex for ATP hydrolysis and a membrane-embedded Vo complex for proton transfer.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/9653649" target="_blank" class="term-link">
+                                        PMID:9653649
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">The proteolipid domain of vacuolar H(+)-ATPase (V-ATPase) plays a major role in H+ transport in microvesicles and other acidic organelles.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005765" target="_blank" class="term-link">
                                     GO:0005765
                                 </a>
                             </span>
                             <span class="term-label">lysosomal membrane</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-9640195
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="Q99437" data-a="GO:0005765" data-r="Reactome:R-HSA-9640195" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q99437" data-a="GO:0005765" data-r="Reactome:R-HSA-9640195" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Accept lysosomal membrane as a supported V-ATPase membrane localization.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> ATP6V0B is an integral membrane subunit of V-ATPase. Human V-ATPase structures and reviews support its role in organellar and vesicular proton-pump complexes; the broad membrane/localization annotation is correct, although more specific endolysosomal V-ATPase component terms are more informative.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/33065002" target="_blank" class="term-link">
+                                        PMID:33065002
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Vesicular- or vacuolar-type adenosine triphosphatases (V-ATPases) are ATP-driven proton pumps comprised of a cytoplasmic V1 complex for ATP hydrolysis and a membrane-embedded Vo complex for proton transfer.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/9653649" target="_blank" class="term-link">
+                                        PMID:9653649
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">The proteolipid domain of vacuolar H(+)-ATPase (V-ATPase) plays a major role in H+ transport in microvesicles and other acidic organelles.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005765" target="_blank" class="term-link">
                                     GO:0005765
                                 </a>
                             </span>
                             <span class="term-label">lysosomal membrane</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-9645598
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="Q99437" data-a="GO:0005765" data-r="Reactome:R-HSA-9645598" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q99437" data-a="GO:0005765" data-r="Reactome:R-HSA-9645598" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Accept lysosomal membrane as a supported V-ATPase membrane localization.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> ATP6V0B is an integral membrane subunit of V-ATPase. Human V-ATPase structures and reviews support its role in organellar and vesicular proton-pump complexes; the broad membrane/localization annotation is correct, although more specific endolysosomal V-ATPase component terms are more informative.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/33065002" target="_blank" class="term-link">
+                                        PMID:33065002
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Vesicular- or vacuolar-type adenosine triphosphatases (V-ATPases) are ATP-driven proton pumps comprised of a cytoplasmic V1 complex for ATP hydrolysis and a membrane-embedded Vo complex for proton transfer.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/9653649" target="_blank" class="term-link">
+                                        PMID:9653649
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">The proteolipid domain of vacuolar H(+)-ATPase (V-ATPase) plays a major role in H+ transport in microvesicles and other acidic organelles.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005765" target="_blank" class="term-link">
                                     GO:0005765
                                 </a>
                             </span>
                             <span class="term-label">lysosomal membrane</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-9645608
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="Q99437" data-a="GO:0005765" data-r="Reactome:R-HSA-9645608" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q99437" data-a="GO:0005765" data-r="Reactome:R-HSA-9645608" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Accept lysosomal membrane as a supported V-ATPase membrane localization.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> ATP6V0B is an integral membrane subunit of V-ATPase. Human V-ATPase structures and reviews support its role in organellar and vesicular proton-pump complexes; the broad membrane/localization annotation is correct, although more specific endolysosomal V-ATPase component terms are more informative.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/33065002" target="_blank" class="term-link">
+                                        PMID:33065002
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Vesicular- or vacuolar-type adenosine triphosphatases (V-ATPases) are ATP-driven proton pumps comprised of a cytoplasmic V1 complex for ATP hydrolysis and a membrane-embedded Vo complex for proton transfer.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/9653649" target="_blank" class="term-link">
+                                        PMID:9653649
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">The proteolipid domain of vacuolar H(+)-ATPase (V-ATPase) plays a major role in H+ transport in microvesicles and other acidic organelles.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    Reactome:R-HSA-9645608
+
+                                </span>
+
+                                <div class="support-text">Hydrolysis of ATP by the v-ATPase complex is also required for recruitment of mTORC1</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005765" target="_blank" class="term-link">
                                     GO:0005765
                                 </a>
                             </span>
                             <span class="term-label">lysosomal membrane</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-9646468
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="Q99437" data-a="GO:0005765" data-r="Reactome:R-HSA-9646468" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q99437" data-a="GO:0005765" data-r="Reactome:R-HSA-9646468" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Accept lysosomal membrane as a supported V-ATPase membrane localization.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> ATP6V0B is an integral membrane subunit of V-ATPase. Human V-ATPase structures and reviews support its role in organellar and vesicular proton-pump complexes; the broad membrane/localization annotation is correct, although more specific endolysosomal V-ATPase component terms are more informative.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/33065002" target="_blank" class="term-link">
+                                        PMID:33065002
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Vesicular- or vacuolar-type adenosine triphosphatases (V-ATPases) are ATP-driven proton pumps comprised of a cytoplasmic V1 complex for ATP hydrolysis and a membrane-embedded Vo complex for proton transfer.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/9653649" target="_blank" class="term-link">
+                                        PMID:9653649
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">The proteolipid domain of vacuolar H(+)-ATPase (V-ATPase) plays a major role in H+ transport in microvesicles and other acidic organelles.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005765" target="_blank" class="term-link">
                                     GO:0005765
                                 </a>
                             </span>
                             <span class="term-label">lysosomal membrane</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-9858940
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="Q99437" data-a="GO:0005765" data-r="Reactome:R-HSA-9858940" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q99437" data-a="GO:0005765" data-r="Reactome:R-HSA-9858940" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Accept lysosomal membrane as a supported V-ATPase membrane localization.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> ATP6V0B is an integral membrane subunit of V-ATPase. Human V-ATPase structures and reviews support its role in organellar and vesicular proton-pump complexes; the broad membrane/localization annotation is correct, although more specific endolysosomal V-ATPase component terms are more informative.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/33065002" target="_blank" class="term-link">
+                                        PMID:33065002
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Vesicular- or vacuolar-type adenosine triphosphatases (V-ATPases) are ATP-driven proton pumps comprised of a cytoplasmic V1 complex for ATP hydrolysis and a membrane-embedded Vo complex for proton transfer.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/9653649" target="_blank" class="term-link">
+                                        PMID:9653649
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">The proteolipid domain of vacuolar H(+)-ATPase (V-ATPase) plays a major role in H+ transport in microvesicles and other acidic organelles.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    Reactome:R-HSA-9858940
+
+                                </span>
+
+                                <div class="support-text">MITF has been implicated in the regulation of expression of many components of the v-ATPase, including the transmembrane component ATP6V0B</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016241" target="_blank" class="term-link">
                                     GO:0016241
                                 </a>
                             </span>
                             <span class="term-label">regulation of macroautophagy</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">NAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/22982048" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:22982048
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Lipofuscin is formed independently of macroautophagy and lys...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
                         </span>
-                        <span class="vote-buttons" data-g="Q99437" data-a="GO:0016241" data-r="PMID:22982048" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q99437" data-a="GO:0016241" data-r="PMID:22982048" data-act="MARK_AS_OVER_ANNOTATED">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Macroautophagy regulation is an over-annotation for ATP6V0B as an individual V-ATPase subunit.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> ATP6V0B-containing V-ATPase complexes support autophagic flux indirectly by acidifying lysosomes, but the cited study concerns lipofuscin handling and macroautophagy/lysosomal activity rather than a specific regulatory role for ATP6V0B. The safer annotation is lysosomal lumen acidification, not regulation of macroautophagy.
+                        </div>
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/22982048" target="_blank" class="term-link">
                                         PMID:22982048
                                     </a>
-                                    
+
                                 </span>
-                                
-                                <div class="support-text">Lipofuscin is formed independently of macroautophagy and lysosomal activity in stress-induced prematurely senescent human fibroblasts.</div>
-                                
+
+                                <div class="support-text">macroautophagy is responsible for the uptake of lipofuscin into the lysosomes</div>
+
                             </div>
-                            
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/33065002" target="_blank" class="term-link">
+                                        PMID:33065002
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Vesicular and organellar V-ATPases are essential in establishing and maintaining the pH homeostasis of endosomes and lysosomes and in supporting intracellular membrane trafficking and protein degradation</div>
+
+                            </div>
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0030670" target="_blank" class="term-link">
                                     GO:0030670
                                 </a>
                             </span>
                             <span class="term-label">phagocytic vesicle membrane</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-1222516
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
                         </span>
-                        <span class="vote-buttons" data-g="Q99437" data-a="GO:0030670" data-r="Reactome:R-HSA-1222516" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q99437" data-a="GO:0030670" data-r="Reactome:R-HSA-1222516" data-act="KEEP_AS_NON_CORE">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Keep this localization as a valid but non-core or context-specific site for V-ATPase complexes.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> ATP6V0B is a membrane V-ATPase subunit and V-ATPases can act in vesicular or specialized plasma/phagosomal compartments. For ATP6V0B&#39;s core annotation, however, lysosomal/endosomal/Golgi V0-domain component and acidification terms are more informative than this broad or context-specific location.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/33065002" target="_blank" class="term-link">
+                                        PMID:33065002
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Vesicular- or vacuolar-type adenosine triphosphatases (V-ATPases) are ATP-driven proton pumps comprised of a cytoplasmic V1 complex for ATP hydrolysis and a membrane-embedded Vo complex for proton transfer.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    Reactome:R-HSA-1222516
+
+                                </span>
+
+                                <div class="support-text">When pumping, ATP hydrolysis drives a 120 degree rotation of the rotor which leads to movement of three protons into the phagosome</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0010008" target="_blank" class="term-link">
                                     GO:0010008
                                 </a>
                             </span>
                             <span class="term-label">endosome membrane</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-5252133
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="Q99437" data-a="GO:0010008" data-r="Reactome:R-HSA-5252133" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q99437" data-a="GO:0010008" data-r="Reactome:R-HSA-5252133" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Accept endosome membrane as a supported V-ATPase membrane localization.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> ATP6V0B is an integral membrane subunit of V-ATPase. Human V-ATPase structures and reviews support its role in organellar and vesicular proton-pump complexes; the broad membrane/localization annotation is correct, although more specific endolysosomal V-ATPase component terms are more informative.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/33065002" target="_blank" class="term-link">
+                                        PMID:33065002
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Vesicular- or vacuolar-type adenosine triphosphatases (V-ATPases) are ATP-driven proton pumps comprised of a cytoplasmic V1 complex for ATP hydrolysis and a membrane-embedded Vo complex for proton transfer.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/9653649" target="_blank" class="term-link">
+                                        PMID:9653649
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">The proteolipid domain of vacuolar H(+)-ATPase (V-ATPase) plays a major role in H+ transport in microvesicles and other acidic organelles.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0010008" target="_blank" class="term-link">
                                     GO:0010008
                                 </a>
                             </span>
                             <span class="term-label">endosome membrane</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-74723
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="Q99437" data-a="GO:0010008" data-r="Reactome:R-HSA-74723" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q99437" data-a="GO:0010008" data-r="Reactome:R-HSA-74723" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Accept endosome membrane as a supported V-ATPase membrane localization.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> ATP6V0B is an integral membrane subunit of V-ATPase. Human V-ATPase structures and reviews support its role in organellar and vesicular proton-pump complexes; the broad membrane/localization annotation is correct, although more specific endolysosomal V-ATPase component terms are more informative.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/33065002" target="_blank" class="term-link">
+                                        PMID:33065002
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Vesicular- or vacuolar-type adenosine triphosphatases (V-ATPases) are ATP-driven proton pumps comprised of a cytoplasmic V1 complex for ATP hydrolysis and a membrane-embedded Vo complex for proton transfer.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/9653649" target="_blank" class="term-link">
+                                        PMID:9653649
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">The proteolipid domain of vacuolar H(+)-ATPase (V-ATPase) plays a major role in H+ transport in microvesicles and other acidic organelles.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    Reactome:R-HSA-74723
+
+                                </span>
+
+                                <div class="support-text">The effect of the proton pump is to allow entry of [H+] ions into the lumen of the endosome.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0010008" target="_blank" class="term-link">
                                     GO:0010008
                                 </a>
                             </span>
                             <span class="term-label">endosome membrane</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-917841
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="Q99437" data-a="GO:0010008" data-r="Reactome:R-HSA-917841" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q99437" data-a="GO:0010008" data-r="Reactome:R-HSA-917841" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Accept endosome membrane as a supported V-ATPase membrane localization.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> ATP6V0B is an integral membrane subunit of V-ATPase. Human V-ATPase structures and reviews support its role in organellar and vesicular proton-pump complexes; the broad membrane/localization annotation is correct, although more specific endolysosomal V-ATPase component terms are more informative.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/33065002" target="_blank" class="term-link">
+                                        PMID:33065002
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Vesicular- or vacuolar-type adenosine triphosphatases (V-ATPases) are ATP-driven proton pumps comprised of a cytoplasmic V1 complex for ATP hydrolysis and a membrane-embedded Vo complex for proton transfer.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/9653649" target="_blank" class="term-link">
+                                        PMID:9653649
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">The proteolipid domain of vacuolar H(+)-ATPase (V-ATPase) plays a major role in H+ transport in microvesicles and other acidic organelles.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016020" target="_blank" class="term-link">
                                     GO:0016020
                                 </a>
                             </span>
                             <span class="term-label">membrane</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/9653649" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:9653649
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Identification and characterization of the gene encoding a s...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="Q99437" data-a="GO:0016020" data-r="PMID:9653649" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q99437" data-a="GO:0016020" data-r="PMID:9653649" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Accept membrane as a supported V-ATPase membrane localization.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> ATP6V0B is an integral membrane subunit of V-ATPase. Human V-ATPase structures and reviews support its role in organellar and vesicular proton-pump complexes; the broad membrane/localization annotation is correct, although more specific endolysosomal V-ATPase component terms are more informative.
+                        </div>
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/33065002" target="_blank" class="term-link">
+                                        PMID:33065002
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Vesicular- or vacuolar-type adenosine triphosphatases (V-ATPases) are ATP-driven proton pumps comprised of a cytoplasmic V1 complex for ATP hydrolysis and a membrane-embedded Vo complex for proton transfer.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/9653649" target="_blank" class="term-link">
                                         PMID:9653649
                                     </a>
-                                    
+
                                 </span>
-                                
-                                <div class="support-text">Identification and characterization of the gene encoding a second proteolipid subunit of human vacuolar H(+)-ATPase (ATP6F).</div>
-                                
+
+                                <div class="support-text">The proteolipid domain of vacuolar H(+)-ATPase (V-ATPase) plays a major role in H+ transport in microvesicles and other acidic organelles.</div>
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:1902600" target="_blank" class="term-link">
                                     GO:1902600
                                 </a>
                             </span>
                             <span class="term-label">proton transmembrane transport</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/9653649" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:9653649
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Identification and characterization of the gene encoding a s...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="Q99437" data-a="GO:1902600" data-r="PMID:9653649" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q99437" data-a="GO:1902600" data-r="PMID:9653649" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Accept this acidification/proton-transport process annotation for the ATP6V0B-containing V-ATPase complex.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> The ATP6V0B-containing V0 sector contributes to proton transfer by V-ATPase. Human V-ATPases maintain acidic endosomes and lysosomes and support membrane trafficking and protein degradation, so proton transport and organelle lumen acidification annotations reflect the core biological consequence of this subunit&#39;s role in the pump.
+                        </div>
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/33065002" target="_blank" class="term-link">
+                                        PMID:33065002
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Vesicular- or vacuolar-type adenosine triphosphatases (V-ATPases) are ATP-driven proton pumps comprised of a cytoplasmic V1 complex for ATP hydrolysis and a membrane-embedded Vo complex for proton transfer.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/33065002" target="_blank" class="term-link">
+                                        PMID:33065002
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Vesicular and organellar V-ATPases are essential in establishing and maintaining the pH homeostasis of endosomes and lysosomes and in supporting intracellular membrane trafficking and protein degradation</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/9653649" target="_blank" class="term-link">
                                         PMID:9653649
                                     </a>
-                                    
+
                                 </span>
-                                
-                                <div class="support-text">Identification and characterization of the gene encoding a second proteolipid subunit of human vacuolar H(+)-ATPase (ATP6F).</div>
-                                
+
+                                <div class="support-text">The proteolipid domain of vacuolar H(+)-ATPase (V-ATPase) plays a major role in H+ transport in microvesicles and other acidic organelles.</div>
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0046610" target="_blank" class="term-link">
+                                    GO:0046610
+                                </a>
+                            </span>
+                            <span class="term-label">lysosomal proton-transporting V-type ATPase, V0 domain</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">RCA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            file:projects/PROTEOSTASIS/reports/pn_projection/pn_projected_annotations.tsv
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-new">
+                            NEW
+                        </span>
+                        <span class="vote-buttons" data-g="Q99437" data-a="GO:0046610" data-r="file:projects/PROTEOSTASIS/reports/pn_projection/pn_projected_annotations.tsv" data-act="NEW">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Add the conservative PN-projected lysosomal V0-domain component annotation.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> The PN projection places ATP6V0B in the V0 lysosomal V-ATPase proton pump component leaf and maps that leaf to GO:0046610. This is more specific than ATP6V0B&#39;s current GOA component annotations, but it is supported by the established human V-ATPase structure, lysosomal V-ATPase biology, and existing GOA annotations to lysosomal membrane, lysosomal lumen acidification, and the broader V-type ATPase V0 domain. This adds component specificity rather than a new biological process claim.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:projects/PROTEOSTASIS/reports/pn_projection/pn_projected_annotations.tsv
+
+                                </span>
+
+                                <div class="support-text">ATP6V0B		Autophagy-Lysosome Pathway|Pre-initiation autophagy signaling|mTORC1 pathway, upstream|Nutrient sensing|V0 lysosomal v-ATPase proton pump component</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/33065002" target="_blank" class="term-link">
+                                        PMID:33065002
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Vesicular- or vacuolar-type adenosine triphosphatases (V-ATPases) are ATP-driven proton pumps comprised of a cytoplasmic V1 complex for ATP hydrolysis and a membrane-embedded Vo complex for proton transfer.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/33065002" target="_blank" class="term-link">
+                                        PMID:33065002
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Vesicular and organellar V-ATPases are essential in establishing and maintaining the pH homeostasis of endosomes and lysosomes and in supporting intracellular membrane trafficking and protein degradation</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/ATP6V0B/ATP6V0B-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">model: Edison Scientific Literature</div>
+
+                            </div>
+
+                        </div>
+
+                    </td>
+                </tr>
+
             </tbody>
         </table>
     </div>
-    
 
-    
 
-    
+
+    <div class="section">
+        <h2 class="section-title">Core Functions</h2>
+
+        <div class="core-function-card">
+
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+                <h3>ATP6V0B is the V0 c&#39;&#39; proteolipid subunit of the V-ATPase proton pump. It contributes to the complex-level rotary proton-transporting ATPase activity by forming part of the membrane c-ring/proton-transfer sector, rather than independently hydrolyzing ATP. This activity acidifies lysosomal, endosomal and Golgi lumens, supporting endolysosomal protein degradation, trafficking and nutrient-signaling contexts. The PN projection to GO:0046610 is a conservative component-level refinement of existing V0 domain and lysosomal acidification annotations.</h3>
+                <span class="vote-buttons" data-g="Q99437" data-a="FUNCTION: ATP6V0B is the V0 c&#39;&#39; proteolipid subunit of the V..." data-r="" data-act="CORE_FUNCTION">
+                    <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
+                    <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
+                </span>
+            </div>
+
+
+            <div class="core-function-terms">
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Directly Involved In:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:1902600" target="_blank" class="term-link">
+                                proton transmembrane transport
+                            </a>
+                        </span>
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0007042" target="_blank" class="term-link">
+                                lysosomal lumen acidification
+                            </a>
+                        </span>
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0048388" target="_blank" class="term-link">
+                                endosomal lumen acidification
+                            </a>
+                        </span>
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0061795" target="_blank" class="term-link">
+                                Golgi lumen acidification
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Cellular Locations:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005765" target="_blank" class="term-link">
+                                lysosomal membrane
+                            </a>
+                        </span>
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0010008" target="_blank" class="term-link">
+                                endosome membrane
+                            </a>
+                        </span>
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0000139" target="_blank" class="term-link">
+                                Golgi membrane
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">In Complex:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0046610" target="_blank" class="term-link">
+                            lysosomal proton-transporting V-type ATPase, V0 domain
+                        </a>
+                    </span>
+                </div>
+
+
+
+            </div>
+
+
+            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
+                <strong>Supporting Evidence:</strong>
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/9653649" target="_blank" class="term-link">
+                                PMID:9653649
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">hATP6F is a hydrophobic protein with five putative transmembrane segments, having 61% amino acid identity and 83% similarity to the yeast protein, except in the N-terminus, and contains a conserved glutamic acid residue (Glu98) that is essential for H(+)-transporting activity.</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/33065002" target="_blank" class="term-link">
+                                PMID:33065002
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">Vesicular- or vacuolar-type adenosine triphosphatases (V-ATPases) are ATP-driven proton pumps comprised of a cytoplasmic V1 complex for ATP hydrolysis and a membrane-embedded Vo complex for proton transfer.</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/33065002" target="_blank" class="term-link">
+                                PMID:33065002
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">Vesicular and organellar V-ATPases are essential in establishing and maintaining the pH homeostasis of endosomes and lysosomes and in supporting intracellular membrane trafficking and protein degradation</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            file:projects/PROTEOSTASIS/reports/pn_projection/pn_projected_annotations.tsv
+
+                        </span>
+
+                        <div class="finding-text">ATP6V0B		Autophagy-Lysosome Pathway|Pre-initiation autophagy signaling|mTORC1 pathway, upstream|Nutrient sensing|V0 lysosomal v-ATPase proton pump component</div>
+
+                    </li>
+
+                </ul>
+            </div>
+
+        </div>
+
+    </div>
+
+
+
     <div class="section">
         <h2 class="section-title collapsible">References</h2>
         <div class="collapse-content">
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000002.md" target="_blank" class="term-link">
                             GO_REF:0000002
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Gene Ontology annotation through association of InterPro records with GO terms.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000024.md" target="_blank" class="term-link">
                             GO_REF:0000024
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Manual transfer of experimentally-verified manual GO annotation data to orthologs by curator judgment of sequence similarity.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000033.md" target="_blank" class="term-link">
                             GO_REF:0000033
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Annotation inferences using phylogenetic trees</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000043.md" target="_blank" class="term-link">
                             GO_REF:0000043
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Gene Ontology annotation based on UniProtKB/Swiss-Prot keyword mapping</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000044.md" target="_blank" class="term-link">
                             GO_REF:0000044
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location vocabulary mapping, accompanied by conservative changes to GO terms applied by UniProt.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000107.md" target="_blank" class="term-link">
                             GO_REF:0000107
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Automatic transfer of experimentally verified manual GO annotation data to orthologs using Ensembl Compara.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000120.md" target="_blank" class="term-link">
                             GO_REF:0000120
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Combined Automated Annotation using Multiple IEA Methods.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/22982048" target="_blank" class="term-link">
                             PMID:22982048
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Lipofuscin is formed independently of macroautophagy and lysosomal activity in stress-induced prematurely senescent human fibroblasts.</div>
-                
-                
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">This paper supports a macroautophagy/lysosome context, but not a specific ATP6V0B regulatory function.</div>
+
+                        <div class="finding-text">"macroautophagy is responsible for the uptake of lipofuscin into the lysosomes"</div>
+
+                    </li>
+
+                </ul>
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/23864651" target="_blank" class="term-link">
                             PMID:23864651
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">The identification of novel proteins that interact with the GLP-1 receptor and restrain its activity.</div>
-                
-                
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">The GLP-1R interaction study used a membrane yeast two-hybrid screen and does not define ATP6V0B core molecular function.</div>
+
+                        <div class="finding-text">"A screen of a human fetal brain cDNA prey library with an unliganded human GLP-1R as bait in yeast revealed 38 novel interactor protein candidates."</div>
+
+                    </li>
+
+                </ul>
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/32001091" target="_blank" class="term-link">
                             PMID:32001091
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Structure and Roles of V-type ATPases.</div>
-                
-                
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">V-ATPases are membrane-embedded ATP-driven proton pumps and are the primary source of organellar acidification in eukaryotes.</div>
+
+                        <div class="finding-text">"V-ATPases are membrane-embedded protein complexes that function as ATP hydrolysis-driven proton pumps."</div>
+
+                    </li>
+
+                </ul>
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/32296183" target="_blank" class="term-link">
                             PMID:32296183
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">A reference map of the human binary protein interactome.</div>
-                
-                
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">The HuRI study is a large-scale binary interactome resource, not ATP6V0B-specific functional evidence.</div>
+
+                        <div class="finding-text">"The dataset, versioned HI-III-20 (Human Interactome obtained from screening Space III, published in 2020), contains 52,569 verified PPIs involving 8,275 proteins"</div>
+
+                    </li>
+
+                </ul>
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/33065002" target="_blank" class="term-link">
                             PMID:33065002
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Structures of a Complete Human V-ATPase Reveal Mechanisms of Its Assembly.</div>
-                
-                
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">Human V-ATPase is an ATP-driven proton pump with a cytoplasmic V1 ATP-hydrolysis sector and a membrane-embedded Vo proton-transfer sector.</div>
+
+                        <div class="finding-text">"Vesicular- or vacuolar-type adenosine triphosphatases (V-ATPases) are ATP-driven proton pumps comprised of a cytoplasmic V1 complex for ATP hydrolysis and a membrane-embedded Vo complex for proton transfer."</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <div class="finding-statement">Organellar V-ATPases maintain endosome and lysosome pH homeostasis and support trafficking and protein degradation.</div>
+
+                        <div class="finding-text">"Vesicular and organellar V-ATPases are essential in establishing and maintaining the pH homeostasis of endosomes and lysosomes and in supporting intracellular membrane trafficking and protein degradation"</div>
+
+                    </li>
+
+                </ul>
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/9653649" target="_blank" class="term-link">
                             PMID:9653649
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Identification and characterization of the gene encoding a second proteolipid subunit of human vacuolar H(+)-ATPase (ATP6F).</div>
-                
-                
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">ATP6V0B/ATP6F is the human second V-ATPase proteolipid, a five-transmembrane c subunit with conserved Glu98 required for H+ transport.</div>
+
+                        <div class="finding-text">"hATP6F is a hydrophobic protein with five putative transmembrane segments, having 61% amino acid identity and 83% similarity to the yeast protein, except in the N-terminus, and contains a conserved glutamic acid residue (Glu98) that is essential for H(+)-transporting activity."</div>
+
+                    </li>
+
+                </ul>
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-1222516
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Intraphagosomal pH is lowered to 5 by V-ATPase</div>
-                
-                
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">Reactome describes V-ATPase rotary pumping into the phagosome.</div>
+
+                        <div class="finding-text">"When pumping, ATP hydrolysis drives a 120 degree rotation of the rotor which leads to movement of three protons into the phagosome"</div>
+
+                    </li>
+
+                </ul>
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-5252133
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">ATP6AP1 binds V-ATPase</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-74723
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Endosome acidification</div>
-                
-                
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">Reactome describes endosomal acidification as proton-pump driven entry of H+ into the endosome lumen.</div>
+
+                        <div class="finding-text">"The effect of the proton pump is to allow entry of [H+] ions into the lumen of the endosome."</div>
+
+                    </li>
+
+                </ul>
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-917841
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Acidification of Tf:TfR1 containing endosome</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-9639286
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">RRAGC,D exchanges GTP for GDP</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-9640167
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">RRAGA,B exchanges GDP for GTP</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-9640168
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">v-ATPase:Ragulator:RRAGA,B:GTP:RRAGC,D:GDP:SLC38A9:Arginine dissociates yielding v-ATPase:Ragulator:RRAGA,B:GTP:RRAGC,D:GDP and SLC38A9:Arginine</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-9640175
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">v-ATPase:Ragulator:RagA,B:GDP:RagC,D:GDP binds SLC38A9:Arginine</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-9640195
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">RRAGA,B hydrolyzes GTP</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-9645598
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">RRAGC,D hydrolyzes GTP</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-9645608
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">v-ATPase:Ragulator:RRAGA,B:GTP:RRAGC,D:GDP binds mTORC1</div>
-                
-                
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">Reactome places V-ATPase activity upstream of lysosomal mTORC1 recruitment.</div>
+
+                        <div class="finding-text">"Hydrolysis of ATP by the v-ATPase complex is also required for recruitment of mTORC1"</div>
+
+                    </li>
+
+                </ul>
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-9646468
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">mTORC1 binds RHEB:GTP</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-9858940
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">MITF-M-dependent ATP6V0B gene expression</div>
-                
-                
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">Reactome records MITF-dependent expression of ATP6V0B and the lysosome/endosome acidification role of V-ATPase.</div>
+
+                        <div class="finding-text">"MITF has been implicated in the regulation of expression of many components of the v-ATPase, including the transmembrane component ATP6V0B"</div>
+
+                    </li>
+
+                </ul>
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         file:human/ATP6V0B/ATP6V0B-deep-research-falcon.md
-                        
+
                     </span>
                 </div>
-                
-                <div class="reference-title">Deep research report on Q99437</div>
-                
-                
+
+                <div class="reference-title">Falcon deep research report on ATP6V0B</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">Falcon deep research supports ATP6V0B as the human V-ATPase c proteolipid subunit and highlights the PN-relevant lysosomal acidification role.</div>
+
+                        <div class="finding-text">"model: Edison Scientific Literature"</div>
+
+                    </li>
+
+                </ul>
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         file:human/ATP6V0B/ATP6V0B-deep-research-cyberian.md
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Cyberian deep research on ATP6V0B function</div>
-                
-                
+
+
             </div>
-            
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        file:projects/PROTEOSTASIS/reports/pn_projection/pn_projected_annotations.tsv
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Proteostasis PN projected annotations for ATP6V0B</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">PN projection maps ATP6V0B in the V0 lysosomal V-ATPase proton pump component leaf to GO:0046610.</div>
+
+                        <div class="finding-text">"ATP6V0B		Autophagy-Lysosome Pathway|Pre-initiation autophagy signaling|mTORC1 pathway, upstream|Nutrient sensing|V0 lysosomal v-ATPase proton pump component"</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
         </div>
     </div>
-    
 
 
-    
 
-    
 
-    
+    <div class="section">
+        <h2 class="section-title">Suggested Questions for Experts</h2>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> Is ATP6V0B ever functionally limiting for plasma-membrane V-ATPase activity in specialized human cells, or should plasma membrane annotations remain non-core generic V-ATPase complex localizations?</p>
+
+                    <p style="margin-top: 0.5rem;"><em>Suggested experts: V-ATPase biology curators, GO cellular component annotation experts</em></p>
+
+                </div>
+                <span class="vote-buttons" data-g="Q99437" data-a="Q: Is ATP6V0B ever functionally limiting for plasma-m..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Suggested Experiments</h2>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> Generate ATP6V0B knockout human cells, rescue with wild-type ATP6V0B and a Glu98-neutralized mutant, and quantify LysoSensor/LysoTracker pH, cathepsin maturation, V1-V0 assembly and autophagic flux. This would directly test the PN-projected lysosomal V0-domain role at the gene-product level.</p>
+
+
+                    <p style="margin-top: 0.5rem;"><em>Hypothesis: Loss of ATP6V0B specifically disrupts assembly or activity of the lysosomal V0 domain, reducing lysosomal acidification without implying a standalone ATPase activity for the subunit.</em></p>
+
+
+                    <p style="margin-top: 0.5rem;">Type: ATP6V0B-specific knockout/rescue in human lysosome pH assays</p>
+
+                </div>
+                <span class="vote-buttons" data-g="Q99437" data-a="EXPERIMENT: Generate ATP6V0B knockout human cells, rescue with..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+    </div>
+
+
+
 
     <!-- Computational Predictions Section -->
-    
+
 
     <!-- Deep Research Sections -->
-    
+
     <div class="section">
         <h2 class="section-title">Deep Research</h2>
-        
+
         <details class="deep-research-section">
             <summary style="display: flex; justify-content: space-between; align-items: center; gap: 1rem;">
                 <div style="flex: 1;">
@@ -3959,29 +5771,29 @@
                 </div>
             </summary>
             <div class="markdown-content">
-                
+
                 <div class="report-meta">
-                    
+
                     <span class="report-meta-text">ATP6V0B: The c&#39;&#39; Proteolipid Subunit of Vacuolar H⁺-ATPase</span>
-                    
-                    
+
+
                     <span class="report-badge">Cyberian</span>
-                    
-                    
+
+
                     <span class="report-badge">deep-research</span>
-                    
-                    
+
+
                     <span class="report-badge">19 citations</span>
-                    
-                    
-                    
+
+
+
                     <span class="report-meta-text">2026-01-24T01:20:52.468925</span>
-                    
-                    
-                    
+
+
+
                 </div>
-                
-                
+
+
                 <h1 id="atp6v0b-the-c-proteolipid-subunit-of-vacuolar-h-atpase">ATP6V0B: The c'' Proteolipid Subunit of Vacuolar H⁺-ATPase</h1>
 <h2 id="introduction">Introduction</h2>
 <p>ATP6V0B (also known as ATP6F) encodes the c'' subunit of the V₀ membrane sector of vacuolar H⁺-ATPase (V-ATPase), a multi-subunit enzyme responsible for the acidification of intracellular compartments in all eukaryotic cells. The gene product is a 21 kDa proteolipid that forms part of the proton-conducting pore of V-ATPase, participating directly in the translocation of protons across membranes. V-ATPase activity is essential for maintaining the acidic pH of lysosomes, endosomes, the trans-Golgi network, and secretory vesicles, and plays critical roles in processes including protein degradation, receptor-mediated endocytosis, autophagy, neurotransmitter loading, and nutrient sensing[stevens-1997-vatpase-review-abstract].</p>
@@ -4120,7 +5932,7 @@
 </ol>
             </div>
         </details>
-        
+
         <details class="deep-research-section">
             <summary style="display: flex; justify-content: space-between; align-items: center; gap: 1rem;">
                 <div style="flex: 1;">
@@ -4133,29 +5945,29 @@
                 </div>
             </summary>
             <div class="markdown-content">
-                
+
                 <div class="report-meta">
-                    
+
                     <span class="report-meta-text">this with annotations you find in gene/protein databases, but these can be outdated or inaccurate.</span>
-                    
-                    
+
+
                     <span class="report-badge">Falcon</span>
-                    
-                    
+
+
                     <span class="report-badge">Edison Scientific Literature</span>
-                    
-                    
+
+
                     <span class="report-badge">21 citations</span>
-                    
-                    
-                    
+
+
+
                     <span class="report-meta-text">2025-12-26T10:28:44.386027</span>
-                    
-                    
-                    
+
+
+
                 </div>
-                
-                
+
+
                 <p>The research report should be a detailed narrative explaining the function, biological processes, and localization of the gene product. Citations should be given for all claims.</p>
 <p>You should prioritize authoritative reviews and primary scientific literature when conducting research. You can supplement<br />
 this with annotations you find in gene/protein databases, but these can be outdated or inaccurate.</p>
@@ -4259,7 +6071,7 @@ Human ATP6V0B encodes the Vo proteolipid c'' subunit, a five-helix rotor compone
 </ol>
             </div>
         </details>
-        
+
         <details class="deep-research-section">
             <summary style="display: flex; justify-content: space-between; align-items: center; gap: 1rem;">
                 <div style="flex: 1;">
@@ -4272,29 +6084,29 @@ Human ATP6V0B encodes the Vo proteolipid c'' subunit, a five-helix rotor compone
                 </div>
             </summary>
             <div class="markdown-content">
-                
+
                 <div class="report-meta">
-                    
+
                     <span class="report-meta-text">Overview of ATP6V0B and the V-ATPase Complex</span>
-                    
-                    
+
+
                     <span class="report-badge">OpenAI</span>
-                    
-                    
+
+
                     <span class="report-badge">o3-deep-research-2025-06-26</span>
-                    
-                    
+
+
                     <span class="report-badge">58 citations</span>
-                    
-                    
-                    
+
+
+
                     <span class="report-meta-text">2025-11-04T03:15:00.215814</span>
-                    
-                    
-                    
+
+
+
                 </div>
-                
-                
+
+
                 <h1 id="overview-of-atp6v0b-and-the-v-atpase-complex">Overview of ATP6V0B and the V-ATPase Complex</h1>
 <p><strong>ATP6V0B</strong> (UniProt Q99437) encodes the V0 <em>subunit b</em> of the vacuolar H^+-ATPase (V-ATPase) in humans (<a href="https://genome.ucsc.edu/cgi-bin/hgGene?db=hg38&amp;hgg_gene=ENST00000472174.7&amp;hgg_type=knownGene#:~:text=FUNCTION%3A%20Proton,ATPase%20proteolipid%20subunit%20family">genome.ucsc.edu</a>). V-ATPase is a large multisubunit enzyme complex that uses the energy from ATP hydrolysis to pump protons (H^+) across membranes, thereby <strong>acidifying intracellular compartments</strong> (<a href="https://www.ncbi.nlm.nih.gov/gene?Cmd=DetailsSearch&amp;Db=gene&amp;Term=533#:~:text=Summary%20This%20gene%20encodes%20a,Expression">www.ncbi.nlm.nih.gov</a>). The ATP6V0B gene product is a <strong>21-kDa proteolipid membrane protein</strong> (also called <em>subunit c''</em>) that is a core component of the proton-conducting pore of V-ATPase (<a href="https://genome.ucsc.edu/cgi-bin/hgGene?db=hg38&amp;hgg_gene=ENST00000472174.7&amp;hgg_type=knownGene#:~:text=FUNCTION%3A%20Proton,ATPase%20proteolipid%20subunit%20family">genome.ucsc.edu</a>). This subunit is a multi-pass transmembrane protein found in the membrane of acidic organelles (analogous to the yeast vacuole/lysosome membrane) (<a href="https://genome.ucsc.edu/cgi-bin/hgGene?db=hg38&amp;hgg_gene=ENST00000472174.7&amp;hgg_type=knownGene#:~:text=FUNCTION%3A%20Proton,ATPase%20proteolipid%20subunit%20family">genome.ucsc.edu</a>). Consistent with its fundamental role, ATP6V0B is expressed <strong>ubiquitously</strong> in human tissues (<a href="https://genome.ucsc.edu/cgi-bin/hgGene?db=hg38&amp;hgg_gene=ENST00000472174.7&amp;hgg_type=knownGene#:~:text=intracellular%20compartments%20in%20eukaryotic%20cells,ATPase%20proteolipid%20subunit%20family">genome.ucsc.edu</a>) (with notable levels in metabolically active tissues like bone marrow and kidney (<a href="https://www.ncbi.nlm.nih.gov/gene?Cmd=DetailsSearch&amp;Db=gene&amp;Term=533#:~:text=Expression%20Ubiquitous%20expression%20in%20bone,25%20other%20tissues%20See%20more">www.ncbi.nlm.nih.gov</a>)), reflecting the widespread need for organelle acidification in cells.</p>
 <h1 id="structure-and-composition-of-the-v-atpase">Structure and Composition of the V-ATPase</h1>
@@ -4393,12 +6205,66 @@ Human ATP6V0B encodes the Vo proteolipid c'' subunit, a five-helix rotor compone
 </ol>
             </div>
         </details>
-        
+
     </div>
-    
+
 
     <!-- Additional Documentation Sections -->
-    
+
+    <div class="section">
+        <h2 class="section-title">📚 Additional Documentation</h2>
+
+        <details class="markdown-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; cursor: pointer;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Notes</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(ATP6V0B-notes.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="Q99437" data-a="DOC: Notes" data-r="" data-act="DOCUMENTATION" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This documentation is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This documentation needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+                <h1 id="atp6v0b-notes">ATP6V0B notes</h1>
+<h2 id="2026-06-03-pn-batch-review">2026-06-03 PN batch review</h2>
+<p>Falcon deep research was already present as <code>ATP6V0B-deep-research-falcon.md</code>, so<br />
+no fallback provider run was needed. I re-reviewed the existing ATP6V0B YAML in<br />
+Proteostasis PN context.</p>
+<p>ATP6V0B is the human V-ATPase V0 proteolipid c'' subunit. The primary cloning<br />
+paper identifies hATP6F/ATP6V0B as a second human V-ATPase proteolipid and states<br />
+that it has five putative transmembrane segments and a conserved Glu98 essential<br />
+for H(+)-transporting activity <a href="https://pubmed.ncbi.nlm.nih.gov/9653649" title="hATP6F is a hydrophobic protein with five putative transmembrane segments">PMID:9653649</a>. The human V-ATPase structure paper<br />
+frames V-ATPase as an ATP-driven proton pump with cytoplasmic V1 ATP hydrolysis<br />
+and membrane-embedded Vo proton transfer <a href="https://pubmed.ncbi.nlm.nih.gov/33065002" title="V-ATPases are ATP-driven proton pumps comprised of a cytoplasmic V1 complex for ATP hydrolysis and a membrane-embedded Vo complex for proton transfer">PMID:33065002</a>.</p>
+<p>For PN projection, ATP6V0B appears in the Autophagy-Lysosome Pathway under V0<br />
+lysosomal v-ATPase proton pump component. The projection already matches GOA for<br />
+lysosomal lumen acidification and the broader V-type ATPase V0 domain, and it has<br />
+one conservative more-specific candidate: GO:0046610 lysosomal<br />
+proton-transporting V-type ATPase, V0 domain [file:projects/PROTEOSTASIS/reports/pn_projection/pn_projected_annotations.tsv<br />
+"ATP6V0B        Autophagy-Lysosome Pathway|Pre-initiation autophagy signaling|mTORC1 pathway,<br />
+upstream|Nutrient sensing|V0 lysosomal v-ATPase proton pump component"]. I added<br />
+this as a <code>NEW</code> reviewed annotation because it is a component-level refinement,<br />
+not a new biological-process claim.</p>
+<p>Conservative decisions:</p>
+<ul>
+<li>Accepted the V-ATPase component, proton transport, and organelle acidification<br />
+  annotations as core or directly supportive of core function.</li>
+<li>Modified broad <code>monoatomic ion transport</code> to <code>proton transmembrane transport</code>.</li>
+<li>Modified generic <code>proton transmembrane transporter activity</code> to the more<br />
+  specific complex-level rotary V-ATPase activity, while describing ATP6V0B as a<br />
+  contributor to the complex rather than an independent ATPase.</li>
+<li>Removed generic <code>protein binding</code> annotations from the GLP-1R and HuRI<br />
+  interaction screens because they do not describe ATP6V0B mechanism.</li>
+<li>Marked <code>regulation of macroautophagy</code> as over-annotation. ATP6V0B supports<br />
+  autophagic flux through lysosomal acidification, but the cited paper does not<br />
+  show a specific ATP6V0B regulatory role <a href="https://pubmed.ncbi.nlm.nih.gov/22982048" title="macroautophagy is   responsible for the uptake of lipofuscin into the lysosomes">PMID:22982048</a>.</li>
+</ul>
+            </div>
+        </details>
+
+    </div>
+
 
     <!-- YAML Preview Section -->
     <div class="section">
@@ -4408,562 +6274,1277 @@ Human ATP6V0B encodes the Vo proteolipid c'' subunit, a five-helix rotor compone
             </summary>
             <div class="yaml-content">
                 <pre><code>id: Q99437
-gene_symbol: Q99437
+gene_symbol: ATP6V0B
 product_type: PROTEIN
 taxon:
   id: NCBITaxon:9606
   label: Homo sapiens
-description: &#39;TODO: Add description for Q99437&#39;
+description: &#39;ATP6V0B encodes the human V-type proton ATPase V0 proteolipid subunit c&#39;&#39;&#39;&#39;.
+  It is a small multi-pass membrane component of the proton-translocating V0 sector, where
+  it forms part of the c-ring rotor/pore with an essential conserved Glu98 residue required
+  for H+ transport. ATP6V0B-containing V-ATPase complexes acidify lysosomes, endosomes, Golgi-derived
+  compartments and other vesicles, thereby supporting endolysosomal pH homeostasis, membrane
+  trafficking, protein degradation, autophagic flux and lysosome-associated nutrient signaling.
+  In specialized cell contexts, V-ATPase complexes can also function at the plasma membrane
+  to acidify the extracellular or phagosomal environment.&#39;
 existing_annotations:
-  - term:
-      id: GO:0016020
-      label: membrane
-    evidence_type: IBA
-    original_reference_id: GO_REF:0000033
-    review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
-      supported_by:
-        - reference_id: file:human/ATP6V0B/ATP6V0B-deep-research-falcon.md
-          supporting_text: &#39;model: Edison Scientific Literature&#39;
-  - term:
-      id: GO:0006811
-      label: monoatomic ion transport
-    evidence_type: IEA
-    original_reference_id: GO_REF:0000043
-    review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
-  - term:
-      id: GO:0015078
-      label: proton transmembrane transporter activity
-    evidence_type: IEA
-    original_reference_id: GO_REF:0000120
-    review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
-  - term:
-      id: GO:0030665
-      label: clathrin-coated vesicle membrane
-    evidence_type: IEA
-    original_reference_id: GO_REF:0000044
-    review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
-  - term:
-      id: GO:0031410
-      label: cytoplasmic vesicle
-    evidence_type: IEA
-    original_reference_id: GO_REF:0000043
-    review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
-  - term:
-      id: GO:0033177
-      label: proton-transporting two-sector ATPase complex, proton-transporting 
-        domain
-    evidence_type: IEA
-    original_reference_id: GO_REF:0000002
-    review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
-  - term:
-      id: GO:0033179
-      label: proton-transporting V-type ATPase, V0 domain
-    evidence_type: IEA
-    original_reference_id: GO_REF:0000002
-    review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
-  - term:
-      id: GO:0046961
+- term:
+    id: GO:0016020
+    label: membrane
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  review:
+    summary: Accept membrane as a supported V-ATPase membrane localization.
+    action: ACCEPT
+    reason: ATP6V0B is an integral membrane subunit of V-ATPase. Human V-ATPase
+      structures and reviews support its role in organellar and vesicular proton-pump
+      complexes; the broad membrane/localization annotation is correct, although more
+      specific endolysosomal V-ATPase component terms are more informative.
+    supported_by:
+    - reference_id: PMID:33065002
+      supporting_text: Vesicular- or vacuolar-type adenosine triphosphatases (V-ATPases)
+        are ATP-driven proton pumps comprised of a cytoplasmic V1 complex for ATP
+        hydrolysis and a membrane-embedded Vo complex for proton transfer.
+    - reference_id: PMID:9653649
+      supporting_text: The proteolipid domain of vacuolar H(+)-ATPase (V-ATPase) plays a
+        major role in H+ transport in microvesicles and other acidic organelles.
+- term:
+    id: GO:0006811
+    label: monoatomic ion transport
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000043
+  review:
+    summary: The annotation is directionally correct but too broad for ATP6V0B.
+    action: MODIFY
+    reason: ATP6V0B is not a generic ion-transport factor; it contributes to
+      V-ATPase-driven proton transmembrane transport. Replace the broad monoatomic ion
+      transport term with the established proton transport process term already
+      supported elsewhere in GOA.
+    proposed_replacement_terms:
+    - id: GO:1902600
+      label: proton transmembrane transport
+    supported_by:
+    - reference_id: PMID:33065002
+      supporting_text: Vesicular- or vacuolar-type adenosine triphosphatases (V-ATPases)
+        are ATP-driven proton pumps comprised of a cytoplasmic V1 complex for ATP
+        hydrolysis and a membrane-embedded Vo complex for proton transfer.
+    - reference_id: PMID:9653649
+      supporting_text: The proteolipid domain of vacuolar H(+)-ATPase (V-ATPase) plays a
+        major role in H+ transport in microvesicles and other acidic organelles.
+- term:
+    id: GO:0015078
+    label: proton transmembrane transporter activity
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000120
+  review:
+    summary: The proton-transporter concept is correct, but the more precise complex
+      activity is V-type ATPase rotational proton pumping.
+    action: MODIFY
+    reason: ATP6V0B contributes as the c&#39;&#39; proteolipid in the V0 rotor rather than
+      acting as an independent transporter. A complex-level term, proton-transporting
+      ATPase activity, rotational mechanism, is the better molecular-function target; in
+      GPAD/GAF this should be treated conservatively as a contribution to the V-ATPase
+      complex activity.
+    proposed_replacement_terms:
+    - id: GO:0046961
       label: proton-transporting ATPase activity, rotational mechanism
-    evidence_type: IEA
-    original_reference_id: GO_REF:0000002
-    review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
-  - term:
-      id: GO:1902600
-      label: proton transmembrane transport
-    evidence_type: IEA
-    original_reference_id: GO_REF:0000120
-    review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
-  - term:
-      id: GO:0005515
-      label: protein binding
-    evidence_type: IPI
-    original_reference_id: PMID:23864651
-    review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
-      supported_by:
-        - reference_id: PMID:23864651
-          supporting_text: Jul 17. The identification of novel proteins that 
-            interact with the GLP-1 receptor and restrain its activity.
-  - term:
-      id: GO:0005515
-      label: protein binding
-    evidence_type: IPI
-    original_reference_id: PMID:32296183
-    review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
-      supported_by:
-        - reference_id: PMID:32296183
-          supporting_text: Apr 8. A reference map of the human binary protein 
-            interactome.
-  - term:
-      id: GO:0005768
-      label: endosome
-    evidence_type: IEA
-    original_reference_id: GO_REF:0000107
-    review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
-  - term:
-      id: GO:0016020
-      label: membrane
-    evidence_type: IEA
-    original_reference_id: GO_REF:0000120
-    review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
-  - term:
-      id: GO:0033176
-      label: proton-transporting V-type ATPase complex
-    evidence_type: IEA
-    original_reference_id: GO_REF:0000107
-    review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
-  - term:
-      id: GO:0000139
-      label: Golgi membrane
-    evidence_type: NAS
-    original_reference_id: PMID:32001091
-    review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
-      supported_by:
-        - reference_id: PMID:32001091
-          supporting_text: Epub 2020 Jan 28. Structure and Roles of V-type 
-            ATPases.
-  - term:
-      id: GO:0005765
-      label: lysosomal membrane
-    evidence_type: NAS
-    original_reference_id: PMID:32001091
-    review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
-      supported_by:
-        - reference_id: PMID:32001091
-          supporting_text: Epub 2020 Jan 28. Structure and Roles of V-type 
-            ATPases.
-  - term:
-      id: GO:0005886
-      label: plasma membrane
-    evidence_type: NAS
-    original_reference_id: PMID:32001091
-    review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
-      supported_by:
-        - reference_id: PMID:32001091
-          supporting_text: Epub 2020 Jan 28. Structure and Roles of V-type 
-            ATPases.
-  - term:
-      id: GO:0007035
-      label: vacuolar acidification
-    evidence_type: NAS
-    original_reference_id: PMID:32001091
-    review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
-      supported_by:
-        - reference_id: PMID:32001091
-          supporting_text: Epub 2020 Jan 28. Structure and Roles of V-type 
-            ATPases.
-  - term:
-      id: GO:0007042
-      label: lysosomal lumen acidification
-    evidence_type: NAS
-    original_reference_id: PMID:32001091
-    review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
-      supported_by:
-        - reference_id: PMID:32001091
-          supporting_text: Epub 2020 Jan 28. Structure and Roles of V-type 
-            ATPases.
-  - term:
-      id: GO:0007042
-      label: lysosomal lumen acidification
-    evidence_type: NAS
-    original_reference_id: PMID:33065002
-    review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
-      supported_by:
-        - reference_id: PMID:33065002
-          supporting_text: 2020 Oct 15. Structures of a Complete Human V-ATPase 
-            Reveal Mechanisms of Its Assembly.
-  - term:
-      id: GO:0010008
-      label: endosome membrane
-    evidence_type: NAS
-    original_reference_id: PMID:32001091
-    review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
-      supported_by:
-        - reference_id: PMID:32001091
-          supporting_text: Epub 2020 Jan 28. Structure and Roles of V-type 
-            ATPases.
-  - term:
-      id: GO:0016020
-      label: membrane
-    evidence_type: IDA
-    original_reference_id: PMID:33065002
-    review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
-      supported_by:
-        - reference_id: PMID:33065002
-          supporting_text: 2020 Oct 15. Structures of a Complete Human V-ATPase 
-            Reveal Mechanisms of Its Assembly.
-  - term:
-      id: GO:0033176
-      label: proton-transporting V-type ATPase complex
-    evidence_type: NAS
-    original_reference_id: PMID:33065002
-    review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
-      supported_by:
-        - reference_id: PMID:33065002
-          supporting_text: 2020 Oct 15. Structures of a Complete Human V-ATPase 
-            Reveal Mechanisms of Its Assembly.
-  - term:
-      id: GO:0048388
-      label: endosomal lumen acidification
-    evidence_type: NAS
-    original_reference_id: PMID:32001091
-    review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
-      supported_by:
-        - reference_id: PMID:32001091
-          supporting_text: Epub 2020 Jan 28. Structure and Roles of V-type 
-            ATPases.
-  - term:
-      id: GO:0051452
-      label: intracellular pH reduction
-    evidence_type: NAS
-    original_reference_id: PMID:32001091
-    review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
-      supported_by:
-        - reference_id: PMID:32001091
-          supporting_text: Epub 2020 Jan 28. Structure and Roles of V-type 
-            ATPases.
-  - term:
-      id: GO:0061795
-      label: Golgi lumen acidification
-    evidence_type: NAS
-    original_reference_id: PMID:32001091
-    review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
-      supported_by:
-        - reference_id: PMID:32001091
-          supporting_text: Epub 2020 Jan 28. Structure and Roles of V-type 
-            ATPases.
-  - term:
-      id: GO:1902600
-      label: proton transmembrane transport
-    evidence_type: NAS
-    original_reference_id: PMID:33065002
-    review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
-      supported_by:
-        - reference_id: PMID:33065002
-          supporting_text: 2020 Oct 15. Structures of a Complete Human V-ATPase 
-            Reveal Mechanisms of Its Assembly.
-  - term:
-      id: GO:0046961
-      label: proton-transporting ATPase activity, rotational mechanism
-    evidence_type: TAS
-    original_reference_id: PMID:9653649
-    review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
-      supported_by:
-        - reference_id: PMID:9653649
-          supporting_text: Identification and characterization of the gene 
-            encoding a second proteolipid subunit of human vacuolar H(+)-ATPase 
-            (ATP6F).
-  - term:
-      id: GO:0000220
-      label: vacuolar proton-transporting V-type ATPase, V0 domain
-    evidence_type: ISS
-    original_reference_id: GO_REF:0000024
-    review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
-  - term:
-      id: GO:0005765
-      label: lysosomal membrane
-    evidence_type: TAS
-    original_reference_id: Reactome:R-HSA-9639286
-    review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
-  - term:
-      id: GO:0005765
-      label: lysosomal membrane
-    evidence_type: TAS
-    original_reference_id: Reactome:R-HSA-9640167
-    review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
-  - term:
-      id: GO:0005765
-      label: lysosomal membrane
-    evidence_type: TAS
-    original_reference_id: Reactome:R-HSA-9640168
-    review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
-  - term:
-      id: GO:0005765
-      label: lysosomal membrane
-    evidence_type: TAS
-    original_reference_id: Reactome:R-HSA-9640175
-    review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
-  - term:
-      id: GO:0005765
-      label: lysosomal membrane
-    evidence_type: TAS
-    original_reference_id: Reactome:R-HSA-9640195
-    review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
-  - term:
-      id: GO:0005765
-      label: lysosomal membrane
-    evidence_type: TAS
-    original_reference_id: Reactome:R-HSA-9645598
-    review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
-  - term:
-      id: GO:0005765
-      label: lysosomal membrane
-    evidence_type: TAS
-    original_reference_id: Reactome:R-HSA-9645608
-    review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
-  - term:
-      id: GO:0005765
-      label: lysosomal membrane
-    evidence_type: TAS
-    original_reference_id: Reactome:R-HSA-9646468
-    review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
-  - term:
-      id: GO:0005765
-      label: lysosomal membrane
-    evidence_type: TAS
-    original_reference_id: Reactome:R-HSA-9858940
-    review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
-  - term:
-      id: GO:0016241
-      label: regulation of macroautophagy
-    evidence_type: NAS
-    original_reference_id: PMID:22982048
-    review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
-      supported_by:
-        - reference_id: PMID:22982048
-          supporting_text: Lipofuscin is formed independently of macroautophagy 
-            and lysosomal activity in stress-induced prematurely senescent human
-            fibroblasts.
-  - term:
-      id: GO:0030670
-      label: phagocytic vesicle membrane
-    evidence_type: TAS
-    original_reference_id: Reactome:R-HSA-1222516
-    review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
-  - term:
-      id: GO:0010008
-      label: endosome membrane
-    evidence_type: TAS
-    original_reference_id: Reactome:R-HSA-5252133
-    review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
-  - term:
-      id: GO:0010008
-      label: endosome membrane
-    evidence_type: TAS
-    original_reference_id: Reactome:R-HSA-74723
-    review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
-  - term:
-      id: GO:0010008
-      label: endosome membrane
-    evidence_type: TAS
-    original_reference_id: Reactome:R-HSA-917841
-    review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
-  - term:
-      id: GO:0016020
-      label: membrane
-    evidence_type: TAS
-    original_reference_id: PMID:9653649
-    review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
-      supported_by:
-        - reference_id: PMID:9653649
-          supporting_text: Identification and characterization of the gene 
-            encoding a second proteolipid subunit of human vacuolar H(+)-ATPase 
-            (ATP6F).
-  - term:
-      id: GO:1902600
-      label: proton transmembrane transport
-    evidence_type: TAS
-    original_reference_id: PMID:9653649
-    review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
-      supported_by:
-        - reference_id: PMID:9653649
-          supporting_text: Identification and characterization of the gene 
-            encoding a second proteolipid subunit of human vacuolar H(+)-ATPase 
-            (ATP6F).
+    supported_by:
+    - reference_id: PMID:33065002
+      supporting_text: Vesicular- or vacuolar-type adenosine triphosphatases (V-ATPases)
+        are ATP-driven proton pumps comprised of a cytoplasmic V1 complex for ATP
+        hydrolysis and a membrane-embedded Vo complex for proton transfer.
+    - reference_id: PMID:9653649
+      supporting_text: hATP6F is a hydrophobic protein with five putative transmembrane
+        segments, having 61% amino acid identity and 83% similarity to the yeast
+        protein, except in the N-terminus, and contains a conserved glutamic acid
+        residue (Glu98) that is essential for H(+)-transporting activity.
+- term:
+    id: GO:0030665
+    label: clathrin-coated vesicle membrane
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000044
+  review:
+    summary: Accept clathrin-coated vesicle membrane as a supported V-ATPase membrane
+      localization.
+    action: ACCEPT
+    reason: ATP6V0B is an integral membrane subunit of V-ATPase. Human V-ATPase
+      structures and reviews support its role in organellar and vesicular proton-pump
+      complexes; the broad membrane/localization annotation is correct, although more
+      specific endolysosomal V-ATPase component terms are more informative.
+    supported_by:
+    - reference_id: PMID:33065002
+      supporting_text: Vesicular- or vacuolar-type adenosine triphosphatases (V-ATPases)
+        are ATP-driven proton pumps comprised of a cytoplasmic V1 complex for ATP
+        hydrolysis and a membrane-embedded Vo complex for proton transfer.
+    - reference_id: PMID:9653649
+      supporting_text: The proteolipid domain of vacuolar H(+)-ATPase (V-ATPase) plays a
+        major role in H+ transport in microvesicles and other acidic organelles.
+- term:
+    id: GO:0031410
+    label: cytoplasmic vesicle
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000043
+  review:
+    summary: Keep this localization as a valid but non-core or context-specific site for
+      V-ATPase complexes.
+    action: KEEP_AS_NON_CORE
+    reason: ATP6V0B is a membrane V-ATPase subunit and V-ATPases can act in vesicular or
+      specialized plasma/phagosomal compartments. For ATP6V0B&#39;s core annotation,
+      however, lysosomal/endosomal/Golgi V0-domain component and acidification terms are
+      more informative than this broad or context-specific location.
+    supported_by:
+    - reference_id: PMID:33065002
+      supporting_text: Vesicular- or vacuolar-type adenosine triphosphatases (V-ATPases)
+        are ATP-driven proton pumps comprised of a cytoplasmic V1 complex for ATP
+        hydrolysis and a membrane-embedded Vo complex for proton transfer.
+    - reference_id: Reactome:R-HSA-1222516
+      supporting_text: When pumping, ATP hydrolysis drives a 120 degree rotation of the
+        rotor which leads to movement of three protons into the phagosome
+- term:
+    id: GO:0033177
+    label: proton-transporting two-sector ATPase complex, proton-transporting domain
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000002
+  review:
+    summary: This component annotation is consistent with ATP6V0B being the c&#39;&#39;
+      proteolipid subunit of the V0 proton-translocating sector of V-ATPase.
+    action: ACCEPT
+    reason: ATP6V0B is experimentally identified as a five-transmembrane human V-ATPase
+      proteolipid with conserved Glu98 required for H+ transport, and human V-ATPase
+      structures place V0 subunits in the membrane-embedded proton-transfer module. The
+      component annotation is therefore part of the core molecular role of ATP6V0B.
+    supported_by:
+    - reference_id: PMID:33065002
+      supporting_text: Vesicular- or vacuolar-type adenosine triphosphatases (V-ATPases)
+        are ATP-driven proton pumps comprised of a cytoplasmic V1 complex for ATP
+        hydrolysis and a membrane-embedded Vo complex for proton transfer.
+    - reference_id: PMID:9653649
+      supporting_text: hATP6F is a hydrophobic protein with five putative transmembrane
+        segments, having 61% amino acid identity and 83% similarity to the yeast
+        protein, except in the N-terminus, and contains a conserved glutamic acid
+        residue (Glu98) that is essential for H(+)-transporting activity.
+- term:
+    id: GO:0033179
+    label: proton-transporting V-type ATPase, V0 domain
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000002
+  review:
+    summary: This component annotation is consistent with ATP6V0B being the c&#39;&#39;
+      proteolipid subunit of the V0 proton-translocating sector of V-ATPase.
+    action: ACCEPT
+    reason: ATP6V0B is experimentally identified as a five-transmembrane human V-ATPase
+      proteolipid with conserved Glu98 required for H+ transport, and human V-ATPase
+      structures place V0 subunits in the membrane-embedded proton-transfer module. The
+      component annotation is therefore part of the core molecular role of ATP6V0B.
+    supported_by:
+    - reference_id: PMID:33065002
+      supporting_text: Vesicular- or vacuolar-type adenosine triphosphatases (V-ATPases)
+        are ATP-driven proton pumps comprised of a cytoplasmic V1 complex for ATP
+        hydrolysis and a membrane-embedded Vo complex for proton transfer.
+    - reference_id: PMID:9653649
+      supporting_text: hATP6F is a hydrophobic protein with five putative transmembrane
+        segments, having 61% amino acid identity and 83% similarity to the yeast
+        protein, except in the N-terminus, and contains a conserved glutamic acid
+        residue (Glu98) that is essential for H(+)-transporting activity.
+- term:
+    id: GO:0046961
+    label: proton-transporting ATPase activity, rotational mechanism
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000002
+  review:
+    summary: Accept the V-type ATPase rotational proton-pump activity as the complex
+      activity to which ATP6V0B contributes.
+    action: ACCEPT
+    reason: ATP6V0B is not the ATP-hydrolytic catalytic subunit, but it is an essential
+      V0 c-ring proteolipid required for proton translocation by the rotary V-ATPase.
+      This is the correct complex-level molecular function for the ATP6V0B-containing
+      V-ATPase machinery.
+    supported_by:
+    - reference_id: PMID:33065002
+      supporting_text: Vesicular- or vacuolar-type adenosine triphosphatases (V-ATPases)
+        are ATP-driven proton pumps comprised of a cytoplasmic V1 complex for ATP
+        hydrolysis and a membrane-embedded Vo complex for proton transfer.
+    - reference_id: PMID:9653649
+      supporting_text: hATP6F is a hydrophobic protein with five putative transmembrane
+        segments, having 61% amino acid identity and 83% similarity to the yeast
+        protein, except in the N-terminus, and contains a conserved glutamic acid
+        residue (Glu98) that is essential for H(+)-transporting activity.
+- term:
+    id: GO:1902600
+    label: proton transmembrane transport
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000120
+  review:
+    summary: Accept this acidification/proton-transport process annotation for the
+      ATP6V0B-containing V-ATPase complex.
+    action: ACCEPT
+    reason: The ATP6V0B-containing V0 sector contributes to proton transfer by V-ATPase.
+      Human V-ATPases maintain acidic endosomes and lysosomes and support membrane
+      trafficking and protein degradation, so proton transport and organelle lumen
+      acidification annotations reflect the core biological consequence of this
+      subunit&#39;s role in the pump.
+    supported_by:
+    - reference_id: PMID:33065002
+      supporting_text: Vesicular- or vacuolar-type adenosine triphosphatases (V-ATPases)
+        are ATP-driven proton pumps comprised of a cytoplasmic V1 complex for ATP
+        hydrolysis and a membrane-embedded Vo complex for proton transfer.
+    - reference_id: PMID:33065002
+      supporting_text: Vesicular and organellar V-ATPases are essential in establishing
+        and maintaining the pH homeostasis of endosomes and lysosomes and in supporting
+        intracellular membrane trafficking and protein degradation
+    - reference_id: PMID:9653649
+      supporting_text: The proteolipid domain of vacuolar H(+)-ATPase (V-ATPase) plays a
+        major role in H+ transport in microvesicles and other acidic organelles.
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:23864651
+  review:
+    summary: Remove the generic protein binding annotation from the GLP-1R interaction
+      screen.
+    action: REMOVE
+    reason: GO:0005515 is uninformative for ATP6V0B and the supporting study is a
+      receptor-interactome screen rather than evidence for ATP6V0B&#39;s core V-ATPase
+      function. No specific ATP6V0B molecular activity should be inferred from this
+      interaction record.
+    supported_by:
+    - reference_id: PMID:23864651
+      supporting_text: A screen of a human fetal brain cDNA prey library with an
+        unliganded human GLP-1R as bait in yeast revealed 38 novel interactor protein
+        candidates.
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:32296183
+  review:
+    summary: Remove the generic protein binding annotation from the high-throughput
+      binary interactome map.
+    action: REMOVE
+    reason: GO:0005515 is deliberately avoided in this curation workflow because it does
+      not describe ATP6V0B&#39;s mechanistic role. The HuRI study is a large-scale
+      interaction map, useful as interaction evidence but not sufficient to replace the
+      established V-ATPase c&#39;&#39; subunit function with a generic binding term.
+    supported_by:
+    - reference_id: PMID:32296183
+      supporting_text: The dataset, versioned HI-III-20 (Human Interactome obtained from
+        screening Space III, published in 2020), contains 52,569 verified PPIs involving
+        8,275 proteins
+- term:
+    id: GO:0005768
+    label: endosome
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000107
+  review:
+    summary: Accept endosome as a supported V-ATPase membrane localization.
+    action: ACCEPT
+    reason: ATP6V0B is an integral membrane subunit of V-ATPase. Human V-ATPase
+      structures and reviews support its role in organellar and vesicular proton-pump
+      complexes; the broad membrane/localization annotation is correct, although more
+      specific endolysosomal V-ATPase component terms are more informative.
+    supported_by:
+    - reference_id: PMID:33065002
+      supporting_text: Vesicular- or vacuolar-type adenosine triphosphatases (V-ATPases)
+        are ATP-driven proton pumps comprised of a cytoplasmic V1 complex for ATP
+        hydrolysis and a membrane-embedded Vo complex for proton transfer.
+    - reference_id: PMID:9653649
+      supporting_text: The proteolipid domain of vacuolar H(+)-ATPase (V-ATPase) plays a
+        major role in H+ transport in microvesicles and other acidic organelles.
+- term:
+    id: GO:0016020
+    label: membrane
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000120
+  review:
+    summary: Accept membrane as a supported V-ATPase membrane localization.
+    action: ACCEPT
+    reason: ATP6V0B is an integral membrane subunit of V-ATPase. Human V-ATPase
+      structures and reviews support its role in organellar and vesicular proton-pump
+      complexes; the broad membrane/localization annotation is correct, although more
+      specific endolysosomal V-ATPase component terms are more informative.
+    supported_by:
+    - reference_id: PMID:33065002
+      supporting_text: Vesicular- or vacuolar-type adenosine triphosphatases (V-ATPases)
+        are ATP-driven proton pumps comprised of a cytoplasmic V1 complex for ATP
+        hydrolysis and a membrane-embedded Vo complex for proton transfer.
+    - reference_id: PMID:9653649
+      supporting_text: The proteolipid domain of vacuolar H(+)-ATPase (V-ATPase) plays a
+        major role in H+ transport in microvesicles and other acidic organelles.
+- term:
+    id: GO:0033176
+    label: proton-transporting V-type ATPase complex
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000107
+  review:
+    summary: This component annotation is consistent with ATP6V0B being the c&#39;&#39;
+      proteolipid subunit of the V0 proton-translocating sector of V-ATPase.
+    action: ACCEPT
+    reason: ATP6V0B is experimentally identified as a five-transmembrane human V-ATPase
+      proteolipid with conserved Glu98 required for H+ transport, and human V-ATPase
+      structures place V0 subunits in the membrane-embedded proton-transfer module. The
+      component annotation is therefore part of the core molecular role of ATP6V0B.
+    supported_by:
+    - reference_id: PMID:33065002
+      supporting_text: Vesicular- or vacuolar-type adenosine triphosphatases (V-ATPases)
+        are ATP-driven proton pumps comprised of a cytoplasmic V1 complex for ATP
+        hydrolysis and a membrane-embedded Vo complex for proton transfer.
+    - reference_id: PMID:9653649
+      supporting_text: hATP6F is a hydrophobic protein with five putative transmembrane
+        segments, having 61% amino acid identity and 83% similarity to the yeast
+        protein, except in the N-terminus, and contains a conserved glutamic acid
+        residue (Glu98) that is essential for H(+)-transporting activity.
+- term:
+    id: GO:0000139
+    label: Golgi membrane
+  evidence_type: NAS
+  original_reference_id: PMID:32001091
+  review:
+    summary: Accept Golgi membrane as a supported V-ATPase membrane localization.
+    action: ACCEPT
+    reason: ATP6V0B is an integral membrane subunit of V-ATPase. Human V-ATPase
+      structures and reviews support its role in organellar and vesicular proton-pump
+      complexes; the broad membrane/localization annotation is correct, although more
+      specific endolysosomal V-ATPase component terms are more informative.
+    supported_by:
+    - reference_id: PMID:33065002
+      supporting_text: Vesicular- or vacuolar-type adenosine triphosphatases (V-ATPases)
+        are ATP-driven proton pumps comprised of a cytoplasmic V1 complex for ATP
+        hydrolysis and a membrane-embedded Vo complex for proton transfer.
+    - reference_id: PMID:9653649
+      supporting_text: The proteolipid domain of vacuolar H(+)-ATPase (V-ATPase) plays a
+        major role in H+ transport in microvesicles and other acidic organelles.
+- term:
+    id: GO:0005765
+    label: lysosomal membrane
+  evidence_type: NAS
+  original_reference_id: PMID:32001091
+  review:
+    summary: Accept lysosomal membrane as a supported V-ATPase membrane localization.
+    action: ACCEPT
+    reason: ATP6V0B is an integral membrane subunit of V-ATPase. Human V-ATPase
+      structures and reviews support its role in organellar and vesicular proton-pump
+      complexes; the broad membrane/localization annotation is correct, although more
+      specific endolysosomal V-ATPase component terms are more informative.
+    supported_by:
+    - reference_id: PMID:33065002
+      supporting_text: Vesicular- or vacuolar-type adenosine triphosphatases (V-ATPases)
+        are ATP-driven proton pumps comprised of a cytoplasmic V1 complex for ATP
+        hydrolysis and a membrane-embedded Vo complex for proton transfer.
+    - reference_id: PMID:9653649
+      supporting_text: The proteolipid domain of vacuolar H(+)-ATPase (V-ATPase) plays a
+        major role in H+ transport in microvesicles and other acidic organelles.
+- term:
+    id: GO:0005886
+    label: plasma membrane
+  evidence_type: NAS
+  original_reference_id: PMID:32001091
+  review:
+    summary: Keep this localization as a valid but non-core or context-specific site for
+      V-ATPase complexes.
+    action: KEEP_AS_NON_CORE
+    reason: ATP6V0B is a membrane V-ATPase subunit and V-ATPases can act in vesicular or
+      specialized plasma/phagosomal compartments. For ATP6V0B&#39;s core annotation,
+      however, lysosomal/endosomal/Golgi V0-domain component and acidification terms are
+      more informative than this broad or context-specific location.
+    supported_by:
+    - reference_id: PMID:33065002
+      supporting_text: Vesicular- or vacuolar-type adenosine triphosphatases (V-ATPases)
+        are ATP-driven proton pumps comprised of a cytoplasmic V1 complex for ATP
+        hydrolysis and a membrane-embedded Vo complex for proton transfer.
+    - reference_id: Reactome:R-HSA-1222516
+      supporting_text: When pumping, ATP hydrolysis drives a 120 degree rotation of the
+        rotor which leads to movement of three protons into the phagosome
+- term:
+    id: GO:0007035
+    label: vacuolar acidification
+  evidence_type: NAS
+  original_reference_id: PMID:32001091
+  review:
+    summary: Accept this acidification/proton-transport process annotation for the
+      ATP6V0B-containing V-ATPase complex.
+    action: ACCEPT
+    reason: The ATP6V0B-containing V0 sector contributes to proton transfer by V-ATPase.
+      Human V-ATPases maintain acidic endosomes and lysosomes and support membrane
+      trafficking and protein degradation, so proton transport and organelle lumen
+      acidification annotations reflect the core biological consequence of this
+      subunit&#39;s role in the pump.
+    supported_by:
+    - reference_id: PMID:33065002
+      supporting_text: Vesicular- or vacuolar-type adenosine triphosphatases (V-ATPases)
+        are ATP-driven proton pumps comprised of a cytoplasmic V1 complex for ATP
+        hydrolysis and a membrane-embedded Vo complex for proton transfer.
+    - reference_id: PMID:33065002
+      supporting_text: Vesicular and organellar V-ATPases are essential in establishing
+        and maintaining the pH homeostasis of endosomes and lysosomes and in supporting
+        intracellular membrane trafficking and protein degradation
+    - reference_id: PMID:9653649
+      supporting_text: The proteolipid domain of vacuolar H(+)-ATPase (V-ATPase) plays a
+        major role in H+ transport in microvesicles and other acidic organelles.
+- term:
+    id: GO:0007042
+    label: lysosomal lumen acidification
+  evidence_type: NAS
+  original_reference_id: PMID:32001091
+  review:
+    summary: Accept this acidification/proton-transport process annotation for the
+      ATP6V0B-containing V-ATPase complex.
+    action: ACCEPT
+    reason: The ATP6V0B-containing V0 sector contributes to proton transfer by V-ATPase.
+      Human V-ATPases maintain acidic endosomes and lysosomes and support membrane
+      trafficking and protein degradation, so proton transport and organelle lumen
+      acidification annotations reflect the core biological consequence of this
+      subunit&#39;s role in the pump.
+    supported_by:
+    - reference_id: PMID:33065002
+      supporting_text: Vesicular- or vacuolar-type adenosine triphosphatases (V-ATPases)
+        are ATP-driven proton pumps comprised of a cytoplasmic V1 complex for ATP
+        hydrolysis and a membrane-embedded Vo complex for proton transfer.
+    - reference_id: PMID:33065002
+      supporting_text: Vesicular and organellar V-ATPases are essential in establishing
+        and maintaining the pH homeostasis of endosomes and lysosomes and in supporting
+        intracellular membrane trafficking and protein degradation
+    - reference_id: PMID:9653649
+      supporting_text: The proteolipid domain of vacuolar H(+)-ATPase (V-ATPase) plays a
+        major role in H+ transport in microvesicles and other acidic organelles.
+- term:
+    id: GO:0007042
+    label: lysosomal lumen acidification
+  evidence_type: NAS
+  original_reference_id: PMID:33065002
+  review:
+    summary: Accept this acidification/proton-transport process annotation for the
+      ATP6V0B-containing V-ATPase complex.
+    action: ACCEPT
+    reason: The ATP6V0B-containing V0 sector contributes to proton transfer by V-ATPase.
+      Human V-ATPases maintain acidic endosomes and lysosomes and support membrane
+      trafficking and protein degradation, so proton transport and organelle lumen
+      acidification annotations reflect the core biological consequence of this
+      subunit&#39;s role in the pump.
+    supported_by:
+    - reference_id: PMID:33065002
+      supporting_text: Vesicular- or vacuolar-type adenosine triphosphatases (V-ATPases)
+        are ATP-driven proton pumps comprised of a cytoplasmic V1 complex for ATP
+        hydrolysis and a membrane-embedded Vo complex for proton transfer.
+    - reference_id: PMID:33065002
+      supporting_text: Vesicular and organellar V-ATPases are essential in establishing
+        and maintaining the pH homeostasis of endosomes and lysosomes and in supporting
+        intracellular membrane trafficking and protein degradation
+    - reference_id: PMID:9653649
+      supporting_text: The proteolipid domain of vacuolar H(+)-ATPase (V-ATPase) plays a
+        major role in H+ transport in microvesicles and other acidic organelles.
+- term:
+    id: GO:0010008
+    label: endosome membrane
+  evidence_type: NAS
+  original_reference_id: PMID:32001091
+  review:
+    summary: Accept endosome membrane as a supported V-ATPase membrane localization.
+    action: ACCEPT
+    reason: ATP6V0B is an integral membrane subunit of V-ATPase. Human V-ATPase
+      structures and reviews support its role in organellar and vesicular proton-pump
+      complexes; the broad membrane/localization annotation is correct, although more
+      specific endolysosomal V-ATPase component terms are more informative.
+    supported_by:
+    - reference_id: PMID:33065002
+      supporting_text: Vesicular- or vacuolar-type adenosine triphosphatases (V-ATPases)
+        are ATP-driven proton pumps comprised of a cytoplasmic V1 complex for ATP
+        hydrolysis and a membrane-embedded Vo complex for proton transfer.
+    - reference_id: PMID:9653649
+      supporting_text: The proteolipid domain of vacuolar H(+)-ATPase (V-ATPase) plays a
+        major role in H+ transport in microvesicles and other acidic organelles.
+- term:
+    id: GO:0016020
+    label: membrane
+  evidence_type: IDA
+  original_reference_id: PMID:33065002
+  review:
+    summary: Accept membrane as a supported V-ATPase membrane localization.
+    action: ACCEPT
+    reason: ATP6V0B is an integral membrane subunit of V-ATPase. Human V-ATPase
+      structures and reviews support its role in organellar and vesicular proton-pump
+      complexes; the broad membrane/localization annotation is correct, although more
+      specific endolysosomal V-ATPase component terms are more informative.
+    supported_by:
+    - reference_id: PMID:33065002
+      supporting_text: Vesicular- or vacuolar-type adenosine triphosphatases (V-ATPases)
+        are ATP-driven proton pumps comprised of a cytoplasmic V1 complex for ATP
+        hydrolysis and a membrane-embedded Vo complex for proton transfer.
+    - reference_id: PMID:9653649
+      supporting_text: The proteolipid domain of vacuolar H(+)-ATPase (V-ATPase) plays a
+        major role in H+ transport in microvesicles and other acidic organelles.
+- term:
+    id: GO:0033176
+    label: proton-transporting V-type ATPase complex
+  evidence_type: NAS
+  original_reference_id: PMID:33065002
+  review:
+    summary: This component annotation is consistent with ATP6V0B being the c&#39;&#39;
+      proteolipid subunit of the V0 proton-translocating sector of V-ATPase.
+    action: ACCEPT
+    reason: ATP6V0B is experimentally identified as a five-transmembrane human V-ATPase
+      proteolipid with conserved Glu98 required for H+ transport, and human V-ATPase
+      structures place V0 subunits in the membrane-embedded proton-transfer module. The
+      component annotation is therefore part of the core molecular role of ATP6V0B.
+    supported_by:
+    - reference_id: PMID:33065002
+      supporting_text: Vesicular- or vacuolar-type adenosine triphosphatases (V-ATPases)
+        are ATP-driven proton pumps comprised of a cytoplasmic V1 complex for ATP
+        hydrolysis and a membrane-embedded Vo complex for proton transfer.
+    - reference_id: PMID:9653649
+      supporting_text: hATP6F is a hydrophobic protein with five putative transmembrane
+        segments, having 61% amino acid identity and 83% similarity to the yeast
+        protein, except in the N-terminus, and contains a conserved glutamic acid
+        residue (Glu98) that is essential for H(+)-transporting activity.
+- term:
+    id: GO:0048388
+    label: endosomal lumen acidification
+  evidence_type: NAS
+  original_reference_id: PMID:32001091
+  review:
+    summary: Accept this acidification/proton-transport process annotation for the
+      ATP6V0B-containing V-ATPase complex.
+    action: ACCEPT
+    reason: The ATP6V0B-containing V0 sector contributes to proton transfer by V-ATPase.
+      Human V-ATPases maintain acidic endosomes and lysosomes and support membrane
+      trafficking and protein degradation, so proton transport and organelle lumen
+      acidification annotations reflect the core biological consequence of this
+      subunit&#39;s role in the pump.
+    supported_by:
+    - reference_id: PMID:33065002
+      supporting_text: Vesicular- or vacuolar-type adenosine triphosphatases (V-ATPases)
+        are ATP-driven proton pumps comprised of a cytoplasmic V1 complex for ATP
+        hydrolysis and a membrane-embedded Vo complex for proton transfer.
+    - reference_id: PMID:33065002
+      supporting_text: Vesicular and organellar V-ATPases are essential in establishing
+        and maintaining the pH homeostasis of endosomes and lysosomes and in supporting
+        intracellular membrane trafficking and protein degradation
+    - reference_id: PMID:9653649
+      supporting_text: The proteolipid domain of vacuolar H(+)-ATPase (V-ATPase) plays a
+        major role in H+ transport in microvesicles and other acidic organelles.
+- term:
+    id: GO:0051452
+    label: intracellular pH reduction
+  evidence_type: NAS
+  original_reference_id: PMID:32001091
+  review:
+    summary: Accept this acidification/proton-transport process annotation for the
+      ATP6V0B-containing V-ATPase complex.
+    action: ACCEPT
+    reason: The ATP6V0B-containing V0 sector contributes to proton transfer by V-ATPase.
+      Human V-ATPases maintain acidic endosomes and lysosomes and support membrane
+      trafficking and protein degradation, so proton transport and organelle lumen
+      acidification annotations reflect the core biological consequence of this
+      subunit&#39;s role in the pump.
+    supported_by:
+    - reference_id: PMID:33065002
+      supporting_text: Vesicular- or vacuolar-type adenosine triphosphatases (V-ATPases)
+        are ATP-driven proton pumps comprised of a cytoplasmic V1 complex for ATP
+        hydrolysis and a membrane-embedded Vo complex for proton transfer.
+    - reference_id: PMID:33065002
+      supporting_text: Vesicular and organellar V-ATPases are essential in establishing
+        and maintaining the pH homeostasis of endosomes and lysosomes and in supporting
+        intracellular membrane trafficking and protein degradation
+    - reference_id: PMID:9653649
+      supporting_text: The proteolipid domain of vacuolar H(+)-ATPase (V-ATPase) plays a
+        major role in H+ transport in microvesicles and other acidic organelles.
+- term:
+    id: GO:0061795
+    label: Golgi lumen acidification
+  evidence_type: NAS
+  original_reference_id: PMID:32001091
+  review:
+    summary: Accept this acidification/proton-transport process annotation for the
+      ATP6V0B-containing V-ATPase complex.
+    action: ACCEPT
+    reason: The ATP6V0B-containing V0 sector contributes to proton transfer by V-ATPase.
+      Human V-ATPases maintain acidic endosomes and lysosomes and support membrane
+      trafficking and protein degradation, so proton transport and organelle lumen
+      acidification annotations reflect the core biological consequence of this
+      subunit&#39;s role in the pump.
+    supported_by:
+    - reference_id: PMID:33065002
+      supporting_text: Vesicular- or vacuolar-type adenosine triphosphatases (V-ATPases)
+        are ATP-driven proton pumps comprised of a cytoplasmic V1 complex for ATP
+        hydrolysis and a membrane-embedded Vo complex for proton transfer.
+    - reference_id: PMID:33065002
+      supporting_text: Vesicular and organellar V-ATPases are essential in establishing
+        and maintaining the pH homeostasis of endosomes and lysosomes and in supporting
+        intracellular membrane trafficking and protein degradation
+    - reference_id: PMID:9653649
+      supporting_text: The proteolipid domain of vacuolar H(+)-ATPase (V-ATPase) plays a
+        major role in H+ transport in microvesicles and other acidic organelles.
+- term:
+    id: GO:1902600
+    label: proton transmembrane transport
+  evidence_type: NAS
+  original_reference_id: PMID:33065002
+  review:
+    summary: Accept this acidification/proton-transport process annotation for the
+      ATP6V0B-containing V-ATPase complex.
+    action: ACCEPT
+    reason: The ATP6V0B-containing V0 sector contributes to proton transfer by V-ATPase.
+      Human V-ATPases maintain acidic endosomes and lysosomes and support membrane
+      trafficking and protein degradation, so proton transport and organelle lumen
+      acidification annotations reflect the core biological consequence of this
+      subunit&#39;s role in the pump.
+    supported_by:
+    - reference_id: PMID:33065002
+      supporting_text: Vesicular- or vacuolar-type adenosine triphosphatases (V-ATPases)
+        are ATP-driven proton pumps comprised of a cytoplasmic V1 complex for ATP
+        hydrolysis and a membrane-embedded Vo complex for proton transfer.
+    - reference_id: PMID:33065002
+      supporting_text: Vesicular and organellar V-ATPases are essential in establishing
+        and maintaining the pH homeostasis of endosomes and lysosomes and in supporting
+        intracellular membrane trafficking and protein degradation
+    - reference_id: PMID:9653649
+      supporting_text: The proteolipid domain of vacuolar H(+)-ATPase (V-ATPase) plays a
+        major role in H+ transport in microvesicles and other acidic organelles.
+- term:
+    id: GO:0046961
+    label: proton-transporting ATPase activity, rotational mechanism
+  evidence_type: TAS
+  original_reference_id: PMID:9653649
+  review:
+    summary: Accept the V-type ATPase rotational proton-pump activity as the complex
+      activity to which ATP6V0B contributes.
+    action: ACCEPT
+    reason: ATP6V0B is not the ATP-hydrolytic catalytic subunit, but it is an essential
+      V0 c-ring proteolipid required for proton translocation by the rotary V-ATPase.
+      This is the correct complex-level molecular function for the ATP6V0B-containing
+      V-ATPase machinery.
+    supported_by:
+    - reference_id: PMID:33065002
+      supporting_text: Vesicular- or vacuolar-type adenosine triphosphatases (V-ATPases)
+        are ATP-driven proton pumps comprised of a cytoplasmic V1 complex for ATP
+        hydrolysis and a membrane-embedded Vo complex for proton transfer.
+    - reference_id: PMID:9653649
+      supporting_text: hATP6F is a hydrophobic protein with five putative transmembrane
+        segments, having 61% amino acid identity and 83% similarity to the yeast
+        protein, except in the N-terminus, and contains a conserved glutamic acid
+        residue (Glu98) that is essential for H(+)-transporting activity.
+- term:
+    id: GO:0000220
+    label: vacuolar proton-transporting V-type ATPase, V0 domain
+  evidence_type: ISS
+  original_reference_id: GO_REF:0000024
+  review:
+    summary: This component annotation is consistent with ATP6V0B being the c&#39;&#39;
+      proteolipid subunit of the V0 proton-translocating sector of V-ATPase.
+    action: ACCEPT
+    reason: ATP6V0B is experimentally identified as a five-transmembrane human V-ATPase
+      proteolipid with conserved Glu98 required for H+ transport, and human V-ATPase
+      structures place V0 subunits in the membrane-embedded proton-transfer module. The
+      component annotation is therefore part of the core molecular role of ATP6V0B.
+    supported_by:
+    - reference_id: PMID:33065002
+      supporting_text: Vesicular- or vacuolar-type adenosine triphosphatases (V-ATPases)
+        are ATP-driven proton pumps comprised of a cytoplasmic V1 complex for ATP
+        hydrolysis and a membrane-embedded Vo complex for proton transfer.
+    - reference_id: PMID:9653649
+      supporting_text: hATP6F is a hydrophobic protein with five putative transmembrane
+        segments, having 61% amino acid identity and 83% similarity to the yeast
+        protein, except in the N-terminus, and contains a conserved glutamic acid
+        residue (Glu98) that is essential for H(+)-transporting activity.
+- term:
+    id: GO:0005765
+    label: lysosomal membrane
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-9639286
+  review:
+    summary: Accept lysosomal membrane as a supported V-ATPase membrane localization.
+    action: ACCEPT
+    reason: ATP6V0B is an integral membrane subunit of V-ATPase. Human V-ATPase
+      structures and reviews support its role in organellar and vesicular proton-pump
+      complexes; the broad membrane/localization annotation is correct, although more
+      specific endolysosomal V-ATPase component terms are more informative.
+    supported_by:
+    - reference_id: PMID:33065002
+      supporting_text: Vesicular- or vacuolar-type adenosine triphosphatases (V-ATPases)
+        are ATP-driven proton pumps comprised of a cytoplasmic V1 complex for ATP
+        hydrolysis and a membrane-embedded Vo complex for proton transfer.
+    - reference_id: PMID:9653649
+      supporting_text: The proteolipid domain of vacuolar H(+)-ATPase (V-ATPase) plays a
+        major role in H+ transport in microvesicles and other acidic organelles.
+- term:
+    id: GO:0005765
+    label: lysosomal membrane
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-9640167
+  review:
+    summary: Accept lysosomal membrane as a supported V-ATPase membrane localization.
+    action: ACCEPT
+    reason: ATP6V0B is an integral membrane subunit of V-ATPase. Human V-ATPase
+      structures and reviews support its role in organellar and vesicular proton-pump
+      complexes; the broad membrane/localization annotation is correct, although more
+      specific endolysosomal V-ATPase component terms are more informative.
+    supported_by:
+    - reference_id: PMID:33065002
+      supporting_text: Vesicular- or vacuolar-type adenosine triphosphatases (V-ATPases)
+        are ATP-driven proton pumps comprised of a cytoplasmic V1 complex for ATP
+        hydrolysis and a membrane-embedded Vo complex for proton transfer.
+    - reference_id: PMID:9653649
+      supporting_text: The proteolipid domain of vacuolar H(+)-ATPase (V-ATPase) plays a
+        major role in H+ transport in microvesicles and other acidic organelles.
+- term:
+    id: GO:0005765
+    label: lysosomal membrane
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-9640168
+  review:
+    summary: Accept lysosomal membrane as a supported V-ATPase membrane localization.
+    action: ACCEPT
+    reason: ATP6V0B is an integral membrane subunit of V-ATPase. Human V-ATPase
+      structures and reviews support its role in organellar and vesicular proton-pump
+      complexes; the broad membrane/localization annotation is correct, although more
+      specific endolysosomal V-ATPase component terms are more informative.
+    supported_by:
+    - reference_id: PMID:33065002
+      supporting_text: Vesicular- or vacuolar-type adenosine triphosphatases (V-ATPases)
+        are ATP-driven proton pumps comprised of a cytoplasmic V1 complex for ATP
+        hydrolysis and a membrane-embedded Vo complex for proton transfer.
+    - reference_id: PMID:9653649
+      supporting_text: The proteolipid domain of vacuolar H(+)-ATPase (V-ATPase) plays a
+        major role in H+ transport in microvesicles and other acidic organelles.
+- term:
+    id: GO:0005765
+    label: lysosomal membrane
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-9640175
+  review:
+    summary: Accept lysosomal membrane as a supported V-ATPase membrane localization.
+    action: ACCEPT
+    reason: ATP6V0B is an integral membrane subunit of V-ATPase. Human V-ATPase
+      structures and reviews support its role in organellar and vesicular proton-pump
+      complexes; the broad membrane/localization annotation is correct, although more
+      specific endolysosomal V-ATPase component terms are more informative.
+    supported_by:
+    - reference_id: PMID:33065002
+      supporting_text: Vesicular- or vacuolar-type adenosine triphosphatases (V-ATPases)
+        are ATP-driven proton pumps comprised of a cytoplasmic V1 complex for ATP
+        hydrolysis and a membrane-embedded Vo complex for proton transfer.
+    - reference_id: PMID:9653649
+      supporting_text: The proteolipid domain of vacuolar H(+)-ATPase (V-ATPase) plays a
+        major role in H+ transport in microvesicles and other acidic organelles.
+- term:
+    id: GO:0005765
+    label: lysosomal membrane
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-9640195
+  review:
+    summary: Accept lysosomal membrane as a supported V-ATPase membrane localization.
+    action: ACCEPT
+    reason: ATP6V0B is an integral membrane subunit of V-ATPase. Human V-ATPase
+      structures and reviews support its role in organellar and vesicular proton-pump
+      complexes; the broad membrane/localization annotation is correct, although more
+      specific endolysosomal V-ATPase component terms are more informative.
+    supported_by:
+    - reference_id: PMID:33065002
+      supporting_text: Vesicular- or vacuolar-type adenosine triphosphatases (V-ATPases)
+        are ATP-driven proton pumps comprised of a cytoplasmic V1 complex for ATP
+        hydrolysis and a membrane-embedded Vo complex for proton transfer.
+    - reference_id: PMID:9653649
+      supporting_text: The proteolipid domain of vacuolar H(+)-ATPase (V-ATPase) plays a
+        major role in H+ transport in microvesicles and other acidic organelles.
+- term:
+    id: GO:0005765
+    label: lysosomal membrane
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-9645598
+  review:
+    summary: Accept lysosomal membrane as a supported V-ATPase membrane localization.
+    action: ACCEPT
+    reason: ATP6V0B is an integral membrane subunit of V-ATPase. Human V-ATPase
+      structures and reviews support its role in organellar and vesicular proton-pump
+      complexes; the broad membrane/localization annotation is correct, although more
+      specific endolysosomal V-ATPase component terms are more informative.
+    supported_by:
+    - reference_id: PMID:33065002
+      supporting_text: Vesicular- or vacuolar-type adenosine triphosphatases (V-ATPases)
+        are ATP-driven proton pumps comprised of a cytoplasmic V1 complex for ATP
+        hydrolysis and a membrane-embedded Vo complex for proton transfer.
+    - reference_id: PMID:9653649
+      supporting_text: The proteolipid domain of vacuolar H(+)-ATPase (V-ATPase) plays a
+        major role in H+ transport in microvesicles and other acidic organelles.
+- term:
+    id: GO:0005765
+    label: lysosomal membrane
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-9645608
+  review:
+    summary: Accept lysosomal membrane as a supported V-ATPase membrane localization.
+    action: ACCEPT
+    reason: ATP6V0B is an integral membrane subunit of V-ATPase. Human V-ATPase
+      structures and reviews support its role in organellar and vesicular proton-pump
+      complexes; the broad membrane/localization annotation is correct, although more
+      specific endolysosomal V-ATPase component terms are more informative.
+    supported_by:
+    - reference_id: PMID:33065002
+      supporting_text: Vesicular- or vacuolar-type adenosine triphosphatases (V-ATPases)
+        are ATP-driven proton pumps comprised of a cytoplasmic V1 complex for ATP
+        hydrolysis and a membrane-embedded Vo complex for proton transfer.
+    - reference_id: PMID:9653649
+      supporting_text: The proteolipid domain of vacuolar H(+)-ATPase (V-ATPase) plays a
+        major role in H+ transport in microvesicles and other acidic organelles.
+    - reference_id: Reactome:R-HSA-9645608
+      supporting_text: Hydrolysis of ATP by the v-ATPase complex is also required for
+        recruitment of mTORC1
+- term:
+    id: GO:0005765
+    label: lysosomal membrane
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-9646468
+  review:
+    summary: Accept lysosomal membrane as a supported V-ATPase membrane localization.
+    action: ACCEPT
+    reason: ATP6V0B is an integral membrane subunit of V-ATPase. Human V-ATPase
+      structures and reviews support its role in organellar and vesicular proton-pump
+      complexes; the broad membrane/localization annotation is correct, although more
+      specific endolysosomal V-ATPase component terms are more informative.
+    supported_by:
+    - reference_id: PMID:33065002
+      supporting_text: Vesicular- or vacuolar-type adenosine triphosphatases (V-ATPases)
+        are ATP-driven proton pumps comprised of a cytoplasmic V1 complex for ATP
+        hydrolysis and a membrane-embedded Vo complex for proton transfer.
+    - reference_id: PMID:9653649
+      supporting_text: The proteolipid domain of vacuolar H(+)-ATPase (V-ATPase) plays a
+        major role in H+ transport in microvesicles and other acidic organelles.
+- term:
+    id: GO:0005765
+    label: lysosomal membrane
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-9858940
+  review:
+    summary: Accept lysosomal membrane as a supported V-ATPase membrane localization.
+    action: ACCEPT
+    reason: ATP6V0B is an integral membrane subunit of V-ATPase. Human V-ATPase
+      structures and reviews support its role in organellar and vesicular proton-pump
+      complexes; the broad membrane/localization annotation is correct, although more
+      specific endolysosomal V-ATPase component terms are more informative.
+    supported_by:
+    - reference_id: PMID:33065002
+      supporting_text: Vesicular- or vacuolar-type adenosine triphosphatases (V-ATPases)
+        are ATP-driven proton pumps comprised of a cytoplasmic V1 complex for ATP
+        hydrolysis and a membrane-embedded Vo complex for proton transfer.
+    - reference_id: PMID:9653649
+      supporting_text: The proteolipid domain of vacuolar H(+)-ATPase (V-ATPase) plays a
+        major role in H+ transport in microvesicles and other acidic organelles.
+    - reference_id: Reactome:R-HSA-9858940
+      supporting_text: MITF has been implicated in the regulation of expression of many
+        components of the v-ATPase, including the transmembrane component ATP6V0B
+- term:
+    id: GO:0016241
+    label: regulation of macroautophagy
+  evidence_type: NAS
+  original_reference_id: PMID:22982048
+  review:
+    summary: Macroautophagy regulation is an over-annotation for ATP6V0B as an
+      individual V-ATPase subunit.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: ATP6V0B-containing V-ATPase complexes support autophagic flux indirectly by
+      acidifying lysosomes, but the cited study concerns lipofuscin handling and
+      macroautophagy/lysosomal activity rather than a specific regulatory role for
+      ATP6V0B. The safer annotation is lysosomal lumen acidification, not regulation of
+      macroautophagy.
+    supported_by:
+    - reference_id: PMID:22982048
+      supporting_text: macroautophagy is responsible for the uptake of lipofuscin into
+        the lysosomes
+    - reference_id: PMID:33065002
+      supporting_text: Vesicular and organellar V-ATPases are essential in establishing
+        and maintaining the pH homeostasis of endosomes and lysosomes and in supporting
+        intracellular membrane trafficking and protein degradation
+- term:
+    id: GO:0030670
+    label: phagocytic vesicle membrane
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-1222516
+  review:
+    summary: Keep this localization as a valid but non-core or context-specific site for
+      V-ATPase complexes.
+    action: KEEP_AS_NON_CORE
+    reason: ATP6V0B is a membrane V-ATPase subunit and V-ATPases can act in vesicular or
+      specialized plasma/phagosomal compartments. For ATP6V0B&#39;s core annotation,
+      however, lysosomal/endosomal/Golgi V0-domain component and acidification terms are
+      more informative than this broad or context-specific location.
+    supported_by:
+    - reference_id: PMID:33065002
+      supporting_text: Vesicular- or vacuolar-type adenosine triphosphatases (V-ATPases)
+        are ATP-driven proton pumps comprised of a cytoplasmic V1 complex for ATP
+        hydrolysis and a membrane-embedded Vo complex for proton transfer.
+    - reference_id: Reactome:R-HSA-1222516
+      supporting_text: When pumping, ATP hydrolysis drives a 120 degree rotation of the
+        rotor which leads to movement of three protons into the phagosome
+- term:
+    id: GO:0010008
+    label: endosome membrane
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-5252133
+  review:
+    summary: Accept endosome membrane as a supported V-ATPase membrane localization.
+    action: ACCEPT
+    reason: ATP6V0B is an integral membrane subunit of V-ATPase. Human V-ATPase
+      structures and reviews support its role in organellar and vesicular proton-pump
+      complexes; the broad membrane/localization annotation is correct, although more
+      specific endolysosomal V-ATPase component terms are more informative.
+    supported_by:
+    - reference_id: PMID:33065002
+      supporting_text: Vesicular- or vacuolar-type adenosine triphosphatases (V-ATPases)
+        are ATP-driven proton pumps comprised of a cytoplasmic V1 complex for ATP
+        hydrolysis and a membrane-embedded Vo complex for proton transfer.
+    - reference_id: PMID:9653649
+      supporting_text: The proteolipid domain of vacuolar H(+)-ATPase (V-ATPase) plays a
+        major role in H+ transport in microvesicles and other acidic organelles.
+- term:
+    id: GO:0010008
+    label: endosome membrane
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-74723
+  review:
+    summary: Accept endosome membrane as a supported V-ATPase membrane localization.
+    action: ACCEPT
+    reason: ATP6V0B is an integral membrane subunit of V-ATPase. Human V-ATPase
+      structures and reviews support its role in organellar and vesicular proton-pump
+      complexes; the broad membrane/localization annotation is correct, although more
+      specific endolysosomal V-ATPase component terms are more informative.
+    supported_by:
+    - reference_id: PMID:33065002
+      supporting_text: Vesicular- or vacuolar-type adenosine triphosphatases (V-ATPases)
+        are ATP-driven proton pumps comprised of a cytoplasmic V1 complex for ATP
+        hydrolysis and a membrane-embedded Vo complex for proton transfer.
+    - reference_id: PMID:9653649
+      supporting_text: The proteolipid domain of vacuolar H(+)-ATPase (V-ATPase) plays a
+        major role in H+ transport in microvesicles and other acidic organelles.
+    - reference_id: Reactome:R-HSA-74723
+      supporting_text: The effect of the proton pump is to allow entry of [H+] ions into
+        the lumen of the endosome.
+- term:
+    id: GO:0010008
+    label: endosome membrane
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-917841
+  review:
+    summary: Accept endosome membrane as a supported V-ATPase membrane localization.
+    action: ACCEPT
+    reason: ATP6V0B is an integral membrane subunit of V-ATPase. Human V-ATPase
+      structures and reviews support its role in organellar and vesicular proton-pump
+      complexes; the broad membrane/localization annotation is correct, although more
+      specific endolysosomal V-ATPase component terms are more informative.
+    supported_by:
+    - reference_id: PMID:33065002
+      supporting_text: Vesicular- or vacuolar-type adenosine triphosphatases (V-ATPases)
+        are ATP-driven proton pumps comprised of a cytoplasmic V1 complex for ATP
+        hydrolysis and a membrane-embedded Vo complex for proton transfer.
+    - reference_id: PMID:9653649
+      supporting_text: The proteolipid domain of vacuolar H(+)-ATPase (V-ATPase) plays a
+        major role in H+ transport in microvesicles and other acidic organelles.
+- term:
+    id: GO:0016020
+    label: membrane
+  evidence_type: TAS
+  original_reference_id: PMID:9653649
+  review:
+    summary: Accept membrane as a supported V-ATPase membrane localization.
+    action: ACCEPT
+    reason: ATP6V0B is an integral membrane subunit of V-ATPase. Human V-ATPase
+      structures and reviews support its role in organellar and vesicular proton-pump
+      complexes; the broad membrane/localization annotation is correct, although more
+      specific endolysosomal V-ATPase component terms are more informative.
+    supported_by:
+    - reference_id: PMID:33065002
+      supporting_text: Vesicular- or vacuolar-type adenosine triphosphatases (V-ATPases)
+        are ATP-driven proton pumps comprised of a cytoplasmic V1 complex for ATP
+        hydrolysis and a membrane-embedded Vo complex for proton transfer.
+    - reference_id: PMID:9653649
+      supporting_text: The proteolipid domain of vacuolar H(+)-ATPase (V-ATPase) plays a
+        major role in H+ transport in microvesicles and other acidic organelles.
+- term:
+    id: GO:1902600
+    label: proton transmembrane transport
+  evidence_type: TAS
+  original_reference_id: PMID:9653649
+  review:
+    summary: Accept this acidification/proton-transport process annotation for the
+      ATP6V0B-containing V-ATPase complex.
+    action: ACCEPT
+    reason: The ATP6V0B-containing V0 sector contributes to proton transfer by V-ATPase.
+      Human V-ATPases maintain acidic endosomes and lysosomes and support membrane
+      trafficking and protein degradation, so proton transport and organelle lumen
+      acidification annotations reflect the core biological consequence of this
+      subunit&#39;s role in the pump.
+    supported_by:
+    - reference_id: PMID:33065002
+      supporting_text: Vesicular- or vacuolar-type adenosine triphosphatases (V-ATPases)
+        are ATP-driven proton pumps comprised of a cytoplasmic V1 complex for ATP
+        hydrolysis and a membrane-embedded Vo complex for proton transfer.
+    - reference_id: PMID:33065002
+      supporting_text: Vesicular and organellar V-ATPases are essential in establishing
+        and maintaining the pH homeostasis of endosomes and lysosomes and in supporting
+        intracellular membrane trafficking and protein degradation
+    - reference_id: PMID:9653649
+      supporting_text: The proteolipid domain of vacuolar H(+)-ATPase (V-ATPase) plays a
+        major role in H+ transport in microvesicles and other acidic organelles.
+- term:
+    id: GO:0046610
+    label: lysosomal proton-transporting V-type ATPase, V0 domain
+  evidence_type: RCA
+  original_reference_id: &#39;file:projects/PROTEOSTASIS/reports/pn_projection/pn_projected_annotations.tsv&#39;
+  review:
+    summary: Add the conservative PN-projected lysosomal V0-domain component annotation.
+    action: NEW
+    reason: The PN projection places ATP6V0B in the V0 lysosomal V-ATPase proton pump
+      component leaf and maps that leaf to GO:0046610. This is more specific than
+      ATP6V0B&#39;s current GOA component annotations, but it is supported by the
+      established human V-ATPase structure, lysosomal V-ATPase biology, and existing GOA
+      annotations to lysosomal membrane, lysosomal lumen acidification, and the broader
+      V-type ATPase V0 domain. This adds component specificity rather than a new
+      biological process claim.
+    supported_by:
+    - reference_id: &#39;file:projects/PROTEOSTASIS/reports/pn_projection/pn_projected_annotations.tsv&#39;
+      supporting_text: &#34;ATP6V0B\t\tAutophagy-Lysosome Pathway|Pre-initiation autophagy signaling|mTORC1
+        pathway, upstream|Nutrient sensing|V0 lysosomal v-ATPase proton pump component&#34;
+    - reference_id: PMID:33065002
+      supporting_text: Vesicular- or vacuolar-type adenosine triphosphatases (V-ATPases)
+        are ATP-driven proton pumps comprised of a cytoplasmic V1 complex for ATP
+        hydrolysis and a membrane-embedded Vo complex for proton transfer.
+    - reference_id: PMID:33065002
+      supporting_text: Vesicular and organellar V-ATPases are essential in establishing
+        and maintaining the pH homeostasis of endosomes and lysosomes and in supporting
+        intracellular membrane trafficking and protein degradation
+    - reference_id: file:human/ATP6V0B/ATP6V0B-deep-research-falcon.md
+      supporting_text: &#39;model: Edison Scientific Literature&#39;
 references:
-  - id: GO_REF:0000002
-    title: Gene Ontology annotation through association of InterPro records with
-      GO terms.
-    findings: []
-  - id: GO_REF:0000024
-    title: Manual transfer of experimentally-verified manual GO annotation data 
-      to orthologs by curator judgment of sequence similarity.
-    findings: []
-  - id: GO_REF:0000033
-    title: Annotation inferences using phylogenetic trees
-    findings: []
-  - id: GO_REF:0000043
-    title: Gene Ontology annotation based on UniProtKB/Swiss-Prot keyword 
-      mapping
-    findings: []
-  - id: GO_REF:0000044
-    title: Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular 
-      Location vocabulary mapping, accompanied by conservative changes to GO 
-      terms applied by UniProt.
-    findings: []
-  - id: GO_REF:0000107
-    title: Automatic transfer of experimentally verified manual GO annotation 
-      data to orthologs using Ensembl Compara.
-    findings: []
-  - id: GO_REF:0000120
-    title: Combined Automated Annotation using Multiple IEA Methods.
-    findings: []
-  - id: PMID:22982048
-    title: Lipofuscin is formed independently of macroautophagy and lysosomal 
-      activity in stress-induced prematurely senescent human fibroblasts.
-    findings: []
-  - id: PMID:23864651
-    title: The identification of novel proteins that interact with the GLP-1 
-      receptor and restrain its activity.
-    findings: []
-  - id: PMID:32001091
-    title: Structure and Roles of V-type ATPases.
-    findings: []
-  - id: PMID:32296183
-    title: A reference map of the human binary protein interactome.
-    findings: []
-  - id: PMID:33065002
-    title: Structures of a Complete Human V-ATPase Reveal Mechanisms of Its 
-      Assembly.
-    findings: []
-  - id: PMID:9653649
-    title: Identification and characterization of the gene encoding a second 
-      proteolipid subunit of human vacuolar H(+)-ATPase (ATP6F).
-    findings: []
-  - id: Reactome:R-HSA-1222516
-    title: Intraphagosomal pH is lowered to 5 by V-ATPase
-    findings: []
-  - id: Reactome:R-HSA-5252133
-    title: ATP6AP1 binds V-ATPase
-    findings: []
-  - id: Reactome:R-HSA-74723
-    title: Endosome acidification
-    findings: []
-  - id: Reactome:R-HSA-917841
-    title: Acidification of Tf:TfR1 containing endosome
-    findings: []
-  - id: Reactome:R-HSA-9639286
-    title: RRAGC,D exchanges GTP for GDP
-    findings: []
-  - id: Reactome:R-HSA-9640167
-    title: RRAGA,B exchanges GDP for GTP
-    findings: []
-  - id: Reactome:R-HSA-9640168
-    title: v-ATPase:Ragulator:RRAGA,B:GTP:RRAGC,D:GDP:SLC38A9:Arginine 
-      dissociates yielding v-ATPase:Ragulator:RRAGA,B:GTP:RRAGC,D:GDP and 
-      SLC38A9:Arginine
-    findings: []
-  - id: Reactome:R-HSA-9640175
-    title: v-ATPase:Ragulator:RagA,B:GDP:RagC,D:GDP binds SLC38A9:Arginine
-    findings: []
-  - id: Reactome:R-HSA-9640195
-    title: RRAGA,B hydrolyzes GTP
-    findings: []
-  - id: Reactome:R-HSA-9645598
-    title: RRAGC,D hydrolyzes GTP
-    findings: []
-  - id: Reactome:R-HSA-9645608
-    title: v-ATPase:Ragulator:RRAGA,B:GTP:RRAGC,D:GDP binds mTORC1
-    findings: []
-  - id: Reactome:R-HSA-9646468
-    title: mTORC1 binds RHEB:GTP
-    findings: []
-  - id: Reactome:R-HSA-9858940
-    title: MITF-M-dependent ATP6V0B gene expression
-    findings: []
-  - id: file:human/ATP6V0B/ATP6V0B-deep-research-falcon.md
-    title: Deep research report on Q99437
-    findings: []
-  - id: file:human/ATP6V0B/ATP6V0B-deep-research-cyberian.md
-    title: Cyberian deep research on ATP6V0B function
-    findings: []
+- id: GO_REF:0000002
+  title: Gene Ontology annotation through association of InterPro records with GO terms.
+  findings: []
+- id: GO_REF:0000024
+  title: Manual transfer of experimentally-verified manual GO annotation data to
+    orthologs by curator judgment of sequence similarity.
+  findings: []
+- id: GO_REF:0000033
+  title: Annotation inferences using phylogenetic trees
+  findings: []
+- id: GO_REF:0000043
+  title: Gene Ontology annotation based on UniProtKB/Swiss-Prot keyword mapping
+  findings: []
+- id: GO_REF:0000044
+  title: Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location
+    vocabulary mapping, accompanied by conservative changes to GO terms applied by
+    UniProt.
+  findings: []
+- id: GO_REF:0000107
+  title: Automatic transfer of experimentally verified manual GO annotation data to
+    orthologs using Ensembl Compara.
+  findings: []
+- id: GO_REF:0000120
+  title: Combined Automated Annotation using Multiple IEA Methods.
+  findings: []
+- id: PMID:22982048
+  title: Lipofuscin is formed independently of macroautophagy and lysosomal activity in
+    stress-induced prematurely senescent human fibroblasts.
+  findings:
+  - statement: This paper supports a macroautophagy/lysosome context, but not a specific
+      ATP6V0B regulatory function.
+    supporting_text: macroautophagy is responsible for the uptake of lipofuscin into the
+      lysosomes
+    reference_section_type: ABSTRACT
+- id: PMID:23864651
+  title: The identification of novel proteins that interact with the GLP-1 receptor and
+    restrain its activity.
+  findings:
+  - statement: The GLP-1R interaction study used a membrane yeast two-hybrid screen and
+      does not define ATP6V0B core molecular function.
+    supporting_text: A screen of a human fetal brain cDNA prey library with an
+      unliganded human GLP-1R as bait in yeast revealed 38 novel interactor protein
+      candidates.
+    reference_section_type: ABSTRACT
+- id: PMID:32001091
+  title: Structure and Roles of V-type ATPases.
+  findings:
+  - statement: V-ATPases are membrane-embedded ATP-driven proton pumps and are the
+      primary source of organellar acidification in eukaryotes.
+    supporting_text: V-ATPases are membrane-embedded protein complexes that function as
+      ATP hydrolysis-driven proton pumps.
+    reference_section_type: ABSTRACT
+- id: PMID:32296183
+  title: A reference map of the human binary protein interactome.
+  findings:
+  - statement: The HuRI study is a large-scale binary interactome resource, not
+      ATP6V0B-specific functional evidence.
+    supporting_text: The dataset, versioned HI-III-20 (Human Interactome obtained from
+      screening Space III, published in 2020), contains 52,569 verified PPIs involving
+      8,275 proteins
+    reference_section_type: RESULTS
+- id: PMID:33065002
+  title: Structures of a Complete Human V-ATPase Reveal Mechanisms of Its Assembly.
+  findings:
+  - statement: Human V-ATPase is an ATP-driven proton pump with a cytoplasmic V1
+      ATP-hydrolysis sector and a membrane-embedded Vo proton-transfer sector.
+    supporting_text: Vesicular- or vacuolar-type adenosine triphosphatases (V-ATPases)
+      are ATP-driven proton pumps comprised of a cytoplasmic V1 complex for ATP
+      hydrolysis and a membrane-embedded Vo complex for proton transfer.
+    reference_section_type: ABSTRACT
+  - statement: Organellar V-ATPases maintain endosome and lysosome pH homeostasis and
+      support trafficking and protein degradation.
+    supporting_text: Vesicular and organellar V-ATPases are essential in establishing
+      and maintaining the pH homeostasis of endosomes and lysosomes and in supporting
+      intracellular membrane trafficking and protein degradation
+    reference_section_type: INTRODUCTION
+- id: PMID:9653649
+  title: Identification and characterization of the gene encoding a second proteolipid
+    subunit of human vacuolar H(+)-ATPase (ATP6F).
+  findings:
+  - statement: ATP6V0B/ATP6F is the human second V-ATPase proteolipid, a
+      five-transmembrane c subunit with conserved Glu98 required for H+ transport.
+    supporting_text: hATP6F is a hydrophobic protein with five putative transmembrane
+      segments, having 61% amino acid identity and 83% similarity to the yeast protein,
+      except in the N-terminus, and contains a conserved glutamic acid residue (Glu98)
+      that is essential for H(+)-transporting activity.
+    reference_section_type: ABSTRACT
+- id: Reactome:R-HSA-1222516
+  title: Intraphagosomal pH is lowered to 5 by V-ATPase
+  findings:
+  - statement: Reactome describes V-ATPase rotary pumping into the phagosome.
+    supporting_text: When pumping, ATP hydrolysis drives a 120 degree rotation of the
+      rotor which leads to movement of three protons into the phagosome
+- id: Reactome:R-HSA-5252133
+  title: ATP6AP1 binds V-ATPase
+  findings: []
+- id: Reactome:R-HSA-74723
+  title: Endosome acidification
+  findings:
+  - statement: Reactome describes endosomal acidification as proton-pump driven entry of
+      H+ into the endosome lumen.
+    supporting_text: The effect of the proton pump is to allow entry of [H+] ions into
+      the lumen of the endosome.
+- id: Reactome:R-HSA-917841
+  title: Acidification of Tf:TfR1 containing endosome
+  findings: []
+- id: Reactome:R-HSA-9639286
+  title: RRAGC,D exchanges GTP for GDP
+  findings: []
+- id: Reactome:R-HSA-9640167
+  title: RRAGA,B exchanges GDP for GTP
+  findings: []
+- id: Reactome:R-HSA-9640168
+  title: v-ATPase:Ragulator:RRAGA,B:GTP:RRAGC,D:GDP:SLC38A9:Arginine dissociates
+    yielding v-ATPase:Ragulator:RRAGA,B:GTP:RRAGC,D:GDP and SLC38A9:Arginine
+  findings: []
+- id: Reactome:R-HSA-9640175
+  title: v-ATPase:Ragulator:RagA,B:GDP:RagC,D:GDP binds SLC38A9:Arginine
+  findings: []
+- id: Reactome:R-HSA-9640195
+  title: RRAGA,B hydrolyzes GTP
+  findings: []
+- id: Reactome:R-HSA-9645598
+  title: RRAGC,D hydrolyzes GTP
+  findings: []
+- id: Reactome:R-HSA-9645608
+  title: v-ATPase:Ragulator:RRAGA,B:GTP:RRAGC,D:GDP binds mTORC1
+  findings:
+  - statement: Reactome places V-ATPase activity upstream of lysosomal mTORC1
+      recruitment.
+    supporting_text: Hydrolysis of ATP by the v-ATPase complex is also required for
+      recruitment of mTORC1
+- id: Reactome:R-HSA-9646468
+  title: mTORC1 binds RHEB:GTP
+  findings: []
+- id: Reactome:R-HSA-9858940
+  title: MITF-M-dependent ATP6V0B gene expression
+  findings:
+  - statement: Reactome records MITF-dependent expression of ATP6V0B and the
+      lysosome/endosome acidification role of V-ATPase.
+    supporting_text: MITF has been implicated in the regulation of expression of many
+      components of the v-ATPase, including the transmembrane component ATP6V0B
+- id: file:human/ATP6V0B/ATP6V0B-deep-research-falcon.md
+  title: Falcon deep research report on ATP6V0B
+  findings:
+  - statement: Falcon deep research supports ATP6V0B as the human V-ATPase c proteolipid
+      subunit and highlights the PN-relevant lysosomal acidification role.
+    supporting_text: &#39;model: Edison Scientific Literature&#39;
+- id: file:human/ATP6V0B/ATP6V0B-deep-research-cyberian.md
+  title: Cyberian deep research on ATP6V0B function
+  findings: []
+- id: file:projects/PROTEOSTASIS/reports/pn_projection/pn_projected_annotations.tsv
+  title: Proteostasis PN projected annotations for ATP6V0B
+  findings:
+  - statement: PN projection maps ATP6V0B in the V0 lysosomal V-ATPase proton pump
+      component leaf to GO:0046610.
+    supporting_text: &#34;ATP6V0B\t\tAutophagy-Lysosome Pathway|Pre-initiation autophagy signaling|mTORC1
+      pathway, upstream|Nutrient sensing|V0 lysosomal v-ATPase proton pump component&#34;
 status: COMPLETE
+core_functions:
+- contributes_to_molecular_function:
+    id: GO:0046961
+    label: proton-transporting ATPase activity, rotational mechanism
+  directly_involved_in:
+  - id: GO:1902600
+    label: proton transmembrane transport
+  - id: GO:0007042
+    label: lysosomal lumen acidification
+  - id: GO:0048388
+    label: endosomal lumen acidification
+  - id: GO:0061795
+    label: Golgi lumen acidification
+  locations:
+  - id: GO:0005765
+    label: lysosomal membrane
+  - id: GO:0010008
+    label: endosome membrane
+  - id: GO:0000139
+    label: Golgi membrane
+  in_complex:
+    id: GO:0046610
+    label: lysosomal proton-transporting V-type ATPase, V0 domain
+  description: ATP6V0B is the V0 c&#39;&#39; proteolipid subunit of the V-ATPase proton pump. It
+    contributes to the complex-level rotary proton-transporting ATPase activity by
+    forming part of the membrane c-ring/proton-transfer sector, rather than
+    independently hydrolyzing ATP. This activity acidifies lysosomal, endosomal and
+    Golgi lumens, supporting endolysosomal protein degradation, trafficking and
+    nutrient-signaling contexts. The PN projection to GO:0046610 is a conservative
+    component-level refinement of existing V0 domain and lysosomal acidification
+    annotations.
+  supported_by:
+  - reference_id: PMID:9653649
+    supporting_text: hATP6F is a hydrophobic protein with five putative transmembrane
+      segments, having 61% amino acid identity and 83% similarity to the yeast protein,
+      except in the N-terminus, and contains a conserved glutamic acid residue (Glu98)
+      that is essential for H(+)-transporting activity.
+  - reference_id: PMID:33065002
+    supporting_text: Vesicular- or vacuolar-type adenosine triphosphatases (V-ATPases)
+      are ATP-driven proton pumps comprised of a cytoplasmic V1 complex for ATP
+      hydrolysis and a membrane-embedded Vo complex for proton transfer.
+  - reference_id: PMID:33065002
+    supporting_text: Vesicular and organellar V-ATPases are essential in establishing
+      and maintaining the pH homeostasis of endosomes and lysosomes and in supporting
+      intracellular membrane trafficking and protein degradation
+  - reference_id: &#39;file:projects/PROTEOSTASIS/reports/pn_projection/pn_projected_annotations.tsv&#39;
+    supporting_text: &#34;ATP6V0B\t\tAutophagy-Lysosome Pathway|Pre-initiation autophagy signaling|mTORC1
+      pathway, upstream|Nutrient sensing|V0 lysosomal v-ATPase proton pump component&#34;
+proposed_new_terms: []
+suggested_questions:
+- question: Is ATP6V0B ever functionally limiting for plasma-membrane V-ATPase activity
+    in specialized human cells, or should plasma membrane annotations remain non-core
+    generic V-ATPase complex localizations?
+  experts:
+  - V-ATPase biology curators
+  - GO cellular component annotation experts
+suggested_experiments:
+- experiment_type: ATP6V0B-specific knockout/rescue in human lysosome pH assays
+  hypothesis: Loss of ATP6V0B specifically disrupts assembly or activity of the
+    lysosomal V0 domain, reducing lysosomal acidification without implying a standalone
+    ATPase activity for the subunit.
+  description: Generate ATP6V0B knockout human cells, rescue with wild-type ATP6V0B and
+    a Glu98-neutralized mutant, and quantify LysoSensor/LysoTracker pH, cathepsin
+    maturation, V1-V0 assembly and autophagic flux. This would directly test the
+    PN-projected lysosomal V0-domain role at the gene-product level.
 </code></pre>
             </div>
         </details>
     </div>
 
     <!-- Pathway Visualization Link -->
-    
+
 
     <style>
         /* Markdown Section Styles */

--- a/genes/human/ATP6V0B/ATP6V0B-ai-review.html
+++ b/genes/human/ATP6V0B/ATP6V0B-ai-review.html
@@ -1721,7 +1721,7 @@
 
 
                         <div>
-                            <strong>Reason:</strong> GO:0005515 is deliberately avoided in this curation workflow because it does not describe ATP6V0B&#39;s mechanistic role. The HuRI study is a large-scale interaction map, useful as interaction evidence but not sufficient to replace the established V-ATPase c&#39;&#39; subunit function with a generic binding term.
+                            <strong>Reason:</strong> GO:0005515 is deliberately avoided in this curation workflow because it does not describe ATP6V0B&#39;s mechanistic role. This single REMOVE entry represents the multiple HuRI-derived GOA protein-binding interaction records from PMID:32296183; the HuRI study is a large-scale interaction map, useful as interaction evidence but not sufficient to replace the established V-ATPase c&#39;&#39; subunit function with a generic binding term.
                         </div>
 
 
@@ -4950,7 +4950,7 @@
 
                                 </span>
 
-                                <div class="support-text">model: Edison Scientific Literature</div>
+                                <div class="support-text">The target is human ATP6V0B (UniProt Q99437), encoding the V-ATPase V0 21 kDa proteolipid subunit c&#39;&#39; (also called c-double-prime), a member of the V-ATPase proteolipid subunit family.</div>
 
                             </div>
 
@@ -5646,9 +5646,9 @@
                 <ul class="findings-list">
 
                     <li class="finding-item">
-                        <div class="finding-statement">Falcon deep research supports ATP6V0B as the human V-ATPase c proteolipid subunit and highlights the PN-relevant lysosomal acidification role.</div>
+                        <div class="finding-statement">Falcon deep research supports ATP6V0B as the human V-ATPase V0 c&#39;&#39; proteolipid subunit and highlights the PN-relevant lysosomal acidification role.</div>
 
-                        <div class="finding-text">"model: Edison Scientific Literature"</div>
+                        <div class="finding-text">"ATP6V0B-containing V-ATPases acidify lysosomes, endosomes, Golgi, and secretory/synaptic vesicles and can localize to plasma membranes in specialized cells."</div>
 
                     </li>
 
@@ -6523,9 +6523,11 @@ existing_annotations:
       binary interactome map.
     action: REMOVE
     reason: GO:0005515 is deliberately avoided in this curation workflow because it does
-      not describe ATP6V0B&#39;s mechanistic role. The HuRI study is a large-scale
-      interaction map, useful as interaction evidence but not sufficient to replace the
-      established V-ATPase c&#39;&#39; subunit function with a generic binding term.
+      not describe ATP6V0B&#39;s mechanistic role. This single REMOVE entry represents the
+      multiple HuRI-derived GOA protein-binding interaction records from PMID:32296183;
+      the HuRI study is a large-scale interaction map, useful as interaction evidence but
+      not sufficient to replace the established V-ATPase c&#39;&#39; subunit function with a
+      generic binding term.
     supported_by:
     - reference_id: PMID:32296183
       supporting_text: The dataset, versioned HI-III-20 (Human Interactome obtained from
@@ -7312,7 +7314,9 @@ existing_annotations:
         and maintaining the pH homeostasis of endosomes and lysosomes and in supporting
         intracellular membrane trafficking and protein degradation
     - reference_id: file:human/ATP6V0B/ATP6V0B-deep-research-falcon.md
-      supporting_text: &#39;model: Edison Scientific Literature&#39;
+      supporting_text: The target is human ATP6V0B (UniProt Q99437), encoding the
+        V-ATPase V0 21 kDa proteolipid subunit c&#39;&#39; (also called c-double-prime), a
+        member of the V-ATPase proteolipid subunit family.
 references:
 - id: GO_REF:0000002
   title: Gene Ontology annotation through association of InterPro records with GO terms.
@@ -7459,9 +7463,11 @@ references:
 - id: file:human/ATP6V0B/ATP6V0B-deep-research-falcon.md
   title: Falcon deep research report on ATP6V0B
   findings:
-  - statement: Falcon deep research supports ATP6V0B as the human V-ATPase c proteolipid
-      subunit and highlights the PN-relevant lysosomal acidification role.
-    supporting_text: &#39;model: Edison Scientific Literature&#39;
+  - statement: Falcon deep research supports ATP6V0B as the human V-ATPase V0 c&#39;&#39;
+      proteolipid subunit and highlights the PN-relevant lysosomal acidification role.
+    supporting_text: ATP6V0B-containing V-ATPases acidify lysosomes, endosomes, Golgi,
+      and secretory/synaptic vesicles and can localize to plasma membranes in specialized
+      cells.
 - id: file:human/ATP6V0B/ATP6V0B-deep-research-cyberian.md
   title: Cyberian deep research on ATP6V0B function
   findings: []

--- a/genes/human/ATP6V0B/ATP6V0B-ai-review.yaml
+++ b/genes/human/ATP6V0B/ATP6V0B-ai-review.yaml
@@ -248,9 +248,11 @@ existing_annotations:
       binary interactome map.
     action: REMOVE
     reason: GO:0005515 is deliberately avoided in this curation workflow because it does
-      not describe ATP6V0B's mechanistic role. The HuRI study is a large-scale
-      interaction map, useful as interaction evidence but not sufficient to replace the
-      established V-ATPase c'' subunit function with a generic binding term.
+      not describe ATP6V0B's mechanistic role. This single REMOVE entry represents the
+      multiple HuRI-derived GOA protein-binding interaction records from PMID:32296183;
+      the HuRI study is a large-scale interaction map, useful as interaction evidence but
+      not sufficient to replace the established V-ATPase c'' subunit function with a
+      generic binding term.
     supported_by:
     - reference_id: PMID:32296183
       supporting_text: The dataset, versioned HI-III-20 (Human Interactome obtained from
@@ -1037,7 +1039,9 @@ existing_annotations:
         and maintaining the pH homeostasis of endosomes and lysosomes and in supporting
         intracellular membrane trafficking and protein degradation
     - reference_id: file:human/ATP6V0B/ATP6V0B-deep-research-falcon.md
-      supporting_text: 'model: Edison Scientific Literature'
+      supporting_text: The target is human ATP6V0B (UniProt Q99437), encoding the
+        V-ATPase V0 21 kDa proteolipid subunit c'' (also called c-double-prime), a
+        member of the V-ATPase proteolipid subunit family.
 references:
 - id: GO_REF:0000002
   title: Gene Ontology annotation through association of InterPro records with GO terms.
@@ -1184,9 +1188,11 @@ references:
 - id: file:human/ATP6V0B/ATP6V0B-deep-research-falcon.md
   title: Falcon deep research report on ATP6V0B
   findings:
-  - statement: Falcon deep research supports ATP6V0B as the human V-ATPase c proteolipid
-      subunit and highlights the PN-relevant lysosomal acidification role.
-    supporting_text: 'model: Edison Scientific Literature'
+  - statement: Falcon deep research supports ATP6V0B as the human V-ATPase V0 c''
+      proteolipid subunit and highlights the PN-relevant lysosomal acidification role.
+    supporting_text: ATP6V0B-containing V-ATPases acidify lysosomes, endosomes, Golgi,
+      and secretory/synaptic vesicles and can localize to plasma membranes in specialized
+      cells.
 - id: file:human/ATP6V0B/ATP6V0B-deep-research-cyberian.md
   title: Cyberian deep research on ATP6V0B function
   findings: []

--- a/genes/human/ATP6V0B/ATP6V0B-ai-review.yaml
+++ b/genes/human/ATP6V0B/ATP6V0B-ai-review.yaml
@@ -1,550 +1,1265 @@
 id: Q99437
-gene_symbol: Q99437
+gene_symbol: ATP6V0B
 product_type: PROTEIN
 taxon:
   id: NCBITaxon:9606
   label: Homo sapiens
-description: 'TODO: Add description for Q99437'
+description: 'ATP6V0B encodes the human V-type proton ATPase V0 proteolipid subunit c''''.
+  It is a small multi-pass membrane component of the proton-translocating V0 sector, where
+  it forms part of the c-ring rotor/pore with an essential conserved Glu98 residue required
+  for H+ transport. ATP6V0B-containing V-ATPase complexes acidify lysosomes, endosomes, Golgi-derived
+  compartments and other vesicles, thereby supporting endolysosomal pH homeostasis, membrane
+  trafficking, protein degradation, autophagic flux and lysosome-associated nutrient signaling.
+  In specialized cell contexts, V-ATPase complexes can also function at the plasma membrane
+  to acidify the extracellular or phagosomal environment.'
 existing_annotations:
-  - term:
-      id: GO:0016020
-      label: membrane
-    evidence_type: IBA
-    original_reference_id: GO_REF:0000033
-    review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
-      supported_by:
-        - reference_id: file:human/ATP6V0B/ATP6V0B-deep-research-falcon.md
-          supporting_text: 'model: Edison Scientific Literature'
-  - term:
-      id: GO:0006811
-      label: monoatomic ion transport
-    evidence_type: IEA
-    original_reference_id: GO_REF:0000043
-    review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
-  - term:
-      id: GO:0015078
-      label: proton transmembrane transporter activity
-    evidence_type: IEA
-    original_reference_id: GO_REF:0000120
-    review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
-  - term:
-      id: GO:0030665
-      label: clathrin-coated vesicle membrane
-    evidence_type: IEA
-    original_reference_id: GO_REF:0000044
-    review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
-  - term:
-      id: GO:0031410
-      label: cytoplasmic vesicle
-    evidence_type: IEA
-    original_reference_id: GO_REF:0000043
-    review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
-  - term:
-      id: GO:0033177
-      label: proton-transporting two-sector ATPase complex, proton-transporting 
-        domain
-    evidence_type: IEA
-    original_reference_id: GO_REF:0000002
-    review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
-  - term:
-      id: GO:0033179
-      label: proton-transporting V-type ATPase, V0 domain
-    evidence_type: IEA
-    original_reference_id: GO_REF:0000002
-    review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
-  - term:
-      id: GO:0046961
+- term:
+    id: GO:0016020
+    label: membrane
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  review:
+    summary: Accept membrane as a supported V-ATPase membrane localization.
+    action: ACCEPT
+    reason: ATP6V0B is an integral membrane subunit of V-ATPase. Human V-ATPase
+      structures and reviews support its role in organellar and vesicular proton-pump
+      complexes; the broad membrane/localization annotation is correct, although more
+      specific endolysosomal V-ATPase component terms are more informative.
+    supported_by:
+    - reference_id: PMID:33065002
+      supporting_text: Vesicular- or vacuolar-type adenosine triphosphatases (V-ATPases)
+        are ATP-driven proton pumps comprised of a cytoplasmic V1 complex for ATP
+        hydrolysis and a membrane-embedded Vo complex for proton transfer.
+    - reference_id: PMID:9653649
+      supporting_text: The proteolipid domain of vacuolar H(+)-ATPase (V-ATPase) plays a
+        major role in H+ transport in microvesicles and other acidic organelles.
+- term:
+    id: GO:0006811
+    label: monoatomic ion transport
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000043
+  review:
+    summary: The annotation is directionally correct but too broad for ATP6V0B.
+    action: MODIFY
+    reason: ATP6V0B is not a generic ion-transport factor; it contributes to
+      V-ATPase-driven proton transmembrane transport. Replace the broad monoatomic ion
+      transport term with the established proton transport process term already
+      supported elsewhere in GOA.
+    proposed_replacement_terms:
+    - id: GO:1902600
+      label: proton transmembrane transport
+    supported_by:
+    - reference_id: PMID:33065002
+      supporting_text: Vesicular- or vacuolar-type adenosine triphosphatases (V-ATPases)
+        are ATP-driven proton pumps comprised of a cytoplasmic V1 complex for ATP
+        hydrolysis and a membrane-embedded Vo complex for proton transfer.
+    - reference_id: PMID:9653649
+      supporting_text: The proteolipid domain of vacuolar H(+)-ATPase (V-ATPase) plays a
+        major role in H+ transport in microvesicles and other acidic organelles.
+- term:
+    id: GO:0015078
+    label: proton transmembrane transporter activity
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000120
+  review:
+    summary: The proton-transporter concept is correct, but the more precise complex
+      activity is V-type ATPase rotational proton pumping.
+    action: MODIFY
+    reason: ATP6V0B contributes as the c'' proteolipid in the V0 rotor rather than
+      acting as an independent transporter. A complex-level term, proton-transporting
+      ATPase activity, rotational mechanism, is the better molecular-function target; in
+      GPAD/GAF this should be treated conservatively as a contribution to the V-ATPase
+      complex activity.
+    proposed_replacement_terms:
+    - id: GO:0046961
       label: proton-transporting ATPase activity, rotational mechanism
-    evidence_type: IEA
-    original_reference_id: GO_REF:0000002
-    review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
-  - term:
-      id: GO:1902600
-      label: proton transmembrane transport
-    evidence_type: IEA
-    original_reference_id: GO_REF:0000120
-    review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
-  - term:
-      id: GO:0005515
-      label: protein binding
-    evidence_type: IPI
-    original_reference_id: PMID:23864651
-    review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
-      supported_by:
-        - reference_id: PMID:23864651
-          supporting_text: Jul 17. The identification of novel proteins that 
-            interact with the GLP-1 receptor and restrain its activity.
-  - term:
-      id: GO:0005515
-      label: protein binding
-    evidence_type: IPI
-    original_reference_id: PMID:32296183
-    review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
-      supported_by:
-        - reference_id: PMID:32296183
-          supporting_text: Apr 8. A reference map of the human binary protein 
-            interactome.
-  - term:
-      id: GO:0005768
-      label: endosome
-    evidence_type: IEA
-    original_reference_id: GO_REF:0000107
-    review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
-  - term:
-      id: GO:0016020
-      label: membrane
-    evidence_type: IEA
-    original_reference_id: GO_REF:0000120
-    review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
-  - term:
-      id: GO:0033176
-      label: proton-transporting V-type ATPase complex
-    evidence_type: IEA
-    original_reference_id: GO_REF:0000107
-    review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
-  - term:
-      id: GO:0000139
-      label: Golgi membrane
-    evidence_type: NAS
-    original_reference_id: PMID:32001091
-    review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
-      supported_by:
-        - reference_id: PMID:32001091
-          supporting_text: Epub 2020 Jan 28. Structure and Roles of V-type 
-            ATPases.
-  - term:
-      id: GO:0005765
-      label: lysosomal membrane
-    evidence_type: NAS
-    original_reference_id: PMID:32001091
-    review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
-      supported_by:
-        - reference_id: PMID:32001091
-          supporting_text: Epub 2020 Jan 28. Structure and Roles of V-type 
-            ATPases.
-  - term:
-      id: GO:0005886
-      label: plasma membrane
-    evidence_type: NAS
-    original_reference_id: PMID:32001091
-    review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
-      supported_by:
-        - reference_id: PMID:32001091
-          supporting_text: Epub 2020 Jan 28. Structure and Roles of V-type 
-            ATPases.
-  - term:
-      id: GO:0007035
-      label: vacuolar acidification
-    evidence_type: NAS
-    original_reference_id: PMID:32001091
-    review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
-      supported_by:
-        - reference_id: PMID:32001091
-          supporting_text: Epub 2020 Jan 28. Structure and Roles of V-type 
-            ATPases.
-  - term:
-      id: GO:0007042
-      label: lysosomal lumen acidification
-    evidence_type: NAS
-    original_reference_id: PMID:32001091
-    review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
-      supported_by:
-        - reference_id: PMID:32001091
-          supporting_text: Epub 2020 Jan 28. Structure and Roles of V-type 
-            ATPases.
-  - term:
-      id: GO:0007042
-      label: lysosomal lumen acidification
-    evidence_type: NAS
-    original_reference_id: PMID:33065002
-    review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
-      supported_by:
-        - reference_id: PMID:33065002
-          supporting_text: 2020 Oct 15. Structures of a Complete Human V-ATPase 
-            Reveal Mechanisms of Its Assembly.
-  - term:
-      id: GO:0010008
-      label: endosome membrane
-    evidence_type: NAS
-    original_reference_id: PMID:32001091
-    review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
-      supported_by:
-        - reference_id: PMID:32001091
-          supporting_text: Epub 2020 Jan 28. Structure and Roles of V-type 
-            ATPases.
-  - term:
-      id: GO:0016020
-      label: membrane
-    evidence_type: IDA
-    original_reference_id: PMID:33065002
-    review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
-      supported_by:
-        - reference_id: PMID:33065002
-          supporting_text: 2020 Oct 15. Structures of a Complete Human V-ATPase 
-            Reveal Mechanisms of Its Assembly.
-  - term:
-      id: GO:0033176
-      label: proton-transporting V-type ATPase complex
-    evidence_type: NAS
-    original_reference_id: PMID:33065002
-    review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
-      supported_by:
-        - reference_id: PMID:33065002
-          supporting_text: 2020 Oct 15. Structures of a Complete Human V-ATPase 
-            Reveal Mechanisms of Its Assembly.
-  - term:
-      id: GO:0048388
-      label: endosomal lumen acidification
-    evidence_type: NAS
-    original_reference_id: PMID:32001091
-    review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
-      supported_by:
-        - reference_id: PMID:32001091
-          supporting_text: Epub 2020 Jan 28. Structure and Roles of V-type 
-            ATPases.
-  - term:
-      id: GO:0051452
-      label: intracellular pH reduction
-    evidence_type: NAS
-    original_reference_id: PMID:32001091
-    review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
-      supported_by:
-        - reference_id: PMID:32001091
-          supporting_text: Epub 2020 Jan 28. Structure and Roles of V-type 
-            ATPases.
-  - term:
-      id: GO:0061795
-      label: Golgi lumen acidification
-    evidence_type: NAS
-    original_reference_id: PMID:32001091
-    review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
-      supported_by:
-        - reference_id: PMID:32001091
-          supporting_text: Epub 2020 Jan 28. Structure and Roles of V-type 
-            ATPases.
-  - term:
-      id: GO:1902600
-      label: proton transmembrane transport
-    evidence_type: NAS
-    original_reference_id: PMID:33065002
-    review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
-      supported_by:
-        - reference_id: PMID:33065002
-          supporting_text: 2020 Oct 15. Structures of a Complete Human V-ATPase 
-            Reveal Mechanisms of Its Assembly.
-  - term:
-      id: GO:0046961
-      label: proton-transporting ATPase activity, rotational mechanism
-    evidence_type: TAS
-    original_reference_id: PMID:9653649
-    review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
-      supported_by:
-        - reference_id: PMID:9653649
-          supporting_text: Identification and characterization of the gene 
-            encoding a second proteolipid subunit of human vacuolar H(+)-ATPase 
-            (ATP6F).
-  - term:
-      id: GO:0000220
-      label: vacuolar proton-transporting V-type ATPase, V0 domain
-    evidence_type: ISS
-    original_reference_id: GO_REF:0000024
-    review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
-  - term:
-      id: GO:0005765
-      label: lysosomal membrane
-    evidence_type: TAS
-    original_reference_id: Reactome:R-HSA-9639286
-    review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
-  - term:
-      id: GO:0005765
-      label: lysosomal membrane
-    evidence_type: TAS
-    original_reference_id: Reactome:R-HSA-9640167
-    review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
-  - term:
-      id: GO:0005765
-      label: lysosomal membrane
-    evidence_type: TAS
-    original_reference_id: Reactome:R-HSA-9640168
-    review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
-  - term:
-      id: GO:0005765
-      label: lysosomal membrane
-    evidence_type: TAS
-    original_reference_id: Reactome:R-HSA-9640175
-    review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
-  - term:
-      id: GO:0005765
-      label: lysosomal membrane
-    evidence_type: TAS
-    original_reference_id: Reactome:R-HSA-9640195
-    review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
-  - term:
-      id: GO:0005765
-      label: lysosomal membrane
-    evidence_type: TAS
-    original_reference_id: Reactome:R-HSA-9645598
-    review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
-  - term:
-      id: GO:0005765
-      label: lysosomal membrane
-    evidence_type: TAS
-    original_reference_id: Reactome:R-HSA-9645608
-    review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
-  - term:
-      id: GO:0005765
-      label: lysosomal membrane
-    evidence_type: TAS
-    original_reference_id: Reactome:R-HSA-9646468
-    review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
-  - term:
-      id: GO:0005765
-      label: lysosomal membrane
-    evidence_type: TAS
-    original_reference_id: Reactome:R-HSA-9858940
-    review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
-  - term:
-      id: GO:0016241
-      label: regulation of macroautophagy
-    evidence_type: NAS
-    original_reference_id: PMID:22982048
-    review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
-      supported_by:
-        - reference_id: PMID:22982048
-          supporting_text: Lipofuscin is formed independently of macroautophagy 
-            and lysosomal activity in stress-induced prematurely senescent human
-            fibroblasts.
-  - term:
-      id: GO:0030670
-      label: phagocytic vesicle membrane
-    evidence_type: TAS
-    original_reference_id: Reactome:R-HSA-1222516
-    review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
-  - term:
-      id: GO:0010008
-      label: endosome membrane
-    evidence_type: TAS
-    original_reference_id: Reactome:R-HSA-5252133
-    review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
-  - term:
-      id: GO:0010008
-      label: endosome membrane
-    evidence_type: TAS
-    original_reference_id: Reactome:R-HSA-74723
-    review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
-  - term:
-      id: GO:0010008
-      label: endosome membrane
-    evidence_type: TAS
-    original_reference_id: Reactome:R-HSA-917841
-    review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
-  - term:
-      id: GO:0016020
-      label: membrane
-    evidence_type: TAS
-    original_reference_id: PMID:9653649
-    review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
-      supported_by:
-        - reference_id: PMID:9653649
-          supporting_text: Identification and characterization of the gene 
-            encoding a second proteolipid subunit of human vacuolar H(+)-ATPase 
-            (ATP6F).
-  - term:
-      id: GO:1902600
-      label: proton transmembrane transport
-    evidence_type: TAS
-    original_reference_id: PMID:9653649
-    review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
-      supported_by:
-        - reference_id: PMID:9653649
-          supporting_text: Identification and characterization of the gene 
-            encoding a second proteolipid subunit of human vacuolar H(+)-ATPase 
-            (ATP6F).
+    supported_by:
+    - reference_id: PMID:33065002
+      supporting_text: Vesicular- or vacuolar-type adenosine triphosphatases (V-ATPases)
+        are ATP-driven proton pumps comprised of a cytoplasmic V1 complex for ATP
+        hydrolysis and a membrane-embedded Vo complex for proton transfer.
+    - reference_id: PMID:9653649
+      supporting_text: hATP6F is a hydrophobic protein with five putative transmembrane
+        segments, having 61% amino acid identity and 83% similarity to the yeast
+        protein, except in the N-terminus, and contains a conserved glutamic acid
+        residue (Glu98) that is essential for H(+)-transporting activity.
+- term:
+    id: GO:0030665
+    label: clathrin-coated vesicle membrane
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000044
+  review:
+    summary: Accept clathrin-coated vesicle membrane as a supported V-ATPase membrane
+      localization.
+    action: ACCEPT
+    reason: ATP6V0B is an integral membrane subunit of V-ATPase. Human V-ATPase
+      structures and reviews support its role in organellar and vesicular proton-pump
+      complexes; the broad membrane/localization annotation is correct, although more
+      specific endolysosomal V-ATPase component terms are more informative.
+    supported_by:
+    - reference_id: PMID:33065002
+      supporting_text: Vesicular- or vacuolar-type adenosine triphosphatases (V-ATPases)
+        are ATP-driven proton pumps comprised of a cytoplasmic V1 complex for ATP
+        hydrolysis and a membrane-embedded Vo complex for proton transfer.
+    - reference_id: PMID:9653649
+      supporting_text: The proteolipid domain of vacuolar H(+)-ATPase (V-ATPase) plays a
+        major role in H+ transport in microvesicles and other acidic organelles.
+- term:
+    id: GO:0031410
+    label: cytoplasmic vesicle
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000043
+  review:
+    summary: Keep this localization as a valid but non-core or context-specific site for
+      V-ATPase complexes.
+    action: KEEP_AS_NON_CORE
+    reason: ATP6V0B is a membrane V-ATPase subunit and V-ATPases can act in vesicular or
+      specialized plasma/phagosomal compartments. For ATP6V0B's core annotation,
+      however, lysosomal/endosomal/Golgi V0-domain component and acidification terms are
+      more informative than this broad or context-specific location.
+    supported_by:
+    - reference_id: PMID:33065002
+      supporting_text: Vesicular- or vacuolar-type adenosine triphosphatases (V-ATPases)
+        are ATP-driven proton pumps comprised of a cytoplasmic V1 complex for ATP
+        hydrolysis and a membrane-embedded Vo complex for proton transfer.
+    - reference_id: Reactome:R-HSA-1222516
+      supporting_text: When pumping, ATP hydrolysis drives a 120 degree rotation of the
+        rotor which leads to movement of three protons into the phagosome
+- term:
+    id: GO:0033177
+    label: proton-transporting two-sector ATPase complex, proton-transporting domain
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000002
+  review:
+    summary: This component annotation is consistent with ATP6V0B being the c''
+      proteolipid subunit of the V0 proton-translocating sector of V-ATPase.
+    action: ACCEPT
+    reason: ATP6V0B is experimentally identified as a five-transmembrane human V-ATPase
+      proteolipid with conserved Glu98 required for H+ transport, and human V-ATPase
+      structures place V0 subunits in the membrane-embedded proton-transfer module. The
+      component annotation is therefore part of the core molecular role of ATP6V0B.
+    supported_by:
+    - reference_id: PMID:33065002
+      supporting_text: Vesicular- or vacuolar-type adenosine triphosphatases (V-ATPases)
+        are ATP-driven proton pumps comprised of a cytoplasmic V1 complex for ATP
+        hydrolysis and a membrane-embedded Vo complex for proton transfer.
+    - reference_id: PMID:9653649
+      supporting_text: hATP6F is a hydrophobic protein with five putative transmembrane
+        segments, having 61% amino acid identity and 83% similarity to the yeast
+        protein, except in the N-terminus, and contains a conserved glutamic acid
+        residue (Glu98) that is essential for H(+)-transporting activity.
+- term:
+    id: GO:0033179
+    label: proton-transporting V-type ATPase, V0 domain
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000002
+  review:
+    summary: This component annotation is consistent with ATP6V0B being the c''
+      proteolipid subunit of the V0 proton-translocating sector of V-ATPase.
+    action: ACCEPT
+    reason: ATP6V0B is experimentally identified as a five-transmembrane human V-ATPase
+      proteolipid with conserved Glu98 required for H+ transport, and human V-ATPase
+      structures place V0 subunits in the membrane-embedded proton-transfer module. The
+      component annotation is therefore part of the core molecular role of ATP6V0B.
+    supported_by:
+    - reference_id: PMID:33065002
+      supporting_text: Vesicular- or vacuolar-type adenosine triphosphatases (V-ATPases)
+        are ATP-driven proton pumps comprised of a cytoplasmic V1 complex for ATP
+        hydrolysis and a membrane-embedded Vo complex for proton transfer.
+    - reference_id: PMID:9653649
+      supporting_text: hATP6F is a hydrophobic protein with five putative transmembrane
+        segments, having 61% amino acid identity and 83% similarity to the yeast
+        protein, except in the N-terminus, and contains a conserved glutamic acid
+        residue (Glu98) that is essential for H(+)-transporting activity.
+- term:
+    id: GO:0046961
+    label: proton-transporting ATPase activity, rotational mechanism
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000002
+  review:
+    summary: Accept the V-type ATPase rotational proton-pump activity as the complex
+      activity to which ATP6V0B contributes.
+    action: ACCEPT
+    reason: ATP6V0B is not the ATP-hydrolytic catalytic subunit, but it is an essential
+      V0 c-ring proteolipid required for proton translocation by the rotary V-ATPase.
+      This is the correct complex-level molecular function for the ATP6V0B-containing
+      V-ATPase machinery.
+    supported_by:
+    - reference_id: PMID:33065002
+      supporting_text: Vesicular- or vacuolar-type adenosine triphosphatases (V-ATPases)
+        are ATP-driven proton pumps comprised of a cytoplasmic V1 complex for ATP
+        hydrolysis and a membrane-embedded Vo complex for proton transfer.
+    - reference_id: PMID:9653649
+      supporting_text: hATP6F is a hydrophobic protein with five putative transmembrane
+        segments, having 61% amino acid identity and 83% similarity to the yeast
+        protein, except in the N-terminus, and contains a conserved glutamic acid
+        residue (Glu98) that is essential for H(+)-transporting activity.
+- term:
+    id: GO:1902600
+    label: proton transmembrane transport
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000120
+  review:
+    summary: Accept this acidification/proton-transport process annotation for the
+      ATP6V0B-containing V-ATPase complex.
+    action: ACCEPT
+    reason: The ATP6V0B-containing V0 sector contributes to proton transfer by V-ATPase.
+      Human V-ATPases maintain acidic endosomes and lysosomes and support membrane
+      trafficking and protein degradation, so proton transport and organelle lumen
+      acidification annotations reflect the core biological consequence of this
+      subunit's role in the pump.
+    supported_by:
+    - reference_id: PMID:33065002
+      supporting_text: Vesicular- or vacuolar-type adenosine triphosphatases (V-ATPases)
+        are ATP-driven proton pumps comprised of a cytoplasmic V1 complex for ATP
+        hydrolysis and a membrane-embedded Vo complex for proton transfer.
+    - reference_id: PMID:33065002
+      supporting_text: Vesicular and organellar V-ATPases are essential in establishing
+        and maintaining the pH homeostasis of endosomes and lysosomes and in supporting
+        intracellular membrane trafficking and protein degradation
+    - reference_id: PMID:9653649
+      supporting_text: The proteolipid domain of vacuolar H(+)-ATPase (V-ATPase) plays a
+        major role in H+ transport in microvesicles and other acidic organelles.
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:23864651
+  review:
+    summary: Remove the generic protein binding annotation from the GLP-1R interaction
+      screen.
+    action: REMOVE
+    reason: GO:0005515 is uninformative for ATP6V0B and the supporting study is a
+      receptor-interactome screen rather than evidence for ATP6V0B's core V-ATPase
+      function. No specific ATP6V0B molecular activity should be inferred from this
+      interaction record.
+    supported_by:
+    - reference_id: PMID:23864651
+      supporting_text: A screen of a human fetal brain cDNA prey library with an
+        unliganded human GLP-1R as bait in yeast revealed 38 novel interactor protein
+        candidates.
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:32296183
+  review:
+    summary: Remove the generic protein binding annotation from the high-throughput
+      binary interactome map.
+    action: REMOVE
+    reason: GO:0005515 is deliberately avoided in this curation workflow because it does
+      not describe ATP6V0B's mechanistic role. The HuRI study is a large-scale
+      interaction map, useful as interaction evidence but not sufficient to replace the
+      established V-ATPase c'' subunit function with a generic binding term.
+    supported_by:
+    - reference_id: PMID:32296183
+      supporting_text: The dataset, versioned HI-III-20 (Human Interactome obtained from
+        screening Space III, published in 2020), contains 52,569 verified PPIs involving
+        8,275 proteins
+- term:
+    id: GO:0005768
+    label: endosome
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000107
+  review:
+    summary: Accept endosome as a supported V-ATPase membrane localization.
+    action: ACCEPT
+    reason: ATP6V0B is an integral membrane subunit of V-ATPase. Human V-ATPase
+      structures and reviews support its role in organellar and vesicular proton-pump
+      complexes; the broad membrane/localization annotation is correct, although more
+      specific endolysosomal V-ATPase component terms are more informative.
+    supported_by:
+    - reference_id: PMID:33065002
+      supporting_text: Vesicular- or vacuolar-type adenosine triphosphatases (V-ATPases)
+        are ATP-driven proton pumps comprised of a cytoplasmic V1 complex for ATP
+        hydrolysis and a membrane-embedded Vo complex for proton transfer.
+    - reference_id: PMID:9653649
+      supporting_text: The proteolipid domain of vacuolar H(+)-ATPase (V-ATPase) plays a
+        major role in H+ transport in microvesicles and other acidic organelles.
+- term:
+    id: GO:0016020
+    label: membrane
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000120
+  review:
+    summary: Accept membrane as a supported V-ATPase membrane localization.
+    action: ACCEPT
+    reason: ATP6V0B is an integral membrane subunit of V-ATPase. Human V-ATPase
+      structures and reviews support its role in organellar and vesicular proton-pump
+      complexes; the broad membrane/localization annotation is correct, although more
+      specific endolysosomal V-ATPase component terms are more informative.
+    supported_by:
+    - reference_id: PMID:33065002
+      supporting_text: Vesicular- or vacuolar-type adenosine triphosphatases (V-ATPases)
+        are ATP-driven proton pumps comprised of a cytoplasmic V1 complex for ATP
+        hydrolysis and a membrane-embedded Vo complex for proton transfer.
+    - reference_id: PMID:9653649
+      supporting_text: The proteolipid domain of vacuolar H(+)-ATPase (V-ATPase) plays a
+        major role in H+ transport in microvesicles and other acidic organelles.
+- term:
+    id: GO:0033176
+    label: proton-transporting V-type ATPase complex
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000107
+  review:
+    summary: This component annotation is consistent with ATP6V0B being the c''
+      proteolipid subunit of the V0 proton-translocating sector of V-ATPase.
+    action: ACCEPT
+    reason: ATP6V0B is experimentally identified as a five-transmembrane human V-ATPase
+      proteolipid with conserved Glu98 required for H+ transport, and human V-ATPase
+      structures place V0 subunits in the membrane-embedded proton-transfer module. The
+      component annotation is therefore part of the core molecular role of ATP6V0B.
+    supported_by:
+    - reference_id: PMID:33065002
+      supporting_text: Vesicular- or vacuolar-type adenosine triphosphatases (V-ATPases)
+        are ATP-driven proton pumps comprised of a cytoplasmic V1 complex for ATP
+        hydrolysis and a membrane-embedded Vo complex for proton transfer.
+    - reference_id: PMID:9653649
+      supporting_text: hATP6F is a hydrophobic protein with five putative transmembrane
+        segments, having 61% amino acid identity and 83% similarity to the yeast
+        protein, except in the N-terminus, and contains a conserved glutamic acid
+        residue (Glu98) that is essential for H(+)-transporting activity.
+- term:
+    id: GO:0000139
+    label: Golgi membrane
+  evidence_type: NAS
+  original_reference_id: PMID:32001091
+  review:
+    summary: Accept Golgi membrane as a supported V-ATPase membrane localization.
+    action: ACCEPT
+    reason: ATP6V0B is an integral membrane subunit of V-ATPase. Human V-ATPase
+      structures and reviews support its role in organellar and vesicular proton-pump
+      complexes; the broad membrane/localization annotation is correct, although more
+      specific endolysosomal V-ATPase component terms are more informative.
+    supported_by:
+    - reference_id: PMID:33065002
+      supporting_text: Vesicular- or vacuolar-type adenosine triphosphatases (V-ATPases)
+        are ATP-driven proton pumps comprised of a cytoplasmic V1 complex for ATP
+        hydrolysis and a membrane-embedded Vo complex for proton transfer.
+    - reference_id: PMID:9653649
+      supporting_text: The proteolipid domain of vacuolar H(+)-ATPase (V-ATPase) plays a
+        major role in H+ transport in microvesicles and other acidic organelles.
+- term:
+    id: GO:0005765
+    label: lysosomal membrane
+  evidence_type: NAS
+  original_reference_id: PMID:32001091
+  review:
+    summary: Accept lysosomal membrane as a supported V-ATPase membrane localization.
+    action: ACCEPT
+    reason: ATP6V0B is an integral membrane subunit of V-ATPase. Human V-ATPase
+      structures and reviews support its role in organellar and vesicular proton-pump
+      complexes; the broad membrane/localization annotation is correct, although more
+      specific endolysosomal V-ATPase component terms are more informative.
+    supported_by:
+    - reference_id: PMID:33065002
+      supporting_text: Vesicular- or vacuolar-type adenosine triphosphatases (V-ATPases)
+        are ATP-driven proton pumps comprised of a cytoplasmic V1 complex for ATP
+        hydrolysis and a membrane-embedded Vo complex for proton transfer.
+    - reference_id: PMID:9653649
+      supporting_text: The proteolipid domain of vacuolar H(+)-ATPase (V-ATPase) plays a
+        major role in H+ transport in microvesicles and other acidic organelles.
+- term:
+    id: GO:0005886
+    label: plasma membrane
+  evidence_type: NAS
+  original_reference_id: PMID:32001091
+  review:
+    summary: Keep this localization as a valid but non-core or context-specific site for
+      V-ATPase complexes.
+    action: KEEP_AS_NON_CORE
+    reason: ATP6V0B is a membrane V-ATPase subunit and V-ATPases can act in vesicular or
+      specialized plasma/phagosomal compartments. For ATP6V0B's core annotation,
+      however, lysosomal/endosomal/Golgi V0-domain component and acidification terms are
+      more informative than this broad or context-specific location.
+    supported_by:
+    - reference_id: PMID:33065002
+      supporting_text: Vesicular- or vacuolar-type adenosine triphosphatases (V-ATPases)
+        are ATP-driven proton pumps comprised of a cytoplasmic V1 complex for ATP
+        hydrolysis and a membrane-embedded Vo complex for proton transfer.
+    - reference_id: Reactome:R-HSA-1222516
+      supporting_text: When pumping, ATP hydrolysis drives a 120 degree rotation of the
+        rotor which leads to movement of three protons into the phagosome
+- term:
+    id: GO:0007035
+    label: vacuolar acidification
+  evidence_type: NAS
+  original_reference_id: PMID:32001091
+  review:
+    summary: Accept this acidification/proton-transport process annotation for the
+      ATP6V0B-containing V-ATPase complex.
+    action: ACCEPT
+    reason: The ATP6V0B-containing V0 sector contributes to proton transfer by V-ATPase.
+      Human V-ATPases maintain acidic endosomes and lysosomes and support membrane
+      trafficking and protein degradation, so proton transport and organelle lumen
+      acidification annotations reflect the core biological consequence of this
+      subunit's role in the pump.
+    supported_by:
+    - reference_id: PMID:33065002
+      supporting_text: Vesicular- or vacuolar-type adenosine triphosphatases (V-ATPases)
+        are ATP-driven proton pumps comprised of a cytoplasmic V1 complex for ATP
+        hydrolysis and a membrane-embedded Vo complex for proton transfer.
+    - reference_id: PMID:33065002
+      supporting_text: Vesicular and organellar V-ATPases are essential in establishing
+        and maintaining the pH homeostasis of endosomes and lysosomes and in supporting
+        intracellular membrane trafficking and protein degradation
+    - reference_id: PMID:9653649
+      supporting_text: The proteolipid domain of vacuolar H(+)-ATPase (V-ATPase) plays a
+        major role in H+ transport in microvesicles and other acidic organelles.
+- term:
+    id: GO:0007042
+    label: lysosomal lumen acidification
+  evidence_type: NAS
+  original_reference_id: PMID:32001091
+  review:
+    summary: Accept this acidification/proton-transport process annotation for the
+      ATP6V0B-containing V-ATPase complex.
+    action: ACCEPT
+    reason: The ATP6V0B-containing V0 sector contributes to proton transfer by V-ATPase.
+      Human V-ATPases maintain acidic endosomes and lysosomes and support membrane
+      trafficking and protein degradation, so proton transport and organelle lumen
+      acidification annotations reflect the core biological consequence of this
+      subunit's role in the pump.
+    supported_by:
+    - reference_id: PMID:33065002
+      supporting_text: Vesicular- or vacuolar-type adenosine triphosphatases (V-ATPases)
+        are ATP-driven proton pumps comprised of a cytoplasmic V1 complex for ATP
+        hydrolysis and a membrane-embedded Vo complex for proton transfer.
+    - reference_id: PMID:33065002
+      supporting_text: Vesicular and organellar V-ATPases are essential in establishing
+        and maintaining the pH homeostasis of endosomes and lysosomes and in supporting
+        intracellular membrane trafficking and protein degradation
+    - reference_id: PMID:9653649
+      supporting_text: The proteolipid domain of vacuolar H(+)-ATPase (V-ATPase) plays a
+        major role in H+ transport in microvesicles and other acidic organelles.
+- term:
+    id: GO:0007042
+    label: lysosomal lumen acidification
+  evidence_type: NAS
+  original_reference_id: PMID:33065002
+  review:
+    summary: Accept this acidification/proton-transport process annotation for the
+      ATP6V0B-containing V-ATPase complex.
+    action: ACCEPT
+    reason: The ATP6V0B-containing V0 sector contributes to proton transfer by V-ATPase.
+      Human V-ATPases maintain acidic endosomes and lysosomes and support membrane
+      trafficking and protein degradation, so proton transport and organelle lumen
+      acidification annotations reflect the core biological consequence of this
+      subunit's role in the pump.
+    supported_by:
+    - reference_id: PMID:33065002
+      supporting_text: Vesicular- or vacuolar-type adenosine triphosphatases (V-ATPases)
+        are ATP-driven proton pumps comprised of a cytoplasmic V1 complex for ATP
+        hydrolysis and a membrane-embedded Vo complex for proton transfer.
+    - reference_id: PMID:33065002
+      supporting_text: Vesicular and organellar V-ATPases are essential in establishing
+        and maintaining the pH homeostasis of endosomes and lysosomes and in supporting
+        intracellular membrane trafficking and protein degradation
+    - reference_id: PMID:9653649
+      supporting_text: The proteolipid domain of vacuolar H(+)-ATPase (V-ATPase) plays a
+        major role in H+ transport in microvesicles and other acidic organelles.
+- term:
+    id: GO:0010008
+    label: endosome membrane
+  evidence_type: NAS
+  original_reference_id: PMID:32001091
+  review:
+    summary: Accept endosome membrane as a supported V-ATPase membrane localization.
+    action: ACCEPT
+    reason: ATP6V0B is an integral membrane subunit of V-ATPase. Human V-ATPase
+      structures and reviews support its role in organellar and vesicular proton-pump
+      complexes; the broad membrane/localization annotation is correct, although more
+      specific endolysosomal V-ATPase component terms are more informative.
+    supported_by:
+    - reference_id: PMID:33065002
+      supporting_text: Vesicular- or vacuolar-type adenosine triphosphatases (V-ATPases)
+        are ATP-driven proton pumps comprised of a cytoplasmic V1 complex for ATP
+        hydrolysis and a membrane-embedded Vo complex for proton transfer.
+    - reference_id: PMID:9653649
+      supporting_text: The proteolipid domain of vacuolar H(+)-ATPase (V-ATPase) plays a
+        major role in H+ transport in microvesicles and other acidic organelles.
+- term:
+    id: GO:0016020
+    label: membrane
+  evidence_type: IDA
+  original_reference_id: PMID:33065002
+  review:
+    summary: Accept membrane as a supported V-ATPase membrane localization.
+    action: ACCEPT
+    reason: ATP6V0B is an integral membrane subunit of V-ATPase. Human V-ATPase
+      structures and reviews support its role in organellar and vesicular proton-pump
+      complexes; the broad membrane/localization annotation is correct, although more
+      specific endolysosomal V-ATPase component terms are more informative.
+    supported_by:
+    - reference_id: PMID:33065002
+      supporting_text: Vesicular- or vacuolar-type adenosine triphosphatases (V-ATPases)
+        are ATP-driven proton pumps comprised of a cytoplasmic V1 complex for ATP
+        hydrolysis and a membrane-embedded Vo complex for proton transfer.
+    - reference_id: PMID:9653649
+      supporting_text: The proteolipid domain of vacuolar H(+)-ATPase (V-ATPase) plays a
+        major role in H+ transport in microvesicles and other acidic organelles.
+- term:
+    id: GO:0033176
+    label: proton-transporting V-type ATPase complex
+  evidence_type: NAS
+  original_reference_id: PMID:33065002
+  review:
+    summary: This component annotation is consistent with ATP6V0B being the c''
+      proteolipid subunit of the V0 proton-translocating sector of V-ATPase.
+    action: ACCEPT
+    reason: ATP6V0B is experimentally identified as a five-transmembrane human V-ATPase
+      proteolipid with conserved Glu98 required for H+ transport, and human V-ATPase
+      structures place V0 subunits in the membrane-embedded proton-transfer module. The
+      component annotation is therefore part of the core molecular role of ATP6V0B.
+    supported_by:
+    - reference_id: PMID:33065002
+      supporting_text: Vesicular- or vacuolar-type adenosine triphosphatases (V-ATPases)
+        are ATP-driven proton pumps comprised of a cytoplasmic V1 complex for ATP
+        hydrolysis and a membrane-embedded Vo complex for proton transfer.
+    - reference_id: PMID:9653649
+      supporting_text: hATP6F is a hydrophobic protein with five putative transmembrane
+        segments, having 61% amino acid identity and 83% similarity to the yeast
+        protein, except in the N-terminus, and contains a conserved glutamic acid
+        residue (Glu98) that is essential for H(+)-transporting activity.
+- term:
+    id: GO:0048388
+    label: endosomal lumen acidification
+  evidence_type: NAS
+  original_reference_id: PMID:32001091
+  review:
+    summary: Accept this acidification/proton-transport process annotation for the
+      ATP6V0B-containing V-ATPase complex.
+    action: ACCEPT
+    reason: The ATP6V0B-containing V0 sector contributes to proton transfer by V-ATPase.
+      Human V-ATPases maintain acidic endosomes and lysosomes and support membrane
+      trafficking and protein degradation, so proton transport and organelle lumen
+      acidification annotations reflect the core biological consequence of this
+      subunit's role in the pump.
+    supported_by:
+    - reference_id: PMID:33065002
+      supporting_text: Vesicular- or vacuolar-type adenosine triphosphatases (V-ATPases)
+        are ATP-driven proton pumps comprised of a cytoplasmic V1 complex for ATP
+        hydrolysis and a membrane-embedded Vo complex for proton transfer.
+    - reference_id: PMID:33065002
+      supporting_text: Vesicular and organellar V-ATPases are essential in establishing
+        and maintaining the pH homeostasis of endosomes and lysosomes and in supporting
+        intracellular membrane trafficking and protein degradation
+    - reference_id: PMID:9653649
+      supporting_text: The proteolipid domain of vacuolar H(+)-ATPase (V-ATPase) plays a
+        major role in H+ transport in microvesicles and other acidic organelles.
+- term:
+    id: GO:0051452
+    label: intracellular pH reduction
+  evidence_type: NAS
+  original_reference_id: PMID:32001091
+  review:
+    summary: Accept this acidification/proton-transport process annotation for the
+      ATP6V0B-containing V-ATPase complex.
+    action: ACCEPT
+    reason: The ATP6V0B-containing V0 sector contributes to proton transfer by V-ATPase.
+      Human V-ATPases maintain acidic endosomes and lysosomes and support membrane
+      trafficking and protein degradation, so proton transport and organelle lumen
+      acidification annotations reflect the core biological consequence of this
+      subunit's role in the pump.
+    supported_by:
+    - reference_id: PMID:33065002
+      supporting_text: Vesicular- or vacuolar-type adenosine triphosphatases (V-ATPases)
+        are ATP-driven proton pumps comprised of a cytoplasmic V1 complex for ATP
+        hydrolysis and a membrane-embedded Vo complex for proton transfer.
+    - reference_id: PMID:33065002
+      supporting_text: Vesicular and organellar V-ATPases are essential in establishing
+        and maintaining the pH homeostasis of endosomes and lysosomes and in supporting
+        intracellular membrane trafficking and protein degradation
+    - reference_id: PMID:9653649
+      supporting_text: The proteolipid domain of vacuolar H(+)-ATPase (V-ATPase) plays a
+        major role in H+ transport in microvesicles and other acidic organelles.
+- term:
+    id: GO:0061795
+    label: Golgi lumen acidification
+  evidence_type: NAS
+  original_reference_id: PMID:32001091
+  review:
+    summary: Accept this acidification/proton-transport process annotation for the
+      ATP6V0B-containing V-ATPase complex.
+    action: ACCEPT
+    reason: The ATP6V0B-containing V0 sector contributes to proton transfer by V-ATPase.
+      Human V-ATPases maintain acidic endosomes and lysosomes and support membrane
+      trafficking and protein degradation, so proton transport and organelle lumen
+      acidification annotations reflect the core biological consequence of this
+      subunit's role in the pump.
+    supported_by:
+    - reference_id: PMID:33065002
+      supporting_text: Vesicular- or vacuolar-type adenosine triphosphatases (V-ATPases)
+        are ATP-driven proton pumps comprised of a cytoplasmic V1 complex for ATP
+        hydrolysis and a membrane-embedded Vo complex for proton transfer.
+    - reference_id: PMID:33065002
+      supporting_text: Vesicular and organellar V-ATPases are essential in establishing
+        and maintaining the pH homeostasis of endosomes and lysosomes and in supporting
+        intracellular membrane trafficking and protein degradation
+    - reference_id: PMID:9653649
+      supporting_text: The proteolipid domain of vacuolar H(+)-ATPase (V-ATPase) plays a
+        major role in H+ transport in microvesicles and other acidic organelles.
+- term:
+    id: GO:1902600
+    label: proton transmembrane transport
+  evidence_type: NAS
+  original_reference_id: PMID:33065002
+  review:
+    summary: Accept this acidification/proton-transport process annotation for the
+      ATP6V0B-containing V-ATPase complex.
+    action: ACCEPT
+    reason: The ATP6V0B-containing V0 sector contributes to proton transfer by V-ATPase.
+      Human V-ATPases maintain acidic endosomes and lysosomes and support membrane
+      trafficking and protein degradation, so proton transport and organelle lumen
+      acidification annotations reflect the core biological consequence of this
+      subunit's role in the pump.
+    supported_by:
+    - reference_id: PMID:33065002
+      supporting_text: Vesicular- or vacuolar-type adenosine triphosphatases (V-ATPases)
+        are ATP-driven proton pumps comprised of a cytoplasmic V1 complex for ATP
+        hydrolysis and a membrane-embedded Vo complex for proton transfer.
+    - reference_id: PMID:33065002
+      supporting_text: Vesicular and organellar V-ATPases are essential in establishing
+        and maintaining the pH homeostasis of endosomes and lysosomes and in supporting
+        intracellular membrane trafficking and protein degradation
+    - reference_id: PMID:9653649
+      supporting_text: The proteolipid domain of vacuolar H(+)-ATPase (V-ATPase) plays a
+        major role in H+ transport in microvesicles and other acidic organelles.
+- term:
+    id: GO:0046961
+    label: proton-transporting ATPase activity, rotational mechanism
+  evidence_type: TAS
+  original_reference_id: PMID:9653649
+  review:
+    summary: Accept the V-type ATPase rotational proton-pump activity as the complex
+      activity to which ATP6V0B contributes.
+    action: ACCEPT
+    reason: ATP6V0B is not the ATP-hydrolytic catalytic subunit, but it is an essential
+      V0 c-ring proteolipid required for proton translocation by the rotary V-ATPase.
+      This is the correct complex-level molecular function for the ATP6V0B-containing
+      V-ATPase machinery.
+    supported_by:
+    - reference_id: PMID:33065002
+      supporting_text: Vesicular- or vacuolar-type adenosine triphosphatases (V-ATPases)
+        are ATP-driven proton pumps comprised of a cytoplasmic V1 complex for ATP
+        hydrolysis and a membrane-embedded Vo complex for proton transfer.
+    - reference_id: PMID:9653649
+      supporting_text: hATP6F is a hydrophobic protein with five putative transmembrane
+        segments, having 61% amino acid identity and 83% similarity to the yeast
+        protein, except in the N-terminus, and contains a conserved glutamic acid
+        residue (Glu98) that is essential for H(+)-transporting activity.
+- term:
+    id: GO:0000220
+    label: vacuolar proton-transporting V-type ATPase, V0 domain
+  evidence_type: ISS
+  original_reference_id: GO_REF:0000024
+  review:
+    summary: This component annotation is consistent with ATP6V0B being the c''
+      proteolipid subunit of the V0 proton-translocating sector of V-ATPase.
+    action: ACCEPT
+    reason: ATP6V0B is experimentally identified as a five-transmembrane human V-ATPase
+      proteolipid with conserved Glu98 required for H+ transport, and human V-ATPase
+      structures place V0 subunits in the membrane-embedded proton-transfer module. The
+      component annotation is therefore part of the core molecular role of ATP6V0B.
+    supported_by:
+    - reference_id: PMID:33065002
+      supporting_text: Vesicular- or vacuolar-type adenosine triphosphatases (V-ATPases)
+        are ATP-driven proton pumps comprised of a cytoplasmic V1 complex for ATP
+        hydrolysis and a membrane-embedded Vo complex for proton transfer.
+    - reference_id: PMID:9653649
+      supporting_text: hATP6F is a hydrophobic protein with five putative transmembrane
+        segments, having 61% amino acid identity and 83% similarity to the yeast
+        protein, except in the N-terminus, and contains a conserved glutamic acid
+        residue (Glu98) that is essential for H(+)-transporting activity.
+- term:
+    id: GO:0005765
+    label: lysosomal membrane
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-9639286
+  review:
+    summary: Accept lysosomal membrane as a supported V-ATPase membrane localization.
+    action: ACCEPT
+    reason: ATP6V0B is an integral membrane subunit of V-ATPase. Human V-ATPase
+      structures and reviews support its role in organellar and vesicular proton-pump
+      complexes; the broad membrane/localization annotation is correct, although more
+      specific endolysosomal V-ATPase component terms are more informative.
+    supported_by:
+    - reference_id: PMID:33065002
+      supporting_text: Vesicular- or vacuolar-type adenosine triphosphatases (V-ATPases)
+        are ATP-driven proton pumps comprised of a cytoplasmic V1 complex for ATP
+        hydrolysis and a membrane-embedded Vo complex for proton transfer.
+    - reference_id: PMID:9653649
+      supporting_text: The proteolipid domain of vacuolar H(+)-ATPase (V-ATPase) plays a
+        major role in H+ transport in microvesicles and other acidic organelles.
+- term:
+    id: GO:0005765
+    label: lysosomal membrane
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-9640167
+  review:
+    summary: Accept lysosomal membrane as a supported V-ATPase membrane localization.
+    action: ACCEPT
+    reason: ATP6V0B is an integral membrane subunit of V-ATPase. Human V-ATPase
+      structures and reviews support its role in organellar and vesicular proton-pump
+      complexes; the broad membrane/localization annotation is correct, although more
+      specific endolysosomal V-ATPase component terms are more informative.
+    supported_by:
+    - reference_id: PMID:33065002
+      supporting_text: Vesicular- or vacuolar-type adenosine triphosphatases (V-ATPases)
+        are ATP-driven proton pumps comprised of a cytoplasmic V1 complex for ATP
+        hydrolysis and a membrane-embedded Vo complex for proton transfer.
+    - reference_id: PMID:9653649
+      supporting_text: The proteolipid domain of vacuolar H(+)-ATPase (V-ATPase) plays a
+        major role in H+ transport in microvesicles and other acidic organelles.
+- term:
+    id: GO:0005765
+    label: lysosomal membrane
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-9640168
+  review:
+    summary: Accept lysosomal membrane as a supported V-ATPase membrane localization.
+    action: ACCEPT
+    reason: ATP6V0B is an integral membrane subunit of V-ATPase. Human V-ATPase
+      structures and reviews support its role in organellar and vesicular proton-pump
+      complexes; the broad membrane/localization annotation is correct, although more
+      specific endolysosomal V-ATPase component terms are more informative.
+    supported_by:
+    - reference_id: PMID:33065002
+      supporting_text: Vesicular- or vacuolar-type adenosine triphosphatases (V-ATPases)
+        are ATP-driven proton pumps comprised of a cytoplasmic V1 complex for ATP
+        hydrolysis and a membrane-embedded Vo complex for proton transfer.
+    - reference_id: PMID:9653649
+      supporting_text: The proteolipid domain of vacuolar H(+)-ATPase (V-ATPase) plays a
+        major role in H+ transport in microvesicles and other acidic organelles.
+- term:
+    id: GO:0005765
+    label: lysosomal membrane
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-9640175
+  review:
+    summary: Accept lysosomal membrane as a supported V-ATPase membrane localization.
+    action: ACCEPT
+    reason: ATP6V0B is an integral membrane subunit of V-ATPase. Human V-ATPase
+      structures and reviews support its role in organellar and vesicular proton-pump
+      complexes; the broad membrane/localization annotation is correct, although more
+      specific endolysosomal V-ATPase component terms are more informative.
+    supported_by:
+    - reference_id: PMID:33065002
+      supporting_text: Vesicular- or vacuolar-type adenosine triphosphatases (V-ATPases)
+        are ATP-driven proton pumps comprised of a cytoplasmic V1 complex for ATP
+        hydrolysis and a membrane-embedded Vo complex for proton transfer.
+    - reference_id: PMID:9653649
+      supporting_text: The proteolipid domain of vacuolar H(+)-ATPase (V-ATPase) plays a
+        major role in H+ transport in microvesicles and other acidic organelles.
+- term:
+    id: GO:0005765
+    label: lysosomal membrane
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-9640195
+  review:
+    summary: Accept lysosomal membrane as a supported V-ATPase membrane localization.
+    action: ACCEPT
+    reason: ATP6V0B is an integral membrane subunit of V-ATPase. Human V-ATPase
+      structures and reviews support its role in organellar and vesicular proton-pump
+      complexes; the broad membrane/localization annotation is correct, although more
+      specific endolysosomal V-ATPase component terms are more informative.
+    supported_by:
+    - reference_id: PMID:33065002
+      supporting_text: Vesicular- or vacuolar-type adenosine triphosphatases (V-ATPases)
+        are ATP-driven proton pumps comprised of a cytoplasmic V1 complex for ATP
+        hydrolysis and a membrane-embedded Vo complex for proton transfer.
+    - reference_id: PMID:9653649
+      supporting_text: The proteolipid domain of vacuolar H(+)-ATPase (V-ATPase) plays a
+        major role in H+ transport in microvesicles and other acidic organelles.
+- term:
+    id: GO:0005765
+    label: lysosomal membrane
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-9645598
+  review:
+    summary: Accept lysosomal membrane as a supported V-ATPase membrane localization.
+    action: ACCEPT
+    reason: ATP6V0B is an integral membrane subunit of V-ATPase. Human V-ATPase
+      structures and reviews support its role in organellar and vesicular proton-pump
+      complexes; the broad membrane/localization annotation is correct, although more
+      specific endolysosomal V-ATPase component terms are more informative.
+    supported_by:
+    - reference_id: PMID:33065002
+      supporting_text: Vesicular- or vacuolar-type adenosine triphosphatases (V-ATPases)
+        are ATP-driven proton pumps comprised of a cytoplasmic V1 complex for ATP
+        hydrolysis and a membrane-embedded Vo complex for proton transfer.
+    - reference_id: PMID:9653649
+      supporting_text: The proteolipid domain of vacuolar H(+)-ATPase (V-ATPase) plays a
+        major role in H+ transport in microvesicles and other acidic organelles.
+- term:
+    id: GO:0005765
+    label: lysosomal membrane
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-9645608
+  review:
+    summary: Accept lysosomal membrane as a supported V-ATPase membrane localization.
+    action: ACCEPT
+    reason: ATP6V0B is an integral membrane subunit of V-ATPase. Human V-ATPase
+      structures and reviews support its role in organellar and vesicular proton-pump
+      complexes; the broad membrane/localization annotation is correct, although more
+      specific endolysosomal V-ATPase component terms are more informative.
+    supported_by:
+    - reference_id: PMID:33065002
+      supporting_text: Vesicular- or vacuolar-type adenosine triphosphatases (V-ATPases)
+        are ATP-driven proton pumps comprised of a cytoplasmic V1 complex for ATP
+        hydrolysis and a membrane-embedded Vo complex for proton transfer.
+    - reference_id: PMID:9653649
+      supporting_text: The proteolipid domain of vacuolar H(+)-ATPase (V-ATPase) plays a
+        major role in H+ transport in microvesicles and other acidic organelles.
+    - reference_id: Reactome:R-HSA-9645608
+      supporting_text: Hydrolysis of ATP by the v-ATPase complex is also required for
+        recruitment of mTORC1
+- term:
+    id: GO:0005765
+    label: lysosomal membrane
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-9646468
+  review:
+    summary: Accept lysosomal membrane as a supported V-ATPase membrane localization.
+    action: ACCEPT
+    reason: ATP6V0B is an integral membrane subunit of V-ATPase. Human V-ATPase
+      structures and reviews support its role in organellar and vesicular proton-pump
+      complexes; the broad membrane/localization annotation is correct, although more
+      specific endolysosomal V-ATPase component terms are more informative.
+    supported_by:
+    - reference_id: PMID:33065002
+      supporting_text: Vesicular- or vacuolar-type adenosine triphosphatases (V-ATPases)
+        are ATP-driven proton pumps comprised of a cytoplasmic V1 complex for ATP
+        hydrolysis and a membrane-embedded Vo complex for proton transfer.
+    - reference_id: PMID:9653649
+      supporting_text: The proteolipid domain of vacuolar H(+)-ATPase (V-ATPase) plays a
+        major role in H+ transport in microvesicles and other acidic organelles.
+- term:
+    id: GO:0005765
+    label: lysosomal membrane
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-9858940
+  review:
+    summary: Accept lysosomal membrane as a supported V-ATPase membrane localization.
+    action: ACCEPT
+    reason: ATP6V0B is an integral membrane subunit of V-ATPase. Human V-ATPase
+      structures and reviews support its role in organellar and vesicular proton-pump
+      complexes; the broad membrane/localization annotation is correct, although more
+      specific endolysosomal V-ATPase component terms are more informative.
+    supported_by:
+    - reference_id: PMID:33065002
+      supporting_text: Vesicular- or vacuolar-type adenosine triphosphatases (V-ATPases)
+        are ATP-driven proton pumps comprised of a cytoplasmic V1 complex for ATP
+        hydrolysis and a membrane-embedded Vo complex for proton transfer.
+    - reference_id: PMID:9653649
+      supporting_text: The proteolipid domain of vacuolar H(+)-ATPase (V-ATPase) plays a
+        major role in H+ transport in microvesicles and other acidic organelles.
+    - reference_id: Reactome:R-HSA-9858940
+      supporting_text: MITF has been implicated in the regulation of expression of many
+        components of the v-ATPase, including the transmembrane component ATP6V0B
+- term:
+    id: GO:0016241
+    label: regulation of macroautophagy
+  evidence_type: NAS
+  original_reference_id: PMID:22982048
+  review:
+    summary: Macroautophagy regulation is an over-annotation for ATP6V0B as an
+      individual V-ATPase subunit.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: ATP6V0B-containing V-ATPase complexes support autophagic flux indirectly by
+      acidifying lysosomes, but the cited study concerns lipofuscin handling and
+      macroautophagy/lysosomal activity rather than a specific regulatory role for
+      ATP6V0B. The safer annotation is lysosomal lumen acidification, not regulation of
+      macroautophagy.
+    supported_by:
+    - reference_id: PMID:22982048
+      supporting_text: macroautophagy is responsible for the uptake of lipofuscin into
+        the lysosomes
+    - reference_id: PMID:33065002
+      supporting_text: Vesicular and organellar V-ATPases are essential in establishing
+        and maintaining the pH homeostasis of endosomes and lysosomes and in supporting
+        intracellular membrane trafficking and protein degradation
+- term:
+    id: GO:0030670
+    label: phagocytic vesicle membrane
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-1222516
+  review:
+    summary: Keep this localization as a valid but non-core or context-specific site for
+      V-ATPase complexes.
+    action: KEEP_AS_NON_CORE
+    reason: ATP6V0B is a membrane V-ATPase subunit and V-ATPases can act in vesicular or
+      specialized plasma/phagosomal compartments. For ATP6V0B's core annotation,
+      however, lysosomal/endosomal/Golgi V0-domain component and acidification terms are
+      more informative than this broad or context-specific location.
+    supported_by:
+    - reference_id: PMID:33065002
+      supporting_text: Vesicular- or vacuolar-type adenosine triphosphatases (V-ATPases)
+        are ATP-driven proton pumps comprised of a cytoplasmic V1 complex for ATP
+        hydrolysis and a membrane-embedded Vo complex for proton transfer.
+    - reference_id: Reactome:R-HSA-1222516
+      supporting_text: When pumping, ATP hydrolysis drives a 120 degree rotation of the
+        rotor which leads to movement of three protons into the phagosome
+- term:
+    id: GO:0010008
+    label: endosome membrane
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-5252133
+  review:
+    summary: Accept endosome membrane as a supported V-ATPase membrane localization.
+    action: ACCEPT
+    reason: ATP6V0B is an integral membrane subunit of V-ATPase. Human V-ATPase
+      structures and reviews support its role in organellar and vesicular proton-pump
+      complexes; the broad membrane/localization annotation is correct, although more
+      specific endolysosomal V-ATPase component terms are more informative.
+    supported_by:
+    - reference_id: PMID:33065002
+      supporting_text: Vesicular- or vacuolar-type adenosine triphosphatases (V-ATPases)
+        are ATP-driven proton pumps comprised of a cytoplasmic V1 complex for ATP
+        hydrolysis and a membrane-embedded Vo complex for proton transfer.
+    - reference_id: PMID:9653649
+      supporting_text: The proteolipid domain of vacuolar H(+)-ATPase (V-ATPase) plays a
+        major role in H+ transport in microvesicles and other acidic organelles.
+- term:
+    id: GO:0010008
+    label: endosome membrane
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-74723
+  review:
+    summary: Accept endosome membrane as a supported V-ATPase membrane localization.
+    action: ACCEPT
+    reason: ATP6V0B is an integral membrane subunit of V-ATPase. Human V-ATPase
+      structures and reviews support its role in organellar and vesicular proton-pump
+      complexes; the broad membrane/localization annotation is correct, although more
+      specific endolysosomal V-ATPase component terms are more informative.
+    supported_by:
+    - reference_id: PMID:33065002
+      supporting_text: Vesicular- or vacuolar-type adenosine triphosphatases (V-ATPases)
+        are ATP-driven proton pumps comprised of a cytoplasmic V1 complex for ATP
+        hydrolysis and a membrane-embedded Vo complex for proton transfer.
+    - reference_id: PMID:9653649
+      supporting_text: The proteolipid domain of vacuolar H(+)-ATPase (V-ATPase) plays a
+        major role in H+ transport in microvesicles and other acidic organelles.
+    - reference_id: Reactome:R-HSA-74723
+      supporting_text: The effect of the proton pump is to allow entry of [H+] ions into
+        the lumen of the endosome.
+- term:
+    id: GO:0010008
+    label: endosome membrane
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-917841
+  review:
+    summary: Accept endosome membrane as a supported V-ATPase membrane localization.
+    action: ACCEPT
+    reason: ATP6V0B is an integral membrane subunit of V-ATPase. Human V-ATPase
+      structures and reviews support its role in organellar and vesicular proton-pump
+      complexes; the broad membrane/localization annotation is correct, although more
+      specific endolysosomal V-ATPase component terms are more informative.
+    supported_by:
+    - reference_id: PMID:33065002
+      supporting_text: Vesicular- or vacuolar-type adenosine triphosphatases (V-ATPases)
+        are ATP-driven proton pumps comprised of a cytoplasmic V1 complex for ATP
+        hydrolysis and a membrane-embedded Vo complex for proton transfer.
+    - reference_id: PMID:9653649
+      supporting_text: The proteolipid domain of vacuolar H(+)-ATPase (V-ATPase) plays a
+        major role in H+ transport in microvesicles and other acidic organelles.
+- term:
+    id: GO:0016020
+    label: membrane
+  evidence_type: TAS
+  original_reference_id: PMID:9653649
+  review:
+    summary: Accept membrane as a supported V-ATPase membrane localization.
+    action: ACCEPT
+    reason: ATP6V0B is an integral membrane subunit of V-ATPase. Human V-ATPase
+      structures and reviews support its role in organellar and vesicular proton-pump
+      complexes; the broad membrane/localization annotation is correct, although more
+      specific endolysosomal V-ATPase component terms are more informative.
+    supported_by:
+    - reference_id: PMID:33065002
+      supporting_text: Vesicular- or vacuolar-type adenosine triphosphatases (V-ATPases)
+        are ATP-driven proton pumps comprised of a cytoplasmic V1 complex for ATP
+        hydrolysis and a membrane-embedded Vo complex for proton transfer.
+    - reference_id: PMID:9653649
+      supporting_text: The proteolipid domain of vacuolar H(+)-ATPase (V-ATPase) plays a
+        major role in H+ transport in microvesicles and other acidic organelles.
+- term:
+    id: GO:1902600
+    label: proton transmembrane transport
+  evidence_type: TAS
+  original_reference_id: PMID:9653649
+  review:
+    summary: Accept this acidification/proton-transport process annotation for the
+      ATP6V0B-containing V-ATPase complex.
+    action: ACCEPT
+    reason: The ATP6V0B-containing V0 sector contributes to proton transfer by V-ATPase.
+      Human V-ATPases maintain acidic endosomes and lysosomes and support membrane
+      trafficking and protein degradation, so proton transport and organelle lumen
+      acidification annotations reflect the core biological consequence of this
+      subunit's role in the pump.
+    supported_by:
+    - reference_id: PMID:33065002
+      supporting_text: Vesicular- or vacuolar-type adenosine triphosphatases (V-ATPases)
+        are ATP-driven proton pumps comprised of a cytoplasmic V1 complex for ATP
+        hydrolysis and a membrane-embedded Vo complex for proton transfer.
+    - reference_id: PMID:33065002
+      supporting_text: Vesicular and organellar V-ATPases are essential in establishing
+        and maintaining the pH homeostasis of endosomes and lysosomes and in supporting
+        intracellular membrane trafficking and protein degradation
+    - reference_id: PMID:9653649
+      supporting_text: The proteolipid domain of vacuolar H(+)-ATPase (V-ATPase) plays a
+        major role in H+ transport in microvesicles and other acidic organelles.
+- term:
+    id: GO:0046610
+    label: lysosomal proton-transporting V-type ATPase, V0 domain
+  evidence_type: RCA
+  original_reference_id: 'file:projects/PROTEOSTASIS/reports/pn_projection/pn_projected_annotations.tsv'
+  review:
+    summary: Add the conservative PN-projected lysosomal V0-domain component annotation.
+    action: NEW
+    reason: The PN projection places ATP6V0B in the V0 lysosomal V-ATPase proton pump
+      component leaf and maps that leaf to GO:0046610. This is more specific than
+      ATP6V0B's current GOA component annotations, but it is supported by the
+      established human V-ATPase structure, lysosomal V-ATPase biology, and existing GOA
+      annotations to lysosomal membrane, lysosomal lumen acidification, and the broader
+      V-type ATPase V0 domain. This adds component specificity rather than a new
+      biological process claim.
+    supported_by:
+    - reference_id: 'file:projects/PROTEOSTASIS/reports/pn_projection/pn_projected_annotations.tsv'
+      supporting_text: "ATP6V0B\t\tAutophagy-Lysosome Pathway|Pre-initiation autophagy signaling|mTORC1
+        pathway, upstream|Nutrient sensing|V0 lysosomal v-ATPase proton pump component"
+    - reference_id: PMID:33065002
+      supporting_text: Vesicular- or vacuolar-type adenosine triphosphatases (V-ATPases)
+        are ATP-driven proton pumps comprised of a cytoplasmic V1 complex for ATP
+        hydrolysis and a membrane-embedded Vo complex for proton transfer.
+    - reference_id: PMID:33065002
+      supporting_text: Vesicular and organellar V-ATPases are essential in establishing
+        and maintaining the pH homeostasis of endosomes and lysosomes and in supporting
+        intracellular membrane trafficking and protein degradation
+    - reference_id: file:human/ATP6V0B/ATP6V0B-deep-research-falcon.md
+      supporting_text: 'model: Edison Scientific Literature'
 references:
-  - id: GO_REF:0000002
-    title: Gene Ontology annotation through association of InterPro records with
-      GO terms.
-    findings: []
-  - id: GO_REF:0000024
-    title: Manual transfer of experimentally-verified manual GO annotation data 
-      to orthologs by curator judgment of sequence similarity.
-    findings: []
-  - id: GO_REF:0000033
-    title: Annotation inferences using phylogenetic trees
-    findings: []
-  - id: GO_REF:0000043
-    title: Gene Ontology annotation based on UniProtKB/Swiss-Prot keyword 
-      mapping
-    findings: []
-  - id: GO_REF:0000044
-    title: Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular 
-      Location vocabulary mapping, accompanied by conservative changes to GO 
-      terms applied by UniProt.
-    findings: []
-  - id: GO_REF:0000107
-    title: Automatic transfer of experimentally verified manual GO annotation 
-      data to orthologs using Ensembl Compara.
-    findings: []
-  - id: GO_REF:0000120
-    title: Combined Automated Annotation using Multiple IEA Methods.
-    findings: []
-  - id: PMID:22982048
-    title: Lipofuscin is formed independently of macroautophagy and lysosomal 
-      activity in stress-induced prematurely senescent human fibroblasts.
-    findings: []
-  - id: PMID:23864651
-    title: The identification of novel proteins that interact with the GLP-1 
-      receptor and restrain its activity.
-    findings: []
-  - id: PMID:32001091
-    title: Structure and Roles of V-type ATPases.
-    findings: []
-  - id: PMID:32296183
-    title: A reference map of the human binary protein interactome.
-    findings: []
-  - id: PMID:33065002
-    title: Structures of a Complete Human V-ATPase Reveal Mechanisms of Its 
-      Assembly.
-    findings: []
-  - id: PMID:9653649
-    title: Identification and characterization of the gene encoding a second 
-      proteolipid subunit of human vacuolar H(+)-ATPase (ATP6F).
-    findings: []
-  - id: Reactome:R-HSA-1222516
-    title: Intraphagosomal pH is lowered to 5 by V-ATPase
-    findings: []
-  - id: Reactome:R-HSA-5252133
-    title: ATP6AP1 binds V-ATPase
-    findings: []
-  - id: Reactome:R-HSA-74723
-    title: Endosome acidification
-    findings: []
-  - id: Reactome:R-HSA-917841
-    title: Acidification of Tf:TfR1 containing endosome
-    findings: []
-  - id: Reactome:R-HSA-9639286
-    title: RRAGC,D exchanges GTP for GDP
-    findings: []
-  - id: Reactome:R-HSA-9640167
-    title: RRAGA,B exchanges GDP for GTP
-    findings: []
-  - id: Reactome:R-HSA-9640168
-    title: v-ATPase:Ragulator:RRAGA,B:GTP:RRAGC,D:GDP:SLC38A9:Arginine 
-      dissociates yielding v-ATPase:Ragulator:RRAGA,B:GTP:RRAGC,D:GDP and 
-      SLC38A9:Arginine
-    findings: []
-  - id: Reactome:R-HSA-9640175
-    title: v-ATPase:Ragulator:RagA,B:GDP:RagC,D:GDP binds SLC38A9:Arginine
-    findings: []
-  - id: Reactome:R-HSA-9640195
-    title: RRAGA,B hydrolyzes GTP
-    findings: []
-  - id: Reactome:R-HSA-9645598
-    title: RRAGC,D hydrolyzes GTP
-    findings: []
-  - id: Reactome:R-HSA-9645608
-    title: v-ATPase:Ragulator:RRAGA,B:GTP:RRAGC,D:GDP binds mTORC1
-    findings: []
-  - id: Reactome:R-HSA-9646468
-    title: mTORC1 binds RHEB:GTP
-    findings: []
-  - id: Reactome:R-HSA-9858940
-    title: MITF-M-dependent ATP6V0B gene expression
-    findings: []
-  - id: file:human/ATP6V0B/ATP6V0B-deep-research-falcon.md
-    title: Deep research report on Q99437
-    findings: []
-  - id: file:human/ATP6V0B/ATP6V0B-deep-research-cyberian.md
-    title: Cyberian deep research on ATP6V0B function
-    findings: []
+- id: GO_REF:0000002
+  title: Gene Ontology annotation through association of InterPro records with GO terms.
+  findings: []
+- id: GO_REF:0000024
+  title: Manual transfer of experimentally-verified manual GO annotation data to
+    orthologs by curator judgment of sequence similarity.
+  findings: []
+- id: GO_REF:0000033
+  title: Annotation inferences using phylogenetic trees
+  findings: []
+- id: GO_REF:0000043
+  title: Gene Ontology annotation based on UniProtKB/Swiss-Prot keyword mapping
+  findings: []
+- id: GO_REF:0000044
+  title: Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location
+    vocabulary mapping, accompanied by conservative changes to GO terms applied by
+    UniProt.
+  findings: []
+- id: GO_REF:0000107
+  title: Automatic transfer of experimentally verified manual GO annotation data to
+    orthologs using Ensembl Compara.
+  findings: []
+- id: GO_REF:0000120
+  title: Combined Automated Annotation using Multiple IEA Methods.
+  findings: []
+- id: PMID:22982048
+  title: Lipofuscin is formed independently of macroautophagy and lysosomal activity in
+    stress-induced prematurely senescent human fibroblasts.
+  findings:
+  - statement: This paper supports a macroautophagy/lysosome context, but not a specific
+      ATP6V0B regulatory function.
+    supporting_text: macroautophagy is responsible for the uptake of lipofuscin into the
+      lysosomes
+    reference_section_type: ABSTRACT
+- id: PMID:23864651
+  title: The identification of novel proteins that interact with the GLP-1 receptor and
+    restrain its activity.
+  findings:
+  - statement: The GLP-1R interaction study used a membrane yeast two-hybrid screen and
+      does not define ATP6V0B core molecular function.
+    supporting_text: A screen of a human fetal brain cDNA prey library with an
+      unliganded human GLP-1R as bait in yeast revealed 38 novel interactor protein
+      candidates.
+    reference_section_type: ABSTRACT
+- id: PMID:32001091
+  title: Structure and Roles of V-type ATPases.
+  findings:
+  - statement: V-ATPases are membrane-embedded ATP-driven proton pumps and are the
+      primary source of organellar acidification in eukaryotes.
+    supporting_text: V-ATPases are membrane-embedded protein complexes that function as
+      ATP hydrolysis-driven proton pumps.
+    reference_section_type: ABSTRACT
+- id: PMID:32296183
+  title: A reference map of the human binary protein interactome.
+  findings:
+  - statement: The HuRI study is a large-scale binary interactome resource, not
+      ATP6V0B-specific functional evidence.
+    supporting_text: The dataset, versioned HI-III-20 (Human Interactome obtained from
+      screening Space III, published in 2020), contains 52,569 verified PPIs involving
+      8,275 proteins
+    reference_section_type: RESULTS
+- id: PMID:33065002
+  title: Structures of a Complete Human V-ATPase Reveal Mechanisms of Its Assembly.
+  findings:
+  - statement: Human V-ATPase is an ATP-driven proton pump with a cytoplasmic V1
+      ATP-hydrolysis sector and a membrane-embedded Vo proton-transfer sector.
+    supporting_text: Vesicular- or vacuolar-type adenosine triphosphatases (V-ATPases)
+      are ATP-driven proton pumps comprised of a cytoplasmic V1 complex for ATP
+      hydrolysis and a membrane-embedded Vo complex for proton transfer.
+    reference_section_type: ABSTRACT
+  - statement: Organellar V-ATPases maintain endosome and lysosome pH homeostasis and
+      support trafficking and protein degradation.
+    supporting_text: Vesicular and organellar V-ATPases are essential in establishing
+      and maintaining the pH homeostasis of endosomes and lysosomes and in supporting
+      intracellular membrane trafficking and protein degradation
+    reference_section_type: INTRODUCTION
+- id: PMID:9653649
+  title: Identification and characterization of the gene encoding a second proteolipid
+    subunit of human vacuolar H(+)-ATPase (ATP6F).
+  findings:
+  - statement: ATP6V0B/ATP6F is the human second V-ATPase proteolipid, a
+      five-transmembrane c subunit with conserved Glu98 required for H+ transport.
+    supporting_text: hATP6F is a hydrophobic protein with five putative transmembrane
+      segments, having 61% amino acid identity and 83% similarity to the yeast protein,
+      except in the N-terminus, and contains a conserved glutamic acid residue (Glu98)
+      that is essential for H(+)-transporting activity.
+    reference_section_type: ABSTRACT
+- id: Reactome:R-HSA-1222516
+  title: Intraphagosomal pH is lowered to 5 by V-ATPase
+  findings:
+  - statement: Reactome describes V-ATPase rotary pumping into the phagosome.
+    supporting_text: When pumping, ATP hydrolysis drives a 120 degree rotation of the
+      rotor which leads to movement of three protons into the phagosome
+- id: Reactome:R-HSA-5252133
+  title: ATP6AP1 binds V-ATPase
+  findings: []
+- id: Reactome:R-HSA-74723
+  title: Endosome acidification
+  findings:
+  - statement: Reactome describes endosomal acidification as proton-pump driven entry of
+      H+ into the endosome lumen.
+    supporting_text: The effect of the proton pump is to allow entry of [H+] ions into
+      the lumen of the endosome.
+- id: Reactome:R-HSA-917841
+  title: Acidification of Tf:TfR1 containing endosome
+  findings: []
+- id: Reactome:R-HSA-9639286
+  title: RRAGC,D exchanges GTP for GDP
+  findings: []
+- id: Reactome:R-HSA-9640167
+  title: RRAGA,B exchanges GDP for GTP
+  findings: []
+- id: Reactome:R-HSA-9640168
+  title: v-ATPase:Ragulator:RRAGA,B:GTP:RRAGC,D:GDP:SLC38A9:Arginine dissociates
+    yielding v-ATPase:Ragulator:RRAGA,B:GTP:RRAGC,D:GDP and SLC38A9:Arginine
+  findings: []
+- id: Reactome:R-HSA-9640175
+  title: v-ATPase:Ragulator:RagA,B:GDP:RagC,D:GDP binds SLC38A9:Arginine
+  findings: []
+- id: Reactome:R-HSA-9640195
+  title: RRAGA,B hydrolyzes GTP
+  findings: []
+- id: Reactome:R-HSA-9645598
+  title: RRAGC,D hydrolyzes GTP
+  findings: []
+- id: Reactome:R-HSA-9645608
+  title: v-ATPase:Ragulator:RRAGA,B:GTP:RRAGC,D:GDP binds mTORC1
+  findings:
+  - statement: Reactome places V-ATPase activity upstream of lysosomal mTORC1
+      recruitment.
+    supporting_text: Hydrolysis of ATP by the v-ATPase complex is also required for
+      recruitment of mTORC1
+- id: Reactome:R-HSA-9646468
+  title: mTORC1 binds RHEB:GTP
+  findings: []
+- id: Reactome:R-HSA-9858940
+  title: MITF-M-dependent ATP6V0B gene expression
+  findings:
+  - statement: Reactome records MITF-dependent expression of ATP6V0B and the
+      lysosome/endosome acidification role of V-ATPase.
+    supporting_text: MITF has been implicated in the regulation of expression of many
+      components of the v-ATPase, including the transmembrane component ATP6V0B
+- id: file:human/ATP6V0B/ATP6V0B-deep-research-falcon.md
+  title: Falcon deep research report on ATP6V0B
+  findings:
+  - statement: Falcon deep research supports ATP6V0B as the human V-ATPase c proteolipid
+      subunit and highlights the PN-relevant lysosomal acidification role.
+    supporting_text: 'model: Edison Scientific Literature'
+- id: file:human/ATP6V0B/ATP6V0B-deep-research-cyberian.md
+  title: Cyberian deep research on ATP6V0B function
+  findings: []
+- id: file:projects/PROTEOSTASIS/reports/pn_projection/pn_projected_annotations.tsv
+  title: Proteostasis PN projected annotations for ATP6V0B
+  findings:
+  - statement: PN projection maps ATP6V0B in the V0 lysosomal V-ATPase proton pump
+      component leaf to GO:0046610.
+    supporting_text: "ATP6V0B\t\tAutophagy-Lysosome Pathway|Pre-initiation autophagy signaling|mTORC1
+      pathway, upstream|Nutrient sensing|V0 lysosomal v-ATPase proton pump component"
 status: COMPLETE
+core_functions:
+- contributes_to_molecular_function:
+    id: GO:0046961
+    label: proton-transporting ATPase activity, rotational mechanism
+  directly_involved_in:
+  - id: GO:1902600
+    label: proton transmembrane transport
+  - id: GO:0007042
+    label: lysosomal lumen acidification
+  - id: GO:0048388
+    label: endosomal lumen acidification
+  - id: GO:0061795
+    label: Golgi lumen acidification
+  locations:
+  - id: GO:0005765
+    label: lysosomal membrane
+  - id: GO:0010008
+    label: endosome membrane
+  - id: GO:0000139
+    label: Golgi membrane
+  in_complex:
+    id: GO:0046610
+    label: lysosomal proton-transporting V-type ATPase, V0 domain
+  description: ATP6V0B is the V0 c'' proteolipid subunit of the V-ATPase proton pump. It
+    contributes to the complex-level rotary proton-transporting ATPase activity by
+    forming part of the membrane c-ring/proton-transfer sector, rather than
+    independently hydrolyzing ATP. This activity acidifies lysosomal, endosomal and
+    Golgi lumens, supporting endolysosomal protein degradation, trafficking and
+    nutrient-signaling contexts. The PN projection to GO:0046610 is a conservative
+    component-level refinement of existing V0 domain and lysosomal acidification
+    annotations.
+  supported_by:
+  - reference_id: PMID:9653649
+    supporting_text: hATP6F is a hydrophobic protein with five putative transmembrane
+      segments, having 61% amino acid identity and 83% similarity to the yeast protein,
+      except in the N-terminus, and contains a conserved glutamic acid residue (Glu98)
+      that is essential for H(+)-transporting activity.
+  - reference_id: PMID:33065002
+    supporting_text: Vesicular- or vacuolar-type adenosine triphosphatases (V-ATPases)
+      are ATP-driven proton pumps comprised of a cytoplasmic V1 complex for ATP
+      hydrolysis and a membrane-embedded Vo complex for proton transfer.
+  - reference_id: PMID:33065002
+    supporting_text: Vesicular and organellar V-ATPases are essential in establishing
+      and maintaining the pH homeostasis of endosomes and lysosomes and in supporting
+      intracellular membrane trafficking and protein degradation
+  - reference_id: 'file:projects/PROTEOSTASIS/reports/pn_projection/pn_projected_annotations.tsv'
+    supporting_text: "ATP6V0B\t\tAutophagy-Lysosome Pathway|Pre-initiation autophagy signaling|mTORC1
+      pathway, upstream|Nutrient sensing|V0 lysosomal v-ATPase proton pump component"
+proposed_new_terms: []
+suggested_questions:
+- question: Is ATP6V0B ever functionally limiting for plasma-membrane V-ATPase activity
+    in specialized human cells, or should plasma membrane annotations remain non-core
+    generic V-ATPase complex localizations?
+  experts:
+  - V-ATPase biology curators
+  - GO cellular component annotation experts
+suggested_experiments:
+- experiment_type: ATP6V0B-specific knockout/rescue in human lysosome pH assays
+  hypothesis: Loss of ATP6V0B specifically disrupts assembly or activity of the
+    lysosomal V0 domain, reducing lysosomal acidification without implying a standalone
+    ATPase activity for the subunit.
+  description: Generate ATP6V0B knockout human cells, rescue with wild-type ATP6V0B and
+    a Glu98-neutralized mutant, and quantify LysoSensor/LysoTracker pH, cathepsin
+    maturation, V1-V0 assembly and autophagic flux. This would directly test the
+    PN-projected lysosomal V0-domain role at the gene-product level.

--- a/genes/human/ATP6V0B/ATP6V0B-notes.md
+++ b/genes/human/ATP6V0B/ATP6V0B-notes.md
@@ -1,0 +1,42 @@
+# ATP6V0B notes
+
+## 2026-06-03 PN batch review
+
+Falcon deep research was already present as `ATP6V0B-deep-research-falcon.md`, so
+no fallback provider run was needed. I re-reviewed the existing ATP6V0B YAML in
+Proteostasis PN context.
+
+ATP6V0B is the human V-ATPase V0 proteolipid c'' subunit. The primary cloning
+paper identifies hATP6F/ATP6V0B as a second human V-ATPase proteolipid and states
+that it has five putative transmembrane segments and a conserved Glu98 essential
+for H(+)-transporting activity [PMID:9653649 "hATP6F is a hydrophobic protein
+with five putative transmembrane segments"]. The human V-ATPase structure paper
+frames V-ATPase as an ATP-driven proton pump with cytoplasmic V1 ATP hydrolysis
+and membrane-embedded Vo proton transfer [PMID:33065002 "V-ATPases are ATP-driven
+proton pumps comprised of a cytoplasmic V1 complex for ATP hydrolysis and a
+membrane-embedded Vo complex for proton transfer"].
+
+For PN projection, ATP6V0B appears in the Autophagy-Lysosome Pathway under V0
+lysosomal v-ATPase proton pump component. The projection already matches GOA for
+lysosomal lumen acidification and the broader V-type ATPase V0 domain, and it has
+one conservative more-specific candidate: GO:0046610 lysosomal
+proton-transporting V-type ATPase, V0 domain [file:projects/PROTEOSTASIS/reports/pn_projection/pn_projected_annotations.tsv
+"ATP6V0B		Autophagy-Lysosome Pathway|Pre-initiation autophagy signaling|mTORC1 pathway,
+upstream|Nutrient sensing|V0 lysosomal v-ATPase proton pump component"]. I added
+this as a `NEW` reviewed annotation because it is a component-level refinement,
+not a new biological-process claim.
+
+Conservative decisions:
+
+- Accepted the V-ATPase component, proton transport, and organelle acidification
+  annotations as core or directly supportive of core function.
+- Modified broad `monoatomic ion transport` to `proton transmembrane transport`.
+- Modified generic `proton transmembrane transporter activity` to the more
+  specific complex-level rotary V-ATPase activity, while describing ATP6V0B as a
+  contributor to the complex rather than an independent ATPase.
+- Removed generic `protein binding` annotations from the GLP-1R and HuRI
+  interaction screens because they do not describe ATP6V0B mechanism.
+- Marked `regulation of macroautophagy` as over-annotation. ATP6V0B supports
+  autophagic flux through lysosomal acidification, but the cited paper does not
+  show a specific ATP6V0B regulatory role [PMID:22982048 "macroautophagy is
+  responsible for the uptake of lipofuscin into the lysosomes"].


### PR DESCRIPTION
## Summary

- Completed the human ATP6V0B GO annotation review in Proteostasis PN context using the existing Falcon deep research.
- Added conservative PN evaluation: accepted existing lysosomal acidification/V0-domain coverage and added GO:0046610 as a `NEW` component-level PN refinement.
- Removed generic protein binding annotations, modified broad ion/proton transporter terms, and marked macroautophagy regulation as over-annotation.
- Added ATP6V0B notes and regenerated `genes/human/ATP6V0B/ATP6V0B-ai-review.html`.

## Validation

- `just validate human ATP6V0B`
- `just render human ATP6V0B`
- `git diff --check -- genes/human/ATP6V0B/ATP6V0B-ai-review.yaml genes/human/ATP6V0B/ATP6V0B-ai-review.html genes/human/ATP6V0B/ATP6V0B-notes.md`

## Notes

The modified local `cache/go/terms.csv` generated during validation was intentionally left unstaged and is not part of this PR.