### PR TITLE
Regenerate pages and browser app

### DIFF
--- a/genes/PSEPK/eda/eda-ai-review.html
+++ b/genes/PSEPK/eda/eda-ai-review.html
@@ -1297,6 +1297,146 @@
                 <div class="reference-header">
                     <span class="reference-id">
                         
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/12393206" target="_blank" class="term-link">
+                            PMID:12393206
+                        </a>
+                        
+                    </span>
+                </div>
+                
+                <div class="reference-title">Analysis of the zwf-pgl-eda-operon in Pseudomonas putida strains H and KT2440.</div>
+                
+                
+                <ul class="findings-list">
+                    
+                    <li class="finding-item">
+                        <div class="finding-statement">In KT2440, eda is part of the zwf-pgl-eda operon, with the divergently transcribed regulator hexR nearby; the operon is induced by carbohydrates including glucose, gluconate, fructose, and glycerol.</div>
+                        
+                    </li>
+                    
+                    <li class="finding-item">
+                        <div class="finding-statement">Operon transcription in KT2440 was about 3-fold higher than in strain H, indicating strain-level differences in expression control.</div>
+                        
+                    </li>
+                    
+                </ul>
+                
+            </div>
+            
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+                        
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/23967821" target="_blank" class="term-link">
+                            PMID:23967821
+                        </a>
+                        
+                    </span>
+                </div>
+                
+                <div class="reference-title">Metabolic and regulatory rearrangements underlying glycerol metabolism in Pseudomonas putida KT2440.</div>
+                
+                
+                <ul class="findings-list">
+                    
+                    <li class="finding-item">
+                        <div class="finding-statement">An eda::mini-Tn5 mutant in KT2440 fails to grow on glucose but grows slowly on glycerol (mu=0.21+/-0.05 h^-1) and succinate (mu=0.34+/-0.02 h^-1).</div>
+                        
+                    </li>
+                    
+                    <li class="finding-item">
+                        <div class="finding-statement">Eda activity in extracts of glucose-grown KT2440 is 635+/-141 units, 2.2-fold higher than on glycerol; transcript expression hierarchy is glucose greater than glycerol greater than succinate.</div>
+                        
+                    </li>
+                    
+                </ul>
+                
+            </div>
+            
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+                        
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/26350459" target="_blank" class="term-link">
+                            PMID:26350459
+                        </a>
+                        
+                    </span>
+                </div>
+                
+                <div class="reference-title">Pseudomonas putida KT2440 strain metabolizes glucose through a cycle formed by enzymes of the Entner-Doudoroff, Embden-Meyerhof-Parnas, and pentose phosphate pathways.</div>
+                
+                
+                <ul class="findings-list">
+                    
+                    <li class="finding-item">
+                        <div class="finding-statement">In KT2440, more than 80 percent of glucose influx is routed through periplasmic oxidation and the Entner-Doudoroff pathway contributes about 50 percent of the flux to pyruvate, placing Eda at a high-flux node in central carbon metabolism.</div>
+                        
+                    </li>
+                    
+                </ul>
+                
+            </div>
+            
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+                        
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/16403639" target="_blank" class="term-link">
+                            PMID:16403639
+                        </a>
+                        
+                    </span>
+                </div>
+                
+                <div class="reference-title">Mechanism of the Class I KDPG aldolase.</div>
+                
+                
+                <ul class="findings-list">
+                    
+                    <li class="finding-item">
+                        <div class="finding-statement">Class I KDPG aldolases including the Pseudomonas putida enzyme operate via a Schiff-base (covalent imine) intermediate formed by a conserved active-site lysine, with a conserved glutamate as general acid/base; the fold is a TIM (alpha/beta) barrel forming a trimeric assembly.</div>
+                        
+                    </li>
+                    
+                </ul>
+                
+            </div>
+            
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+                        
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/39589324" target="_blank" class="term-link">
+                            PMID:39589324
+                        </a>
+                        
+                    </span>
+                </div>
+                
+                <div class="reference-title">GnuR Represses the Expression of Glucose and Gluconate Catabolism in Pseudomonas putida KT2440.</div>
+                
+                
+                <ul class="findings-list">
+                    
+                    <li class="finding-item">
+                        <div class="finding-statement">GnuR is a transcriptional repressor that directly represses glucose and gluconate catabolic genes including ED-pathway genes such as eda (ChIP-seq enrichment ~1.74 at the eda locus), participating in an incoherent feedforward loop with glucose/gluconate induction.</div>
+                        
+                    </li>
+                    
+                    <li class="finding-item">
+                        <div class="finding-statement">ΔgnuR shortens lag time on 22 mM glucose or 4 mM gluconate without changing exponential growth rate, indicating GnuR primarily tunes transition dynamics for catabolite switching.</div>
+                        
+                    </li>
+                    
+                </ul>
+                
+            </div>
+            
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+                        
                         file:PSEPK/eda/eda-deep-research-falcon.md
                         
                     </span>
@@ -1512,7 +1652,7 @@
                     <span class="report-badge">2 artifacts</span>
                     
                     
-                    <span class="report-meta-text">2026-06-01T07:47:42.057532</span>
+                    <span class="report-meta-text">2026-05-22T22:02:14.935277</span>
                     
                     
                     
@@ -1973,6 +2113,50 @@ references:
   - statement: Eda belongs to the KHG/KDPG aldolase family and is predicted to form
       a homotrimer
     supporting_text: &#39;SIMILARITY: Belongs to the KHG/KDPG aldolase family.&#39;
+- id: PMID:12393206
+  title: Analysis of the zwf-pgl-eda-operon in Pseudomonas putida strains H and KT2440.
+  findings:
+  - statement: In KT2440, eda is part of the zwf-pgl-eda operon, with the divergently
+      transcribed regulator hexR nearby; the operon is induced by carbohydrates including
+      glucose, gluconate, fructose, and glycerol.
+  - statement: Operon transcription in KT2440 was about 3-fold higher than in strain
+      H, indicating strain-level differences in expression control.
+- id: PMID:23967821
+  title: Metabolic and regulatory rearrangements underlying glycerol metabolism in
+    Pseudomonas putida KT2440.
+  findings:
+  - statement: An eda::mini-Tn5 mutant in KT2440 fails to grow on glucose but grows
+      slowly on glycerol (mu=0.21+/-0.05 h^-1) and succinate (mu=0.34+/-0.02 h^-1).
+  - statement: Eda activity in extracts of glucose-grown KT2440 is 635+/-141 units,
+      2.2-fold higher than on glycerol; transcript expression hierarchy is glucose
+      greater than glycerol greater than succinate.
+- id: PMID:26350459
+  title: Pseudomonas putida KT2440 strain metabolizes glucose through a cycle formed
+    by enzymes of the Entner-Doudoroff, Embden-Meyerhof-Parnas, and pentose phosphate
+    pathways.
+  findings:
+  - statement: In KT2440, more than 80 percent of glucose influx is routed through
+      periplasmic oxidation and the Entner-Doudoroff pathway contributes about 50
+      percent of the flux to pyruvate, placing Eda at a high-flux node in central
+      carbon metabolism.
+- id: PMID:16403639
+  title: Mechanism of the Class I KDPG aldolase.
+  findings:
+  - statement: Class I KDPG aldolases including the Pseudomonas putida enzyme operate
+      via a Schiff-base (covalent imine) intermediate formed by a conserved active-site
+      lysine, with a conserved glutamate as general acid/base; the fold is a TIM
+      (alpha/beta) barrel forming a trimeric assembly.
+- id: PMID:39589324
+  title: GnuR Represses the Expression of Glucose and Gluconate Catabolism in Pseudomonas
+    putida KT2440.
+  findings:
+  - statement: GnuR is a transcriptional repressor that directly represses glucose
+      and gluconate catabolic genes including ED-pathway genes such as eda (ChIP-seq
+      enrichment ~1.74 at the eda locus), participating in an incoherent feedforward
+      loop with glucose/gluconate induction.
+  - statement: ΔgnuR shortens lag time on 22 mM glucose or 4 mM gluconate without
+      changing exponential growth rate, indicating GnuR primarily tunes transition
+      dynamics for catabolite switching.
 - id: file:PSEPK/eda/eda-deep-research-falcon.md
   title: &#39;Falcon (Edison Scientific) deep research report: eda (PP_1024; UniProt Q88P29)
     in Pseudomonas putida KT2440&#39;


### PR DESCRIPTION
## Summary

Automated regeneration of static assets after gene review or template changes.

## Generated Assets

| Asset | Count/Status |
|-------|--------------|
| Gene review YAML files | 2067 |
| Gene review HTML pages | 2067 |
| Project pages | 129 |
| Browser app (data.js) | Updated |
| Validation report | Updated |

## Trigger

This PR was triggered by changes to:
- genes/**/*.yaml - gene review data files
- src/ai_gene_review/schema/** - LinkML schema files
- src/ai_gene_review/templates/** - Jinja2 templates
- src/ai_gene_review/render.py - rendering code
- src/ai_gene_review/export/** - export code
- src/ai_gene_review/browser/** - browser app assets
- src/ai_gene_review/tools/minify_linkml_browser_data.py - browser data compaction
- projects/*.md - project definitions
- project.justfile - just recipes used by CI
- .github/workflows/generate-pages.yaml - workflow definition

## Review

- [ ] Spot-check a few gene review HTML pages render correctly
- [ ] Verify browser app loads and filters work
- [ ] Check validation report for new issues
