### PR TITLE
[codex] Review ATP6V0D2 PN projection

### DIFF
--- a/genes/human/ATP6V0D2/ATP6V0D2-ai-review.html
+++ b/genes/human/ATP6V0D2/ATP6V0D2-ai-review.html
@@ -1503,12 +1503,12 @@
                     <td>
                         
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Duplicate of IBA annotation. This IEA from InterPro correctly assigns the molecular function of the V-ATPase complex to which ATP6V0D2 belongs.
+                            <strong>Summary:</strong> Duplicate of IBA annotation. This IEA from InterPro correctly assigns the molecular function of the V-ATPase complex to which ATP6V0D2 belongs. As with the IBA row, this should be understood as ATP6V0D2 contributing to the assembled complex activity rather than independently enabling ATPase activity.
                         </div>
                         
                         
                         <div>
-                            <strong>Reason:</strong> Correct annotation from InterPro mapping. The d2 subunit is integral to the rotational mechanism of the V-ATPase.
+                            <strong>Reason:</strong> Correct annotation from InterPro mapping. The d2 subunit is integral to the rotational mechanism of the V-ATPase, but the biologically appropriate qualifier for this structural subunit is contributes_to.
                         </div>
                         
                         
@@ -4259,11 +4259,15 @@ existing_annotations:
   review:
     summary: &gt;-
       Duplicate of IBA annotation. This IEA from InterPro correctly assigns the
-      molecular function of the V-ATPase complex to which ATP6V0D2 belongs.
+      molecular function of the V-ATPase complex to which ATP6V0D2 belongs. As
+      with the IBA row, this should be understood as ATP6V0D2 contributing to
+      the assembled complex activity rather than independently enabling ATPase
+      activity.
     action: ACCEPT
     reason: &gt;-
       Correct annotation from InterPro mapping. The d2 subunit is integral to the
-      rotational mechanism of the V-ATPase.
+      rotational mechanism of the V-ATPase, but the biologically appropriate
+      qualifier for this structural subunit is contributes_to.
 - term:
     id: GO:1902600
     label: proton transmembrane transport

--- a/genes/human/ATP6V0D2/ATP6V0D2-ai-review.html
+++ b/genes/human/ATP6V0D2/ATP6V0D2-ai-review.html
@@ -794,7 +794,7 @@
                 <button class="vote-btn" data-v="down" title="Disagree with this description">👎</button>
             </span>
         </div>
-        <p>ATP6V0D2 encodes the d2 isoform of the V0 d subunit of the vacuolar H+-ATPase (V-ATPase). The V-ATPase is a multisubunit enzyme consisting of a peripheral V1 domain that hydrolyzes ATP and a membrane-integral V0 domain responsible for proton translocation. The d subunit is part of the V0 domain and plays a central role in coupling ATP hydrolysis to proton transport by directly interacting with the D and F subunits of the V1 central stalk. ATP6V0D2 shows tissue-restricted expression, predominantly in kidney intercalated cells and osteoclasts, where V-ATPases function at the plasma membrane for urinary acidification and bone resorption, respectively. Recent studies have also demonstrated that ATP6V0D2 facilitates autophagosome-lysosome fusion by interacting with RAB7 and HOPS complex components (e.g., VPS41), thereby promoting SNARE complex assembly. This fusion-promoting function is distinct from the classical proton-pumping role and has implications for lysosomal degradation and autophagy.</p>
+        <p>ATP6V0D2 encodes the d2 isoform of the V0 d subunit of the vacuolar H+-ATPase (V-ATPase). The V-ATPase is a multisubunit enzyme consisting of a peripheral V1 domain that hydrolyzes ATP and a membrane-integral V0 domain responsible for proton translocation. The d subunit is part of the V0 domain and plays a central role in coupling ATP hydrolysis to proton transport by directly interacting with the D and F subunits of the V1 central stalk. ATP6V0D2 shows tissue-restricted expression, predominantly in kidney intercalated cells and osteoclasts, where V-ATPases function at the plasma membrane for urinary acidification and bone resorption, respectively. In clear-cell renal carcinoma models, ATP6V0D2 has also been reported to promote late autophagy by increasing lysosomal acidification and by facilitating autophagosome-lysosome fusion through RAB7/HOPS/SNARE machinery, suggesting a context-dependent role in lysosomal degradative flux in addition to its established V-ATPase subunit function.</p>
     </div>
     
 
@@ -1050,10 +1050,10 @@
                         
                     </td>
                     <td>
-                        <span class="action-badge action-accept">
-                            ACCEPT
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
                         </span>
-                        <span class="vote-buttons" data-g="Q8N8Y2" data-a="GO:0007034" data-r="GO_REF:0000033" data-act="ACCEPT">
+                        <span class="vote-buttons" data-g="Q8N8Y2" data-a="GO:0007034" data-r="GO_REF:0000033" data-act="KEEP_AS_NON_CORE">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
@@ -1061,12 +1061,12 @@
                     <td>
                         
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> ATP6V0D2 participates in vacuolar/lysosomal function through its role in the V-ATPase. Recent evidence shows ATP6V0D2 directly facilitates autophagosome-lysosome fusion by interacting with RAB7 and HOPS complex components, promoting SNARE complex formation [Li et al. 2025, Autophagy &#34;ATP6V0D2 directly promotes autophagosome-lysosome fusion by physically interacting with RAB7 and HOPS complex components&#34;].
+                            <strong>Summary:</strong> ATP6V0D2 participates in vacuolar/lysosomal function through its role in the V-ATPase, but &#34;vacuolar transport&#34; is a broad process term for this subunit. The clearest established process is compartment acidification. A more recent ccRCC study also supports a context-specific role in autophagosome-lysosome fusion through RAB7/HOPS machinery [PMID:39477683].
                         </div>
                         
                         
                         <div>
-                            <strong>Reason:</strong> This annotation is appropriate given the role of ATP6V0D2 in both vacuolar acidification (via V-ATPase function) and autophagosome-lysosome fusion. Recent studies provide strong evidence for the involvement of ATP6V0D2 in lysosomal transport/fusion processes.
+                            <strong>Reason:</strong> Retain this broad IBA term as non-core. It is consistent with V-ATPase-dependent acidification and with newer late-autophagy evidence, but the core ATP6V0D2 functions are better represented by V-ATPase complex membership, V0-domain contribution to rotary proton pumping, and vacuolar/lysosomal acidification.
                         </div>
                         
                         
@@ -1083,7 +1083,7 @@
                                     
                                 </span>
                                 
-                                <div class="support-text">ATP6V0D2 directly promotes autophagosome-lysosome fusion by physically interacting with RAB7 and HOPS complex components</div>
+                                <div class="support-text">Mechanistically, ATP6V0D2 directly bound to RAB7 and VPS41 and promoted the RAB7-HOPS interaction, facilitating SNARE complex assembly and autophagosome-lysosome fusion.</div>
                                 
                             </div>
                             
@@ -1130,7 +1130,7 @@
                     <td>
                         
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> ATP6V0D2 is a core component of the V-ATPase responsible for acidification of vacuolar compartments and, in specialized cells, the extracellular environment. In human kidney intercalated cells, d2 co-localizes with the a4 subunit at the plasma membrane for urinary acidification [PMID:15800125]. Recent studies show that ATP6V0D2 depletion impairs lysosomal acidification in human cancer cells [Li et al. 2025 Autophagy].
+                            <strong>Summary:</strong> ATP6V0D2 is a core component of the V-ATPase responsible for acidification of vacuolar compartments and, in specialized cells, the extracellular environment. In human kidney intercalated cells, d2 co-localizes with the a4 subunit at the plasma membrane for urinary acidification [PMID:15800125]. Recent ccRCC work also reports that ATP6V0D2 promotes lysosomal acidification and activity during late autophagy [PMID:39477683]. The Proteostasis Network projection supports adding the more specific GO:0007042 lysosomal lumen acidification term for this gene.
                         </div>
                         
                         
@@ -1165,7 +1165,7 @@
                                     
                                 </span>
                                 
-                                <div class="support-text">ATP6V0D2 enhances lysosomal acidification and activity: depletion increased RFP+GFP+ LC3 puncta (indicating impaired fusion/degradation)</div>
+                                <div class="support-text">ATP6V0D2 promoted autolysosome degradation by increasing the acidification and activity of lysosomes during the later stages of macroautophagy/autophagy.</div>
                                 
                             </div>
                             
@@ -1372,10 +1372,10 @@
                         
                     </td>
                     <td>
-                        <span class="action-badge action-accept">
-                            ACCEPT
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
                         </span>
-                        <span class="vote-buttons" data-g="Q8N8Y2" data-a="GO:0030670" data-r="GO_REF:0000117" data-act="ACCEPT">
+                        <span class="vote-buttons" data-g="Q8N8Y2" data-a="GO:0030670" data-r="GO_REF:0000117" data-act="KEEP_AS_NON_CORE">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
@@ -1383,31 +1383,15 @@
                     <td>
                         
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> V-ATPases are present in phagocytic vesicle membranes where they acidify the phagosome. Given ATP6V0D2&#39;s role in macrophages and immune cells (facilitating autophagosome-lysosome fusion and phagosome acidification), this localization is plausible. Reviews note that &#34;in macrophages ATP6V0D2 facilitates autophagosome-lysosome fusion to restrain inflammasome activation and bacterial infection&#34; [Chen et al. 2025 Biomolecules].
+                            <strong>Summary:</strong> V-ATPases are present in phagocytic vesicle membranes where they acidify the phagosome, and Reactome also projects ATP6V0D2 to a phagosomal acidification event. For ATP6V0D2 specifically, however, the strongest primary human evidence emphasizes kidney/osteoclast plasma membrane pumps, V0-domain complex membership, and lysosomal/autophagy functions rather than a directly tested phagocytic-vesicle localization.
                         </div>
                         
                         
                         <div>
-                            <strong>Reason:</strong> This is a reasonable localization given the known role of ATP6V0D2 in macrophages and immune function. V-ATPases are required for phagosome acidification.
+                            <strong>Reason:</strong> Keep as a plausible non-core V-ATPase localization from automated inference, but do not treat it as a defining ATP6V0D2 cellular component for the PN proteostasis review.
                         </div>
                         
                         
-                        
-                        <div class="supported-by">
-                            <div class="supported-by-title">Supporting Evidence:</div>
-                            
-                            <div class="support-item">
-                                <span class="support-ref">
-                                    
-                                    unindexed:chen2025biomolecules
-                                    
-                                </span>
-                                
-                                <div class="support-text">in macrophages ATP6V0D2 facilitates autophagosome-lysosome fusion to restrain inflammasome activation and bacterial infection</div>
-                                
-                            </div>
-                            
-                        </div>
                         
                     </td>
                 </tr>
@@ -1854,7 +1838,7 @@
                     <td>
                         
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> ATP6V0D2 localizes to lysosomal membranes where it functions in V-ATPase-mediated acidification and autophagosome-lysosome fusion. This is well-supported by recent literature showing ATP6V0D2 at lysosomes in human cancer cells [Li et al. 2025 Autophagy &#34;In human cells, ATP6V0D2 localizes to lysosomes/acidic vesicles, where it contributes to lysosomal acidification and degradative capacity&#34;].
+                            <strong>Summary:</strong> Reactome places ATP6V0D2-containing V-ATPase events at the lysosomal membrane. The lysosomal interpretation is also consistent with ccRCC evidence that ATP6V0D2 increases lysosomal acidification/activity during autophagic degradation [PMID:39477683].
                         </div>
                         
                         
@@ -1876,7 +1860,7 @@
                                     
                                 </span>
                                 
-                                <div class="support-text">In human cells, ATP6V0D2 localizes to lysosomes/acidic vesicles, where it contributes to lysosomal acidification and degradative capacity</div>
+                                <div class="support-text">ATP6V0D2 promoted autolysosome degradation by increasing the acidification and activity of lysosomes during the later stages of macroautophagy/autophagy.</div>
                                 
                             </div>
                             
@@ -2280,10 +2264,10 @@
                         
                     </td>
                     <td>
-                        <span class="action-badge action-accept">
-                            ACCEPT
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
                         </span>
-                        <span class="vote-buttons" data-g="Q8N8Y2" data-a="GO:0016241" data-r="PMID:22982048" data-act="ACCEPT">
+                        <span class="vote-buttons" data-g="Q8N8Y2" data-a="GO:0016241" data-r="PMID:22982048" data-act="KEEP_AS_NON_CORE">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
@@ -2291,12 +2275,12 @@
                     <td>
                         
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> The referenced paper [PMID:22982048] studies lipofuscin formation and autophagy but does not specifically address ATP6V0D2. It examines general V-ATPase inhibition effects. However, recent literature strongly supports ATP6V0D2&#39;s role in autophagy regulation, particularly autophagosome-lysosome fusion [Li et al. 2025 &#34;ATP6V0D2 directly promotes autophagosome-lysosome fusion&#34;].
+                            <strong>Summary:</strong> The referenced paper [PMID:22982048] studies lipofuscin formation and autophagy but does not specifically address ATP6V0D2. It examines general V-ATPase inhibition effects. However, PMID:39477683 provides direct evidence in ccRCC models that ATP6V0D2 promotes autophagosome-lysosome fusion and later autolysosome degradation.
                         </div>
                         
                         
                         <div>
-                            <strong>Reason:</strong> While the original reference may not specifically study ATP6V0D2, recent literature confirms ATP6V0D2 regulates autophagy by facilitating autophagosome-lysosome fusion. The annotation is correct based on current understanding.
+                            <strong>Reason:</strong> Keep the annotation because there is newer ATP6V0D2-specific evidence for late macroautophagy/autophagosome-lysosome fusion, but classify it as non-core because the original NAS citation is not ATP6V0D2-specific and the best-established core function remains V-ATPase-mediated acidification.
                         </div>
                         
                         
@@ -2313,7 +2297,7 @@
                                     
                                 </span>
                                 
-                                <div class="support-text">ATP6V0D2 directly promotes autophagosome-lysosome fusion by physically interacting with RAB7 and HOPS complex components</div>
+                                <div class="support-text">Mechanistically, ATP6V0D2 directly bound to RAB7 and VPS41 and promoted the RAB7-HOPS interaction, facilitating SNARE complex assembly and autophagosome-lysosome fusion.</div>
                                 
                             </div>
                             
@@ -2491,10 +2475,10 @@
                         
                     </td>
                     <td>
-                        <span class="action-badge action-accept">
-                            ACCEPT
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
                         </span>
-                        <span class="vote-buttons" data-g="Q8N8Y2" data-a="GO:0030670" data-r="Reactome:R-HSA-1222516" data-act="ACCEPT">
+                        <span class="vote-buttons" data-g="Q8N8Y2" data-a="GO:0030670" data-r="Reactome:R-HSA-1222516" data-act="KEEP_AS_NON_CORE">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
@@ -2507,7 +2491,7 @@
                         
                         
                         <div>
-                            <strong>Reason:</strong> Consistent with the known function of V-ATPases in phagosomal acidification and ATP6V0D2&#39;s expression in macrophages and osteoclasts.
+                            <strong>Reason:</strong> Reactome pathway context makes this plausible, but it is a generalized V-ATPase/phagosome localization rather than a primary ATP6V0D2-defining localization. Keep as a non-core compartmental context.
                         </div>
                         
                         
@@ -2542,10 +2526,10 @@
                         
                     </td>
                     <td>
-                        <span class="action-badge action-accept">
-                            ACCEPT
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
                         </span>
-                        <span class="vote-buttons" data-g="Q8N8Y2" data-a="GO:0010008" data-r="Reactome:R-HSA-5252133" data-act="ACCEPT">
+                        <span class="vote-buttons" data-g="Q8N8Y2" data-a="GO:0010008" data-r="Reactome:R-HSA-5252133" data-act="KEEP_AS_NON_CORE">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
@@ -2558,7 +2542,7 @@
                         
                         
                         <div>
-                            <strong>Reason:</strong> V-ATPases function at endosome membranes for acidification. This is a reasonable localization annotation.
+                            <strong>Reason:</strong> V-ATPases function at endosome membranes for acidification, so this is reasonable. For ATP6V0D2 specifically, the better-supported core locations are lysosomal membrane and specialized apical/plasma membrane V-ATPases.
                         </div>
                         
                         
@@ -2593,10 +2577,10 @@
                         
                     </td>
                     <td>
-                        <span class="action-badge action-accept">
-                            ACCEPT
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
                         </span>
-                        <span class="vote-buttons" data-g="Q8N8Y2" data-a="GO:0010008" data-r="Reactome:R-HSA-74723" data-act="ACCEPT">
+                        <span class="vote-buttons" data-g="Q8N8Y2" data-a="GO:0010008" data-r="Reactome:R-HSA-74723" data-act="KEEP_AS_NON_CORE">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
@@ -2609,7 +2593,7 @@
                         
                         
                         <div>
-                            <strong>Reason:</strong> Consistent with V-ATPase function in endosomal acidification.
+                            <strong>Reason:</strong> Consistent with V-ATPase function in endosomal acidification, but retained as non-core for ATP6V0D2 because the direct evidence emphasizes lysosomal and specialized plasma membrane contexts.
                         </div>
                         
                         
@@ -2644,10 +2628,10 @@
                         
                     </td>
                     <td>
-                        <span class="action-badge action-accept">
-                            ACCEPT
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
                         </span>
-                        <span class="vote-buttons" data-g="Q8N8Y2" data-a="GO:0010008" data-r="Reactome:R-HSA-917841" data-act="ACCEPT">
+                        <span class="vote-buttons" data-g="Q8N8Y2" data-a="GO:0010008" data-r="Reactome:R-HSA-917841" data-act="KEEP_AS_NON_CORE">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
@@ -2660,7 +2644,7 @@
                         
                         
                         <div>
-                            <strong>Reason:</strong> Consistent with V-ATPase function in endosomal acidification.
+                            <strong>Reason:</strong> Consistent with V-ATPase function in endosomal acidification, but retained as non-core for ATP6V0D2 because the direct evidence emphasizes lysosomal and specialized plasma membrane contexts.
                         </div>
                         
                         
@@ -2890,6 +2874,157 @@
                     </td>
                 </tr>
                 
+                <tr>
+                    <td>
+                        <div class="term-info">
+                            
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0007042" target="_blank" class="term-link">
+                                    GO:0007042
+                                </a>
+                            </span>
+                            <span class="term-label">lysosomal lumen acidification</span>
+                            
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">NAS</span>
+                        
+                        
+                        
+                        <br>
+                        <span style="font-size: 0.75rem;">
+                            
+                            file:projects/PROTEOSTASIS/mappings/autophagy_lysosome_pathway.yaml
+                            
+                        </span>
+                        
+                    </td>
+                    <td>
+                        <span class="action-badge action-new">
+                            NEW
+                        </span>
+                        <span class="vote-buttons" data-g="Q8N8Y2" data-a="GO:0007042" data-r="file:projects/PROTEOSTASIS/mappings/autophagy_lysosome_pathway.yaml" data-act="NEW">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+                        
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> NEW annotation proposed from the Proteostasis Network projection. ATP6V0D2 already has the broader GO:0007035 vacuolar acidification annotation, and the PN autophagy-lysosome mapping projects the lysosomal acidification branch to GO:0007042. PMID:39477683 provides ATP6V0D2-specific support for increased lysosomal acidification/activity in late autophagy.
+                        </div>
+                        
+                        
+                        <div>
+                            <strong>Reason:</strong> This is a conservative PN projection because it is more specific than the existing vacuolar acidification GOA term and is supported by ATP6V0D2&#39;s lysosomal V-ATPase context. It should be added as a lysosome-specific acidification annotation rather than as a broad proteostasis-process claim.
+                        </div>
+                        
+                        
+                        
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+                            
+                            <div class="support-item">
+                                <span class="support-ref">
+                                    
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/39477683" target="_blank" class="term-link">
+                                        PMID:39477683
+                                    </a>
+                                    
+                                </span>
+                                
+                                <div class="support-text">ATP6V0D2 promoted autolysosome degradation by increasing the acidification and activity of lysosomes during the later stages of macroautophagy/autophagy.</div>
+                                
+                            </div>
+                            
+                        </div>
+                        
+                    </td>
+                </tr>
+                
+                <tr>
+                    <td>
+                        <div class="term-info">
+                            
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0046610" target="_blank" class="term-link">
+                                    GO:0046610
+                                </a>
+                            </span>
+                            <span class="term-label">lysosomal proton-transporting V-type ATPase, V0 domain</span>
+                            
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">NAS</span>
+                        
+                        
+                        
+                        <br>
+                        <span style="font-size: 0.75rem;">
+                            
+                            file:projects/PROTEOSTASIS/mappings/autophagy_lysosome_pathway.yaml
+                            
+                        </span>
+                        
+                    </td>
+                    <td>
+                        <span class="action-badge action-new">
+                            NEW
+                        </span>
+                        <span class="vote-buttons" data-g="Q8N8Y2" data-a="GO:0046610" data-r="file:projects/PROTEOSTASIS/mappings/autophagy_lysosome_pathway.yaml" data-act="NEW">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+                        
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> NEW annotation proposed from the Proteostasis Network projection. ATP6V0D2 is already annotated to the V0 domain (GO:0033179), the V-ATPase complex (GO:0016471), and lysosomal membrane (GO:0005765). The PN mapping recommends the more specific lysosomal V0-domain component term GO:0046610 for V0-sector lysosomal V-ATPase components.
+                        </div>
+                        
+                        
+                        <div>
+                            <strong>Reason:</strong> This is a conservative compositional refinement of existing GOA rather than a novel mechanistic claim. ATP6V0D2 is the d2 V0-domain subunit and is represented in lysosomal V-ATPase Reactome contexts; GO:0046610 captures that lysosomal V0-domain component role more precisely than the existing separate V0-domain and lysosomal-membrane annotations.
+                        </div>
+                        
+                        
+                        
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+                            
+                            <div class="support-item">
+                                <span class="support-ref">
+                                    
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/18752060" target="_blank" class="term-link">
+                                        PMID:18752060
+                                    </a>
+                                    
+                                </span>
+                                
+                                <div class="support-text">The multi-subunit vacuolar-type H(+)-ATPase consists of a V(1) domain (A-H subunits) catalyzing ATP hydrolysis and a V(0) domain (a, c, c&#39;, c&#34;, d, e) responsible for H(+) translocation.</div>
+                                
+                            </div>
+                            
+                            <div class="support-item">
+                                <span class="support-ref">
+                                    
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/39477683" target="_blank" class="term-link">
+                                        PMID:39477683
+                                    </a>
+                                    
+                                </span>
+                                
+                                <div class="support-text">it promoted autophagic degradation of EPAS1 by upregulating the ATPase subunit ATP6V0D2 (ATPase H+ transporting V0 subunit d2) to increase lysosomal function</div>
+                                
+                            </div>
+                            
+                        </div>
+                        
+                    </td>
+                </tr>
+                
             </tbody>
         </table>
     </div>
@@ -2911,15 +3046,6 @@
             
 
             <div class="core-function-terms">
-                
-                <div class="function-term-group">
-                    <div class="function-term-label">Molecular Function:</div>
-                    <span class="badge">
-                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0046961" target="_blank" class="term-link">
-                            proton-transporting ATPase activity, rotational mechanism
-                        </a>
-                    </span>
-                </div>
                 
 
                 
@@ -2946,7 +3072,7 @@
         <div class="core-function-card">
             
             <div style="display: flex; justify-content: space-between; align-items: center;">
-                <h3>As part of the V-ATPase, ATP6V0D2 contributes to acidification of intracellular compartments (lysosomes, endosomes) and extracellular spaces (in specialized cells like kidney intercalated cells and osteoclasts). Immunolocalization in kidney intercalated cells [PMID:15800125]; functional studies showing ATP6V0D2 depletion impairs lysosomal acidification [Li et al. 2025 Autophagy].</h3>
+                <h3>As part of the V-ATPase, ATP6V0D2 contributes to acidification of intracellular compartments (lysosomes, endosomes) and extracellular spaces (in specialized cells like kidney intercalated cells and osteoclasts). Immunolocalization in kidney intercalated cells [PMID:15800125]; ccRCC autophagy experiments showing ATP6V0D2-dependent lysosomal acidification/activity [PMID:39477683].</h3>
                 <span class="vote-buttons" data-g="Q8N8Y2" data-a="FUNCTION: As part of the V-ATPase, ATP6V0D2 contributes to a..." data-r="" data-act="CORE_FUNCTION">
                     <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
                     <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
@@ -2955,15 +3081,6 @@
             
 
             <div class="core-function-terms">
-                
-                <div class="function-term-group">
-                    <div class="function-term-label">Molecular Function:</div>
-                    <span class="badge">
-                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0046961" target="_blank" class="term-link">
-                            proton-transporting ATPase activity, rotational mechanism
-                        </a>
-                    </span>
-                </div>
                 
 
                 
@@ -2974,6 +3091,12 @@
                         <span class="badge">
                             <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0007035" target="_blank" class="term-link">
                                 vacuolar acidification
+                            </a>
+                        </span>
+                        
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0007042" target="_blank" class="term-link">
+                                lysosomal lumen acidification
                             </a>
                         </span>
                         
@@ -3008,66 +3131,23 @@
             </div>
 
             
-        </div>
-        
-        <div class="core-function-card">
-            
-            <div style="display: flex; justify-content: space-between; align-items: center;">
-                <h3>ATP6V0D2 facilitates autophagosome-lysosome fusion independent of its role in proton pumping, by directly interacting with RAB7 and HOPS complex components (VPS41), promoting SNARE complex assembly. Co-IP, GST pulldown, and colocalization studies in human cells [Li et al. 2025 Autophagy] showing direct interaction with RAB7 and VPS41; knockdown impairs fusion and increases autophagosome accumulation.</h3>
-                <span class="vote-buttons" data-g="Q8N8Y2" data-a="FUNCTION: ATP6V0D2 facilitates autophagosome-lysosome fusion..." data-r="" data-act="CORE_FUNCTION">
-                    <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
-                    <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
-                </span>
-            </div>
-            
-
-            <div class="core-function-terms">
-                
-                <div class="function-term-group">
-                    <div class="function-term-label">Molecular Function:</div>
-                    <span class="badge">
-                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0046961" target="_blank" class="term-link">
-                            proton-transporting ATPase activity, rotational mechanism
-                        </a>
-                    </span>
-                </div>
-                
-
-                
-                <div class="function-term-group">
-                    <div class="function-term-label">Directly Involved In:</div>
-                    <div class="function-annotations">
-                        
-                        <span class="badge">
-                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016241" target="_blank" class="term-link">
-                                regulation of macroautophagy
-                            </a>
+            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
+                <strong>Supporting Evidence:</strong>
+                <ul class="findings-list">
+                    
+                    <li class="finding-item">
+                        <span class="reference-id">
+                            
+                            file:human/ATP6V0D2/ATP6V0D2-deep-research-falcon.md
+                            
                         </span>
                         
-                    </div>
-                </div>
-                
-
-                
-                <div class="function-term-group">
-                    <div class="function-term-label">Cellular Locations:</div>
-                    <div class="function-annotations">
+                        <div class="finding-text">Lysosomal acidification and degradation in human cells: The same study shows ATP6V0D2 enhances lysosomal acidification and activity</div>
                         
-                        <span class="badge">
-                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005765" target="_blank" class="term-link">
-                                lysosomal membrane
-                            </a>
-                        </span>
-                        
-                    </div>
-                </div>
-                
-
-                
-
-                
+                    </li>
+                    
+                </ul>
             </div>
-
             
         </div>
         
@@ -3488,6 +3568,105 @@
                 
             </div>
             
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+                        
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/39477683" target="_blank" class="term-link">
+                            PMID:39477683
+                        </a>
+                        
+                    </span>
+                </div>
+                
+                <div class="reference-title">Atractylenolide I inhibits angiogenesis and reverses sunitinib resistance in clear cell renal cell carcinoma through ATP6V0D2-mediated autophagic degradation of EPAS1/HIF2alpha.</div>
+                
+                
+                <ul class="findings-list">
+                    
+                    <li class="finding-item">
+                        <div class="finding-statement">ATP6V0D2 promotes autophagosome-lysosome fusion through RAB7/HOPS and SNARE-complex assembly in ccRCC models.</div>
+                        
+                    </li>
+                    
+                    <li class="finding-item">
+                        <div class="finding-statement">ATP6V0D2 increases lysosomal acidification and activity during late autophagy in ccRCC models.</div>
+                        
+                    </li>
+                    
+                </ul>
+                
+            </div>
+            
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+                        
+                        file:human/ATP6V0D2/ATP6V0D2-deep-research-falcon.md
+                        
+                    </span>
+                </div>
+                
+                <div class="reference-title">Falcon deep research report for ATP6V0D2</div>
+                
+                
+                <ul class="findings-list">
+                    
+                    <li class="finding-item">
+                        <div class="finding-statement">ATP6V0D2 is a V-ATPase V0 d2 subunit with evidence for specialized kidney, osteoclast, lysosomal, and late-autophagy roles.</div>
+                        
+                    </li>
+                    
+                </ul>
+                
+            </div>
+            
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+                        
+                        file:human/ATP6V0D2/ATP6V0D2-notes.md
+                        
+                    </span>
+                </div>
+                
+                <div class="reference-title">ATP6V0D2 PN curation notes</div>
+                
+                
+                <ul class="findings-list">
+                    
+                    <li class="finding-item">
+                        <div class="finding-statement">Manual PN review treated lysosomal acidification and lysosomal V0-domain projection as conservative new annotation candidates, while keeping broader proteostasis/autophagy claims non-core.</div>
+                        
+                    </li>
+                    
+                </ul>
+                
+            </div>
+            
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+                        
+                        file:projects/PROTEOSTASIS/mappings/autophagy_lysosome_pathway.yaml
+                        
+                    </span>
+                </div>
+                
+                <div class="reference-title">Proteostasis Network autophagy-lysosome pathway mappings</div>
+                
+                
+                <ul class="findings-list">
+                    
+                    <li class="finding-item">
+                        <div class="finding-statement">PN mappings project the lysosomal acidification node to GO:0007042 and the V0 lysosomal V-ATPase component node to GO:0046610.</div>
+                        
+                    </li>
+                    
+                </ul>
+                
+            </div>
+            
         </div>
     </div>
     
@@ -3517,6 +3696,19 @@
                     
                 </div>
                 <span class="vote-buttons" data-g="Q8N8Y2" data-a="Q: Is the autophagosome-lysosome fusion function of A..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+        
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> Should the PN-projected GO:0046610 lysosomal proton-transporting V-type ATPase, V0 domain annotation be added by propagation for ATP6V0D2, or should it wait for direct lysosomal V0-domain complex evidence specific to the d2 isoform?</p>
+                    
+                </div>
+                <span class="vote-buttons" data-g="Q8N8Y2" data-a="Q: Should the PN-projected GO:0046610 lysosomal proto..." data-r="" data-act="QUESTION">
                     <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
                     <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
                 </span>
@@ -3723,6 +3915,83 @@ this with annotations you find in gene/protein databases, but these can be outda
 
     <!-- Additional Documentation Sections -->
     
+    <div class="section">
+        <h2 class="section-title">📚 Additional Documentation</h2>
+        
+        <details class="markdown-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; cursor: pointer;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Notes</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(ATP6V0D2-notes.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="Q8N8Y2" data-a="DOC: Notes" data-r="" data-act="DOCUMENTATION" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This documentation is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This documentation needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+                <h1 id="atp6v0d2-review-notes">ATP6V0D2 review notes</h1>
+<h2 id="core-function">Core function</h2>
+<p>ATP6V0D2 encodes the d2 isoform of the V-ATPase V0 d subunit. The core function<br />
+is as a structural V0-sector component that contributes to the assembled<br />
+V-ATPase rotary proton pump, not as an independently catalytic ATPase. Smith et<br />
+al. show that the mammalian V0 d subunit has d1 and d2 forms and that d2 is<br />
+predominantly expressed in kidney and osteoclast <a href="https://pubmed.ncbi.nlm.nih.gov/18752060" title="d2 is predominantly expressed at the cell surface in kidney and osteoclast">PMID:18752060</a>.<br />
+The same paper supports a central-stalk/rotary mechanism role because the human<br />
+d subunits pull down V1 D and F subunits and the authors conclude that the d<br />
+subunit is centrally located in the pump <a href="https://pubmed.ncbi.nlm.nih.gov/18752060" title="the d subunit in man forms part of the pump's central stalk">PMID:18752060</a>.</p>
+<p>The direct tissue-localization evidence supports specialized plasma membrane<br />
+V-ATPases in kidney intercalated cells and osteoclasts. Smith et al. report<br />
+human collecting-duct intercalated-cell staining that co-localized with the a4<br />
+subunit <a href="https://pubmed.ncbi.nlm.nih.gov/15800125" title="high-intensity d2 staining was observed only in intercalated cells of the collecting duct in fresh-frozen human kidney">PMID:15800125</a> and bone<br />
+osteoclast co-localization with a3 <a href="https://pubmed.ncbi.nlm.nih.gov/15800125" title="In human bone, d2 co-localized with the a3 subunit in osteoclasts">PMID:15800125</a>.</p>
+<h2 id="pn-projection">PN projection</h2>
+<p>Falcon deep research already existed as<br />
+<code>genes/human/ATP6V0D2/ATP6V0D2-deep-research-falcon.md</code>, so this was handled as<br />
+a PN-context re-review rather than a new deep-research run.</p>
+<p>The PN projection has two ATP6V0D2 candidate additions from<br />
+<code>projects/PROTEOSTASIS/reports/pn_projection/pn_projected_gene_go_summary.tsv</code>:<br />
+<code>GO:0007042 lysosomal lumen acidification</code> and <code>GO:0046610 lysosomal proton-transporting V-type ATPase, V0 domain</code>.<br />
+I treated both as conservative <code>action: NEW</code> recommendations. <code>GO:0007042</code> is<br />
+a specific child/refinement of the existing GOA <code>GO:0007035 vacuolar
+acidification</code> and is supported by the ATP6V0D2-specific Autophagy abstract,<br />
+which states that ATP6V0D2 promoted autolysosome degradation by increasing<br />
+lysosomal acidification/activity <a href="https://pubmed.ncbi.nlm.nih.gov/39477683" title="ATP6V0D2 promoted autolysosome degradation by increasing the acidification and activity of lysosomes">PMID:39477683</a>.</p>
+<p><code>GO:0046610</code> is a compositional PN refinement, not a single direct experiment:<br />
+ATP6V0D2 is already in GOA as V0 domain, V-ATPase complex, and lysosomal<br />
+membrane, and the PN mapping<br />
+<code>Autophagy-Lysosome Pathway|Pre-initiation autophagy signaling|mTORC1 pathway, upstream|Nutrient sensing|V0 lysosomal v-ATPase proton pump component</code><br />
+targets <code>GO:0046610</code> [file:projects/PROTEOSTASIS/mappings/autophagy_lysosome_pathway.yaml].<br />
+Because this depends on combining existing GOA/Reactome context with V0-subunit<br />
+identity, I recorded it as a conservative proposed annotation and added an expert<br />
+question about whether direct d2-specific lysosomal V0-domain evidence should be<br />
+required.</p>
+<h2 id="conservative-annotation-decisions">Conservative annotation decisions</h2>
+<ul>
+<li>Kept <code>GO:0007035 vacuolar acidification</code>, V-ATPase complex, V0 domain, and<br />
+  plasma membrane V-ATPase complex as core.</li>
+<li>Added PN-projected <code>GO:0007042</code> and <code>GO:0046610</code> as <code>NEW</code> recommendations.</li>
+<li>Moved broad <code>GO:0007034 vacuolar transport</code> to non-core because acidification<br />
+  is the cleaner core process.</li>
+<li>Kept macroautophagy regulation as non-core. PMID:39477683 supports a real<br />
+  late-autophagy/fusion role, but the original GOA citation PMID:22982048 is not<br />
+  ATP6V0D2-specific and instead addresses lipofuscin/autophagy generally<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/22982048" title="macroautophagy is responsible for the uptake of lipofuscin into the lysosomes">PMID:22982048</a>.</li>
+<li>Kept phagocytic vesicle membrane and endosome membrane localizations as<br />
+  non-core Reactome/automated contexts rather than ATP6V0D2-defining locations.</li>
+<li>Removed generic <code>GO:0005515 protein binding</code> annotations because they are less<br />
+  informative than V-ATPase complex membership and specific mechanistic process<br />
+  annotations.</li>
+</ul>
+<h2 id="description-cleanup-note">Description cleanup note</h2>
+<p>The YAML description was kept project-independent. PN-specific rationale and<br />
+curation commentary are recorded here and in individual annotation review<br />
+reasons, not in the top-level biological summary.</p>
+            </div>
+        </details>
+        
+    </div>
+    
 
     <!-- YAML Preview Section -->
     <div class="section">
@@ -3750,12 +4019,11 @@ description: &gt;-
   ATP6V0D2 shows tissue-restricted expression, predominantly in kidney intercalated
   cells
   and osteoclasts, where V-ATPases function at the plasma membrane for urinary acidification
-  and bone resorption, respectively. Recent studies have also demonstrated that ATP6V0D2
-  facilitates autophagosome-lysosome fusion by interacting with RAB7 and HOPS complex
-  components (e.g., VPS41), thereby promoting SNARE complex assembly. This fusion-promoting
-  function is distinct from the classical proton-pumping role and has implications
-  for
-  lysosomal degradation and autophagy.
+  and bone resorption, respectively. In clear-cell renal carcinoma models,
+  ATP6V0D2 has also been reported to promote late autophagy by increasing
+  lysosomal acidification and by facilitating autophagosome-lysosome fusion through
+  RAB7/HOPS/SNARE machinery, suggesting a context-dependent role in lysosomal
+  degradative flux in addition to its established V-ATPase subunit function.
 existing_annotations:
 - term:
     id: GO:0016471
@@ -3840,23 +4108,23 @@ existing_annotations:
   review:
     summary: &gt;-
       ATP6V0D2 participates in vacuolar/lysosomal function through its role in the
-      V-ATPase. Recent evidence shows ATP6V0D2 directly facilitates autophagosome-lysosome
-      fusion by interacting with RAB7 and HOPS complex components, promoting SNARE
-      complex formation [Li et al. 2025, Autophagy &#34;ATP6V0D2 directly promotes
-      autophagosome-lysosome fusion by physically interacting with RAB7 and HOPS
-      complex
-      components&#34;].
-    action: ACCEPT
+      V-ATPase, but &#34;vacuolar transport&#34; is a broad process term for this subunit.
+      The clearest established process is compartment acidification. A more recent
+      ccRCC study also supports a context-specific role in autophagosome-lysosome
+      fusion through RAB7/HOPS machinery [PMID:39477683].
+    action: KEEP_AS_NON_CORE
     reason: &gt;-
-      This annotation is appropriate given the role of ATP6V0D2 in both vacuolar
-      acidification (via V-ATPase function) and autophagosome-lysosome fusion.
-      Recent studies provide strong evidence for the involvement of ATP6V0D2 in
-      lysosomal transport/fusion processes.
+      Retain this broad IBA term as non-core. It is consistent with V-ATPase-dependent
+      acidification and with newer late-autophagy evidence, but the core ATP6V0D2
+      functions are better represented by V-ATPase complex membership, V0-domain
+      contribution to rotary proton pumping, and vacuolar/lysosomal acidification.
+    additional_reference_ids:
+    - file:human/ATP6V0D2/ATP6V0D2-deep-research-falcon.md
     supported_by:
     - reference_id: PMID:39477683
-      supporting_text: ATP6V0D2 directly promotes autophagosome-lysosome fusion 
-        by physically interacting with RAB7 and HOPS complex components
-      full_text_unavailable: true
+      supporting_text: Mechanistically, ATP6V0D2 directly bound to RAB7 and VPS41
+        and promoted the RAB7-HOPS interaction, facilitating SNARE complex assembly
+        and autophagosome-lysosome fusion.
 - term:
     id: GO:0007035
     label: vacuolar acidification
@@ -3868,11 +4136,11 @@ existing_annotations:
       of
       vacuolar compartments and, in specialized cells, the extracellular environment.
       In human kidney intercalated cells, d2 co-localizes with the a4 subunit at
-      the
-      plasma membrane for urinary acidification [PMID:15800125]. Recent studies
-      show
-      that ATP6V0D2 depletion impairs lysosomal acidification in human cancer cells
-      [Li et al. 2025 Autophagy].
+      the plasma membrane for urinary acidification [PMID:15800125]. Recent
+      ccRCC work also reports that ATP6V0D2 promotes lysosomal acidification and
+      activity during late autophagy [PMID:39477683]. The Proteostasis Network
+      projection supports adding the more specific GO:0007042 lysosomal lumen
+      acidification term for this gene.
     action: ACCEPT
     reason: &gt;-
       This is a core function of ATP6V0D2 as part of the V-ATPase proton pump.
@@ -3885,9 +4153,9 @@ existing_annotations:
         where it co-localized with the a4 subunit in the characteristic plasma 
         membrane-enhanced pattern
     - reference_id: PMID:39477683
-      supporting_text: &#39;ATP6V0D2 enhances lysosomal acidification and activity: depletion
-        increased RFP+GFP+ LC3 puncta (indicating impaired fusion/degradation)&#39;
-      full_text_unavailable: true
+      supporting_text: ATP6V0D2 promoted autolysosome degradation by increasing
+        the acidification and activity of lysosomes during the later stages of
+        macroautophagy/autophagy.
 - term:
     id: GO:0033181
     label: plasma membrane proton-transporting V-type ATPase complex
@@ -3952,22 +4220,16 @@ existing_annotations:
   review:
     summary: &gt;-
       V-ATPases are present in phagocytic vesicle membranes where they acidify the
-      phagosome. Given ATP6V0D2&#39;s role in macrophages and immune cells (facilitating
-      autophagosome-lysosome fusion and phagosome acidification), this localization
-      is plausible. Reviews note that &#34;in macrophages ATP6V0D2 facilitates autophagosome-lysosome
-      fusion to restrain inflammasome activation and bacterial infection&#34; [Chen
-      et
-      al.
-      2025 Biomolecules].
-    action: ACCEPT
+      phagosome, and Reactome also projects ATP6V0D2 to a phagosomal acidification
+      event. For ATP6V0D2 specifically, however, the strongest primary human evidence
+      emphasizes kidney/osteoclast plasma membrane pumps, V0-domain complex
+      membership, and lysosomal/autophagy functions rather than a directly tested
+      phagocytic-vesicle localization.
+    action: KEEP_AS_NON_CORE
     reason: &gt;-
-      This is a reasonable localization given the known role of ATP6V0D2 in macrophages
-      and immune function. V-ATPases are required for phagosome acidification.
-    supported_by:
-    - reference_id: unindexed:chen2025biomolecules
-      supporting_text: in macrophages ATP6V0D2 facilitates 
-        autophagosome-lysosome fusion to restrain inflammasome activation and 
-        bacterial infection
+      Keep as a plausible non-core V-ATPase localization from automated inference,
+      but do not treat it as a defining ATP6V0D2 cellular component for the PN
+      proteostasis review.
 - term:
     id: GO:0033179
     label: proton-transporting V-type ATPase, V0 domain
@@ -4089,22 +4351,19 @@ existing_annotations:
   original_reference_id: Reactome:R-HSA-9639286
   review:
     summary: &gt;-
-      ATP6V0D2 localizes to lysosomal membranes where it functions in V-ATPase-mediated
-      acidification and autophagosome-lysosome fusion. This is well-supported by
-      recent literature showing ATP6V0D2 at lysosomes in human cancer cells
-      [Li et al. 2025 Autophagy &#34;In human cells, ATP6V0D2 localizes to lysosomes/acidic
-      vesicles, where it contributes to lysosomal acidification and degradative
-      capacity&#34;].
+      Reactome places ATP6V0D2-containing V-ATPase events at the lysosomal membrane.
+      The lysosomal interpretation is also consistent with ccRCC evidence that
+      ATP6V0D2 increases lysosomal acidification/activity during autophagic
+      degradation [PMID:39477683].
     action: ACCEPT
     reason: &gt;-
       Lysosomal membrane localization is a core annotation for ATP6V0D2, supported
       by multiple Reactome entries and primary literature.
     supported_by:
     - reference_id: PMID:39477683
-      supporting_text: In human cells, ATP6V0D2 localizes to lysosomes/acidic 
-        vesicles, where it contributes to lysosomal acidification and 
-        degradative capacity
-      full_text_unavailable: true
+      supporting_text: ATP6V0D2 promoted autolysosome degradation by increasing
+        the acidification and activity of lysosomes during the later stages of
+        macroautophagy/autophagy.
 - term:
     id: GO:0005765
     label: lysosomal membrane
@@ -4193,20 +4452,20 @@ existing_annotations:
     summary: &gt;-
       The referenced paper [PMID:22982048] studies lipofuscin formation and autophagy
       but does not specifically address ATP6V0D2. It examines general V-ATPase
-      inhibition effects. However, recent literature strongly supports ATP6V0D2&#39;s
-      role in autophagy regulation, particularly autophagosome-lysosome fusion
-      [Li et al. 2025 &#34;ATP6V0D2 directly promotes autophagosome-lysosome fusion&#34;].
-    action: ACCEPT
+      inhibition effects. However, PMID:39477683 provides direct evidence in ccRCC
+      models that ATP6V0D2 promotes autophagosome-lysosome fusion and later
+      autolysosome degradation.
+    action: KEEP_AS_NON_CORE
     reason: &gt;-
-      While the original reference may not specifically study ATP6V0D2, recent
-      literature confirms ATP6V0D2 regulates autophagy by facilitating
-      autophagosome-lysosome fusion. The annotation is correct based on
-      current understanding.
+      Keep the annotation because there is newer ATP6V0D2-specific evidence for
+      late macroautophagy/autophagosome-lysosome fusion, but classify it as
+      non-core because the original NAS citation is not ATP6V0D2-specific and
+      the best-established core function remains V-ATPase-mediated acidification.
     supported_by:
     - reference_id: PMID:39477683
-      supporting_text: ATP6V0D2 directly promotes autophagosome-lysosome fusion 
-        by physically interacting with RAB7 and HOPS complex components
-      full_text_unavailable: true
+      supporting_text: Mechanistically, ATP6V0D2 directly bound to RAB7 and VPS41
+        and promoted the RAB7-HOPS interaction, facilitating SNARE complex assembly
+        and autophagosome-lysosome fusion.
 - term:
     id: GO:0016324
     label: apical plasma membrane
@@ -4257,10 +4516,11 @@ existing_annotations:
       V-ATPases including ATP6V0D2 function in phagosome acidification. This is
       consistent with d2&#39;s role in osteoclasts (which have specialized phagocytic
       activity) and macrophages.
-    action: ACCEPT
+    action: KEEP_AS_NON_CORE
     reason: &gt;-
-      Consistent with the known function of V-ATPases in phagosomal acidification
-      and ATP6V0D2&#39;s expression in macrophages and osteoclasts.
+      Reactome pathway context makes this plausible, but it is a generalized
+      V-ATPase/phagosome localization rather than a primary ATP6V0D2-defining
+      localization. Keep as a non-core compartmental context.
 - term:
     id: GO:0010008
     label: endosome membrane
@@ -4270,10 +4530,11 @@ existing_annotations:
     summary: &gt;-
       From Reactome pathway showing ATP6AP1 binding to V-ATPase. Endosome membrane
       localization is consistent with V-ATPase function in endosomal acidification.
-    action: ACCEPT
+    action: KEEP_AS_NON_CORE
     reason: &gt;-
-      V-ATPases function at endosome membranes for acidification. This is a
-      reasonable localization annotation.
+      V-ATPases function at endosome membranes for acidification, so this is
+      reasonable. For ATP6V0D2 specifically, the better-supported core locations
+      are lysosomal membrane and specialized apical/plasma membrane V-ATPases.
 - term:
     id: GO:0010008
     label: endosome membrane
@@ -4282,9 +4543,11 @@ existing_annotations:
   review:
     summary: &gt;-
       From Reactome pathway &#34;Endosome acidification&#34;. Core function of V-ATPase.
-    action: ACCEPT
+    action: KEEP_AS_NON_CORE
     reason: &gt;-
-      Consistent with V-ATPase function in endosomal acidification.
+      Consistent with V-ATPase function in endosomal acidification, but retained
+      as non-core for ATP6V0D2 because the direct evidence emphasizes lysosomal
+      and specialized plasma membrane contexts.
 - term:
     id: GO:0010008
     label: endosome membrane
@@ -4294,9 +4557,11 @@ existing_annotations:
     summary: &gt;-
       From Reactome pathway &#34;Acidification of Tf:TfR1 containing endosome&#34;.
       V-ATPases acidify endosomes containing transferrin receptor.
-    action: ACCEPT
+    action: KEEP_AS_NON_CORE
     reason: &gt;-
-      Consistent with V-ATPase function in endosomal acidification.
+      Consistent with V-ATPase function in endosomal acidification, but retained
+      as non-core for ATP6V0D2 because the direct evidence emphasizes lysosomal
+      and specialized plasma membrane contexts.
 - term:
     id: GO:0005515
     label: protein binding
@@ -4355,6 +4620,64 @@ existing_annotations:
       supporting_text: d1-GST and d2-GST, but not GST alone, are each able to 
         pull down the H+-ATPase D and F subunits from solubilized human kidney 
         membrane preparations
+- term:
+    id: GO:0007042
+    label: lysosomal lumen acidification
+  evidence_type: NAS
+  original_reference_id: file:projects/PROTEOSTASIS/mappings/autophagy_lysosome_pathway.yaml
+  review:
+    summary: &gt;-
+      NEW annotation proposed from the Proteostasis Network projection. ATP6V0D2
+      already has the broader GO:0007035 vacuolar acidification annotation, and
+      the PN autophagy-lysosome mapping projects the lysosomal acidification branch
+      to GO:0007042. PMID:39477683 provides ATP6V0D2-specific support for increased
+      lysosomal acidification/activity in late autophagy.
+    action: NEW
+    reason: &gt;-
+      This is a conservative PN projection because it is more specific than the
+      existing vacuolar acidification GOA term and is supported by ATP6V0D2&#39;s
+      lysosomal V-ATPase context. It should be added as a lysosome-specific
+      acidification annotation rather than as a broad proteostasis-process claim.
+    additional_reference_ids:
+    - PMID:39477683
+    - file:human/ATP6V0D2/ATP6V0D2-deep-research-falcon.md
+    supported_by:
+    - reference_id: PMID:39477683
+      supporting_text: ATP6V0D2 promoted autolysosome degradation by increasing
+        the acidification and activity of lysosomes during the later stages of
+        macroautophagy/autophagy.
+- term:
+    id: GO:0046610
+    label: lysosomal proton-transporting V-type ATPase, V0 domain
+  evidence_type: NAS
+  original_reference_id: file:projects/PROTEOSTASIS/mappings/autophagy_lysosome_pathway.yaml
+  review:
+    summary: &gt;-
+      NEW annotation proposed from the Proteostasis Network projection. ATP6V0D2
+      is already annotated to the V0 domain (GO:0033179), the V-ATPase complex
+      (GO:0016471), and lysosomal membrane (GO:0005765). The PN mapping recommends
+      the more specific lysosomal V0-domain component term GO:0046610 for
+      V0-sector lysosomal V-ATPase components.
+    action: NEW
+    reason: &gt;-
+      This is a conservative compositional refinement of existing GOA rather than
+      a novel mechanistic claim. ATP6V0D2 is the d2 V0-domain subunit and is
+      represented in lysosomal V-ATPase Reactome contexts; GO:0046610 captures
+      that lysosomal V0-domain component role more precisely than the existing
+      separate V0-domain and lysosomal-membrane annotations.
+    additional_reference_ids:
+    - PMID:18752060
+    - PMID:39477683
+    - file:human/ATP6V0D2/ATP6V0D2-deep-research-falcon.md
+    supported_by:
+    - reference_id: PMID:18752060
+      supporting_text: The multi-subunit vacuolar-type H(+)-ATPase consists of a
+        V(1) domain (A-H subunits) catalyzing ATP hydrolysis and a V(0) domain
+        (a, c, c&#39;, c&#34;, d, e) responsible for H(+) translocation.
+    - reference_id: PMID:39477683
+      supporting_text: it promoted autophagic degradation of EPAS1 by upregulating
+        the ATPase subunit ATP6V0D2 (ATPase H+ transporting V0 subunit d2) to
+        increase lysosomal function
 references:
 - id: GO_REF:0000002
   title: Gene Ontology annotation through association of InterPro records with 
@@ -4445,6 +4768,31 @@ references:
 - id: Reactome:R-HSA-9646468
   title: mTORC1 binds RHEB:GTP
   findings: []
+- id: PMID:39477683
+  title: Atractylenolide I inhibits angiogenesis and reverses sunitinib resistance
+    in clear cell renal cell carcinoma through ATP6V0D2-mediated autophagic
+    degradation of EPAS1/HIF2alpha.
+  findings:
+  - statement: ATP6V0D2 promotes autophagosome-lysosome fusion through RAB7/HOPS
+      and SNARE-complex assembly in ccRCC models.
+  - statement: ATP6V0D2 increases lysosomal acidification and activity during
+      late autophagy in ccRCC models.
+- id: file:human/ATP6V0D2/ATP6V0D2-deep-research-falcon.md
+  title: Falcon deep research report for ATP6V0D2
+  findings:
+  - statement: ATP6V0D2 is a V-ATPase V0 d2 subunit with evidence for specialized
+      kidney, osteoclast, lysosomal, and late-autophagy roles.
+- id: file:human/ATP6V0D2/ATP6V0D2-notes.md
+  title: ATP6V0D2 PN curation notes
+  findings:
+  - statement: Manual PN review treated lysosomal acidification and lysosomal
+      V0-domain projection as conservative new annotation candidates, while keeping
+      broader proteostasis/autophagy claims non-core.
+- id: file:projects/PROTEOSTASIS/mappings/autophagy_lysosome_pathway.yaml
+  title: Proteostasis Network autophagy-lysosome pathway mappings
+  findings:
+  - statement: PN mappings project the lysosomal acidification node to GO:0007042
+      and the V0 lysosomal V-ATPase component node to GO:0046610.
 core_functions:
 - description: &gt;-
     ATP6V0D2 is a structural component of the V0 domain of the vacuolar H+-ATPase,
@@ -4453,7 +4801,7 @@ core_functions:
     coupling ATP hydrolysis to proton translocation. Direct biochemical evidence
     from pull-down and in vitro binding experiments [PMID:18752060]; structural
     modeling showing d2 is orthologous to bacterial A-ATPase subunit C.
-  molecular_function:
+  contributes_to_molecular_function:
     id: GO:0046961
     label: proton-transporting ATPase activity, rotational mechanism
   in_complex:
@@ -4463,35 +4811,25 @@ core_functions:
     As part of the V-ATPase, ATP6V0D2 contributes to acidification of intracellular
     compartments (lysosomes, endosomes) and extracellular spaces (in specialized
     cells like kidney intercalated cells and osteoclasts). Immunolocalization in
-    kidney intercalated cells [PMID:15800125]; functional studies showing ATP6V0D2
-    depletion impairs lysosomal acidification [Li et al. 2025 Autophagy].
-  molecular_function:
+    kidney intercalated cells [PMID:15800125]; ccRCC autophagy experiments showing
+    ATP6V0D2-dependent lysosomal acidification/activity [PMID:39477683].
+  contributes_to_molecular_function:
     id: GO:0046961
     label: proton-transporting ATPase activity, rotational mechanism
   directly_involved_in:
   - id: GO:0007035
     label: vacuolar acidification
+  - id: GO:0007042
+    label: lysosomal lumen acidification
   locations:
   - id: GO:0005765
     label: lysosomal membrane
   - id: GO:0016324
     label: apical plasma membrane
-- description: &gt;-
-    ATP6V0D2 facilitates autophagosome-lysosome fusion independent of its role
-    in proton pumping, by directly interacting with RAB7 and HOPS complex
-    components (VPS41), promoting SNARE complex assembly. Co-IP, GST pulldown,
-    and colocalization studies in human cells [Li et al. 2025 Autophagy] showing
-    direct interaction with RAB7 and VPS41; knockdown impairs fusion and increases
-    autophagosome accumulation.
-  molecular_function:
-    id: GO:0046961
-    label: proton-transporting ATPase activity, rotational mechanism
-  directly_involved_in:
-  - id: GO:0016241
-    label: regulation of macroautophagy
-  locations:
-  - id: GO:0005765
-    label: lysosomal membrane
+  supported_by:
+  - reference_id: file:human/ATP6V0D2/ATP6V0D2-deep-research-falcon.md
+    supporting_text: &#39;Lysosomal acidification and degradation in human cells:
+      The same study shows ATP6V0D2 enhances lysosomal acidification and activity&#39;
 proposed_new_terms: []
 suggested_questions:
 - question: &gt;-
@@ -4505,6 +4843,10 @@ suggested_questions:
     its incorporation into the V-ATPase complex? Recent studies suggest ATP6V0D2
     promotes fusion via RAB7/HOPS interactions. It is unclear whether this
     requires assembled V-ATPase or if d2 has an independent fusion-promoting function.
+- question: &gt;-
+    Should the PN-projected GO:0046610 lysosomal proton-transporting V-type ATPase,
+    V0 domain annotation be added by propagation for ATP6V0D2, or should it wait
+    for direct lysosomal V0-domain complex evidence specific to the d2 isoform?
 suggested_experiments:
 - description: &gt;-
     Test whether ATP6V0D2 mutants that cannot interact with D/F subunits

--- a/genes/human/ATP6V0D2/ATP6V0D2-ai-review.html
+++ b/genes/human/ATP6V0D2/ATP6V0D2-ai-review.html
@@ -2895,7 +2895,18 @@
                         <br>
                         <span style="font-size: 0.75rem;">
                             
-                            file:projects/PROTEOSTASIS/mappings/autophagy_lysosome_pathway.yaml
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/39477683" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:39477683
+                            </a>
+                            
+                                
+                                
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Atractylenolide I inhibits angiogenesis and reverses sunitin...
+                                </span>
+                                
+                            
                             
                         </span>
                         
@@ -2904,7 +2915,7 @@
                         <span class="action-badge action-new">
                             NEW
                         </span>
-                        <span class="vote-buttons" data-g="Q8N8Y2" data-a="GO:0007042" data-r="file:projects/PROTEOSTASIS/mappings/autophagy_lysosome_pathway.yaml" data-act="NEW">
+                        <span class="vote-buttons" data-g="Q8N8Y2" data-a="GO:0007042" data-r="PMID:39477683" data-act="NEW">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
@@ -2964,7 +2975,18 @@
                         <br>
                         <span style="font-size: 0.75rem;">
                             
-                            file:projects/PROTEOSTASIS/mappings/autophagy_lysosome_pathway.yaml
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/18752060" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:18752060
+                            </a>
+                            
+                                
+                                
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    The d subunit plays a central role in human vacuolar H(+)-AT...
+                                </span>
+                                
+                            
                             
                         </span>
                         
@@ -2973,7 +2995,7 @@
                         <span class="action-badge action-new">
                             NEW
                         </span>
-                        <span class="vote-buttons" data-g="Q8N8Y2" data-a="GO:0046610" data-r="file:projects/PROTEOSTASIS/mappings/autophagy_lysosome_pathway.yaml" data-act="NEW">
+                        <span class="vote-buttons" data-g="Q8N8Y2" data-a="GO:0046610" data-r="PMID:18752060" data-act="NEW">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
@@ -2981,7 +3003,7 @@
                     <td>
                         
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> NEW annotation proposed from the Proteostasis Network projection. ATP6V0D2 is already annotated to the V0 domain (GO:0033179), the V-ATPase complex (GO:0016471), and lysosomal membrane (GO:0005765). The PN mapping recommends the more specific lysosomal V0-domain component term GO:0046610 for V0-sector lysosomal V-ATPase components. No single supporting source directly demonstrates a d2-containing lysosomal V0-domain complex; this recommendation combines existing V0-domain evidence with lysosomal-membrane annotations.
+                            <strong>Summary:</strong> NEW annotation proposed from the Proteostasis Network projection. ATP6V0D2 is already annotated to the V0 domain (GO:0033179), the V-ATPase complex (GO:0016471), and lysosomal membrane (GO:0005765). The PN mapping recommends the more specific lysosomal V0-domain component term GO:0046610 for V0-sector lysosomal V-ATPase components. No single supporting source directly demonstrates a d2-containing lysosomal V0-domain complex; this recommendation combines the accepted GO:0033179 V0-domain annotation with accepted GO:0005765 lysosomal-membrane annotations.
                         </div>
                         
                         
@@ -4054,6 +4076,7 @@ existing_annotations:
 - term:
     id: GO:0046961
     label: proton-transporting ATPase activity, rotational mechanism
+  qualifier: contributes_to
   evidence_type: IBA
   original_reference_id: GO_REF:0000033
   review:
@@ -4254,6 +4277,7 @@ existing_annotations:
 - term:
     id: GO:0046961
     label: proton-transporting ATPase activity, rotational mechanism
+  qualifier: enables
   evidence_type: IEA
   original_reference_id: GO_REF:0000002
   review:
@@ -4627,7 +4651,7 @@ existing_annotations:
     id: GO:0007042
     label: lysosomal lumen acidification
   evidence_type: NAS
-  original_reference_id: file:projects/PROTEOSTASIS/mappings/autophagy_lysosome_pathway.yaml
+  original_reference_id: PMID:39477683
   review:
     summary: &gt;-
       NEW annotation proposed from the Proteostasis Network projection. ATP6V0D2
@@ -4642,7 +4666,7 @@ existing_annotations:
       lysosomal V-ATPase context. It should be added as a lysosome-specific
       acidification annotation rather than as a broad proteostasis-process claim.
     additional_reference_ids:
-    - PMID:39477683
+    - file:projects/PROTEOSTASIS/mappings/autophagy_lysosome_pathway.yaml
     - file:human/ATP6V0D2/ATP6V0D2-deep-research-falcon.md
     supported_by:
     - reference_id: PMID:39477683
@@ -4653,7 +4677,7 @@ existing_annotations:
     id: GO:0046610
     label: lysosomal proton-transporting V-type ATPase, V0 domain
   evidence_type: IC
-  original_reference_id: file:projects/PROTEOSTASIS/mappings/autophagy_lysosome_pathway.yaml
+  original_reference_id: PMID:18752060
   review:
     summary: &gt;-
       NEW annotation proposed from the Proteostasis Network projection. ATP6V0D2
@@ -4662,7 +4686,8 @@ existing_annotations:
       the more specific lysosomal V0-domain component term GO:0046610 for
       V0-sector lysosomal V-ATPase components. No single supporting source directly
       demonstrates a d2-containing lysosomal V0-domain complex; this recommendation
-      combines existing V0-domain evidence with lysosomal-membrane annotations.
+      combines the accepted GO:0033179 V0-domain annotation with accepted GO:0005765
+      lysosomal-membrane annotations.
     action: NEW
     reason: &gt;-
       This is a conservative compositional refinement of existing GOA rather than
@@ -4673,7 +4698,7 @@ existing_annotations:
       literature establishes the pieces of this inference rather than directly
       testing lysosomal GO:0046610 membership for the d2 isoform.
     additional_reference_ids:
-    - PMID:18752060
+    - file:projects/PROTEOSTASIS/mappings/autophagy_lysosome_pathway.yaml
     - PMID:39477683
     - file:human/ATP6V0D2/ATP6V0D2-deep-research-falcon.md
     supported_by:

--- a/genes/human/ATP6V0D2/ATP6V0D2-ai-review.html
+++ b/genes/human/ATP6V0D2/ATP6V0D2-ai-review.html
@@ -1130,7 +1130,7 @@
                     <td>
                         
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> ATP6V0D2 is a core component of the V-ATPase responsible for acidification of vacuolar compartments and, in specialized cells, the extracellular environment. In human kidney intercalated cells, d2 co-localizes with the a4 subunit at the plasma membrane for urinary acidification [PMID:15800125]. Recent ccRCC work also reports that ATP6V0D2 promotes lysosomal acidification and activity during late autophagy [PMID:39477683]. The Proteostasis Network projection supports adding the more specific GO:0007042 lysosomal lumen acidification term for this gene.
+                            <strong>Summary:</strong> ATP6V0D2 is a core component of the V-ATPase responsible for acidification of vacuolar compartments and, in specialized cells, the extracellular environment. In human kidney intercalated cells, d2 co-localizes with the a4 subunit at the plasma membrane for urinary acidification [PMID:15800125]. Recent ccRCC work also reports that ATP6V0D2 promotes lysosomal acidification and activity during late autophagy [PMID:39477683]. The evidence also supports the more specific GO:0007042 lysosomal lumen acidification term for this gene.
                         </div>
                         
                         
@@ -1388,7 +1388,7 @@
                         
                         
                         <div>
-                            <strong>Reason:</strong> Keep as a plausible non-core V-ATPase localization from automated inference, but do not treat it as a defining ATP6V0D2 cellular component for the PN proteostasis review.
+                            <strong>Reason:</strong> Keep as a plausible non-core V-ATPase localization from automated inference, but do not treat it as a defining ATP6V0D2 cellular component.
                         </div>
                         
                         
@@ -2981,12 +2981,12 @@
                     <td>
                         
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> NEW annotation proposed from the Proteostasis Network projection. ATP6V0D2 is already annotated to the V0 domain (GO:0033179), the V-ATPase complex (GO:0016471), and lysosomal membrane (GO:0005765). The PN mapping recommends the more specific lysosomal V0-domain component term GO:0046610 for V0-sector lysosomal V-ATPase components.
+                            <strong>Summary:</strong> NEW annotation proposed from the Proteostasis Network projection. ATP6V0D2 is already annotated to the V0 domain (GO:0033179), the V-ATPase complex (GO:0016471), and lysosomal membrane (GO:0005765). The PN mapping recommends the more specific lysosomal V0-domain component term GO:0046610 for V0-sector lysosomal V-ATPase components. No single supporting source directly demonstrates a d2-containing lysosomal V0-domain complex; this recommendation combines existing V0-domain evidence with lysosomal-membrane annotations.
                         </div>
                         
                         
                         <div>
-                            <strong>Reason:</strong> This is a conservative compositional refinement of existing GOA rather than a novel mechanistic claim. ATP6V0D2 is the d2 V0-domain subunit and is represented in lysosomal V-ATPase Reactome contexts; GO:0046610 captures that lysosomal V0-domain component role more precisely than the existing separate V0-domain and lysosomal-membrane annotations.
+                            <strong>Reason:</strong> This is a conservative compositional refinement of existing GOA rather than a novel mechanistic claim. ATP6V0D2 is the d2 V0-domain subunit and is represented in lysosomal V-ATPase Reactome contexts; GO:0046610 captures that lysosomal V0-domain component role more precisely than the existing separate V0-domain and lysosomal-membrane annotations. The supporting literature establishes the pieces of this inference rather than directly testing lysosomal GO:0046610 membership for the d2 isoform.
                         </div>
                         
                         
@@ -4138,9 +4138,9 @@ existing_annotations:
       In human kidney intercalated cells, d2 co-localizes with the a4 subunit at
       the plasma membrane for urinary acidification [PMID:15800125]. Recent
       ccRCC work also reports that ATP6V0D2 promotes lysosomal acidification and
-      activity during late autophagy [PMID:39477683]. The Proteostasis Network
-      projection supports adding the more specific GO:0007042 lysosomal lumen
-      acidification term for this gene.
+      activity during late autophagy [PMID:39477683]. The evidence also supports
+      the more specific GO:0007042 lysosomal lumen acidification term for this
+      gene.
     action: ACCEPT
     reason: &gt;-
       This is a core function of ATP6V0D2 as part of the V-ATPase proton pump.
@@ -4228,8 +4228,7 @@ existing_annotations:
     action: KEEP_AS_NON_CORE
     reason: &gt;-
       Keep as a plausible non-core V-ATPase localization from automated inference,
-      but do not treat it as a defining ATP6V0D2 cellular component for the PN
-      proteostasis review.
+      but do not treat it as a defining ATP6V0D2 cellular component.
 - term:
     id: GO:0033179
     label: proton-transporting V-type ATPase, V0 domain
@@ -4657,14 +4656,18 @@ existing_annotations:
       is already annotated to the V0 domain (GO:0033179), the V-ATPase complex
       (GO:0016471), and lysosomal membrane (GO:0005765). The PN mapping recommends
       the more specific lysosomal V0-domain component term GO:0046610 for
-      V0-sector lysosomal V-ATPase components.
+      V0-sector lysosomal V-ATPase components. No single supporting source directly
+      demonstrates a d2-containing lysosomal V0-domain complex; this recommendation
+      combines existing V0-domain evidence with lysosomal-membrane annotations.
     action: NEW
     reason: &gt;-
       This is a conservative compositional refinement of existing GOA rather than
       a novel mechanistic claim. ATP6V0D2 is the d2 V0-domain subunit and is
       represented in lysosomal V-ATPase Reactome contexts; GO:0046610 captures
       that lysosomal V0-domain component role more precisely than the existing
-      separate V0-domain and lysosomal-membrane annotations.
+      separate V0-domain and lysosomal-membrane annotations. The supporting
+      literature establishes the pieces of this inference rather than directly
+      testing lysosomal GO:0046610 membership for the d2 isoform.
     additional_reference_ids:
     - PMID:18752060
     - PMID:39477683

--- a/genes/human/ATP6V0D2/ATP6V0D2-ai-review.html
+++ b/genes/human/ATP6V0D2/ATP6V0D2-ai-review.html
@@ -2957,7 +2957,7 @@
                         </div>
                     </td>
                     <td>
-                        <span class="evidence-code">NAS</span>
+                        <span class="evidence-code">IC</span>
                         
                         
                         
@@ -4648,7 +4648,7 @@ existing_annotations:
 - term:
     id: GO:0046610
     label: lysosomal proton-transporting V-type ATPase, V0 domain
-  evidence_type: NAS
+  evidence_type: IC
   original_reference_id: file:projects/PROTEOSTASIS/mappings/autophagy_lysosome_pathway.yaml
   review:
     summary: &gt;-

--- a/genes/human/ATP6V0D2/ATP6V0D2-ai-review.yaml
+++ b/genes/human/ATP6V0D2/ATP6V0D2-ai-review.yaml
@@ -257,11 +257,15 @@ existing_annotations:
   review:
     summary: >-
       Duplicate of IBA annotation. This IEA from InterPro correctly assigns the
-      molecular function of the V-ATPase complex to which ATP6V0D2 belongs.
+      molecular function of the V-ATPase complex to which ATP6V0D2 belongs. As
+      with the IBA row, this should be understood as ATP6V0D2 contributing to
+      the assembled complex activity rather than independently enabling ATPase
+      activity.
     action: ACCEPT
     reason: >-
       Correct annotation from InterPro mapping. The d2 subunit is integral to the
-      rotational mechanism of the V-ATPase.
+      rotational mechanism of the V-ATPase, but the biologically appropriate
+      qualifier for this structural subunit is contributes_to.
 - term:
     id: GO:1902600
     label: proton transmembrane transport

--- a/genes/human/ATP6V0D2/ATP6V0D2-ai-review.yaml
+++ b/genes/human/ATP6V0D2/ATP6V0D2-ai-review.yaml
@@ -646,7 +646,7 @@ existing_annotations:
 - term:
     id: GO:0046610
     label: lysosomal proton-transporting V-type ATPase, V0 domain
-  evidence_type: NAS
+  evidence_type: IC
   original_reference_id: file:projects/PROTEOSTASIS/mappings/autophagy_lysosome_pathway.yaml
   review:
     summary: >-

--- a/genes/human/ATP6V0D2/ATP6V0D2-ai-review.yaml
+++ b/genes/human/ATP6V0D2/ATP6V0D2-ai-review.yaml
@@ -17,12 +17,11 @@ description: >-
   ATP6V0D2 shows tissue-restricted expression, predominantly in kidney intercalated
   cells
   and osteoclasts, where V-ATPases function at the plasma membrane for urinary acidification
-  and bone resorption, respectively. Recent studies have also demonstrated that ATP6V0D2
-  facilitates autophagosome-lysosome fusion by interacting with RAB7 and HOPS complex
-  components (e.g., VPS41), thereby promoting SNARE complex assembly. This fusion-promoting
-  function is distinct from the classical proton-pumping role and has implications
-  for
-  lysosomal degradation and autophagy.
+  and bone resorption, respectively. In clear-cell renal carcinoma models,
+  ATP6V0D2 has also been reported to promote late autophagy by increasing
+  lysosomal acidification and by facilitating autophagosome-lysosome fusion through
+  RAB7/HOPS/SNARE machinery, suggesting a context-dependent role in lysosomal
+  degradative flux in addition to its established V-ATPase subunit function.
 existing_annotations:
 - term:
     id: GO:0016471
@@ -107,23 +106,23 @@ existing_annotations:
   review:
     summary: >-
       ATP6V0D2 participates in vacuolar/lysosomal function through its role in the
-      V-ATPase. Recent evidence shows ATP6V0D2 directly facilitates autophagosome-lysosome
-      fusion by interacting with RAB7 and HOPS complex components, promoting SNARE
-      complex formation [Li et al. 2025, Autophagy "ATP6V0D2 directly promotes
-      autophagosome-lysosome fusion by physically interacting with RAB7 and HOPS
-      complex
-      components"].
-    action: ACCEPT
+      V-ATPase, but "vacuolar transport" is a broad process term for this subunit.
+      The clearest established process is compartment acidification. A more recent
+      ccRCC study also supports a context-specific role in autophagosome-lysosome
+      fusion through RAB7/HOPS machinery [PMID:39477683].
+    action: KEEP_AS_NON_CORE
     reason: >-
-      This annotation is appropriate given the role of ATP6V0D2 in both vacuolar
-      acidification (via V-ATPase function) and autophagosome-lysosome fusion.
-      Recent studies provide strong evidence for the involvement of ATP6V0D2 in
-      lysosomal transport/fusion processes.
+      Retain this broad IBA term as non-core. It is consistent with V-ATPase-dependent
+      acidification and with newer late-autophagy evidence, but the core ATP6V0D2
+      functions are better represented by V-ATPase complex membership, V0-domain
+      contribution to rotary proton pumping, and vacuolar/lysosomal acidification.
+    additional_reference_ids:
+    - file:human/ATP6V0D2/ATP6V0D2-deep-research-falcon.md
     supported_by:
     - reference_id: PMID:39477683
-      supporting_text: ATP6V0D2 directly promotes autophagosome-lysosome fusion 
-        by physically interacting with RAB7 and HOPS complex components
-      full_text_unavailable: true
+      supporting_text: Mechanistically, ATP6V0D2 directly bound to RAB7 and VPS41
+        and promoted the RAB7-HOPS interaction, facilitating SNARE complex assembly
+        and autophagosome-lysosome fusion.
 - term:
     id: GO:0007035
     label: vacuolar acidification
@@ -135,11 +134,11 @@ existing_annotations:
       of
       vacuolar compartments and, in specialized cells, the extracellular environment.
       In human kidney intercalated cells, d2 co-localizes with the a4 subunit at
-      the
-      plasma membrane for urinary acidification [PMID:15800125]. Recent studies
-      show
-      that ATP6V0D2 depletion impairs lysosomal acidification in human cancer cells
-      [Li et al. 2025 Autophagy].
+      the plasma membrane for urinary acidification [PMID:15800125]. Recent
+      ccRCC work also reports that ATP6V0D2 promotes lysosomal acidification and
+      activity during late autophagy [PMID:39477683]. The Proteostasis Network
+      projection supports adding the more specific GO:0007042 lysosomal lumen
+      acidification term for this gene.
     action: ACCEPT
     reason: >-
       This is a core function of ATP6V0D2 as part of the V-ATPase proton pump.
@@ -152,9 +151,9 @@ existing_annotations:
         where it co-localized with the a4 subunit in the characteristic plasma 
         membrane-enhanced pattern
     - reference_id: PMID:39477683
-      supporting_text: 'ATP6V0D2 enhances lysosomal acidification and activity: depletion
-        increased RFP+GFP+ LC3 puncta (indicating impaired fusion/degradation)'
-      full_text_unavailable: true
+      supporting_text: ATP6V0D2 promoted autolysosome degradation by increasing
+        the acidification and activity of lysosomes during the later stages of
+        macroautophagy/autophagy.
 - term:
     id: GO:0033181
     label: plasma membrane proton-transporting V-type ATPase complex
@@ -219,22 +218,16 @@ existing_annotations:
   review:
     summary: >-
       V-ATPases are present in phagocytic vesicle membranes where they acidify the
-      phagosome. Given ATP6V0D2's role in macrophages and immune cells (facilitating
-      autophagosome-lysosome fusion and phagosome acidification), this localization
-      is plausible. Reviews note that "in macrophages ATP6V0D2 facilitates autophagosome-lysosome
-      fusion to restrain inflammasome activation and bacterial infection" [Chen
-      et
-      al.
-      2025 Biomolecules].
-    action: ACCEPT
+      phagosome, and Reactome also projects ATP6V0D2 to a phagosomal acidification
+      event. For ATP6V0D2 specifically, however, the strongest primary human evidence
+      emphasizes kidney/osteoclast plasma membrane pumps, V0-domain complex
+      membership, and lysosomal/autophagy functions rather than a directly tested
+      phagocytic-vesicle localization.
+    action: KEEP_AS_NON_CORE
     reason: >-
-      This is a reasonable localization given the known role of ATP6V0D2 in macrophages
-      and immune function. V-ATPases are required for phagosome acidification.
-    supported_by:
-    - reference_id: unindexed:chen2025biomolecules
-      supporting_text: in macrophages ATP6V0D2 facilitates 
-        autophagosome-lysosome fusion to restrain inflammasome activation and 
-        bacterial infection
+      Keep as a plausible non-core V-ATPase localization from automated inference,
+      but do not treat it as a defining ATP6V0D2 cellular component for the PN
+      proteostasis review.
 - term:
     id: GO:0033179
     label: proton-transporting V-type ATPase, V0 domain
@@ -356,22 +349,19 @@ existing_annotations:
   original_reference_id: Reactome:R-HSA-9639286
   review:
     summary: >-
-      ATP6V0D2 localizes to lysosomal membranes where it functions in V-ATPase-mediated
-      acidification and autophagosome-lysosome fusion. This is well-supported by
-      recent literature showing ATP6V0D2 at lysosomes in human cancer cells
-      [Li et al. 2025 Autophagy "In human cells, ATP6V0D2 localizes to lysosomes/acidic
-      vesicles, where it contributes to lysosomal acidification and degradative
-      capacity"].
+      Reactome places ATP6V0D2-containing V-ATPase events at the lysosomal membrane.
+      The lysosomal interpretation is also consistent with ccRCC evidence that
+      ATP6V0D2 increases lysosomal acidification/activity during autophagic
+      degradation [PMID:39477683].
     action: ACCEPT
     reason: >-
       Lysosomal membrane localization is a core annotation for ATP6V0D2, supported
       by multiple Reactome entries and primary literature.
     supported_by:
     - reference_id: PMID:39477683
-      supporting_text: In human cells, ATP6V0D2 localizes to lysosomes/acidic 
-        vesicles, where it contributes to lysosomal acidification and 
-        degradative capacity
-      full_text_unavailable: true
+      supporting_text: ATP6V0D2 promoted autolysosome degradation by increasing
+        the acidification and activity of lysosomes during the later stages of
+        macroautophagy/autophagy.
 - term:
     id: GO:0005765
     label: lysosomal membrane
@@ -460,20 +450,20 @@ existing_annotations:
     summary: >-
       The referenced paper [PMID:22982048] studies lipofuscin formation and autophagy
       but does not specifically address ATP6V0D2. It examines general V-ATPase
-      inhibition effects. However, recent literature strongly supports ATP6V0D2's
-      role in autophagy regulation, particularly autophagosome-lysosome fusion
-      [Li et al. 2025 "ATP6V0D2 directly promotes autophagosome-lysosome fusion"].
-    action: ACCEPT
+      inhibition effects. However, PMID:39477683 provides direct evidence in ccRCC
+      models that ATP6V0D2 promotes autophagosome-lysosome fusion and later
+      autolysosome degradation.
+    action: KEEP_AS_NON_CORE
     reason: >-
-      While the original reference may not specifically study ATP6V0D2, recent
-      literature confirms ATP6V0D2 regulates autophagy by facilitating
-      autophagosome-lysosome fusion. The annotation is correct based on
-      current understanding.
+      Keep the annotation because there is newer ATP6V0D2-specific evidence for
+      late macroautophagy/autophagosome-lysosome fusion, but classify it as
+      non-core because the original NAS citation is not ATP6V0D2-specific and
+      the best-established core function remains V-ATPase-mediated acidification.
     supported_by:
     - reference_id: PMID:39477683
-      supporting_text: ATP6V0D2 directly promotes autophagosome-lysosome fusion 
-        by physically interacting with RAB7 and HOPS complex components
-      full_text_unavailable: true
+      supporting_text: Mechanistically, ATP6V0D2 directly bound to RAB7 and VPS41
+        and promoted the RAB7-HOPS interaction, facilitating SNARE complex assembly
+        and autophagosome-lysosome fusion.
 - term:
     id: GO:0016324
     label: apical plasma membrane
@@ -524,10 +514,11 @@ existing_annotations:
       V-ATPases including ATP6V0D2 function in phagosome acidification. This is
       consistent with d2's role in osteoclasts (which have specialized phagocytic
       activity) and macrophages.
-    action: ACCEPT
+    action: KEEP_AS_NON_CORE
     reason: >-
-      Consistent with the known function of V-ATPases in phagosomal acidification
-      and ATP6V0D2's expression in macrophages and osteoclasts.
+      Reactome pathway context makes this plausible, but it is a generalized
+      V-ATPase/phagosome localization rather than a primary ATP6V0D2-defining
+      localization. Keep as a non-core compartmental context.
 - term:
     id: GO:0010008
     label: endosome membrane
@@ -537,10 +528,11 @@ existing_annotations:
     summary: >-
       From Reactome pathway showing ATP6AP1 binding to V-ATPase. Endosome membrane
       localization is consistent with V-ATPase function in endosomal acidification.
-    action: ACCEPT
+    action: KEEP_AS_NON_CORE
     reason: >-
-      V-ATPases function at endosome membranes for acidification. This is a
-      reasonable localization annotation.
+      V-ATPases function at endosome membranes for acidification, so this is
+      reasonable. For ATP6V0D2 specifically, the better-supported core locations
+      are lysosomal membrane and specialized apical/plasma membrane V-ATPases.
 - term:
     id: GO:0010008
     label: endosome membrane
@@ -549,9 +541,11 @@ existing_annotations:
   review:
     summary: >-
       From Reactome pathway "Endosome acidification". Core function of V-ATPase.
-    action: ACCEPT
+    action: KEEP_AS_NON_CORE
     reason: >-
-      Consistent with V-ATPase function in endosomal acidification.
+      Consistent with V-ATPase function in endosomal acidification, but retained
+      as non-core for ATP6V0D2 because the direct evidence emphasizes lysosomal
+      and specialized plasma membrane contexts.
 - term:
     id: GO:0010008
     label: endosome membrane
@@ -561,9 +555,11 @@ existing_annotations:
     summary: >-
       From Reactome pathway "Acidification of Tf:TfR1 containing endosome".
       V-ATPases acidify endosomes containing transferrin receptor.
-    action: ACCEPT
+    action: KEEP_AS_NON_CORE
     reason: >-
-      Consistent with V-ATPase function in endosomal acidification.
+      Consistent with V-ATPase function in endosomal acidification, but retained
+      as non-core for ATP6V0D2 because the direct evidence emphasizes lysosomal
+      and specialized plasma membrane contexts.
 - term:
     id: GO:0005515
     label: protein binding
@@ -622,6 +618,64 @@ existing_annotations:
       supporting_text: d1-GST and d2-GST, but not GST alone, are each able to 
         pull down the H+-ATPase D and F subunits from solubilized human kidney 
         membrane preparations
+- term:
+    id: GO:0007042
+    label: lysosomal lumen acidification
+  evidence_type: NAS
+  original_reference_id: file:projects/PROTEOSTASIS/mappings/autophagy_lysosome_pathway.yaml
+  review:
+    summary: >-
+      NEW annotation proposed from the Proteostasis Network projection. ATP6V0D2
+      already has the broader GO:0007035 vacuolar acidification annotation, and
+      the PN autophagy-lysosome mapping projects the lysosomal acidification branch
+      to GO:0007042. PMID:39477683 provides ATP6V0D2-specific support for increased
+      lysosomal acidification/activity in late autophagy.
+    action: NEW
+    reason: >-
+      This is a conservative PN projection because it is more specific than the
+      existing vacuolar acidification GOA term and is supported by ATP6V0D2's
+      lysosomal V-ATPase context. It should be added as a lysosome-specific
+      acidification annotation rather than as a broad proteostasis-process claim.
+    additional_reference_ids:
+    - PMID:39477683
+    - file:human/ATP6V0D2/ATP6V0D2-deep-research-falcon.md
+    supported_by:
+    - reference_id: PMID:39477683
+      supporting_text: ATP6V0D2 promoted autolysosome degradation by increasing
+        the acidification and activity of lysosomes during the later stages of
+        macroautophagy/autophagy.
+- term:
+    id: GO:0046610
+    label: lysosomal proton-transporting V-type ATPase, V0 domain
+  evidence_type: NAS
+  original_reference_id: file:projects/PROTEOSTASIS/mappings/autophagy_lysosome_pathway.yaml
+  review:
+    summary: >-
+      NEW annotation proposed from the Proteostasis Network projection. ATP6V0D2
+      is already annotated to the V0 domain (GO:0033179), the V-ATPase complex
+      (GO:0016471), and lysosomal membrane (GO:0005765). The PN mapping recommends
+      the more specific lysosomal V0-domain component term GO:0046610 for
+      V0-sector lysosomal V-ATPase components.
+    action: NEW
+    reason: >-
+      This is a conservative compositional refinement of existing GOA rather than
+      a novel mechanistic claim. ATP6V0D2 is the d2 V0-domain subunit and is
+      represented in lysosomal V-ATPase Reactome contexts; GO:0046610 captures
+      that lysosomal V0-domain component role more precisely than the existing
+      separate V0-domain and lysosomal-membrane annotations.
+    additional_reference_ids:
+    - PMID:18752060
+    - PMID:39477683
+    - file:human/ATP6V0D2/ATP6V0D2-deep-research-falcon.md
+    supported_by:
+    - reference_id: PMID:18752060
+      supporting_text: The multi-subunit vacuolar-type H(+)-ATPase consists of a
+        V(1) domain (A-H subunits) catalyzing ATP hydrolysis and a V(0) domain
+        (a, c, c', c", d, e) responsible for H(+) translocation.
+    - reference_id: PMID:39477683
+      supporting_text: it promoted autophagic degradation of EPAS1 by upregulating
+        the ATPase subunit ATP6V0D2 (ATPase H+ transporting V0 subunit d2) to
+        increase lysosomal function
 references:
 - id: GO_REF:0000002
   title: Gene Ontology annotation through association of InterPro records with 
@@ -712,6 +766,31 @@ references:
 - id: Reactome:R-HSA-9646468
   title: mTORC1 binds RHEB:GTP
   findings: []
+- id: PMID:39477683
+  title: Atractylenolide I inhibits angiogenesis and reverses sunitinib resistance
+    in clear cell renal cell carcinoma through ATP6V0D2-mediated autophagic
+    degradation of EPAS1/HIF2alpha.
+  findings:
+  - statement: ATP6V0D2 promotes autophagosome-lysosome fusion through RAB7/HOPS
+      and SNARE-complex assembly in ccRCC models.
+  - statement: ATP6V0D2 increases lysosomal acidification and activity during
+      late autophagy in ccRCC models.
+- id: file:human/ATP6V0D2/ATP6V0D2-deep-research-falcon.md
+  title: Falcon deep research report for ATP6V0D2
+  findings:
+  - statement: ATP6V0D2 is a V-ATPase V0 d2 subunit with evidence for specialized
+      kidney, osteoclast, lysosomal, and late-autophagy roles.
+- id: file:human/ATP6V0D2/ATP6V0D2-notes.md
+  title: ATP6V0D2 PN curation notes
+  findings:
+  - statement: Manual PN review treated lysosomal acidification and lysosomal
+      V0-domain projection as conservative new annotation candidates, while keeping
+      broader proteostasis/autophagy claims non-core.
+- id: file:projects/PROTEOSTASIS/mappings/autophagy_lysosome_pathway.yaml
+  title: Proteostasis Network autophagy-lysosome pathway mappings
+  findings:
+  - statement: PN mappings project the lysosomal acidification node to GO:0007042
+      and the V0 lysosomal V-ATPase component node to GO:0046610.
 core_functions:
 - description: >-
     ATP6V0D2 is a structural component of the V0 domain of the vacuolar H+-ATPase,
@@ -720,7 +799,7 @@ core_functions:
     coupling ATP hydrolysis to proton translocation. Direct biochemical evidence
     from pull-down and in vitro binding experiments [PMID:18752060]; structural
     modeling showing d2 is orthologous to bacterial A-ATPase subunit C.
-  molecular_function:
+  contributes_to_molecular_function:
     id: GO:0046961
     label: proton-transporting ATPase activity, rotational mechanism
   in_complex:
@@ -730,35 +809,25 @@ core_functions:
     As part of the V-ATPase, ATP6V0D2 contributes to acidification of intracellular
     compartments (lysosomes, endosomes) and extracellular spaces (in specialized
     cells like kidney intercalated cells and osteoclasts). Immunolocalization in
-    kidney intercalated cells [PMID:15800125]; functional studies showing ATP6V0D2
-    depletion impairs lysosomal acidification [Li et al. 2025 Autophagy].
-  molecular_function:
+    kidney intercalated cells [PMID:15800125]; ccRCC autophagy experiments showing
+    ATP6V0D2-dependent lysosomal acidification/activity [PMID:39477683].
+  contributes_to_molecular_function:
     id: GO:0046961
     label: proton-transporting ATPase activity, rotational mechanism
   directly_involved_in:
   - id: GO:0007035
     label: vacuolar acidification
+  - id: GO:0007042
+    label: lysosomal lumen acidification
   locations:
   - id: GO:0005765
     label: lysosomal membrane
   - id: GO:0016324
     label: apical plasma membrane
-- description: >-
-    ATP6V0D2 facilitates autophagosome-lysosome fusion independent of its role
-    in proton pumping, by directly interacting with RAB7 and HOPS complex
-    components (VPS41), promoting SNARE complex assembly. Co-IP, GST pulldown,
-    and colocalization studies in human cells [Li et al. 2025 Autophagy] showing
-    direct interaction with RAB7 and VPS41; knockdown impairs fusion and increases
-    autophagosome accumulation.
-  molecular_function:
-    id: GO:0046961
-    label: proton-transporting ATPase activity, rotational mechanism
-  directly_involved_in:
-  - id: GO:0016241
-    label: regulation of macroautophagy
-  locations:
-  - id: GO:0005765
-    label: lysosomal membrane
+  supported_by:
+  - reference_id: file:human/ATP6V0D2/ATP6V0D2-deep-research-falcon.md
+    supporting_text: 'Lysosomal acidification and degradation in human cells:
+      The same study shows ATP6V0D2 enhances lysosomal acidification and activity'
 proposed_new_terms: []
 suggested_questions:
 - question: >-
@@ -772,6 +841,10 @@ suggested_questions:
     its incorporation into the V-ATPase complex? Recent studies suggest ATP6V0D2
     promotes fusion via RAB7/HOPS interactions. It is unclear whether this
     requires assembled V-ATPase or if d2 has an independent fusion-promoting function.
+- question: >-
+    Should the PN-projected GO:0046610 lysosomal proton-transporting V-type ATPase,
+    V0 domain annotation be added by propagation for ATP6V0D2, or should it wait
+    for direct lysosomal V0-domain complex evidence specific to the d2 isoform?
 suggested_experiments:
 - description: >-
     Test whether ATP6V0D2 mutants that cannot interact with D/F subunits

--- a/genes/human/ATP6V0D2/ATP6V0D2-ai-review.yaml
+++ b/genes/human/ATP6V0D2/ATP6V0D2-ai-review.yaml
@@ -136,9 +136,9 @@ existing_annotations:
       In human kidney intercalated cells, d2 co-localizes with the a4 subunit at
       the plasma membrane for urinary acidification [PMID:15800125]. Recent
       ccRCC work also reports that ATP6V0D2 promotes lysosomal acidification and
-      activity during late autophagy [PMID:39477683]. The Proteostasis Network
-      projection supports adding the more specific GO:0007042 lysosomal lumen
-      acidification term for this gene.
+      activity during late autophagy [PMID:39477683]. The evidence also supports
+      the more specific GO:0007042 lysosomal lumen acidification term for this
+      gene.
     action: ACCEPT
     reason: >-
       This is a core function of ATP6V0D2 as part of the V-ATPase proton pump.
@@ -226,8 +226,7 @@ existing_annotations:
     action: KEEP_AS_NON_CORE
     reason: >-
       Keep as a plausible non-core V-ATPase localization from automated inference,
-      but do not treat it as a defining ATP6V0D2 cellular component for the PN
-      proteostasis review.
+      but do not treat it as a defining ATP6V0D2 cellular component.
 - term:
     id: GO:0033179
     label: proton-transporting V-type ATPase, V0 domain
@@ -655,14 +654,18 @@ existing_annotations:
       is already annotated to the V0 domain (GO:0033179), the V-ATPase complex
       (GO:0016471), and lysosomal membrane (GO:0005765). The PN mapping recommends
       the more specific lysosomal V0-domain component term GO:0046610 for
-      V0-sector lysosomal V-ATPase components.
+      V0-sector lysosomal V-ATPase components. No single supporting source directly
+      demonstrates a d2-containing lysosomal V0-domain complex; this recommendation
+      combines existing V0-domain evidence with lysosomal-membrane annotations.
     action: NEW
     reason: >-
       This is a conservative compositional refinement of existing GOA rather than
       a novel mechanistic claim. ATP6V0D2 is the d2 V0-domain subunit and is
       represented in lysosomal V-ATPase Reactome contexts; GO:0046610 captures
       that lysosomal V0-domain component role more precisely than the existing
-      separate V0-domain and lysosomal-membrane annotations.
+      separate V0-domain and lysosomal-membrane annotations. The supporting
+      literature establishes the pieces of this inference rather than directly
+      testing lysosomal GO:0046610 membership for the d2 isoform.
     additional_reference_ids:
     - PMID:18752060
     - PMID:39477683

--- a/genes/human/ATP6V0D2/ATP6V0D2-ai-review.yaml
+++ b/genes/human/ATP6V0D2/ATP6V0D2-ai-review.yaml
@@ -52,6 +52,7 @@ existing_annotations:
 - term:
     id: GO:0046961
     label: proton-transporting ATPase activity, rotational mechanism
+  qualifier: contributes_to
   evidence_type: IBA
   original_reference_id: GO_REF:0000033
   review:
@@ -252,6 +253,7 @@ existing_annotations:
 - term:
     id: GO:0046961
     label: proton-transporting ATPase activity, rotational mechanism
+  qualifier: enables
   evidence_type: IEA
   original_reference_id: GO_REF:0000002
   review:
@@ -625,7 +627,7 @@ existing_annotations:
     id: GO:0007042
     label: lysosomal lumen acidification
   evidence_type: NAS
-  original_reference_id: file:projects/PROTEOSTASIS/mappings/autophagy_lysosome_pathway.yaml
+  original_reference_id: PMID:39477683
   review:
     summary: >-
       NEW annotation proposed from the Proteostasis Network projection. ATP6V0D2
@@ -640,7 +642,7 @@ existing_annotations:
       lysosomal V-ATPase context. It should be added as a lysosome-specific
       acidification annotation rather than as a broad proteostasis-process claim.
     additional_reference_ids:
-    - PMID:39477683
+    - file:projects/PROTEOSTASIS/mappings/autophagy_lysosome_pathway.yaml
     - file:human/ATP6V0D2/ATP6V0D2-deep-research-falcon.md
     supported_by:
     - reference_id: PMID:39477683
@@ -651,7 +653,7 @@ existing_annotations:
     id: GO:0046610
     label: lysosomal proton-transporting V-type ATPase, V0 domain
   evidence_type: IC
-  original_reference_id: file:projects/PROTEOSTASIS/mappings/autophagy_lysosome_pathway.yaml
+  original_reference_id: PMID:18752060
   review:
     summary: >-
       NEW annotation proposed from the Proteostasis Network projection. ATP6V0D2
@@ -660,7 +662,8 @@ existing_annotations:
       the more specific lysosomal V0-domain component term GO:0046610 for
       V0-sector lysosomal V-ATPase components. No single supporting source directly
       demonstrates a d2-containing lysosomal V0-domain complex; this recommendation
-      combines existing V0-domain evidence with lysosomal-membrane annotations.
+      combines the accepted GO:0033179 V0-domain annotation with accepted GO:0005765
+      lysosomal-membrane annotations.
     action: NEW
     reason: >-
       This is a conservative compositional refinement of existing GOA rather than
@@ -671,7 +674,7 @@ existing_annotations:
       literature establishes the pieces of this inference rather than directly
       testing lysosomal GO:0046610 membership for the d2 isoform.
     additional_reference_ids:
-    - PMID:18752060
+    - file:projects/PROTEOSTASIS/mappings/autophagy_lysosome_pathway.yaml
     - PMID:39477683
     - file:human/ATP6V0D2/ATP6V0D2-deep-research-falcon.md
     supported_by:

--- a/genes/human/ATP6V0D2/ATP6V0D2-notes.md
+++ b/genes/human/ATP6V0D2/ATP6V0D2-notes.md
@@ -1,0 +1,66 @@
+# ATP6V0D2 review notes
+
+## Core function
+
+ATP6V0D2 encodes the d2 isoform of the V-ATPase V0 d subunit. The core function
+is as a structural V0-sector component that contributes to the assembled
+V-ATPase rotary proton pump, not as an independently catalytic ATPase. Smith et
+al. show that the mammalian V0 d subunit has d1 and d2 forms and that d2 is
+predominantly expressed in kidney and osteoclast [PMID:18752060 "d2 is predominantly expressed at the cell surface in kidney and osteoclast"].
+The same paper supports a central-stalk/rotary mechanism role because the human
+d subunits pull down V1 D and F subunits and the authors conclude that the d
+subunit is centrally located in the pump [PMID:18752060 "the d subunit in man forms part of the pump's central stalk"].
+
+The direct tissue-localization evidence supports specialized plasma membrane
+V-ATPases in kidney intercalated cells and osteoclasts. Smith et al. report
+human collecting-duct intercalated-cell staining that co-localized with the a4
+subunit [PMID:15800125 "high-intensity d2 staining was observed only in intercalated cells of the collecting duct in fresh-frozen human kidney"] and bone
+osteoclast co-localization with a3 [PMID:15800125 "In human bone, d2 co-localized with the a3 subunit in osteoclasts"].
+
+## PN projection
+
+Falcon deep research already existed as
+`genes/human/ATP6V0D2/ATP6V0D2-deep-research-falcon.md`, so this was handled as
+a PN-context re-review rather than a new deep-research run.
+
+The PN projection has two ATP6V0D2 candidate additions from
+`projects/PROTEOSTASIS/reports/pn_projection/pn_projected_gene_go_summary.tsv`:
+`GO:0007042 lysosomal lumen acidification` and `GO:0046610 lysosomal proton-transporting V-type ATPase, V0 domain`.
+I treated both as conservative `action: NEW` recommendations. `GO:0007042` is
+a specific child/refinement of the existing GOA `GO:0007035 vacuolar
+acidification` and is supported by the ATP6V0D2-specific Autophagy abstract,
+which states that ATP6V0D2 promoted autolysosome degradation by increasing
+lysosomal acidification/activity [PMID:39477683 "ATP6V0D2 promoted autolysosome degradation by increasing the acidification and activity of lysosomes"].
+
+`GO:0046610` is a compositional PN refinement, not a single direct experiment:
+ATP6V0D2 is already in GOA as V0 domain, V-ATPase complex, and lysosomal
+membrane, and the PN mapping
+`Autophagy-Lysosome Pathway|Pre-initiation autophagy signaling|mTORC1 pathway, upstream|Nutrient sensing|V0 lysosomal v-ATPase proton pump component`
+targets `GO:0046610` [file:projects/PROTEOSTASIS/mappings/autophagy_lysosome_pathway.yaml].
+Because this depends on combining existing GOA/Reactome context with V0-subunit
+identity, I recorded it as a conservative proposed annotation and added an expert
+question about whether direct d2-specific lysosomal V0-domain evidence should be
+required.
+
+## Conservative annotation decisions
+
+- Kept `GO:0007035 vacuolar acidification`, V-ATPase complex, V0 domain, and
+  plasma membrane V-ATPase complex as core.
+- Added PN-projected `GO:0007042` and `GO:0046610` as `NEW` recommendations.
+- Moved broad `GO:0007034 vacuolar transport` to non-core because acidification
+  is the cleaner core process.
+- Kept macroautophagy regulation as non-core. PMID:39477683 supports a real
+  late-autophagy/fusion role, but the original GOA citation PMID:22982048 is not
+  ATP6V0D2-specific and instead addresses lipofuscin/autophagy generally
+  [PMID:22982048 "macroautophagy is responsible for the uptake of lipofuscin into the lysosomes"].
+- Kept phagocytic vesicle membrane and endosome membrane localizations as
+  non-core Reactome/automated contexts rather than ATP6V0D2-defining locations.
+- Removed generic `GO:0005515 protein binding` annotations because they are less
+  informative than V-ATPase complex membership and specific mechanistic process
+  annotations.
+
+## Description cleanup note
+
+The YAML description was kept project-independent. PN-specific rationale and
+curation commentary are recorded here and in individual annotation review
+reasons, not in the top-level biological summary.


### PR DESCRIPTION
## Summary

- Re-reviewed human `ATP6V0D2` in Proteostasis PN context using the existing Falcon deep research report.
- Evaluated the PN projection conservatively: added `GO:0007042 lysosomal lumen acidification` and `GO:0046610 lysosomal proton-transporting V-type ATPase, V0 domain` as `action: NEW` recommendations.
- Kept broad/contextual proteostasis rows non-core where appropriate, including broad vacuolar transport, macroautophagy regulation, phagocytic vesicle membrane, and endosome membrane; retained core V-ATPase complex, V0-domain, acidification, and specialized plasma membrane annotations.
- Added `ATP6V0D2-notes.md` with PN rationale and regenerated `genes/human/ATP6V0D2/ATP6V0D2-ai-review.html`.

## Validation

- `just fetch-gene-pmids human ATP6V0D2`
- `just validate human ATP6V0D2`
- `just render human ATP6V0D2`
