### PR TITLE
Regenerate pages and browser app

### DIFF
--- a/genes/human/TIMM22/TIMM22-ai-review.html
+++ b/genes/human/TIMM22/TIMM22-ai-review.html
@@ -3098,6 +3098,24 @@
                 <div class="reference-title">Organization and function of the small Tim complexes acting along the import pathway of metabolite carriers into mammalian mitochondria.</div>
                 
                 
+                <ul class="findings-list">
+                    
+                    <li class="finding-item">
+                        <div class="finding-statement">Human small Tim proteins (Tim9, Tim10a, Tim10b) form two hetero-oligomeric complexes including a 450-kDa assembly that operates along the TIM22 carrier import pathway.</div>
+                        
+                        <div class="finding-text">"Here, we show that the human small  proteins form two distinct hetero-oligomeric complexes. A 70-kDa complex that  contains Tim9 and Tim10a and a Tim9-10a-10b that is part of a higher molecular  weight assembly of 450 kDa."</div>
+                        
+                    </li>
+                    
+                    <li class="finding-item">
+                        <div class="finding-statement">During import the small Tim chaperones deliver carrier preproteins to human Tim22, identified as the putative insertion pore of the TIM22 translocase.</div>
+                        
+                        <div class="finding-text">"For  insertion of carrier preproteins into the inner membrane, the human small Tim  proteins directly interact with human Tim22, the putative insertion pore of the  TIM22 translocase."</div>
+                        
+                    </li>
+                    
+                </ul>
+                
             </div>
             
             <div class="reference-item">
@@ -3113,6 +3131,31 @@
                 
                 <div class="reference-title">The presence of disulfide bonds reveals an evolutionarily conserved mechanism involved in mitochondrial protein translocase assembly.</div>
                 
+                
+                <ul class="findings-list">
+                    
+                    <li class="finding-item">
+                        <div class="finding-statement">TIMM22 is a core inner-membrane translocase component of the Tim17/Tim22/Tim23 family that forms intramolecular disulfide bonds required for proper assembly into the TIM22 complex.</div>
+                        
+                        <div class="finding-text">"Tim22, a membrane protein  and core component of the mitochondrial translocase TIM22, forms an  intramolecular disulfide bond in yeast. Tim22 belongs to the Tim17/Tim22/Tim23  family of protein translocases."</div>
+                        
+                    </li>
+                    
+                    <li class="finding-item">
+                        <div class="finding-statement">Human TIMM22 carries two intramolecular disulfide bonds (Cys69-Cys141 and Cys160-Cys179), and the Cys160-Cys179 bond is prerequisite for TIMM22 assembly into the mature TIM22 complex.</div>
+                        
+                        <div class="finding-text">"Altogether, the biochemical analyses and transmembrane prediction for human TIMM22 indicate that one disulfide bond could be formed on the IMS side of TIMM22 between Cys69 and Cys141, and another disulfide bond that joins the TM3 and TM4 is formed between Cys160 and Cys179"</div>
+                        
+                    </li>
+                    
+                    <li class="finding-item">
+                        <div class="finding-statement">Loss of the TIMM22 disulfide bond linking Cys160-Cys179 abolishes assembly into the mature human TIM22 translocase despite retained membrane integration.</div>
+                        
+                        <div class="finding-text">"Thus, the lack of the second disulfide bond that is present in the human TIMM22 structure renders the protein unable to assemble into the mature TIM22 complex, despite its ability for membrane integration"</div>
+                        
+                    </li>
+                    
+                </ul>
                 
             </div>
             
@@ -3130,6 +3173,31 @@
                 <div class="reference-title">Tim29 is a novel subunit of the human TIM22 translocase and is involved in complex assembly and stability.</div>
                 
                 
+                <ul class="findings-list">
+                    
+                    <li class="finding-item">
+                        <div class="finding-statement">TIM22 mediates import of hydrophobic carrier proteins into the mitochondrial inner membrane, and Tim29 (C19orf52) was identified as a metazoan-specific subunit of the human TIM22 complex.</div>
+                        
+                        <div class="finding-text">"The TIM22 complex mediates the import of hydrophobic carrier proteins into the  mitochondrial inner membrane... we  identify Tim29 (C19orf52) as a novel, metazoan-specific subunit of the human  TIM22 complex."</div>
+                        
+                    </li>
+                    
+                    <li class="finding-item">
+                        <div class="finding-statement">Tim29 is required for assembly and stability of the human TIM22 complex and links it to the TOM complex for transfer of hydrophobic substrates across the intermembrane space.</div>
+                        
+                        <div class="finding-text">"Tim29 is required for  the stability of the TIM22 complex and functions in the assembly of hTim22.  Furthermore, Tim29 contacts the Translocase of the Outer Mitochondrial Membrane,  TOM complex, enabling a mechanism for transport of hydrophobic carrier  substrates across the aqueous intermembrane space."</div>
+                        
+                    </li>
+                    
+                    <li class="finding-item">
+                        <div class="finding-statement">The human TIM22 complex migrates at ~450 kDa and contains TIMM22 as the channel-forming subunit together with the small TIM chaperones hTim9, hTim10a and hTim10b.</div>
+                        
+                        <div class="finding-text">"Like yeast, the human TIM22 complex consists of the channel-forming hTim22 protein, along with subunits of the small TIM family, hTim9, hTim10a, and hTim10b"</div>
+                        
+                    </li>
+                    
+                </ul>
+                
             </div>
             
             <div class="reference-item">
@@ -3145,6 +3213,31 @@
                 
                 <div class="reference-title">TIM29 is a subunit of the human carrier translocase required for protein transport.</div>
                 
+                
+                <ul class="findings-list">
+                    
+                    <li class="finding-item">
+                        <div class="finding-statement">Hydrophobic inner-membrane proteins with internal targeting signals such as metabolite carriers are inserted into the inner membrane by the TIM22 carrier translocase, and defects in this pathway are linked to neurodegenerative disorders.</div>
+                        
+                        <div class="finding-text">"Hydrophobic inner mitochondrial membrane proteins with internal targeting  signals, such as the metabolite carriers, use the carrier translocase (TIM22  complex) for transport into the inner membrane. Defects in this transport  pathway have been associated with neurodegenerative disorders."</div>
+                        
+                    </li>
+                    
+                    <li class="finding-item">
+                        <div class="finding-statement">TIM29 is a 440 kDa human TIM22 complex constituent that interacts with oxidized TIMM22 and is required for structural integrity of the complex and import of carrier substrates.</div>
+                        
+                        <div class="finding-text">"We show that TIM29 is a constituent of the 440 kDa TIM22 complex and interacts with oxidized TIM22. Our analyses  demonstrate that TIM29 is required for the structural integrity of the TIM22  complex and for import of substrate proteins by the carrier translocase."</div>
+                        
+                    </li>
+                    
+                    <li class="finding-item">
+                        <div class="finding-statement">TIMM22 is the central pore-forming subunit of the carrier translocase whose human form shares ~40% identity with yeast Tim22 and is conserved across eukaryotes.</div>
+                        
+                        <div class="finding-text">"Tim22 is the central, pore‐forming, subunit of the complex... The human TIM22 displays 40% homology with the yeast Tim22"</div>
+                        
+                    </li>
+                    
+                </ul>
                 
             </div>
             
@@ -3162,6 +3255,24 @@
                 <div class="reference-title">Acylglycerol Kinase Mutated in Sengers Syndrome Is a Subunit of the TIM22 Protein Translocase in Mitochondria.</div>
                 
                 
+                <ul class="findings-list">
+                    
+                    <li class="finding-item">
+                        <div class="finding-statement">AGK, the lipid kinase mutated in Sengers syndrome, was identified as a constituent of the inner-membrane TIM22 complex that assembles with TIMM22 and TIMM29 to support import of a subset of multi-spanning membrane proteins.</div>
+                        
+                        <div class="finding-text">"Determining its mitochondrial interactome, we have identified  AGK as a constituent of the TIM22 complex in the mitochondrial inner membrane.  AGK assembles with TIMM22 and TIMM29 and supports the import of a subset of  multi-spanning membrane proteins."</div>
+                        
+                    </li>
+                    
+                    <li class="finding-item">
+                        <div class="finding-statement">AGK&#39;s role as a TIM22 subunit is kinase-independent, linking Sengers syndrome pathogenesis to defects in TIM22-mediated mitochondrial protein biogenesis as well as phospholipid metabolism.</div>
+                        
+                        <div class="finding-text">"The function of AGK as a subunit of the TIM22  complex does not depend on its kinase activity... The dual function of AGK as lipid kinase and  constituent of the TIM22 complex reveals that disturbances in both phospholipid  metabolism and mitochondrial protein biogenesis contribute to the pathogenesis  of Sengers syndrome."</div>
+                        
+                    </li>
+                    
+                </ul>
+                
             </div>
             
             <div class="reference-item">
@@ -3177,6 +3288,24 @@
                 
                 <div class="reference-title">Sengers Syndrome-Associated Mitochondrial Acylglycerol Kinase Is a Subunit of the Human TIM22 Protein Import Complex.</div>
                 
+                
+                <ul class="findings-list">
+                    
+                    <li class="finding-item">
+                        <div class="finding-statement">AGK is a bona fide subunit of the human TIM22 import complex that acts kinase-independently to maintain TIM22 integrity and facilitate the import and assembly of mitochondrial carrier proteins.</div>
+                        
+                        <div class="finding-text">"Here we identified  AGK as a subunit of the mitochondrial TIM22 protein import complex. We show that  AGK functions in a kinase-independent manner to maintain the integrity of the  TIM22 complex, where it facilitates the import and assembly of mitochondrial  carrier proteins."</div>
+                        
+                    </li>
+                    
+                    <li class="finding-item">
+                        <div class="finding-statement">Mitochondria from Sengers syndrome patients show a destabilized TIM22 complex and defective biogenesis of carrier substrates, linking TIM22-mediated protein import directly to disease.</div>
+                        
+                        <div class="finding-text">"Mitochondria isolated from Sengers syndrome patient cells and  tissues show a destabilized TIM22 complex and defects in the biogenesis of  carrier substrates."</div>
+                        
+                    </li>
+                    
+                </ul>
                 
             </div>
             
@@ -3194,6 +3323,17 @@
                 <div class="reference-title">A reference map of the human binary protein interactome.</div>
                 
                 
+                <ul class="findings-list">
+                    
+                    <li class="finding-item">
+                        <div class="finding-statement">HuRI is a proteome-wide binary protein interactome map; the cited excerpt does not directly mention TIMM22, and inclusion here provides only indirect, peripheral context for systematic PPI data that could be queried for TIMM22 interactors.</div>
+                        
+                        <div class="finding-text">"Here we present a human &#39;all-by-all&#39;  reference interactome map of human binary protein interactions, or &#39;HuRI&#39;. With  approximately 53,000 protein-protein interactions, HuRI has approximately four  times as many such interactions as there are high-quality curated interactions  from small-scale studies... We demonstrate the utility of  HuRI in identifying the specific subcellular roles of protein-protein  interactions."</div>
+                        
+                    </li>
+                    
+                </ul>
+                
             </div>
             
             <div class="reference-item">
@@ -3210,6 +3350,17 @@
                 <div class="reference-title">Cryo-EM structure of the human mitochondrial translocase TIM22 complex.</div>
                 
                 
+                <ul class="findings-list">
+                    
+                    <li class="finding-item">
+                        <div class="finding-statement">This study determined the cryo-EM structure of the human mitochondrial TIM22 carrier translocase, providing the structural framework for TIMM22-mediated insertion of multi-spanning inner-membrane proteins.</div>
+                        
+                        <div class="finding-text">"Cryo-EM structure of the human mitochondrial translocase TIM22 complex."</div>
+                        
+                    </li>
+                    
+                </ul>
+                
             </div>
             
             <div class="reference-item">
@@ -3225,6 +3376,17 @@
                 
                 <div class="reference-title">Quantitative high-confidence human mitochondrial proteome and its dynamics in cellular context.</div>
                 
+                
+                <ul class="findings-list">
+                    
+                    <li class="finding-item">
+                        <div class="finding-statement">The TIM22 complex imports metabolite carriers into the mitochondrial inner membrane and TIMM22 also inserts the precursors of TIMM23 and TIMM17A/B, with its short half-life suggesting a regulatory role in adjusting carrier import to metabolic conditions.</div>
+                        
+                        <div class="finding-text">"The TIM22 complex is responsible for importing the large number of metabolite carriers into the inner membrane that are crucial in controlling the metabolite flux between the mitochondrial matrix and other cellular compartments... The short half-life of TIMM22 may represent a means for rapidly adjusting the import of metabolite carriers to changing metabolic conditions... TIMM22 also inserts the precursors of TIMM23 and TIMM17A/B into the inner membrane"</div>
+                        
+                    </li>
+                    
+                </ul>
                 
             </div>
             
@@ -4068,31 +4230,104 @@ references:
   findings: []
 - id: PMID:14726512
   title: Organization and function of the small Tim complexes acting along the import pathway of metabolite carriers into mammalian mitochondria.
-  findings: []
+  findings:
+  - statement: Human small Tim proteins (Tim9, Tim10a, Tim10b) form two hetero-oligomeric complexes including a 450-kDa assembly that operates along the TIM22 carrier import pathway.
+    supporting_text: &gt;-
+      Here, we show that the human small  proteins form two distinct hetero-oligomeric complexes. A 70-kDa complex that  contains Tim9 and Tim10a and a Tim9-10a-10b that is part of a higher molecular  weight assembly of 450 kDa.
+    reference_section_type: ABSTRACT
+  - statement: During import the small Tim chaperones deliver carrier preproteins to human Tim22, identified as the putative insertion pore of the TIM22 translocase.
+    supporting_text: &gt;-
+      For  insertion of carrier preproteins into the inner membrane, the human small Tim  proteins directly interact with human Tim22, the putative insertion pore of the  TIM22 translocase.
+    reference_section_type: ABSTRACT
 - id: PMID:27265872
   title: The presence of disulfide bonds reveals an evolutionarily conserved mechanism involved in mitochondrial protein translocase assembly.
-  findings: []
+  findings:
+  - statement: TIMM22 is a core inner-membrane translocase component of the Tim17/Tim22/Tim23 family that forms intramolecular disulfide bonds required for proper assembly into the TIM22 complex.
+    supporting_text: &gt;-
+      Tim22, a membrane protein  and core component of the mitochondrial translocase TIM22, forms an  intramolecular disulfide bond in yeast. Tim22 belongs to the Tim17/Tim22/Tim23  family of protein translocases.
+    reference_section_type: ABSTRACT
+  - statement: Human TIMM22 carries two intramolecular disulfide bonds (Cys69-Cys141 and Cys160-Cys179), and the Cys160-Cys179 bond is prerequisite for TIMM22 assembly into the mature TIM22 complex.
+    supporting_text: &gt;-
+      Altogether, the biochemical analyses and transmembrane prediction for human TIMM22 indicate that one disulfide bond could be formed on the IMS side of TIMM22 between Cys69 and Cys141, and another disulfide bond that joins the TM3 and TM4 is formed between Cys160 and Cys179
+    reference_section_type: RESULTS
+  - statement: Loss of the TIMM22 disulfide bond linking Cys160-Cys179 abolishes assembly into the mature human TIM22 translocase despite retained membrane integration.
+    supporting_text: &gt;-
+      Thus, the lack of the second disulfide bond that is present in the human TIMM22 structure renders the protein unable to assemble into the mature TIM22 complex, despite its ability for membrane integration
+    reference_section_type: RESULTS
 - id: PMID:27554484
   title: Tim29 is a novel subunit of the human TIM22 translocase and is involved in complex assembly and stability.
-  findings: []
+  findings:
+  - statement: TIM22 mediates import of hydrophobic carrier proteins into the mitochondrial inner membrane, and Tim29 (C19orf52) was identified as a metazoan-specific subunit of the human TIM22 complex.
+    supporting_text: &gt;-
+      The TIM22 complex mediates the import of hydrophobic carrier proteins into the  mitochondrial inner membrane... we  identify Tim29 (C19orf52) as a novel, metazoan-specific subunit of the human  TIM22 complex.
+    reference_section_type: ABSTRACT
+  - statement: Tim29 is required for assembly and stability of the human TIM22 complex and links it to the TOM complex for transfer of hydrophobic substrates across the intermembrane space.
+    supporting_text: &gt;-
+      Tim29 is required for  the stability of the TIM22 complex and functions in the assembly of hTim22.  Furthermore, Tim29 contacts the Translocase of the Outer Mitochondrial Membrane,  TOM complex, enabling a mechanism for transport of hydrophobic carrier  substrates across the aqueous intermembrane space.
+    reference_section_type: ABSTRACT
+  - statement: The human TIM22 complex migrates at ~450 kDa and contains TIMM22 as the channel-forming subunit together with the small TIM chaperones hTim9, hTim10a and hTim10b.
+    supporting_text: &gt;-
+      Like yeast, the human TIM22 complex consists of the channel-forming hTim22 protein, along with subunits of the small TIM family, hTim9, hTim10a, and hTim10b
+    reference_section_type: INTRODUCTION
 - id: PMID:27718247
   title: TIM29 is a subunit of the human carrier translocase required for protein transport.
-  findings: []
+  findings:
+  - statement: Hydrophobic inner-membrane proteins with internal targeting signals such as metabolite carriers are inserted into the inner membrane by the TIM22 carrier translocase, and defects in this pathway are linked to neurodegenerative disorders.
+    supporting_text: &gt;-
+      Hydrophobic inner mitochondrial membrane proteins with internal targeting  signals, such as the metabolite carriers, use the carrier translocase (TIM22  complex) for transport into the inner membrane. Defects in this transport  pathway have been associated with neurodegenerative disorders.
+    reference_section_type: ABSTRACT
+  - statement: TIM29 is a 440 kDa human TIM22 complex constituent that interacts with oxidized TIMM22 and is required for structural integrity of the complex and import of carrier substrates.
+    supporting_text: &gt;-
+      We show that TIM29 is a constituent of the 440 kDa TIM22 complex and interacts with oxidized TIM22. Our analyses  demonstrate that TIM29 is required for the structural integrity of the TIM22  complex and for import of substrate proteins by the carrier translocase.
+    reference_section_type: ABSTRACT
+  - statement: TIMM22 is the central pore-forming subunit of the carrier translocase whose human form shares ~40% identity with yeast Tim22 and is conserved across eukaryotes.
+    supporting_text: &gt;-
+      Tim22 is the central, pore‐forming, subunit of the complex... The human TIM22 displays 40% homology with the yeast Tim22
+    reference_section_type: INTRODUCTION
 - id: PMID:28712724
   title: Acylglycerol Kinase Mutated in Sengers Syndrome Is a Subunit of the TIM22 Protein Translocase in Mitochondria.
-  findings: []
+  findings:
+  - statement: AGK, the lipid kinase mutated in Sengers syndrome, was identified as a constituent of the inner-membrane TIM22 complex that assembles with TIMM22 and TIMM29 to support import of a subset of multi-spanning membrane proteins.
+    supporting_text: &gt;-
+      Determining its mitochondrial interactome, we have identified  AGK as a constituent of the TIM22 complex in the mitochondrial inner membrane.  AGK assembles with TIMM22 and TIMM29 and supports the import of a subset of  multi-spanning membrane proteins.
+    reference_section_type: ABSTRACT
+  - statement: AGK&#39;s role as a TIM22 subunit is kinase-independent, linking Sengers syndrome pathogenesis to defects in TIM22-mediated mitochondrial protein biogenesis as well as phospholipid metabolism.
+    supporting_text: &gt;-
+      The function of AGK as a subunit of the TIM22  complex does not depend on its kinase activity... The dual function of AGK as lipid kinase and  constituent of the TIM22 complex reveals that disturbances in both phospholipid  metabolism and mitochondrial protein biogenesis contribute to the pathogenesis  of Sengers syndrome.
+    reference_section_type: ABSTRACT
 - id: PMID:28712726
   title: Sengers Syndrome-Associated Mitochondrial Acylglycerol Kinase Is a Subunit of the Human TIM22 Protein Import Complex.
-  findings: []
+  findings:
+  - statement: AGK is a bona fide subunit of the human TIM22 import complex that acts kinase-independently to maintain TIM22 integrity and facilitate the import and assembly of mitochondrial carrier proteins.
+    supporting_text: &gt;-
+      Here we identified  AGK as a subunit of the mitochondrial TIM22 protein import complex. We show that  AGK functions in a kinase-independent manner to maintain the integrity of the  TIM22 complex, where it facilitates the import and assembly of mitochondrial  carrier proteins.
+    reference_section_type: ABSTRACT
+  - statement: Mitochondria from Sengers syndrome patients show a destabilized TIM22 complex and defective biogenesis of carrier substrates, linking TIM22-mediated protein import directly to disease.
+    supporting_text: &gt;-
+      Mitochondria isolated from Sengers syndrome patient cells and  tissues show a destabilized TIM22 complex and defects in the biogenesis of  carrier substrates.
+    reference_section_type: ABSTRACT
 - id: PMID:32296183
   title: A reference map of the human binary protein interactome.
-  findings: []
+  findings:
+  - statement: HuRI is a proteome-wide binary protein interactome map; the cited excerpt does not directly mention TIMM22, and inclusion here provides only indirect, peripheral context for systematic PPI data that could be queried for TIMM22 interactors.
+    supporting_text: &gt;-
+      Here we present a human &#39;all-by-all&#39;  reference interactome map of human binary protein interactions, or &#39;HuRI&#39;. With  approximately 53,000 protein-protein interactions, HuRI has approximately four  times as many such interactions as there are high-quality curated interactions  from small-scale studies... We demonstrate the utility of  HuRI in identifying the specific subcellular roles of protein-protein  interactions.
+    reference_section_type: ABSTRACT
 - id: PMID:32901109
   title: Cryo-EM structure of the human mitochondrial translocase TIM22 complex.
-  findings: []
+  findings:
+  - statement: This study determined the cryo-EM structure of the human mitochondrial TIM22 carrier translocase, providing the structural framework for TIMM22-mediated insertion of multi-spanning inner-membrane proteins.
+    supporting_text: &gt;-
+      Cryo-EM structure of the human mitochondrial translocase TIM22 complex.
+    full_text_unavailable: true
+    reference_section_type: ABSTRACT
 - id: PMID:34800366
   title: Quantitative high-confidence human mitochondrial proteome and its dynamics in cellular context.
-  findings: []
+  findings:
+  - statement: The TIM22 complex imports metabolite carriers into the mitochondrial inner membrane and TIMM22 also inserts the precursors of TIMM23 and TIMM17A/B, with its short half-life suggesting a regulatory role in adjusting carrier import to metabolic conditions.
+    supporting_text: &gt;-
+      The TIM22 complex is responsible for importing the large number of metabolite carriers into the inner membrane that are crucial in controlling the metabolite flux between the mitochondrial matrix and other cellular compartments... The short half-life of TIMM22 may represent a means for rapidly adjusting the import of metabolite carriers to changing metabolic conditions... TIMM22 also inserts the precursors of TIMM23 and TIMM17A/B into the inner membrane
+    reference_section_type: DISCUSSION
 - id: Reactome:R-HSA-1955380
   title: TIMM9:TIMM10 transfers proteins to TIMM22
   findings: []


### PR DESCRIPTION
## Summary

Automated regeneration of static assets after gene review or template changes.

## Generated Assets

| Asset | Count/Status |
|-------|--------------|
| Gene review YAML files | 2068 |
| Gene review HTML pages | 2068 |
| Project pages | 129 |
| Browser app (data.js) | Updated |
| Validation report | Updated |

## Trigger

This PR was triggered by changes to:
- genes/**/*.yaml - gene review data files
- src/ai_gene_review/schema/** - LinkML schema files
- src/ai_gene_review/templates/** - Jinja2 templates
- src/ai_gene_review/render.py - rendering code
- src/ai_gene_review/export/** - export code
- src/ai_gene_review/browser/** - browser app assets
- src/ai_gene_review/tools/minify_linkml_browser_data.py - browser data compaction
- projects/*.md - project definitions
- project.justfile - just recipes used by CI
- .github/workflows/generate-pages.yaml - workflow definition

## Review

- [ ] Spot-check a few gene review HTML pages render correctly
- [ ] Verify browser app loads and filters work
- [ ] Check validation report for new issues
