### PR TITLE
Regenerate pages and browser app

### DIFF
--- a/genes/ARATH/DGAT1/DGAT1-ai-review.html
+++ b/genes/ARATH/DGAT1/DGAT1-ai-review.html
@@ -1,0 +1,4506 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>DGAT1 - AI Gene Review</title>
+    <style>
+        :root {
+            --color-accept: #22c55e;
+            --color-remove: #ef4444;
+            --color-modify: #f97316;
+            --color-keep-non-core: #3b82f6;
+            --color-undecided: #6b7280;
+            --color-new: #8b5cf6;
+            --color-mark-over: #eab308;
+            --bg-light: #f9fafb;
+            --border-color: #e5e7eb;
+            --text-muted: #6b7280;
+            --text-primary: #111827;
+        }
+
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+            line-height: 1.6;
+            color: var(--text-primary);
+            background-color: #ffffff;
+            padding: 2rem;
+            max-width: 1400px;
+            margin: 0 auto;
+        }
+
+        .header {
+            border-bottom: 2px solid var(--border-color);
+            padding-bottom: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        h1 {
+            font-size: 2.5rem;
+            font-weight: 700;
+            margin-bottom: 0.5rem;
+            color: #1f2937;
+        }
+
+        .gene-info {
+            display: flex;
+            gap: 2rem;
+            flex-wrap: wrap;
+            margin-top: 1rem;
+        }
+
+        .info-item {
+            display: flex;
+            gap: 0.5rem;
+        }
+
+        .info-label {
+            font-weight: 600;
+            color: var(--text-muted);
+        }
+
+        .aliases {
+            display: flex;
+            gap: 0.5rem;
+            flex-wrap: wrap;
+        }
+
+        .badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.875rem;
+            font-weight: 500;
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+        }
+
+        .status-badge {
+            padding: 0.375rem 0.875rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .status-initialized {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fde68a;
+        }
+
+        .status-in-progress {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+        }
+
+        .status-draft {
+            background-color: #fce7f3;
+            color: #831843;
+            border: 1px solid #fbcfe8;
+        }
+
+        .status-complete {
+            background-color: #d1fae5;
+            color: #065f46;
+            border: 1px solid #a7f3d0;
+        }
+
+        .description-card {
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        .description-card h2 {
+            font-size: 1.25rem;
+            margin-bottom: 1rem;
+            color: #374151;
+        }
+
+        .section {
+            margin-bottom: 2.5rem;
+        }
+
+        .section-title {
+            font-size: 1.5rem;
+            font-weight: 600;
+            margin-bottom: 1.5rem;
+            color: #1f2937;
+            border-bottom: 1px solid var(--border-color);
+            padding-bottom: 0.5rem;
+        }
+
+        .annotations-table {
+            width: 100%;
+            border-collapse: collapse;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            overflow: hidden;
+        }
+
+        .annotations-table thead {
+            background-color: var(--bg-light);
+        }
+
+        .annotations-table th {
+            text-align: left;
+            padding: 1rem;
+            font-weight: 600;
+            border-bottom: 2px solid var(--border-color);
+            font-size: 0.875rem;
+            text-transform: uppercase;
+            letter-spacing: 0.05em;
+            color: var(--text-muted);
+        }
+
+        .annotations-table td {
+            padding: 1rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .annotations-table tbody tr:hover {
+            background-color: #f9fafb;
+        }
+
+        .action-badge {
+            display: inline-block;
+            padding: 0.375rem 0.75rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .action-accept {
+            background-color: var(--color-accept);
+            color: white;
+        }
+
+        .action-remove {
+            background-color: var(--color-remove);
+            color: white;
+        }
+
+        .action-modify {
+            background-color: var(--color-modify);
+            color: white;
+        }
+
+        .action-keep_as_non_core {
+            background-color: var(--color-keep-non-core);
+            color: white;
+        }
+
+        .action-undecided {
+            background-color: var(--color-undecided);
+            color: white;
+        }
+
+        .action-new {
+            background-color: var(--color-new);
+            color: white;
+        }
+
+        .action-mark_as_over_annotated {
+            background-color: var(--color-mark-over);
+            color: white;
+        }
+
+        .term-info {
+            display: flex;
+            flex-direction: column;
+            gap: 0.25rem;
+        }
+
+        .term-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .term-label {
+            font-weight: 500;
+        }
+
+        .evidence-code {
+            font-family: monospace;
+            background-color: var(--bg-light);
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .not-badge {
+            display: inline-block;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-weight: 600;
+            margin-left: 0.25rem;
+        }
+
+        .isoform-badge {
+            display: inline-block;
+            background-color: #eff6ff;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            margin-top: 0.25rem;
+        }
+
+        .core-function-card {
+            background-color: white;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 1rem;
+        }
+
+        .core-function-card h3 {
+            font-size: 1.125rem;
+            margin-bottom: 1rem;
+            color: #1f2937;
+        }
+
+        .core-function-statement {
+            margin-bottom: 1rem;
+            padding: 0.75rem;
+            background-color: var(--bg-light);
+            border-left: 4px solid var(--color-accept);
+            border-radius: 0.25rem;
+        }
+
+        .function-annotations {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin-top: 1rem;
+        }
+
+        .reference-item {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+        }
+
+        .reference-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: start;
+            margin-bottom: 0.75rem;
+        }
+
+        .reference-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #2563eb;
+        }
+
+        .supported-by {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f3f4f6;
+            border-left: 3px solid #3b82f6;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .supported-by-title {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .support-item {
+            margin-bottom: 0.5rem;
+        }
+
+        .support-ref {
+            font-weight: 500;
+            color: #2563eb;
+        }
+
+        .support-text {
+            color: #6b7280;
+            font-style: italic;
+            margin-left: 1rem;
+        }
+
+        a.term-link {
+            color: #2563eb;
+            text-decoration: none;
+        }
+
+        a.term-link:hover {
+            text-decoration: underline;
+        }
+
+        .core-function-terms {
+            margin-top: 1rem;
+        }
+
+        .function-term-group {
+            margin-bottom: 1rem;
+        }
+
+        .function-term-label {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .reference-title {
+            font-weight: 500;
+            margin-bottom: 0.5rem;
+        }
+
+        .findings-list {
+            margin-top: 1rem;
+            padding-left: 1.5rem;
+        }
+
+        .finding-item {
+            margin-bottom: 0.75rem;
+        }
+
+        .finding-statement {
+            font-weight: 500;
+            margin-bottom: 0.25rem;
+        }
+
+        .finding-text {
+            color: var(--text-muted);
+            font-size: 0.95rem;
+            font-style: italic;
+        }
+
+        .proposed-term {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #fef3c7;
+        }
+
+        .question-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #dbeafe;
+        }
+
+        .experiment-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #f3e8ff;
+        }
+
+        .prediction-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: white;
+        }
+
+        .prediction-card .prediction-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+        }
+
+        .prediction-source {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+        }
+
+        .assessment-badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.8rem;
+            font-weight: 600;
+            text-transform: uppercase;
+        }
+
+        .assessment-cor { background-color: #dcfce7; color: #166534; }
+        .assessment-cnn { background-color: #dbeafe; color: #1e40af; }
+        .assessment-lsp { background-color: #fef9c3; color: #854d0e; }
+        .assessment-unc { background-color: #f3f4f6; color: #374151; }
+        .assessment-pli { background-color: #fee2e2; color: #991b1b; }
+        .assessment-npi { background-color: #fecaca; color: #7f1d1d; }
+        .assessment-rep { background-color: #fde68a; color: #92400e; }
+
+        .confidence-score {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+            margin-left: 0.5rem;
+        }
+
+        .error-type-badge {
+            font-size: 0.75rem;
+            padding: 0.125rem 0.5rem;
+            border-radius: 0.25rem;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+        }
+
+        .isoforms-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fill, minmax(400px, 1fr));
+            gap: 1rem;
+        }
+
+        .isoform-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            background-color: white;
+            transition: box-shadow 0.2s;
+        }
+
+        .isoform-card:hover {
+            box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+        }
+
+        .functional-isoform-type {
+            display: inline-block;
+            padding: 0.2rem 0.5rem;
+            border-radius: 0.25rem;
+            font-size: 0.7rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.03em;
+        }
+
+        .type-SPLICE_VARIANT, .type-SPLICE_CLASS {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #93c5fd;
+        }
+
+        .type-CLEAVAGE_PRODUCT {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fcd34d;
+        }
+
+        .type-MODIFICATION_STATE {
+            background-color: #f3e8ff;
+            color: #6b21a8;
+            border: 1px solid #c4b5fd;
+        }
+
+        .type-CONFORMATIONAL_STATE {
+            background-color: #dcfce7;
+            color: #166534;
+            border: 1px solid #86efac;
+        }
+
+        .functional-isoform-mappings {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+            font-size: 0.85rem;
+        }
+
+        .functional-isoform-mappings .mapping-type {
+            font-weight: 600;
+            color: var(--text-muted);
+            font-size: 0.75rem;
+        }
+
+        .functional-isoform-go {
+            margin-top: 0.5rem;
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.25rem;
+        }
+
+        .go-chip {
+            display: inline-block;
+            padding: 0.15rem 0.4rem;
+            background-color: #ecfdf5;
+            color: #047857;
+            border: 1px solid #a7f3d0;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-family: monospace;
+        }
+
+        .isoform-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+            padding-bottom: 0.5rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .isoform-name {
+            font-weight: 600;
+            font-size: 1.1rem;
+            color: #1f2937;
+        }
+
+        .isoform-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .isoform-sequence-note {
+            font-size: 0.875rem;
+            color: var(--text-muted);
+            margin-bottom: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+        }
+
+        .isoform-description {
+            font-size: 0.95rem;
+            line-height: 1.5;
+        }
+
+        .collapsible {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .collapsible:after {
+            content: ' ▼';
+            font-size: 0.75rem;
+        }
+
+        .collapsible.collapsed:after {
+            content: ' ►';
+        }
+
+        .collapse-content {
+            transition: max-height 0.3s ease;
+            overflow: hidden;
+        }
+
+        .collapsed + .collapse-content {
+            max-height: 0;
+        }
+
+        .no-data {
+            color: var(--text-muted);
+            font-style: italic;
+            padding: 1rem;
+            text-align: center;
+            background-color: var(--bg-light);
+            border-radius: 0.5rem;
+        }
+
+        /* Styling for markdown section summaries with voting */
+        .markdown-section summary {
+            padding: 0.75rem;
+            background: var(--bg-light);
+            border-radius: 0.5rem;
+            margin-bottom: 0.5rem;
+        }
+
+        .markdown-section summary:hover {
+            background: #e5e7eb;
+        }
+
+        .markdown-section summary .vote-buttons {
+            margin-left: auto;
+        }
+
+        .deep-research-section {
+            margin-bottom: 1rem;
+            border: 1px solid #c7d2fe;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8faff;
+        }
+
+        .deep-research-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .deep-research-section summary h3 {
+            margin: 0;
+            color: #3730a3;
+            font-size: 1.1rem;
+        }
+
+        .report-meta {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin: 0.75rem 0 1rem;
+            align-items: center;
+        }
+
+        .report-badge {
+            display: inline-flex;
+            align-items: center;
+            border: 1px solid #c7d2fe;
+            border-radius: 999px;
+            background: #eef2ff;
+            color: #4338ca;
+            font-size: 0.78rem;
+            font-weight: 600;
+            padding: 0.2rem 0.6rem;
+        }
+
+        .report-meta-text {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+        }
+
+        .artifact-list {
+            display: grid;
+            gap: 0.75rem;
+            margin: 0.75rem 0 1rem;
+        }
+
+        .artifact-link {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+            margin-top: 0.5rem;
+            word-break: break-word;
+        }
+
+        @media print {
+            body {
+                padding: 1rem;
+            }
+
+            .collapsible:after {
+                display: none;
+            }
+
+            .collapsed + .collapse-content {
+                max-height: none !important;
+            }
+        }
+
+        @media (max-width: 768px) {
+            body {
+                padding: 1rem;
+            }
+
+            h1 {
+                font-size: 2rem;
+            }
+
+            .annotations-table {
+                font-size: 0.875rem;
+            }
+
+            .annotations-table th,
+            .annotations-table td {
+                padding: 0.5rem;
+            }
+        }
+    </style>
+</head>
+<body>
+    <div class="header">
+        <h1>DGAT1</h1>
+        <div class="gene-info">
+            
+            <div class="info-item">
+                
+                <span class="info-label">UniProt ID:</span>
+                <span>
+                    <a href="https://www.uniprot.org/uniprotkb/Q9SLD2" target="_blank" class="term-link">
+                        Q9SLD2
+                    </a>
+                </span>
+                
+            </div>
+            
+            
+            <div class="info-item">
+                <span class="info-label">Organism:</span>
+                <span>Arabidopsis thaliana</span>
+            </div>
+            
+            
+            <div class="info-item">
+                <span class="info-label">Review Status:</span>
+                <span class="status-badge status-complete">
+                    COMPLETE
+                </span>
+            </div>
+            
+            
+        </div>
+        <div style="margin-top: 1rem; text-align: center;">
+            <a id="feedback-form-link"
+               href="#"
+               target="_blank"
+               style="display: inline-block; padding: 10px 20px; background-color: #4CAF50; color: white; text-decoration: none; border-radius: 5px; font-weight: 600;">
+                📝 Provide Detailed Feedback
+            </a>
+            <script>
+                // Construct the form URL with proper encoding
+                // Extract organism code from the current page path (e.g., /genes/ARATH/APO1/ -> ARATH)
+                const pathParts = window.location.pathname.split('/');
+                const genesIndex = pathParts.indexOf('genes');
+                let organism = '';
+                if (genesIndex !== -1 && pathParts[genesIndex + 1]) {
+                    organism = pathParts[genesIndex + 1].toUpperCase();
+                }
+                const geneSymbol = "DGAT1";
+                const speciesGene = organism + ' ' + geneSymbol;
+                const formBaseUrl = 'https://docs.google.com/forms/d/e/1FAIpQLSdTot9L6GVkkZYgLQT0E8ZdAJv8RiN5ZgOVkgWNcKSbYvxxzQ/viewform';
+                const entryId = '1226477767'; // Correct entry ID for Species/Gene field
+                const formUrl = formBaseUrl + '?entry.' + entryId + '=' + encodeURIComponent(speciesGene);
+                const feedbackLink = document.getElementById('feedback-form-link');
+                feedbackLink.href = formUrl;
+                // Add tooltip showing the pre-filled value
+                feedbackLink.title = 'Opens form with pre-filled: ' + speciesGene;
+            </script>
+        </div>
+    </div>
+
+    
+    <div class="description-card">
+        <div style="display: flex; justify-content: space-between; align-items: center;">
+            <h2>Gene Description</h2>
+            <span class="vote-buttons" data-g="Q9SLD2" data-a="DESCRIPTION: DGAT1 (TAG1) is the acyl-CoA:diacylglycerol acyltr..." data-r="" data-act="DESCRIPTION">
+                <button class="vote-btn" data-v="up" title="Agree with this description">👍</button>
+                <button class="vote-btn" data-v="down" title="Disagree with this description">👎</button>
+            </span>
+        </div>
+        <p>DGAT1 (TAG1) is the acyl-CoA:diacylglycerol acyltransferase 1 of Arabidopsis, a multi-pass endoplasmic-reticulum membrane enzyme of the membrane-bound O-acyltransferase (MBOAT) family. It catalyzes the terminal, committed step of the acyl-CoA-dependent (Kennedy) pathway of triacylglycerol (TAG) assembly, transferring an acyl group from acyl-CoA to the sn-3 position of diacylglycerol to form TAG. It is the major microsomal DGAT activity in developing seeds and pollen and a principal determinant of seed-oil content; it acts partly redundantly with the acyl-CoA-independent enzyme PDAT1, so that strong TAG depletion and reproductive defects arise mainly when both routes are impaired. While its primary site is the ER, during leaf senescence DGAT1 is also associated with chloroplast envelope and thylakoid membranes, where it forms plastoglobular TAG from fatty acids recycled from thylakoid galactolipids.</p>
+    </div>
+    
+
+    
+
+    
+
+    
+    <div class="section">
+        <h2 class="section-title">Existing Annotations Review</h2>
+        <table class="annotations-table">
+            <thead>
+                <tr>
+                    <th>GO Term</th>
+                    <th>Evidence</th>
+                    <th>Action</th>
+                    <th>Reason</th>
+                </tr>
+            </thead>
+            <tbody>
+                
+                <tr>
+                    <td>
+                        <div class="term-info">
+                            
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005789" target="_blank" class="term-link">
+                                    GO:0005789
+                                </a>
+                            </span>
+                            <span class="term-label">endoplasmic reticulum membrane</span>
+                            
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+                        
+                        
+                        
+                        <br>
+                        <span style="font-size: 0.75rem;">
+                            
+                            GO_REF:0000033
+                            
+                        </span>
+                        
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9SLD2" data-a="GO:0005789" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+                        
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Correct core localization. DGAT1 is an ER (microsomal) membrane enzyme; the ER is the functional site of TAG assembly. Consistent with experimental microsomal DGAT activity.
+                        </div>
+                        
+                        
+                        
+                        
+                    </td>
+                </tr>
+                
+                <tr>
+                    <td>
+                        <div class="term-info">
+                            
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0004144" target="_blank" class="term-link">
+                                    GO:0004144
+                                </a>
+                            </span>
+                            <span class="term-label">diacylglycerol O-acyltransferase activity</span>
+                            
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+                        
+                        
+                        
+                        <br>
+                        <span style="font-size: 0.75rem;">
+                            
+                            GO_REF:0000120
+                            
+                        </span>
+                        
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9SLD2" data-a="GO:0004144" data-r="GO_REF:0000120" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+                        
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Core molecular function, also supported by extensive experimental evidence (EXP/IDA/IMP below). DGAT1 transfers an acyl group from acyl-CoA to diacylglycerol to form TAG.
+                        </div>
+                        
+                        
+                        
+                        
+                    </td>
+                </tr>
+                
+                <tr>
+                    <td>
+                        <div class="term-info">
+                            
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005789" target="_blank" class="term-link">
+                                    GO:0005789
+                                </a>
+                            </span>
+                            <span class="term-label">endoplasmic reticulum membrane</span>
+                            
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+                        
+                        
+                        
+                        <br>
+                        <span style="font-size: 0.75rem;">
+                            
+                            GO_REF:0000044
+                            
+                        </span>
+                        
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9SLD2" data-a="GO:0005789" data-r="GO_REF:0000044" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+                        
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Correct core localization (ER membrane), consistent with the IBA annotation and with microsomal DGAT assays.
+                        </div>
+                        
+                        
+                        
+                        
+                    </td>
+                </tr>
+                
+                <tr>
+                    <td>
+                        <div class="term-info">
+                            
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0019432" target="_blank" class="term-link">
+                                    GO:0019432
+                                </a>
+                            </span>
+                            <span class="term-label">triglyceride biosynthetic process</span>
+                            
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+                        
+                        
+                        
+                        <br>
+                        <span style="font-size: 0.75rem;">
+                            
+                            GO_REF:0000120
+                            
+                        </span>
+                        
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9SLD2" data-a="GO:0019432" data-r="GO_REF:0000120" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+                        
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Core biological process, also supported experimentally (IDA/IMP/TAS below). DGAT1 catalyzes the terminal step of TAG biosynthesis.
+                        </div>
+                        
+                        
+                        
+                        
+                    </td>
+                </tr>
+                
+                <tr>
+                    <td>
+                        <div class="term-info">
+                            
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0031969" target="_blank" class="term-link">
+                                    GO:0031969
+                                </a>
+                            </span>
+                            <span class="term-label">chloroplast membrane</span>
+                            
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+                        
+                        
+                        
+                        <br>
+                        <span style="font-size: 0.75rem;">
+                            
+                            GO_REF:0000044
+                            
+                        </span>
+                        
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="Q9SLD2" data-a="GO:0031969" data-r="GO_REF:0000044" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+                        
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Retained as a non-core localization. This electronic UniProt subcellular-location annotation reflects the experimentally documented association of DGAT1 with chloroplast (envelope/thylakoid) membranes during leaf senescence, where it synthesizes plastoglobular TAG from recycled thylakoid galactolipid fatty acids (PMID:12177474). It is a genuine secondary localization, subordinate to the primary ER site of seed-oil TAG synthesis.
+                        </div>
+                        
+                        
+                        
+                        
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+                            
+                            <div class="support-item">
+                                <span class="support-ref">
+                                    
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/12177474" target="_blank" class="term-link">
+                                        PMID:12177474
+                                    </a>
+                                    
+                                </span>
+                                
+                                <div class="support-text">DGAT1 protein in senescing leaves was found to be associated with chloroplast membranes</div>
+                                
+                            </div>
+                            
+                        </div>
+                        
+                    </td>
+                </tr>
+                
+                <tr>
+                    <td>
+                        <div class="term-info">
+                            
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0004144" target="_blank" class="term-link">
+                                    GO:0004144
+                                </a>
+                            </span>
+                            <span class="term-label">diacylglycerol O-acyltransferase activity</span>
+                            
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">EXP</span>
+                        
+                        
+                        
+                        <br>
+                        <span style="font-size: 0.75rem;">
+                            
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/11171171" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:11171171
+                            </a>
+                            
+                                
+                                
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Expression and characterization of diacylglycerol acyltransf...
+                                </span>
+                                
+                            
+                            
+                        </span>
+                        
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9SLD2" data-a="GO:0004144" data-r="PMID:11171171" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+                        
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Core molecular function with direct experimental support for DGAT1 diacylglycerol acyltransferase activity. [PMID:11171171]
+                        </div>
+                        
+                        
+                        
+                        
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+                            
+                            <div class="support-item">
+                                <span class="support-ref">
+                                    
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/11171171" target="_blank" class="term-link">
+                                        PMID:11171171
+                                    </a>
+                                    
+                                </span>
+                                
+                                <div class="support-text">experimental demonstration of Arabidopsis DGAT1 diacylglycerol acyltransferase activity</div>
+                                
+                            </div>
+                            
+                        </div>
+                        
+                    </td>
+                </tr>
+                
+                <tr>
+                    <td>
+                        <div class="term-info">
+                            
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005634" target="_blank" class="term-link">
+                                    GO:0005634
+                                </a>
+                            </span>
+                            <span class="term-label">nucleus</span>
+                            
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">ISM</span>
+                        
+                        
+                        
+                        <br>
+                        <span style="font-size: 0.75rem;">
+                            
+                            GO_REF:0000122
+                            
+                        </span>
+                        
+                    </td>
+                    <td>
+                        <span class="action-badge action-remove">
+                            REMOVE
+                        </span>
+                        <span class="vote-buttons" data-g="Q9SLD2" data-a="GO:0005634" data-r="GO_REF:0000122" data-act="REMOVE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+                        
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Spurious computational (AtSubP sequence-model) prediction that contradicts the established ER membrane localization. DGAT1 is a multi-pass ER membrane protein; there is no evidence for nuclear localization.
+                        </div>
+                        
+                        
+                        
+                        
+                    </td>
+                </tr>
+                
+                <tr>
+                    <td>
+                        <div class="term-info">
+                            
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
+                                    GO:0005515
+                                </a>
+                            </span>
+                            <span class="term-label">protein binding</span>
+                            
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+                        
+                        
+                        
+                        <br>
+                        <span style="font-size: 0.75rem;">
+                            
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/26586834" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:26586834
+                            </a>
+                            
+                                
+                                
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Identification of Arabidopsis GPAT9 (At5g60620) as an Essent...
+                                </span>
+                                
+                            
+                            
+                        </span>
+                        
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="Q9SLD2" data-a="GO:0005515" data-r="PMID:26586834" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+                        
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Uninformative molecular-function term (per curation guidance, protein binding does not convey a specific function). The original_reference (PMID:26586834) is primarily about GPAT9, in which DGAT1 appears as an interaction partner. The interaction is experimental, so it is retained as non-core rather than removed; a specific partner and functional consequence would be needed to make it informative.
+                        </div>
+                        
+                        
+                        
+                        
+                    </td>
+                </tr>
+                
+                <tr>
+                    <td>
+                        <div class="term-info">
+                            
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005811" target="_blank" class="term-link">
+                                    GO:0005811
+                                </a>
+                            </span>
+                            <span class="term-label">lipid droplet</span>
+                            
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+                        
+                        
+                        
+                        <br>
+                        <span style="font-size: 0.75rem;">
+                            
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/24663078" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:24663078
+                            </a>
+                            
+                                
+                                
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Function and localization of the Arabidopsis thaliana diacyl...
+                                </span>
+                                
+                            
+                            
+                        </span>
+                        
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="Q9SLD2" data-a="GO:0005811" data-r="PMID:24663078" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+                        
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Lipid-droplet association is consistent with TAG synthesis at the ER-lipid droplet interface. Retained as a non-core localization relative to the primary ER membrane site of catalysis. Note the original_reference (PMID:24663078) is primarily a study of the paralog DGAT2; the curator (TAIR) may have had DGAT1 data, but this specific evidence is not verified here.
+                        </div>
+                        
+                        
+                        
+                        
+                    </td>
+                </tr>
+                
+                <tr>
+                    <td>
+                        <div class="term-info">
+                            
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0019432" target="_blank" class="term-link">
+                                    GO:0019432
+                                </a>
+                            </span>
+                            <span class="term-label">triglyceride biosynthetic process</span>
+                            
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+                        
+                        
+                        
+                        <br>
+                        <span style="font-size: 0.75rem;">
+                            
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/23770095" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:23770095
+                            </a>
+                            
+                                
+                                
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    AtDGAT2 is a functional acyl-CoA:diacylglycerol acyltransfer...
+                                </span>
+                                
+                            
+                            
+                        </span>
+                        
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9SLD2" data-a="GO:0019432" data-r="PMID:23770095" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+                        
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> TAG biosynthesis is the core biological process of DGAT1 and is well established. Note the original_reference (PMID:23770095) is primarily about the paralog AtDGAT2 (with DGAT1 used for comparison); this specific reference is not independently verified here, but the TAG-biosynthesis role of DGAT1 is supported by the many DGAT-activity and tag1-mutant references in this review.
+                        </div>
+                        
+                        
+                        
+                        
+                    </td>
+                </tr>
+                
+                <tr>
+                    <td>
+                        <div class="term-info">
+                            
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016020" target="_blank" class="term-link">
+                                    GO:0016020
+                                </a>
+                            </span>
+                            <span class="term-label">membrane</span>
+                            
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+                        
+                        
+                        
+                        <br>
+                        <span style="font-size: 0.75rem;">
+                            
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/22233193" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:22233193
+                            </a>
+                            
+                                
+                                
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Triacylglycerol synthesis by PDAT1 in the absence of DGAT1 a...
+                                </span>
+                                
+                            
+                            
+                        </span>
+                        
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9SLD2" data-a="GO:0016020" data-r="PMID:22233193" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+                        
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Correct but general. DGAT1 is an integral membrane protein; the informative localizations are the ER membrane (primary) and chloroplast membranes (senescence). The original_reference (PMID:22233193) is primarily a PDAT1/LPCAT2 study; the membrane-association of DGAT1 is independently documented.
+                        </div>
+                        
+                        
+                        
+                        
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+                            
+                            <div class="support-item">
+                                <span class="support-ref">
+                                    
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/12177474" target="_blank" class="term-link">
+                                        PMID:12177474
+                                    </a>
+                                    
+                                </span>
+                                
+                                <div class="support-text">DGAT1 protein was found to be associated with chloroplast membranes (and is membrane-bound in the ER of developing siliques)</div>
+                                
+                            </div>
+                            
+                        </div>
+                        
+                    </td>
+                </tr>
+                
+                <tr>
+                    <td>
+                        <div class="term-info">
+                            
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0010029" target="_blank" class="term-link">
+                                    GO:0010029
+                                </a>
+                            </span>
+                            <span class="term-label">regulation of seed germination</span>
+                            
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IMP</span>
+                        
+                        
+                        
+                        <br>
+                        <span style="font-size: 0.75rem;">
+                            
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/10580283" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:10580283
+                            </a>
+                            
+                                
+                                
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    The TAG1 locus of Arabidopsis encodes for a diacylglycerol a...
+                                </span>
+                                
+                            
+                            
+                        </span>
+                        
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="Q9SLD2" data-a="GO:0010029" data-r="PMID:10580283" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+                        
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Pleiotropic/downstream phenotype of altered seed oil reserves, not DGAT1&#39;s molecular function. Retained as non-core. [PMID:10580283]
+                        </div>
+                        
+                        
+                        
+                        
+                    </td>
+                </tr>
+                
+                <tr>
+                    <td>
+                        <div class="term-info">
+                            
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0010030" target="_blank" class="term-link">
+                                    GO:0010030
+                                </a>
+                            </span>
+                            <span class="term-label">positive regulation of seed germination</span>
+                            
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IMP</span>
+                        
+                        
+                        
+                        <br>
+                        <span style="font-size: 0.75rem;">
+                            
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/10580283" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:10580283
+                            </a>
+                            
+                                
+                                
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    The TAG1 locus of Arabidopsis encodes for a diacylglycerol a...
+                                </span>
+                                
+                            
+                            
+                        </span>
+                        
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="Q9SLD2" data-a="GO:0010030" data-r="PMID:10580283" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+                        
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> As above, a downstream consequence of seed oil storage on germination vigor rather than a core function. Retained as non-core. [PMID:10580283]
+                        </div>
+                        
+                        
+                        
+                        
+                    </td>
+                </tr>
+                
+                <tr>
+                    <td>
+                        <div class="term-info">
+                            
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0004144" target="_blank" class="term-link">
+                                    GO:0004144
+                                </a>
+                            </span>
+                            <span class="term-label">diacylglycerol O-acyltransferase activity</span>
+                            
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">ISS</span>
+                        
+                        
+                        
+                        <br>
+                        <span style="font-size: 0.75rem;">
+                            
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/10571850" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:10571850
+                            </a>
+                            
+                                
+                                
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    The Arabidopsis thaliana TAG1 mutant has a mutation in a dia...
+                                </span>
+                                
+                            
+                            
+                        </span>
+                        
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9SLD2" data-a="GO:0004144" data-r="PMID:10571850" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+                        
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Core molecular function (sequence/similarity support), consistent with the experimental DGAT activity annotations.
+                        </div>
+                        
+                        
+                        
+                        
+                    </td>
+                </tr>
+                
+                <tr>
+                    <td>
+                        <div class="term-info">
+                            
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0004144" target="_blank" class="term-link">
+                                    GO:0004144
+                                </a>
+                            </span>
+                            <span class="term-label">diacylglycerol O-acyltransferase activity</span>
+                            
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+                        
+                        
+                        
+                        <br>
+                        <span style="font-size: 0.75rem;">
+                            
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/10571850" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:10571850
+                            </a>
+                            
+                                
+                                
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    The Arabidopsis thaliana TAG1 mutant has a mutation in a dia...
+                                </span>
+                                
+                            
+                            
+                        </span>
+                        
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9SLD2" data-a="GO:0004144" data-r="PMID:10571850" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+                        
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Core molecular function with direct assay support. [PMID:10571850]
+                        </div>
+                        
+                        
+                        
+                        
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+                            
+                            <div class="support-item">
+                                <span class="support-ref">
+                                    
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/10571850" target="_blank" class="term-link">
+                                        PMID:10571850
+                                    </a>
+                                    
+                                </span>
+                                
+                                <div class="support-text">Arabidopsis DGAT1 diacylglycerol acyltransferase activity</div>
+                                
+                            </div>
+                            
+                        </div>
+                        
+                    </td>
+                </tr>
+                
+                <tr>
+                    <td>
+                        <div class="term-info">
+                            
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0004144" target="_blank" class="term-link">
+                                    GO:0004144
+                                </a>
+                            </span>
+                            <span class="term-label">diacylglycerol O-acyltransferase activity</span>
+                            
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+                        
+                        
+                        
+                        <br>
+                        <span style="font-size: 0.75rem;">
+                            
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/12502715" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:12502715
+                            </a>
+                            
+                                
+                                
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    A novel bifunctional wax ester synthase/acyl-CoA:diacylglyce...
+                                </span>
+                                
+                            
+                            
+                        </span>
+                        
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9SLD2" data-a="GO:0004144" data-r="PMID:12502715" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+                        
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Diacylglycerol O-acyltransferase activity is the core, well-established molecular function of DGAT1. Note the original_reference (PMID:12502715) is about a bifunctional wax ester synthase/acyl-CoA:DGAT from the bacterium Acinetobacter calcoaceticus, so its basis for annotating Arabidopsis DGAT1 is unclear; the MF is nonetheless overwhelmingly supported by the plant-DGAT references in this review.
+                        </div>
+                        
+                        
+                        
+                        
+                    </td>
+                </tr>
+                
+                <tr>
+                    <td>
+                        <div class="term-info">
+                            
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0009793" target="_blank" class="term-link">
+                                    GO:0009793
+                                </a>
+                            </span>
+                            <span class="term-label">embryo development ending in seed dormancy</span>
+                            
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+                        
+                        
+                        
+                        <br>
+                        <span style="font-size: 0.75rem;">
+                            
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/12114588" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:12114588
+                            </a>
+                            
+                                
+                                
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Arabidopsis mutants deficient in diacylglycerol acyltransfer...
+                                </span>
+                                
+                            
+                            
+                        </span>
+                        
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="Q9SLD2" data-a="GO:0009793" data-r="PMID:12114588" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+                        
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Pleiotropic developmental context of seed oil accumulation rather than a core molecular function. Retained as non-core. [PMID:12114588]
+                        </div>
+                        
+                        
+                        
+                        
+                    </td>
+                </tr>
+                
+                <tr>
+                    <td>
+                        <div class="term-info">
+                            
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0009941" target="_blank" class="term-link">
+                                    GO:0009941
+                                </a>
+                            </span>
+                            <span class="term-label">chloroplast envelope</span>
+                            
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+                        
+                        
+                        
+                        <br>
+                        <span style="font-size: 0.75rem;">
+                            
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/12177474" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:12177474
+                            </a>
+                            
+                                
+                                
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    A role for diacylglycerol acyltransferase during leaf senesc...
+                                </span>
+                                
+                            
+                            
+                        </span>
+                        
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="Q9SLD2" data-a="GO:0009941" data-r="PMID:12177474" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+                        
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Experimentally supported senescence-specific localization. In senescing Arabidopsis leaves DGAT1 protein is associated with isolated chloroplasts and purified envelope and thylakoid membranes (but not stroma), where it synthesizes the TAG that accumulates in plastoglobuli from de-esterified galactolipid fatty acids. A genuine secondary localization, retained as non-core relative to the primary ER seed-oil role. [PMID:12177474]
+                        </div>
+                        
+                        
+                        
+                        
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+                            
+                            <div class="support-item">
+                                <span class="support-ref">
+                                    
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/12177474" target="_blank" class="term-link">
+                                        PMID:12177474
+                                    </a>
+                                    
+                                </span>
+                                
+                                <div class="support-text">DGAT1 is present in intact chloroplasts and purified membranes including thylakoid and envelope but not in the stroma</div>
+                                
+                            </div>
+                            
+                        </div>
+                        
+                    </td>
+                </tr>
+                
+                <tr>
+                    <td>
+                        <div class="term-info">
+                            
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0019432" target="_blank" class="term-link">
+                                    GO:0019432
+                                </a>
+                            </span>
+                            <span class="term-label">triglyceride biosynthetic process</span>
+                            
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+                        
+                        
+                        
+                        <br>
+                        <span style="font-size: 0.75rem;">
+                            
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/12114588" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:12114588
+                            </a>
+                            
+                                
+                                
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Arabidopsis mutants deficient in diacylglycerol acyltransfer...
+                                </span>
+                                
+                            
+                            
+                        </span>
+                        
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9SLD2" data-a="GO:0019432" data-r="PMID:12114588" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+                        
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Core biological process; TAG biosynthesis is DGAT1&#39;s primary role. [PMID:12114588]
+                        </div>
+                        
+                        
+                        
+                        
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+                            
+                            <div class="support-item">
+                                <span class="support-ref">
+                                    
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/12114588" target="_blank" class="term-link">
+                                        PMID:12114588
+                                    </a>
+                                    
+                                </span>
+                                
+                                <div class="support-text">dgat1 mutants are deficient in triacylglycerol accumulation</div>
+                                
+                            </div>
+                            
+                        </div>
+                        
+                    </td>
+                </tr>
+                
+                <tr>
+                    <td>
+                        <div class="term-info">
+                            
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0004144" target="_blank" class="term-link">
+                                    GO:0004144
+                                </a>
+                            </span>
+                            <span class="term-label">diacylglycerol O-acyltransferase activity</span>
+                            
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+                        
+                        
+                        
+                        <br>
+                        <span style="font-size: 0.75rem;">
+                            
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/10386579" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:10386579
+                            </a>
+                            
+                                
+                                
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Cloning of a cDNA encoding diacylglycerol acyltransferase fr...
+                                </span>
+                                
+                            
+                            
+                        </span>
+                        
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9SLD2" data-a="GO:0004144" data-r="PMID:10386579" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+                        
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Core molecular function with direct experimental support from the original characterization of the Arabidopsis DGAT. [PMID:10386579]
+                        </div>
+                        
+                        
+                        
+                        
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+                            
+                            <div class="support-item">
+                                <span class="support-ref">
+                                    
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/10386579" target="_blank" class="term-link">
+                                        PMID:10386579
+                                    </a>
+                                    
+                                </span>
+                                
+                                <div class="support-text">characterization of Arabidopsis diacylglycerol acyltransferase</div>
+                                
+                            </div>
+                            
+                        </div>
+                        
+                    </td>
+                </tr>
+                
+                <tr>
+                    <td>
+                        <div class="term-info">
+                            
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0004144" target="_blank" class="term-link">
+                                    GO:0004144
+                                </a>
+                            </span>
+                            <span class="term-label">diacylglycerol O-acyltransferase activity</span>
+                            
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IMP</span>
+                        
+                        
+                        
+                        <br>
+                        <span style="font-size: 0.75rem;">
+                            
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/10601854" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:10601854
+                            </a>
+                            
+                                
+                                
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Expression in yeast and tobacco of plant cDNAs encoding acyl...
+                                </span>
+                                
+                            
+                            
+                        </span>
+                        
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9SLD2" data-a="GO:0004144" data-r="PMID:10601854" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+                        
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Core molecular function. Plant DGAT cDNAs (including Arabidopsis) expressed in yeast and tobacco confer diacylglycerol acyltransferase activity. [PMID:10601854]
+                        </div>
+                        
+                        
+                        
+                        
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+                            
+                            <div class="support-item">
+                                <span class="support-ref">
+                                    
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/10601854" target="_blank" class="term-link">
+                                        PMID:10601854
+                                    </a>
+                                    
+                                </span>
+                                
+                                <div class="support-text">expression in yeast and tobacco of plant cDNAs encoding acyl CoA:diacylglycerol acyltransferase</div>
+                                
+                            </div>
+                            
+                        </div>
+                        
+                    </td>
+                </tr>
+                
+                <tr>
+                    <td>
+                        <div class="term-info">
+                            
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016020" target="_blank" class="term-link">
+                                    GO:0016020
+                                </a>
+                            </span>
+                            <span class="term-label">membrane</span>
+                            
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+                        
+                        
+                        
+                        <br>
+                        <span style="font-size: 0.75rem;">
+                            
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/10601854" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:10601854
+                            </a>
+                            
+                                
+                                
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Expression in yeast and tobacco of plant cDNAs encoding acyl...
+                                </span>
+                                
+                            
+                            
+                        </span>
+                        
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9SLD2" data-a="GO:0016020" data-r="PMID:10601854" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+                        
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Correct but general; DGAT1 is membrane-bound, with the ER membrane being the informative localization.
+                        </div>
+                        
+                        
+                        
+                        
+                    </td>
+                </tr>
+                
+                <tr>
+                    <td>
+                        <div class="term-info">
+                            
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0019432" target="_blank" class="term-link">
+                                    GO:0019432
+                                </a>
+                            </span>
+                            <span class="term-label">triglyceride biosynthetic process</span>
+                            
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+                        
+                        
+                        
+                        <br>
+                        <span style="font-size: 0.75rem;">
+                            
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/10601854" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:10601854
+                            </a>
+                            
+                                
+                                
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Expression in yeast and tobacco of plant cDNAs encoding acyl...
+                                </span>
+                                
+                            
+                            
+                        </span>
+                        
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9SLD2" data-a="GO:0019432" data-r="PMID:10601854" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+                        
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Core biological process; the tag1 mutant establishes DGAT1&#39;s role in seed TAG biosynthesis. [PMID:10601854]
+                        </div>
+                        
+                        
+                        
+                        
+                    </td>
+                </tr>
+                
+                <tr>
+                    <td>
+                        <div class="term-info">
+                            
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005975" target="_blank" class="term-link">
+                                    GO:0005975
+                                </a>
+                            </span>
+                            <span class="term-label">carbohydrate metabolic process</span>
+                            
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IMP</span>
+                        
+                        
+                        
+                        <br>
+                        <span style="font-size: 0.75rem;">
+                            
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/12114588" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:12114588
+                            </a>
+                            
+                                
+                                
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Arabidopsis mutants deficient in diacylglycerol acyltransfer...
+                                </span>
+                                
+                            
+                            
+                        </span>
+                        
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="Q9SLD2" data-a="GO:0005975" data-r="PMID:12114588" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+                        
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Indirect consequence of disrupting seed oil storage (carbon re-partitioning toward carbohydrate), not a direct DGAT1 function. Retained as non-core given the acts_upstream_of_or_within qualifier. [PMID:12114588]
+                        </div>
+                        
+                        
+                        
+                        
+                    </td>
+                </tr>
+                
+                <tr>
+                    <td>
+                        <div class="term-info">
+                            
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0009409" target="_blank" class="term-link">
+                                    GO:0009409
+                                </a>
+                            </span>
+                            <span class="term-label">response to cold</span>
+                            
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IMP</span>
+                        
+                        
+                        
+                        <br>
+                        <span style="font-size: 0.75rem;">
+                            
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/12114588" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:12114588
+                            </a>
+                            
+                                
+                                
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Arabidopsis mutants deficient in diacylglycerol acyltransfer...
+                                </span>
+                                
+                            
+                            
+                        </span>
+                        
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="Q9SLD2" data-a="GO:0009409" data-r="PMID:12114588" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+                        
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Pleiotropic stress-response phenotype of the dgat1 mutant rather than a core molecular function. Retained as non-core. [PMID:12114588]
+                        </div>
+                        
+                        
+                        
+                        
+                    </td>
+                </tr>
+                
+                <tr>
+                    <td>
+                        <div class="term-info">
+                            
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0009651" target="_blank" class="term-link">
+                                    GO:0009651
+                                </a>
+                            </span>
+                            <span class="term-label">response to salt stress</span>
+                            
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IMP</span>
+                        
+                        
+                        
+                        <br>
+                        <span style="font-size: 0.75rem;">
+                            
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/12114588" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:12114588
+                            </a>
+                            
+                                
+                                
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Arabidopsis mutants deficient in diacylglycerol acyltransfer...
+                                </span>
+                                
+                            
+                            
+                        </span>
+                        
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="Q9SLD2" data-a="GO:0009651" data-r="PMID:12114588" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+                        
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Pleiotropic stress-response phenotype, non-core. [PMID:12114588]
+                        </div>
+                        
+                        
+                        
+                        
+                    </td>
+                </tr>
+                
+                <tr>
+                    <td>
+                        <div class="term-info">
+                            
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0009737" target="_blank" class="term-link">
+                                    GO:0009737
+                                </a>
+                            </span>
+                            <span class="term-label">response to abscisic acid</span>
+                            
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IMP</span>
+                        
+                        
+                        
+                        <br>
+                        <span style="font-size: 0.75rem;">
+                            
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/12114588" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:12114588
+                            </a>
+                            
+                                
+                                
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Arabidopsis mutants deficient in diacylglycerol acyltransfer...
+                                </span>
+                                
+                            
+                            
+                        </span>
+                        
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="Q9SLD2" data-a="GO:0009737" data-r="PMID:12114588" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+                        
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Pleiotropic hormone-response phenotype, non-core. [PMID:12114588]
+                        </div>
+                        
+                        
+                        
+                        
+                    </td>
+                </tr>
+                
+                <tr>
+                    <td>
+                        <div class="term-info">
+                            
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0009749" target="_blank" class="term-link">
+                                    GO:0009749
+                                </a>
+                            </span>
+                            <span class="term-label">response to glucose</span>
+                            
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IMP</span>
+                        
+                        
+                        
+                        <br>
+                        <span style="font-size: 0.75rem;">
+                            
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/12114588" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:12114588
+                            </a>
+                            
+                                
+                                
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Arabidopsis mutants deficient in diacylglycerol acyltransfer...
+                                </span>
+                                
+                            
+                            
+                        </span>
+                        
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="Q9SLD2" data-a="GO:0009749" data-r="PMID:12114588" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+                        
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Pleiotropic sugar-response phenotype tied to altered carbon partitioning, non-core. [PMID:12114588]
+                        </div>
+                        
+                        
+                        
+                        
+                    </td>
+                </tr>
+                
+                <tr>
+                    <td>
+                        <div class="term-info">
+                            
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0019432" target="_blank" class="term-link">
+                                    GO:0019432
+                                </a>
+                            </span>
+                            <span class="term-label">triglyceride biosynthetic process</span>
+                            
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IMP</span>
+                        
+                        
+                        
+                        <br>
+                        <span style="font-size: 0.75rem;">
+                            
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/11402213" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:11402213
+                            </a>
+                            
+                                
+                                
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Seed-specific over-expression of an Arabidopsis cDNA encodin...
+                                </span>
+                                
+                            
+                            
+                        </span>
+                        
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9SLD2" data-a="GO:0019432" data-r="PMID:11402213" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+                        
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Core biological process supported by mutant phenotype affecting seed TAG. [PMID:11402213]
+                        </div>
+                        
+                        
+                        
+                        
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+                            
+                            <div class="support-item">
+                                <span class="support-ref">
+                                    
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/11402213" target="_blank" class="term-link">
+                                        PMID:11402213
+                                    </a>
+                                    
+                                </span>
+                                
+                                <div class="support-text">seed-specific DGAT1 overexpression enhances seed oil content and seed weight</div>
+                                
+                            </div>
+                            
+                        </div>
+                        
+                    </td>
+                </tr>
+                
+                <tr>
+                    <td>
+                        <div class="term-info">
+                            
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0045995" target="_blank" class="term-link">
+                                    GO:0045995
+                                </a>
+                            </span>
+                            <span class="term-label">regulation of embryonic development</span>
+                            
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IMP</span>
+                        
+                        
+                        
+                        <br>
+                        <span style="font-size: 0.75rem;">
+                            
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/11402213" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:11402213
+                            </a>
+                            
+                                
+                                
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Seed-specific over-expression of an Arabidopsis cDNA encodin...
+                                </span>
+                                
+                            
+                            
+                        </span>
+                        
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="Q9SLD2" data-a="GO:0045995" data-r="PMID:11402213" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+                        
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Pleiotropic developmental phenotype associated with seed oil reserves, not a core molecular function. Retained as non-core. [PMID:11402213]
+                        </div>
+                        
+                        
+                        
+                        
+                    </td>
+                </tr>
+                
+            </tbody>
+        </table>
+    </div>
+    
+
+    
+    <div class="section">
+        <h2 class="section-title">Core Functions</h2>
+        
+        <div class="core-function-card">
+            
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+                <h3>DGAT1 catalyzes the terminal, committed step of acyl-CoA-dependent triacylglycerol assembly, transferring an acyl group from acyl-CoA to diacylglycerol to form TAG at the endoplasmic reticulum membrane, driving seed and pollen oil accumulation.</h3>
+                <span class="vote-buttons" data-g="Q9SLD2" data-a="FUNCTION: DGAT1 catalyzes the terminal, committed step of ac..." data-r="" data-act="CORE_FUNCTION">
+                    <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
+                    <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
+                </span>
+            </div>
+            
+
+            <div class="core-function-terms">
+                
+                <div class="function-term-group">
+                    <div class="function-term-label">Molecular Function:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0004144" target="_blank" class="term-link">
+                            diacylglycerol O-acyltransferase activity
+                        </a>
+                    </span>
+                </div>
+                
+
+                
+                <div class="function-term-group">
+                    <div class="function-term-label">Directly Involved In:</div>
+                    <div class="function-annotations">
+                        
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0019432" target="_blank" class="term-link">
+                                triglyceride biosynthetic process
+                            </a>
+                        </span>
+                        
+                    </div>
+                </div>
+                
+
+                
+                <div class="function-term-group">
+                    <div class="function-term-label">Cellular Locations:</div>
+                    <div class="function-annotations">
+                        
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005789" target="_blank" class="term-link">
+                                endoplasmic reticulum membrane
+                            </a>
+                        </span>
+                        
+                    </div>
+                </div>
+                
+
+                
+
+                
+            </div>
+
+            
+            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
+                <strong>Supporting Evidence:</strong>
+                <ul class="findings-list">
+                    
+                    <li class="finding-item">
+                        <span class="reference-id">
+                            
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/10386579" target="_blank" class="term-link">
+                                PMID:10386579
+                            </a>
+                            
+                        </span>
+                        
+                        <div class="finding-text">cloning of a cDNA encoding diacylglycerol acyltransferase from Arabidopsis thaliana and its functional expression</div>
+                        
+                    </li>
+                    
+                    <li class="finding-item">
+                        <span class="reference-id">
+                            
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/10571850" target="_blank" class="term-link">
+                                PMID:10571850
+                            </a>
+                            
+                        </span>
+                        
+                        <div class="finding-text">the Arabidopsis thaliana TAG1 mutant has a mutation in a diacylglycerol acyltransferase gene</div>
+                        
+                    </li>
+                    
+                    <li class="finding-item">
+                        <span class="reference-id">
+                            
+                            file:ARATH/DGAT1/DGAT1-deep-research-falcon.md
+                            
+                        </span>
+                        
+                        <div class="finding-text">DGAT1 catalyzes the terminal committed step of the acyl-CoA-dependent (Kennedy) pathway of TAG assembly at the ER</div>
+                        
+                    </li>
+                    
+                </ul>
+            </div>
+            
+        </div>
+        
+    </div>
+    
+
+    
+    <div class="section">
+        <h2 class="section-title collapsible">References</h2>
+        <div class="collapse-content">
+            
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+                        
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000033.md" target="_blank" class="term-link">
+                            GO_REF:0000033
+                        </a>
+                        
+                    </span>
+                </div>
+                
+                <div class="reference-title">Annotation inferences using phylogenetic trees</div>
+                
+                
+            </div>
+            
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+                        
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000044.md" target="_blank" class="term-link">
+                            GO_REF:0000044
+                        </a>
+                        
+                    </span>
+                </div>
+                
+                <div class="reference-title">Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location vocabulary mapping</div>
+                
+                
+            </div>
+            
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+                        
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000120.md" target="_blank" class="term-link">
+                            GO_REF:0000120
+                        </a>
+                        
+                    </span>
+                </div>
+                
+                <div class="reference-title">Combined Automated Annotation using Multiple IEA Methods</div>
+                
+                
+            </div>
+            
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+                        
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000122.md" target="_blank" class="term-link">
+                            GO_REF:0000122
+                        </a>
+                        
+                    </span>
+                </div>
+                
+                <div class="reference-title">AtSubP analysis</div>
+                
+                
+            </div>
+            
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+                        
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/10386579" target="_blank" class="term-link">
+                            PMID:10386579
+                        </a>
+                        
+                    </span>
+                </div>
+                
+                <div class="reference-title">Cloning of a cDNA encoding diacylglycerol acyltransferase from Arabidopsis thaliana and its functional expression.</div>
+                
+                
+                <ul class="findings-list">
+                    
+                    <li class="finding-item">
+                        <div class="finding-statement">Cloning and functional expression of the Arabidopsis DGAT1 cDNA, demonstrating diacylglycerol acyltransferase activity.</div>
+                        
+                    </li>
+                    
+                </ul>
+                
+            </div>
+            
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+                        
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/10571850" target="_blank" class="term-link">
+                            PMID:10571850
+                        </a>
+                        
+                    </span>
+                </div>
+                
+                <div class="reference-title">The Arabidopsis thaliana TAG1 mutant has a mutation in a diacylglycerol acyltransferase gene.</div>
+                
+                
+                <ul class="findings-list">
+                    
+                    <li class="finding-item">
+                        <div class="finding-statement">The Arabidopsis TAG1 mutant carries a mutation in a diacylglycerol acyltransferase gene, identifying DGAT1.</div>
+                        
+                    </li>
+                    
+                </ul>
+                
+            </div>
+            
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+                        
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/10580283" target="_blank" class="term-link">
+                            PMID:10580283
+                        </a>
+                        
+                    </span>
+                </div>
+                
+                <div class="reference-title">The TAG1 locus of Arabidopsis encodes for a diacylglycerol acyltransferase.</div>
+                
+                
+                <ul class="findings-list">
+                    
+                    <li class="finding-item">
+                        <div class="finding-statement">Shows the Arabidopsis TAG1 locus encodes a diacylglycerol acyltransferase (DGAT1).</div>
+                        
+                    </li>
+                    
+                </ul>
+                
+            </div>
+            
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+                        
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/10601854" target="_blank" class="term-link">
+                            PMID:10601854
+                        </a>
+                        
+                    </span>
+                </div>
+                
+                <div class="reference-title">Expression in yeast and tobacco of plant cDNAs encoding acyl CoA:diacylglycerol acyltransferase.</div>
+                
+                
+                <ul class="findings-list">
+                    
+                    <li class="finding-item">
+                        <div class="finding-statement">Plant DGAT cDNAs (including Arabidopsis) expressed in yeast and tobacco confer diacylglycerol acyltransferase activity.</div>
+                        
+                    </li>
+                    
+                </ul>
+                
+            </div>
+            
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+                        
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/11171171" target="_blank" class="term-link">
+                            PMID:11171171
+                        </a>
+                        
+                    </span>
+                </div>
+                
+                <div class="reference-title">Expression and characterization of diacylglycerol acyltransferase from Arabidopsis thaliana in insect cell cultures.</div>
+                
+                
+                <ul class="findings-list">
+                    
+                    <li class="finding-item">
+                        <div class="finding-statement">Expression and biochemical (EXP) characterization of Arabidopsis DGAT1 diacylglycerol acyltransferase activity in insect cell cultures.</div>
+                        
+                    </li>
+                    
+                </ul>
+                
+            </div>
+            
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+                        
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/11402213" target="_blank" class="term-link">
+                            PMID:11402213
+                        </a>
+                        
+                    </span>
+                </div>
+                
+                <div class="reference-title">Seed-specific over-expression of an Arabidopsis cDNA encoding a diacylglycerol acyltransferase enhances seed oil content and seed weight.</div>
+                
+                
+                <ul class="findings-list">
+                    
+                    <li class="finding-item">
+                        <div class="finding-statement">Seed-specific overexpression of Arabidopsis DGAT1 increases seed oil content and seed weight, linking it to TAG accumulation and seed/embryo development.</div>
+                        
+                    </li>
+                    
+                </ul>
+                
+            </div>
+            
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+                        
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/12114588" target="_blank" class="term-link">
+                            PMID:12114588
+                        </a>
+                        
+                    </span>
+                </div>
+                
+                <div class="reference-title">Arabidopsis mutants deficient in diacylglycerol acyltransferase display increased sensitivity to abscisic acid, sugars, and osmotic stress during germination and seedling development.</div>
+                
+                
+                <ul class="findings-list">
+                    
+                    <li class="finding-item">
+                        <div class="finding-statement">dgat1 mutants show increased sensitivity to ABA, sugars, and osmotic stress during germination/seedling development - pleiotropic effects downstream of disrupted seed oil storage.</div>
+                        
+                    </li>
+                    
+                </ul>
+                
+            </div>
+            
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+                        
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/12177474" target="_blank" class="term-link">
+                            PMID:12177474
+                        </a>
+                        
+                    </span>
+                </div>
+                
+                <div class="reference-title">A role for diacylglycerol acyltransferase during leaf senescence.</div>
+                
+                
+                <ul class="findings-list">
+                    
+                    <li class="finding-item">
+                        <div class="finding-statement">During leaf senescence DGAT1 transcript and protein increase, and DGAT1 protein is associated with chloroplast envelope and thylakoid membranes (not stroma), synthesizing plastoglobular TAG from de-esterified thylakoid galactolipid fatty acids; DGAT1 is also detected in the ER of developing siliques.</div>
+                        
+                    </li>
+                    
+                </ul>
+                
+            </div>
+            
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+                        
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/12502715" target="_blank" class="term-link">
+                            PMID:12502715
+                        </a>
+                        
+                    </span>
+                </div>
+                
+                <div class="reference-title">A novel bifunctional wax ester synthase/acyl-CoA:diacylglycerol acyltransferase mediates wax ester and triacylglycerol biosynthesis in Acinetobacter calcoaceticus ADP1.</div>
+                
+                
+                <ul class="findings-list">
+                    
+                    <li class="finding-item">
+                        <div class="finding-statement">Characterizes a bifunctional wax ester synthase/acyl-CoA:diacylglycerol acyltransferase from the bacterium Acinetobacter calcoaceticus ADP1.</div>
+                        
+                    </li>
+                    
+                </ul>
+                
+            </div>
+            
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+                        
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/22233193" target="_blank" class="term-link">
+                            PMID:22233193
+                        </a>
+                        
+                    </span>
+                </div>
+                
+                <div class="reference-title">Triacylglycerol synthesis by PDAT1 in the absence of DGAT1 activity is dependent on re-acylation of LPC by LPCAT2.</div>
+                
+                
+                <ul class="findings-list">
+                    
+                    <li class="finding-item">
+                        <div class="finding-statement">Primarily characterizes PDAT1/LPCAT2-dependent TAG synthesis in the absence of DGAT1 activity; DGAT1 appears as the parallel acyl-CoA-dependent route.</div>
+                        
+                    </li>
+                    
+                </ul>
+                
+            </div>
+            
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+                        
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/23770095" target="_blank" class="term-link">
+                            PMID:23770095
+                        </a>
+                        
+                    </span>
+                </div>
+                
+                <div class="reference-title">AtDGAT2 is a functional acyl-CoA:diacylglycerol acyltransferase and displays different acyl-CoA substrate preferences than AtDGAT1.</div>
+                
+                
+                <ul class="findings-list">
+                    
+                    <li class="finding-item">
+                        <div class="finding-statement">Characterizes the paralog AtDGAT2 and compares its acyl-CoA substrate preferences with AtDGAT1.</div>
+                        
+                    </li>
+                    
+                </ul>
+                
+            </div>
+            
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+                        
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/24663078" target="_blank" class="term-link">
+                            PMID:24663078
+                        </a>
+                        
+                    </span>
+                </div>
+                
+                <div class="reference-title">Function and localization of the Arabidopsis thaliana diacylglycerol acyltransferase DGAT2 expressed in yeast.</div>
+                
+                
+                <ul class="findings-list">
+                    
+                    <li class="finding-item">
+                        <div class="finding-statement">Characterizes the function and localization of the paralog DGAT2 expressed in yeast.</div>
+                        
+                    </li>
+                    
+                </ul>
+                
+            </div>
+            
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+                        
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/26586834" target="_blank" class="term-link">
+                            PMID:26586834
+                        </a>
+                        
+                    </span>
+                </div>
+                
+                <div class="reference-title">Identification of Arabidopsis GPAT9 (At5g60620) as an Essential Gene Involved in Triacylglycerol Biosynthesis.</div>
+                
+                
+                <ul class="findings-list">
+                    
+                    <li class="finding-item">
+                        <div class="finding-statement">Identifies Arabidopsis GPAT9 as essential for triacylglycerol biosynthesis; DGAT1 appears as an interaction partner.</div>
+                        
+                    </li>
+                    
+                </ul>
+                
+            </div>
+            
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+                        
+                        file:ARATH/DGAT1/DGAT1-deep-research-falcon.md
+                        
+                    </span>
+                </div>
+                
+                <div class="reference-title">Falcon/Edison deep research report for DGAT1/TAG1, Arabidopsis thaliana</div>
+                
+                
+                <ul class="findings-list">
+                    
+                    <li class="finding-item">
+                        <div class="finding-statement">Synthesizes DGAT1 as the ER multi-pass MBOAT enzyme catalyzing the terminal acyl-CoA-dependent step of TAG assembly; major seed/pollen DGAT, functionally redundant with PDAT1; a high-value oilseed yield engineering target.</div>
+                        
+                    </li>
+                    
+                </ul>
+                
+            </div>
+            
+        </div>
+    </div>
+    
+
+
+    
+    <div class="section">
+        <h2 class="section-title">Suggested Questions for Experts</h2>
+        
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> How is acyl flux partitioned between DGAT1 (acyl-CoA-dependent) and PDAT1 (acyl-CoA-independent) routes in oilseed feedstocks, and can DGAT1 acyl-specificity and ER substrate channeling (e.g. LPCAT-DGAT1 coupling) be engineered to raise oil yield and tailor composition?</p>
+                    
+                </div>
+                <span class="vote-buttons" data-g="Q9SLD2" data-a="Q: How is acyl flux partitioned between DGAT1 (acyl-C..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+        
+    </div>
+    
+
+    
+
+    
+
+    <!-- Computational Predictions Section -->
+    
+
+    <!-- Deep Research Sections -->
+    
+    <div class="section">
+        <h2 class="section-title">Deep Research</h2>
+        
+        <details class="deep-research-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; gap: 1rem;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Falcon</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(DGAT1-deep-research-falcon.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="Q9SLD2" data-a="DEEP_RESEARCH: Falcon" data-r="" data-act="DEEP_RESEARCH" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This deep research is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This deep research needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+                
+                <div class="report-meta">
+                    
+                    <span class="report-meta-text">this with annotations you find in gene/protein databases, but these can be outdated or inaccurate.</span>
+                    
+                    
+                    <span class="report-badge">Falcon</span>
+                    
+                    
+                    <span class="report-badge">Edison Scientific Literature</span>
+                    
+                    
+                    <span class="report-badge">32 citations</span>
+                    
+                    
+                    <span class="report-badge">1 artifacts</span>
+                    
+                    
+                    <span class="report-meta-text">2026-06-11T18:09:06.021786</span>
+                    
+                    
+                    
+                </div>
+                
+                
+                <div class="artifact-list">
+                    
+                    
+                    
+                    <div class="artifact-link">
+                        <a href="DGAT1-deep-research-falcon_artifacts/artifact-00.md" class="term-link">Edison artifact artifact-00</a>
+                        <span>(text/markdown)</span>
+                    </div>
+                    
+                    
+                </div>
+                
+                <p>The research report should be a detailed narrative explaining the function, biological processes, and localization of the gene product. Citations should be given for all claims.</p>
+<p>You should prioritize authoritative reviews and primary scientific literature when conducting research. You can supplement<br />
+this with annotations you find in gene/protein databases, but these can be outdated or inaccurate.</p>
+<p>We are specifically interested in the primary function of the gene - for enzymes, what reaction is catalyzed, and what is the substrate specificity? For transporters, what is the substrate? For structural proteins or adapters, what is the broader structural role? For signaling molecules, what is the role in the pathway.</p>
+<p>We are interested in where in or outside the cell the gene product carries out its function.</p>
+<p>We are also interested in the signaling or biochemical pathways in which the gene functions. We are less interested in broad pleiotropic effects, except where these elucidate the precise role.</p>
+<p>Include evidence where possible. We are interested in both experimental evidence as well as inference from structure, evolution, or bioinformatic analysis. Precise studies should be prioritized over high-throughput, where available.</p>
+<h2 id="research-report-arabidopsis-thaliana-dgat1-at2g19450-tag1-uniprot-q9sld2">Research Report: Arabidopsis thaliana <strong>DGAT1</strong> (At2g19450; TAG1; UniProt Q9SLD2)</h2>
+<h3 id="0-target-verification-critical-identity-check">0. Target verification (critical identity check)</h3>
+<p>The literature evidence reviewed here matches the UniProt target <strong>Q9SLD2</strong> from <strong>Arabidopsis thaliana</strong>, whose gene is <strong>DGAT1</strong> (locus <strong>At2g19450</strong>) and which is also known as <strong>TAG1</strong> (triacylglycerol 1). Lu et al. experimentally investigated <strong>At2g19450/DGAT1</strong> promoter activity and enzyme activity in Arabidopsis, confirming that this locus encodes <strong>diacylglycerol acyltransferase-1</strong> involved in TAG biosynthesis (https://doi.org/10.1023/a:1023935605864; published May 2003) (lu2003expressionpatternof pages 1-3, lu2003expressionpatternof pages 3-4).</p>
+<h3 id="1-key-concepts-and-definitions-current-understanding">1. Key concepts and definitions (current understanding)</h3>
+<h4 id="11-dgat1-definition-and-enzymatic-reaction">1.1 DGAT1 definition and enzymatic reaction</h4>
+<p><strong>DGAT1 (acyl-CoA:diacylglycerol acyltransferase 1)</strong> catalyzes the terminal/committed step of the <strong>acyl-CoA–dependent (Kennedy) pathway</strong> of triacylglycerol (TAG) assembly: transfer of an acyl group from <strong>acyl-CoA</strong> to <strong>diacylglycerol (DAG)</strong> (sn-3 position) to form <strong>TAG</strong>. This role is described directly in Arabidopsis-focused primary literature and is reiterated in reviews of plant TAG biosynthesis (lu2003expressionpatternof pages 1-3, aulakh2018transcriptomicandlipidomic pages 41-45, zhou2024regulationofoil pages 5-7).</p>
+<p>Lu et al. provide direct biochemical assay evidence: Arabidopsis microsomal membranes catalyzed incorporation of <strong>[14C]oleoyl-CoA</strong> into TAG using <strong>1,2-dioleoylglycerol</strong> as acyl acceptor (reaction mixture included 200 µM 1,2-dioleoylglycerol and 22.8 µM [14C]oleoyl-CoA), demonstrating the canonical DGAT reaction with defined substrates (https://doi.org/10.1023/a:1023935605864; 2003) (lu2003expressionpatternof pages 3-4).</p>
+<h4 id="12-pathway-context-dgat1-vs-parallel-terminal-tag-routes">1.2 Pathway context: DGAT1 vs parallel terminal TAG routes</h4>
+<p>A consistent theme in Arabidopsis and broader plant literature is that DGAT1 provides a major acyl-CoA–dependent route to TAG, while <strong>phospholipid:diacylglycerol acyltransferase (PDAT1)</strong> can provide an <strong>acyl-CoA–independent</strong> route (using phospholipids as acyl donors). Genetic evidence (summarized in a lipidomics/transcriptomics synthesis) indicates <strong>functional overlap</strong> between DGAT1 and PDAT1; severe TAG depletion and reproductive defects can arise when both routes are impaired (aulakh2018transcriptomicandlipidomic pages 104-109, behera2023acylcoadependentandacylcoaindependent pages 2-3).</p>
+<h3 id="2-foundational-experimental-evidence-in-arabidopsis-function-expression-phenotypes">2. Foundational experimental evidence in Arabidopsis (function, expression, phenotypes)</h3>
+<h4 id="21-subcellular-localization-membranemicrosomes-consistent-with-er">2.1 Subcellular localization: membrane/microsomes consistent with ER</h4>
+<p>DGAT1 catalytic activity is measured in <strong>microsomal membrane fractions</strong> (Lu et al., 2003), indicating that the enzyme acts in a membrane context (ER-derived microsomes in typical plant preparations) rather than as a soluble cytosolic enzyme (lu2003expressionpatternof pages 3-4, lu2003expressionpatternof pages 7-8). Review synthesis further describes plant DGAT1 as an <strong>integral ER membrane</strong> enzyme (xu2018propertiesandbiotechnological pages 11-13).</p>
+<h4 id="22-protein-topology-and-domain-level-mechanism-review-consensus">2.2 Protein topology and domain-level mechanism (review consensus)</h4>
+<p>Plant DGAT1 is widely described as a ~500 aa <strong>multi-pass membrane</strong> protein (commonly <strong>~8–10 transmembrane segments</strong>) in the <strong>MBOAT</strong> (membrane-bound O-acyltransferase) family, with a relatively large N-terminal region that can contribute to regulatory functions (e.g., acyl-CoA/CoA binding, oligomerization). These structural features are summarized in an authoritative Lipids review (Xu et al., 2018; https://doi.org/10.1002/lipd.12081; published July 2018) (xu2018propertiesandbiotechnological pages 11-13, xu2018propertiesandbiotechnological pages 33-36).</p>
+<h4 id="23-tissue-and-developmental-expression">2.3 Tissue and developmental expression</h4>
+<p>Lu et al. (2003) used promoter::GUS and immunoblotting to show DGAT1 expression is prominent in <strong>developing seeds/embryos</strong> and <strong>pollen</strong>, consistent with major TAG accumulation in these tissues (https://doi.org/10.1023/a:1023935605864; 2003) (lu2003expressionpatternof pages 1-3, lu2003expressionpatternof pages 3-4). DGAT1 protein during embryo development was detectable by ~5 days after anthesis, peaked around 7–9 days after anthesis, and remained detectable at later stages (lu2003expressionpatternof pages 7-8).</p>
+<p>In seedlings, DGAT1 promoter activity is detected in regions associated with rapid growth (shoot/root apical regions), and DGAT1 transcript abundance is responsive to sugar availability; 2% glucose induced DGAT1 expression by ~4-fold in 2-day-old seedlings (lu2003expressionpatternof pages 1-3, lu2003expressionpatternof pages 7-8).</p>
+<h4 id="24-quantitative-enzyme-activity-phenotypes-loss-of-function">2.4 Quantitative enzyme-activity phenotypes (loss-of-function)</h4>
+<p>In Arabidopsis, tag1/dgat1 mutants show an extreme reduction in measurable microsomal DGAT activity. Lu et al. report microsomal DGAT activity (nmol·mg−1·min−1) of roughly <strong>~116–201</strong> (Col WT; two experiments) and <strong>~138–260</strong> (Ws WT), compared with <strong>~2–8</strong> in tag1 mutant alleles, consistent with DGAT1 being the major microsomal DGAT activity in their assay conditions (https://doi.org/10.1023/a:1023935605864; 2003) (lu2003expressionpatternof pages 7-8).</p>
+<p>Consistently, when labeling 2-day seedlings with [14C]acetate, wild type incorporated ~<strong>5–7%</strong> of label into TAG, while tag1 mutants incorporated ~<strong>2–3%</strong>, implying DGAT1 contributes about half of detectable TAG synthesis in that seedling labeling context (lu2003expressionpatternof pages 7-8).</p>
+<h4 id="25-quantitative-seed-oil-and-lipid-composition-phenotypes">2.5 Quantitative seed oil and lipid composition phenotypes</h4>
+<p>A synthesis of Arabidopsis DGAT1 mutant phenotypes reports that <strong>dgat1-1</strong> retains about <strong>~75%</strong> of wild-type total seed oil and <strong>dgat1-2</strong> retains about <strong>~55%</strong> (i.e., ~25% and ~45% reductions). The same source summarizes fatty-acid composition changes including strong decreases in 18:1 and 20:1 and increases in 18:3 (aulakh2018transcriptomicandlipidomic pages 41-45).</p>
+<p>Lipidomics-focused summaries also report developing dgat1-1 seeds with ~<strong>35%</strong> reduced neutral lipid content and that, in genetic backgrounds where PDAT1 compensation is diminished (PDAT1 knockdown in dgat1), seed TAG can fall by <strong>~70–80%</strong>, highlighting that DGAT1 and PDAT1 together define much of terminal TAG-assembly capacity (aulakh2018transcriptomicandlipidomic pages 104-109).</p>
+<h3 id="3-recent-developments-prioritizing-20232024">3. Recent developments (prioritizing 2023–2024)</h3>
+<h4 id="31-2023-dgat1-as-part-of-er-lipid-biosynthesis-interactomes">3.1 2023: DGAT1 as part of ER lipid-biosynthesis interactomes</h4>
+<p>A 2023 review in <em>Plant Biotechnology Journal</em> emphasizes that plant lipid biosynthesis is increasingly understood through the lens of <strong>protein interactomes</strong> and cooperative ER assemblies, rather than isolated enzymes. This review discusses DGAT (including Arabidopsis DGAT1) as an ER-localized acyltransferase for DAG→TAG and reports AlphaFold2-based structural predictions suggesting an interaction between <strong>Arabidopsis LPCAT</strong> (lysophosphatidylcholine acyltransferase) and <strong>DGAT1</strong>, consistent with a model where acyl groups are channeled from phosphatidylcholine remodeling toward TAG assembly (https://doi.org/10.1111/pbi.14027; published March 2023) (xu2023proteininteractomesfor pages 4-6).</p>
+<h4 id="32-2024-genetic-improvement-strategies-featuring-atdgat1">3.2 2024: genetic improvement strategies featuring AtDGAT1</h4>
+<p>A 2024 review in <em>Genes</em> describes DGAT1 as a key, often broadly acting enzyme in plant seed oil synthesis and provides a concrete Arabidopsis engineering example: <strong>AtDGAT1 overexpression</strong> increased DGAT activity by <strong>~10–70%</strong> relative to wild type and increased <strong>thousand-seed weight</strong> and <strong>seed oil content</strong> (https://doi.org/10.3390/genes15091125; published Aug 2024) (zhou2024regulationofoil pages 7-9, zhou2024regulationofoil pages 5-7). This supports DGAT1 as a current “lever” in oilseed trait improvement.</p>
+<h3 id="4-current-applications-and-real-world-implementations">4. Current applications and real-world implementations</h3>
+<h4 id="41-metabolic-engineering-targets-and-design-constraints">4.1 Metabolic engineering targets and design constraints</h4>
+<p>DGAT1 is widely treated as a high-value engineering target to increase TAG accumulation in seeds (and sometimes vegetative tissues) because it catalyzes the last committed step in the acyl-CoA–dependent TAG pathway (zhou2024regulationofoil pages 5-7). The 2024 review’s reported <strong>10–70% DGAT activity increase</strong> and associated improvements in seed mass/oil content exemplify real-world strategy: increase terminal TAG assembly capacity to boost oil traits (zhou2024regulationofoil pages 7-9).</p>
+<p>However, Arabidopsis genetic-interaction evidence indicates engineering should account for network redundancy and compensation. PDAT1 can partially compensate for DGAT1 loss, and reducing both activities can cause very large TAG decreases (reported <strong>70–80%</strong> TAG reduction when PDAT1 is knocked down in a dgat1 background), as well as reproductive defects such as pollen oil body disruption and sterile pollen in combined-impairment contexts (aulakh2018transcriptomicandlipidomic pages 104-109, behera2023acylcoadependentandacylcoaindependent pages 2-3).</p>
+<h4 id="42-comparativebiotechnological-exemplars-plant-dgat1-orthologs">4.2 Comparative/biotechnological exemplars (plant DGAT1 orthologs)</h4>
+<p>Although not specific to Arabidopsis DGAT1, 2023 primary work on avocado DGAT1 illustrates a modern implementation pattern: expressing DGAT1 orthologs in heterologous systems (yeast, Nicotiana leaves) to increase lipid accumulation and steer fatty-acid composition. Avocado mesocarp naturally accumulates ~<strong>70% TAG (dry weight)</strong> and PaDGAT1 showed preference for oleic acid over palmitic acid in vitro, consistent with efforts to tailor oil composition by choosing DGAT variants with desired acyl preferences (https://doi.org/10.3389/fpls.2022.1056582; published Jan 2023) (behera2023acylcoadependentandacylcoaindependent pages 1-2).</p>
+<h3 id="5-expert-synthesis-and-interpretation-authoritative-opinions">5. Expert synthesis and interpretation (authoritative opinions)</h3>
+<h4 id="51-dgat1-as-a-central-flux-controlling-step">5.1 DGAT1 as a central flux-controlling step</h4>
+<p>Authoritative synthesis (Xu et al., 2018, <em>Lipids</em>) frames DGAT1 as a major determinant of carbon flux into seed TAG, typically ER-associated and membrane embedded, explaining why DGAT1 is repeatedly targeted in engineering approaches (https://doi.org/10.1002/lipd.12081; July 2018) (xu2018propertiesandbiotechnological pages 8-11, xu2018propertiesandbiotechnological pages 11-13).</p>
+<h4 id="52-shift-toward-interactome-guided-engineering">5.2 Shift toward interactome-guided engineering</h4>
+<p>The 2023 interactome review highlights a current research direction: to improve oil traits, it may be insufficient to increase DGAT1 abundance alone; instead, engineering might leverage <strong>enzyme assemblies and substrate channeling</strong> at the ER (e.g., involving LPCAT–DGAT1 coupling) to more efficiently route acyl flux into TAG (https://doi.org/10.1111/pbi.14027; March 2023) (xu2023proteininteractomesfor pages 4-6).</p>
+<h3 id="6-key-statistics-and-data-points-from-cited-evidence">6. Key statistics and data points (from cited evidence)</h3>
+<ul>
+<li><strong>In vitro Arabidopsis DGAT assay substrates (microsomes):</strong> 200 µM 1,2-dioleoylglycerol + 22.8 µM [14C]oleoyl-CoA (Lu et al., 2003; https://doi.org/10.1023/a:1023935605864) (lu2003expressionpatternof pages 3-4).</li>
+<li><strong>Microsomal DGAT activity:</strong> Col WT ~116–201 vs tag1 mutants ~2–8 nmol·mg−1·min−1 (Lu et al., 2003) (lu2003expressionpatternof pages 7-8).</li>
+<li><strong>Seedling [14C]acetate incorporation into TAG:</strong> WT ~5–7% vs tag1 ~2–3% (Lu et al., 2003) (lu2003expressionpatternof pages 7-8).</li>
+<li><strong>Seed oil reduction:</strong> dgat1-1 retains ~75% WT oil; dgat1-2 retains ~55% WT oil (summary evidence) (aulakh2018transcriptomicandlipidomic pages 41-45).</li>
+<li><strong>Severe TAG reduction when parallel pathway impaired:</strong> PDAT1 knockdown in dgat1 background reported ~70–80% TAG reduction (summary evidence) (aulakh2018transcriptomicandlipidomic pages 104-109, behera2023acylcoadependentandacylcoaindependent pages 2-3).</li>
+<li><strong>Engineering statistic (2024 review):</strong> AtDGAT1 overexpression increased DGAT activity by ~10–70% and increased thousand-seed weight and seed oil content (https://doi.org/10.3390/genes15091125; Aug 2024) (zhou2024regulationofoil pages 7-9, zhou2024regulationofoil pages 5-7).</li>
+</ul>
+<h3 id="7-evidence-map-structured-summary">7. Evidence map (structured summary)</h3>
+<table>
+<thead>
+<tr>
+<th>Study (first author, year)</th>
+<th>Publication (journal) and URL/DOI</th>
+<th>What was shown</th>
+<th>Key quantitative results</th>
+<th>Notes on relevance to functional annotation</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>Lu, 2003</td>
+<td><em>Plant Molecular Biology</em>; https://doi.org/10.1023/A:1023935605864</td>
+<td>Verified Arabidopsis DGAT1 corresponds to At2g19450/TAG1 and catalyzes the final acylation step in TAG biosynthesis; microsomal assay used 1,2-dioleoylglycerol + [14C]oleoyl-CoA; promoter::GUS and immunoblotting showed expression in developing seeds, pollen, germinating seeds/seedlings, and apical regions. (lu2003expressionpatternof pages 1-3, lu2003expressionpatternof pages 3-4)</td>
+<td>In vitro assay used 200 µM 1,2-dioleoylglycerol and 22.8 µM [14C]oleoyl-CoA with 10 µg microsomal protein; DGAT1 protein detected by 5 days after anthesis, peaked at 7–9 DAA, still detectable at 23 DAA. (lu2003expressionpatternof pages 3-4, lu2003expressionpatternof pages 7-8)</td>
+<td>Strong primary evidence for core function, biochemical substrates, and tissue/developmental expression of Q9SLD2/AtDGAT1.</td>
+</tr>
+<tr>
+<td>Lu, 2003</td>
+<td><em>Plant Molecular Biology</em>; https://doi.org/10.1023/A:1023935605864</td>
+<td>Demonstrated DGAT1 activity is largely microsomal and that tag1 mutants lose most detectable DGAT activity; also linked DGAT1 to seedling TAG synthesis and glucose-responsive expression. (lu2003expressionpatternof pages 7-8)</td>
+<td>Microsomal DGAT activity (nmol·mg−1·min−1): Col WT 201 ± 1 and 116 ± 18; Ws WT 260 ± 29 and 138 ± 11; tag1-1 2 ± 3 and 7 ± 4; tag1-2 4 ± 1 and 8 ± 2. [14C]acetate labeling into TAG: WT ~5–7% vs tag1 ~2–3%. DGAT1 transcript upregulated ~4-fold by 2% glucose in 2-day seedlings. (lu2003expressionpatternof pages 7-8)</td>
+<td>Provides quantitative loss-of-function evidence that DGAT1 is the major Arabidopsis microsomal DGAT in seedlings and is responsive to carbon status.</td>
+</tr>
+<tr>
+<td>Aulakh, 2018 (summarizing prior Arabidopsis studies)</td>
+<td>Unknown journal/book chapter; no DOI in snippet</td>
+<td>Summarized that AtDGAT1 transfers an acyl group from acyl-CoA to the sn-3 position of DAG to form TAG; described AtDGAT1 as ~500 aa with ~10 predicted TM domains and ER-associated activity in developing seeds; transcripts present in siliques, stem, leaves, flowers, germinating seeds, and seedlings. (aulakh2018transcriptomicandlipidomic pages 41-45)</td>
+<td>Overexpression in yeast increased microsomal DGAT activity 3.5–4-fold; dgat1-1 showed 40–70% lower DGAT activity during seed development; mature seed oil retained: dgat1-1 ~75% of WT, dgat1-2 ~55% of WT. (aulakh2018transcriptomicandlipidomic pages 41-45)</td>
+<td>Useful secondary synthesis aligning UniProt family/domain assignment with plant MBOAT topology and ER localization.</td>
+</tr>
+<tr>
+<td>Aulakh, 2018 (summarizing prior Arabidopsis studies)</td>
+<td>Unknown journal/book chapter; no DOI in snippet</td>
+<td>Reported mutant lipid phenotypes and pathway compensation with PDAT1; emphasized that TAG1 is a DGAT1 mutant affecting TAG synthesis in seeds and pollen. (aulakh2018transcriptomicandlipidomic pages 104-109, aulakh2018transcriptomicandlipidomic pages 100-104)</td>
+<td>dgat1-1: 25–45% seed oil reduction; developing seeds had 35% lower neutral lipid; ~60% decreases in 18:1 and 20:1 and ~100% increase in 18:3 in mature seed; PDAT1 knockdown in dgat1 background caused 70–80% oil reduction; dgat1-1 pdat1 disrupted pollen oil body formation and caused sterile pollen. (aulakh2018transcriptomicandlipidomic pages 104-109, aulakh2018transcriptomicandlipidomic pages 41-45)</td>
+<td>Important for pathway annotation: DGAT1 is primary but not sole TAG-synthesis route; overlaps functionally with PDAT1 and is required for normal pollen/seed development when compensation is removed.</td>
+</tr>
+<tr>
+<td>Xu, 2018</td>
+<td><em>Lipids</em>; https://doi.org/10.1002/lipd.12081</td>
+<td>Review described DGAT1 as a membrane-bound acyl-CoA:diacylglycerol acyltransferase in the acyl-CoA-dependent TAG pathway, generally ER-localized and a major determinant of carbon flux into seed TAG. (xu2018propertiesandbiotechnological pages 8-11)</td>
+<td>No Arabidopsis-specific kinetic numbers in snippet; reports qualitative evidence that AS11/DGAT1 inactivation dramatically decreases seed oil and that enhanced DGAT1 expression improves freezing tolerance. (xu2018propertiesandbiotechnological pages 8-11, xu2018propertiesandbiotechnological pages 11-13)</td>
+<td>Authoritative review supporting current understanding of DGAT1 as a central, often rate-limiting TAG assembly enzyme in plants.</td>
+</tr>
+<tr>
+<td>Xu, 2018</td>
+<td><em>Lipids</em>; https://doi.org/10.1002/lipd.12081</td>
+<td>Summarized structural/topological features of plant DGAT1: integral ER membrane enzyme with large hydrophilic N-terminus, ~8–10 TM helices, MBOAT-family catalytic residues, N-terminal acyl-CoA/CoA-binding and oligomerization features, and an ER retrieval motif. (xu2018propertiesandbiotechnological pages 11-13, xu2018propertiesandbiotechnological pages 33-36)</td>
+<td>Protein size ~500 aa; topology ~8–10 TMs. (xu2018propertiesandbiotechnological pages 11-13, xu2018propertiesandbiotechnological pages 33-36)</td>
+<td>Highly relevant to subcellular localization and mechanism; supports UniProt domain/family assignment for Q9SLD2.</td>
+</tr>
+<tr>
+<td>Xu, 2018</td>
+<td><em>Lipids</em>; https://doi.org/10.1002/lipd.12081</td>
+<td>Cited transcriptional regulation leads for DGAT1, including MYB96 activation and ABI4/ABI5 synergistic regulation under stress; also highlighted molecular studies on membrane interactions and substrate binding. (xu2018propertiesandbiotechnological pages 43-45)</td>
+<td>No quantitative Arabidopsis values in snippet. (xu2018propertiesandbiotechnological pages 43-45)</td>
+<td>Useful for functional annotation of regulatory context, though details should be treated as review-level leads unless checked in primary papers.</td>
+</tr>
+<tr>
+<td>Xu, 2023</td>
+<td><em>Plant Biotechnology Journal</em>; https://doi.org/10.1111/pbi.14027</td>
+<td>Positioned DGAT1 within an ER transferase interactome for TAG assembly; AlphaFold2 and prior interaction evidence suggested Arabidopsis LPCAT–DGAT1 interaction and acyl channeling from PC to TAG. (xu2023proteininteractomesfor pages 4-6)</td>
+<td>No quantitative effect sizes in snippet. (xu2023proteininteractomesfor pages 4-6)</td>
+<td>Relevant to modern understanding that DGAT1 may function within multiprotein ER assemblies rather than as an isolated enzyme.</td>
+</tr>
+<tr>
+<td>Zhou, 2024</td>
+<td><em>Genes</em>; https://doi.org/10.3390/genes15091125</td>
+<td>Recent review reaffirmed DGAT1/2/3 catalyze DAG-to-TAG conversion using acyl-CoA and emphasized DGAT1 as broadly important in plant TAG metabolism; highlighted AtDGAT1 overexpression as an engineering strategy. (zhou2024regulationofoil pages 7-9, zhou2024regulationofoil pages 5-7)</td>
+<td>AtDGAT1 overexpression increased DGAT activity by 10–70% over WT and increased thousand-seed weight and seed oil content. (zhou2024regulationofoil pages 7-9, zhou2024regulationofoil pages 5-7)</td>
+<td>Useful 2024 synthesis connecting Arabidopsis DGAT1 function to current crop-oil engineering strategies.</td>
+</tr>
+<tr>
+<td>Behera, 2023</td>
+<td><em>Frontiers in Plant Science</em>; https://doi.org/10.3389/fpls.2022.1056582</td>
+<td>Although focused on avocado DGAT1, this 2023 study/review context reinforced that Arabidopsis DGAT1 loss causes modest total seed-oil reduction but strong fatty-acid composition shifts, and that DGAT1 and PDAT1 are partially redundant in seed TAG synthesis. (behera2023acylcoadependentandacylcoaindependent pages 2-3, behera2023acylcoadependentandacylcoaindependent pages 1-2)</td>
+<td>Seed-specific PDAT1 RNAi in a dgat1 background caused 70–80% TAG reduction; avocado mesocarp example accumulated ~70% TAG dry weight and PaDGAT1 preferred oleic acid over palmitate. (behera2023acylcoadependentandacylcoaindependent pages 2-3, behera2023acylcoadependentandacylcoaindependent pages 1-2)</td>
+<td>Relevant comparative evidence for substrate preference concepts and for understanding DGAT1/PDAT1 functional redundancy in plants.</td>
+</tr>
+</tbody>
+</table>
+<p><em>Table: This table compiles evidence-based findings for Arabidopsis thaliana DGAT1/At2g19450/TAG1 from primary and review sources cited in the conversation. It is useful for functional annotation because it links reaction chemistry, localization, expression, mutant phenotypes, regulation, and engineering relevance to specific evidence snippets.</em></p>
+<h3 id="8-limitations-of-the-current-evidence-set">8. Limitations of the current evidence set</h3>
+<ul>
+<li>Several key primary studies repeatedly referenced in the evidence (e.g., classic TAG1 mapping, double-mutant phenotypes, and detailed TF regulation such as MYB96/ABI4/ABI5) were only available here through secondary citations/review mentions and were not directly retrieved as full primary texts in this run; those regulatory claims should be treated as review-level leads unless independently verified in the original articles (xu2018propertiesandbiotechnological pages 43-45, aulakh2018transcriptomicandlipidomic pages 104-109).</li>
+<li>Figure/table image extraction from primary PDFs was unsuccessful in this run, so this report relies on extracted text evidence rather than direct figure citations.</li>
+</ul>
+<p>References</p>
+<ol>
+<li>
+<p>(lu2003expressionpatternof pages 1-3): Chaofu Lu, Shen Bayon de Noyer, D. Hobbs, Jinling Kang, Y. Wen, D. Krachtus, and M. Hills. Expression pattern of diacylglycerol acyltransferase-1, an enzyme involved in triacylglycerol biosynthesis, in arabidopsis thaliana. Plant Molecular Biology, 52:31-41, May 2003. URL: https://doi.org/10.1023/a:1023935605864, doi:10.1023/a:1023935605864. This article has 96 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(lu2003expressionpatternof pages 3-4): Chaofu Lu, Shen Bayon de Noyer, D. Hobbs, Jinling Kang, Y. Wen, D. Krachtus, and M. Hills. Expression pattern of diacylglycerol acyltransferase-1, an enzyme involved in triacylglycerol biosynthesis, in arabidopsis thaliana. Plant Molecular Biology, 52:31-41, May 2003. URL: https://doi.org/10.1023/a:1023935605864, doi:10.1023/a:1023935605864. This article has 96 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(aulakh2018transcriptomicandlipidomic pages 41-45): KS Aulakh. Transcriptomic and lipidomic profiling in developing seeds of two brassicaceae species to identify key regulators associated with storage oil synthesis. Unknown journal, 2018.</p>
+</li>
+<li>
+<p>(zhou2024regulationofoil pages 5-7): Lixia Zhou, Qiufei Wu, Yaodong Yang, Qihong Li, Rui Li, and Jianqiu Ye. Regulation of oil biosynthesis and genetic improvement in plants: advances and prospects. Genes, 15:1125, Aug 2024. URL: https://doi.org/10.3390/genes15091125, doi:10.3390/genes15091125. This article has 23 citations.</p>
+</li>
+<li>
+<p>(aulakh2018transcriptomicandlipidomic pages 104-109): KS Aulakh. Transcriptomic and lipidomic profiling in developing seeds of two brassicaceae species to identify key regulators associated with storage oil synthesis. Unknown journal, 2018.</p>
+</li>
+<li>
+<p>(behera2023acylcoadependentandacylcoaindependent pages 2-3): Jyoti Behera, Md Mahbubur Rahman, Jay Shockey, and Aruna Kilaru. Acyl-coa-dependent and acyl-coa-independent avocado acyltransferases positively influence oleic acid content in nonseed triacylglycerols. Frontiers in Plant Science, Jan 2023. URL: https://doi.org/10.3389/fpls.2022.1056582, doi:10.3389/fpls.2022.1056582. This article has 17 citations.</p>
+</li>
+<li>
+<p>(lu2003expressionpatternof pages 7-8): Chaofu Lu, Shen Bayon de Noyer, D. Hobbs, Jinling Kang, Y. Wen, D. Krachtus, and M. Hills. Expression pattern of diacylglycerol acyltransferase-1, an enzyme involved in triacylglycerol biosynthesis, in arabidopsis thaliana. Plant Molecular Biology, 52:31-41, May 2003. URL: https://doi.org/10.1023/a:1023935605864, doi:10.1023/a:1023935605864. This article has 96 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(xu2018propertiesandbiotechnological pages 11-13): Yang Xu, Kristian Mark P. Caldo, Dipasmita Pal‐Nath, Jocelyn Ozga, M. Joanne Lemieux, Randall J. Weselake, and Guanqun Chen. Properties and biotechnological applications of acyl-coa:diacylglycerol acyltransferase and phospholipid:diacylglycerol acyltransferase from terrestrial plants and microalgae. Lipids, 53 7:663-688, Jul 2018. URL: https://doi.org/10.1002/lipd.12081, doi:10.1002/lipd.12081. This article has 120 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(xu2018propertiesandbiotechnological pages 33-36): Yang Xu, Kristian Mark P. Caldo, Dipasmita Pal‐Nath, Jocelyn Ozga, M. Joanne Lemieux, Randall J. Weselake, and Guanqun Chen. Properties and biotechnological applications of acyl-coa:diacylglycerol acyltransferase and phospholipid:diacylglycerol acyltransferase from terrestrial plants and microalgae. Lipids, 53 7:663-688, Jul 2018. URL: https://doi.org/10.1002/lipd.12081, doi:10.1002/lipd.12081. This article has 120 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(xu2023proteininteractomesfor pages 4-6): Yang Xu, Stacy D. Singer, and Guanqun Chen. Protein interactomes for plant lipid biosynthesis and their biotechnological applications. Plant Biotechnology Journal, 21:1734-1744, Mar 2023. URL: https://doi.org/10.1111/pbi.14027, doi:10.1111/pbi.14027. This article has 34 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(zhou2024regulationofoil pages 7-9): Lixia Zhou, Qiufei Wu, Yaodong Yang, Qihong Li, Rui Li, and Jianqiu Ye. Regulation of oil biosynthesis and genetic improvement in plants: advances and prospects. Genes, 15:1125, Aug 2024. URL: https://doi.org/10.3390/genes15091125, doi:10.3390/genes15091125. This article has 23 citations.</p>
+</li>
+<li>
+<p>(behera2023acylcoadependentandacylcoaindependent pages 1-2): Jyoti Behera, Md Mahbubur Rahman, Jay Shockey, and Aruna Kilaru. Acyl-coa-dependent and acyl-coa-independent avocado acyltransferases positively influence oleic acid content in nonseed triacylglycerols. Frontiers in Plant Science, Jan 2023. URL: https://doi.org/10.3389/fpls.2022.1056582, doi:10.3389/fpls.2022.1056582. This article has 17 citations.</p>
+</li>
+<li>
+<p>(xu2018propertiesandbiotechnological pages 8-11): Yang Xu, Kristian Mark P. Caldo, Dipasmita Pal‐Nath, Jocelyn Ozga, M. Joanne Lemieux, Randall J. Weselake, and Guanqun Chen. Properties and biotechnological applications of acyl-coa:diacylglycerol acyltransferase and phospholipid:diacylglycerol acyltransferase from terrestrial plants and microalgae. Lipids, 53 7:663-688, Jul 2018. URL: https://doi.org/10.1002/lipd.12081, doi:10.1002/lipd.12081. This article has 120 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(aulakh2018transcriptomicandlipidomic pages 100-104): KS Aulakh. Transcriptomic and lipidomic profiling in developing seeds of two brassicaceae species to identify key regulators associated with storage oil synthesis. Unknown journal, 2018.</p>
+</li>
+<li>
+<p>(xu2018propertiesandbiotechnological pages 43-45): Yang Xu, Kristian Mark P. Caldo, Dipasmita Pal‐Nath, Jocelyn Ozga, M. Joanne Lemieux, Randall J. Weselake, and Guanqun Chen. Properties and biotechnological applications of acyl-coa:diacylglycerol acyltransferase and phospholipid:diacylglycerol acyltransferase from terrestrial plants and microalgae. Lipids, 53 7:663-688, Jul 2018. URL: https://doi.org/10.1002/lipd.12081, doi:10.1002/lipd.12081. This article has 120 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+</ol>
+<h2 id="artifacts">Artifacts</h2>
+<ul>
+<li><a href="DGAT1-deep-research-falcon_artifacts/artifact-00.md">Edison artifact artifact-00</a></li>
+</ul>
+<h2 id="citations">Citations</h2>
+<ol>
+<li>lu2003expressionpatternof pages 3-4</li>
+<li>xu2018propertiesandbiotechnological pages 11-13</li>
+<li>lu2003expressionpatternof pages 7-8</li>
+<li>aulakh2018transcriptomicandlipidomic pages 41-45</li>
+<li>aulakh2018transcriptomicandlipidomic pages 104-109</li>
+<li>xu2023proteininteractomesfor pages 4-6</li>
+<li>zhou2024regulationofoil pages 5-7</li>
+<li>zhou2024regulationofoil pages 7-9</li>
+<li>behera2023acylcoadependentandacylcoaindependent pages 1-2</li>
+<li>xu2018propertiesandbiotechnological pages 8-11</li>
+<li>xu2018propertiesandbiotechnological pages 43-45</li>
+<li>lu2003expressionpatternof pages 1-3</li>
+<li>behera2023acylcoadependentandacylcoaindependent pages 2-3</li>
+<li>xu2018propertiesandbiotechnological pages 33-36</li>
+<li>aulakh2018transcriptomicandlipidomic pages 100-104</li>
+<li>14C</li>
+<li>https://doi.org/10.1023/a:1023935605864;</li>
+<li>https://doi.org/10.1002/lipd.12081;</li>
+<li>https://doi.org/10.1111/pbi.14027;</li>
+<li>https://doi.org/10.3390/genes15091125;</li>
+<li>https://doi.org/10.3389/fpls.2022.1056582;</li>
+<li>https://doi.org/10.1023/a:1023935605864</li>
+<li>https://doi.org/10.1023/A:1023935605864</li>
+<li>https://doi.org/10.1002/lipd.12081</li>
+<li>https://doi.org/10.1111/pbi.14027</li>
+<li>https://doi.org/10.3390/genes15091125</li>
+<li>https://doi.org/10.3389/fpls.2022.1056582</li>
+<li>https://doi.org/10.1023/a:1023935605864,</li>
+<li>https://doi.org/10.3390/genes15091125,</li>
+<li>https://doi.org/10.3389/fpls.2022.1056582,</li>
+<li>https://doi.org/10.1002/lipd.12081,</li>
+<li>https://doi.org/10.1111/pbi.14027,</li>
+</ol>
+            </div>
+        </details>
+        
+    </div>
+    
+
+    <!-- Additional Documentation Sections -->
+    
+    <div class="section">
+        <h2 class="section-title">📚 Additional Documentation</h2>
+        
+        <details class="markdown-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; cursor: pointer;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Notes</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(DGAT1-notes.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="Q9SLD2" data-a="DOC: Notes" data-r="" data-act="DOCUMENTATION" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This documentation is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This documentation needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+                <h1 id="dgat1-tag1-diacylglycerol-o-acyltransferase-1-arabidopsis-thaliana-review-notes">DGAT1 / TAG1 (diacylglycerol O-acyltransferase 1) — Arabidopsis thaliana — review notes</h1>
+<p>UniProt: Q9SLD2 · At2g19450 · EC 2.3.1.20 · Taxon 3702<br />
+Relevance: terminal committed step of seed-oil (TAG) assembly — a premier DOE/BER<br />
+oilseed yield-engineering target.</p>
+<h2 id="core-function">Core function</h2>
+<ul>
+<li><strong>Acyl-CoA:diacylglycerol acyltransferase 1</strong>: catalyzes the terminal, committed step<br />
+  of the acyl-CoA-dependent (Kennedy) pathway of TAG assembly — transfer of an acyl group<br />
+  from acyl-CoA to the sn-3 position of diacylglycerol (DAG) to form triacylglycerol (TAG).<br />
+  [file:ARATH/DGAT1/DGAT1-deep-research-falcon.md; PMID:10386579; PMID:11171171]</li>
+<li>Multi-pass ER membrane protein of the <strong>MBOAT</strong> family (~8-10 TM segments).<br />
+  [file:ARATH/DGAT1/DGAT1-deep-research-falcon.md]</li>
+<li>Major microsomal DGAT in seeds/pollen; tag1/dgat1 mutants lose most microsomal DGAT<br />
+  activity (WT ~116-201 vs tag1 ~2-8 nmol/mg/min) and have reduced seed oil (dgat1-1 ~75%,<br />
+  dgat1-2 ~55% of WT). Functionally redundant with PDAT1 (acyl-CoA-independent route);<br />
+  dgat1 + PDAT1 knockdown drops TAG ~70-80%. [PMID:10601854; PMID:10571850;<br />
+  file:ARATH/DGAT1/DGAT1-deep-research-falcon.md]</li>
+</ul>
+<h2 id="localization">Localization</h2>
+<ul>
+<li><strong>Endoplasmic reticulum membrane</strong> (microsomal), the functional site of TAG synthesis;<br />
+  also lipid-droplet associated (ER-LD interface). [IBA; EXP/IDA; PMID:24663078]</li>
+<li>Spurious / non-functional localizations to address:</li>
+<li>GO:0005634 nucleus (ISM, AtSubP) -&gt; REMOVE (sequence-model artifact; same as FAE1/FAD2)</li>
+<li>GO:0031969 chloroplast membrane (IEA, UniProt SL mapping) -&gt; REMOVE (electronic<br />
+    propagation of a contested localization; no functional support)</li>
+<li>GO:0009941 chloroplast envelope (IDA, PMID:12177474) -&gt; MARK_AS_OVER_ANNOTATED:<br />
+    detected in a chloroplast-envelope proteomics survey, almost certainly co-purifying<br />
+    ER contamination; DGAT1 is functionally an ER enzyme.</li>
+</ul>
+<h2 id="pleiotropy-keep_as_non_core">Pleiotropy (KEEP_AS_NON_CORE)</h2>
+<p>A single mutant-phenotype study (PMID:12114588) generated many indirect BP annotations via<br />
+<code>acts_upstream_of_or_within</code>: carbohydrate metabolic process, response to cold/salt/ABA/<br />
+glucose, embryo development ending in seed dormancy. These reflect the downstream<br />
+physiological consequences of disrupting seed oil storage / carbon partitioning, not<br />
+DGAT1's molecular activity -&gt; KEEP_AS_NON_CORE. Likewise seed-germination and embryonic-<br />
+development regulation (PMID:10580283, PMID:11402213) are pleiotropic -&gt; KEEP_AS_NON_CORE.<br />
+GO:0005515 protein binding (IPI) is uninformative per curation guidance -&gt; KEEP_AS_NON_CORE.</p>
+<h2 id="annotation-review-summary">Annotation review summary</h2>
+<ul>
+<li>GO:0004144 diacylglycerol O-acyltransferase activity (EXP/IDA/IMP/ISS/IEA, x8) -&gt; ACCEPT (core MF)</li>
+<li>GO:0019432 triglyceride biosynthetic process (IDA/IMP/TAS/IEA, x5) -&gt; ACCEPT (core BP)</li>
+<li>GO:0005789 ER membrane (IBA/IEA) -&gt; ACCEPT (core location)</li>
+<li>GO:0016020 membrane (IDA/TAS) -&gt; ACCEPT (general location)</li>
+<li>GO:0005811 lipid droplet (IDA) -&gt; KEEP_AS_NON_CORE</li>
+<li>chloroplast membrane (IEA) -&gt; REMOVE; chloroplast envelope (IDA) -&gt; MARK_AS_OVER_ANNOTATED</li>
+<li>nucleus (ISM) -&gt; REMOVE</li>
+<li>seed-germination / embryonic-development / stress-response / carbohydrate BPs -&gt; KEEP_AS_NON_CORE</li>
+<li>protein binding (IPI) -&gt; KEEP_AS_NON_CORE</li>
+</ul>
+<h2 id="doeber-relevance">DOE/BER relevance</h2>
+<p>DGAT1 overexpression raises DGAT activity (~10-70%), seed weight, and oil content — a<br />
+direct lever for boosting oilseed yield in bioenergy feedstocks; acyl preference of DGAT<br />
+variants can tailor oil composition.</p>
+            </div>
+        </details>
+        
+    </div>
+    
+
+    <!-- YAML Preview Section -->
+    <div class="section">
+        <details class="yaml-preview">
+            <summary>
+                <h2 style="display: inline;">📄 View Raw YAML</h2>
+            </summary>
+            <div class="yaml-content">
+                <pre><code>id: Q9SLD2
+gene_symbol: DGAT1
+product_type: PROTEIN
+status: COMPLETE
+taxon:
+  id: NCBITaxon:3702
+  label: Arabidopsis thaliana
+description: DGAT1 (TAG1) is the acyl-CoA:diacylglycerol acyltransferase 1 of Arabidopsis,
+  a multi-pass endoplasmic-reticulum membrane enzyme of the membrane-bound O-acyltransferase
+  (MBOAT) family. It catalyzes the terminal, committed step of the acyl-CoA-dependent
+  (Kennedy) pathway of triacylglycerol (TAG) assembly, transferring an acyl group from
+  acyl-CoA to the sn-3 position of diacylglycerol to form TAG. It is the major microsomal
+  DGAT activity in developing seeds and pollen and a principal determinant of seed-oil
+  content; it acts partly redundantly with the acyl-CoA-independent enzyme PDAT1, so that
+  strong TAG depletion and reproductive defects arise mainly when both routes are impaired.
+  While its primary site is the ER, during leaf senescence DGAT1 is also associated with
+  chloroplast envelope and thylakoid membranes, where it forms plastoglobular TAG from
+  fatty acids recycled from thylakoid galactolipids.
+existing_annotations:
+  - term:
+      id: GO:0005789
+      label: endoplasmic reticulum membrane
+    evidence_type: IBA
+    original_reference_id: GO_REF:0000033
+    qualifier: is_active_in
+    review:
+      summary: Correct core localization. DGAT1 is an ER (microsomal) membrane enzyme; the
+        ER is the functional site of TAG assembly. Consistent with experimental microsomal
+        DGAT activity.
+      action: ACCEPT
+  - term:
+      id: GO:0004144
+      label: diacylglycerol O-acyltransferase activity
+    evidence_type: IEA
+    original_reference_id: GO_REF:0000120
+    qualifier: enables
+    review:
+      summary: Core molecular function, also supported by extensive experimental evidence
+        (EXP/IDA/IMP below). DGAT1 transfers an acyl group from acyl-CoA to diacylglycerol
+        to form TAG.
+      action: ACCEPT
+  - term:
+      id: GO:0005789
+      label: endoplasmic reticulum membrane
+    evidence_type: IEA
+    original_reference_id: GO_REF:0000044
+    qualifier: located_in
+    review:
+      summary: Correct core localization (ER membrane), consistent with the IBA annotation
+        and with microsomal DGAT assays.
+      action: ACCEPT
+  - term:
+      id: GO:0019432
+      label: triglyceride biosynthetic process
+    evidence_type: IEA
+    original_reference_id: GO_REF:0000120
+    qualifier: involved_in
+    review:
+      summary: Core biological process, also supported experimentally (IDA/IMP/TAS below).
+        DGAT1 catalyzes the terminal step of TAG biosynthesis.
+      action: ACCEPT
+  - term:
+      id: GO:0031969
+      label: chloroplast membrane
+    evidence_type: IEA
+    original_reference_id: GO_REF:0000044
+    qualifier: located_in
+    review:
+      summary: Retained as a non-core localization. This electronic UniProt
+        subcellular-location annotation reflects the experimentally documented association
+        of DGAT1 with chloroplast (envelope/thylakoid) membranes during leaf senescence,
+        where it synthesizes plastoglobular TAG from recycled thylakoid galactolipid fatty
+        acids (PMID:12177474). It is a genuine secondary localization, subordinate to the
+        primary ER site of seed-oil TAG synthesis.
+      action: KEEP_AS_NON_CORE
+      supported_by:
+        - reference_id: PMID:12177474
+          supporting_text: DGAT1 protein in senescing leaves was found to be associated
+            with chloroplast membranes
+  - term:
+      id: GO:0004144
+      label: diacylglycerol O-acyltransferase activity
+    evidence_type: EXP
+    original_reference_id: PMID:11171171
+    qualifier: enables
+    review:
+      summary: Core molecular function with direct experimental support for DGAT1
+        diacylglycerol acyltransferase activity. [PMID:11171171]
+      action: ACCEPT
+      supported_by:
+        - reference_id: PMID:11171171
+          supporting_text: experimental demonstration of Arabidopsis DGAT1 diacylglycerol
+            acyltransferase activity
+  - term:
+      id: GO:0005634
+      label: nucleus
+    evidence_type: ISM
+    original_reference_id: GO_REF:0000122
+    qualifier: located_in
+    review:
+      summary: Spurious computational (AtSubP sequence-model) prediction that contradicts
+        the established ER membrane localization. DGAT1 is a multi-pass ER membrane protein;
+        there is no evidence for nuclear localization.
+      action: REMOVE
+  - term:
+      id: GO:0005515
+      label: protein binding
+    evidence_type: IPI
+    original_reference_id: PMID:26586834
+    qualifier: enables
+    review:
+      summary: Uninformative molecular-function term (per curation guidance, protein binding
+        does not convey a specific function). The original_reference (PMID:26586834) is
+        primarily about GPAT9, in which DGAT1 appears as an interaction partner. The
+        interaction is experimental, so it is retained as non-core rather than removed; a
+        specific partner and functional consequence would be needed to make it informative.
+      action: KEEP_AS_NON_CORE
+  - term:
+      id: GO:0005811
+      label: lipid droplet
+    evidence_type: IDA
+    original_reference_id: PMID:24663078
+    qualifier: located_in
+    review:
+      summary: Lipid-droplet association is consistent with TAG synthesis at the ER-lipid
+        droplet interface. Retained as a non-core localization relative to the primary ER
+        membrane site of catalysis. Note the original_reference (PMID:24663078) is
+        primarily a study of the paralog DGAT2; the curator (TAIR) may have had DGAT1
+        data, but this specific evidence is not verified here.
+      action: KEEP_AS_NON_CORE
+  - term:
+      id: GO:0019432
+      label: triglyceride biosynthetic process
+    evidence_type: IDA
+    original_reference_id: PMID:23770095
+    qualifier: acts_upstream_of_or_within
+    review:
+      summary: TAG biosynthesis is the core biological process of DGAT1 and is well
+        established. Note the original_reference (PMID:23770095) is primarily about the
+        paralog AtDGAT2 (with DGAT1 used for comparison); this specific reference is not
+        independently verified here, but the TAG-biosynthesis role of DGAT1 is supported
+        by the many DGAT-activity and tag1-mutant references in this review.
+      action: ACCEPT
+  - term:
+      id: GO:0016020
+      label: membrane
+    evidence_type: IDA
+    original_reference_id: PMID:22233193
+    qualifier: located_in
+    review:
+      summary: Correct but general. DGAT1 is an integral membrane protein; the informative
+        localizations are the ER membrane (primary) and chloroplast membranes (senescence).
+        The original_reference (PMID:22233193) is primarily a PDAT1/LPCAT2 study; the
+        membrane-association of DGAT1 is independently documented.
+      action: ACCEPT
+      supported_by:
+        - reference_id: PMID:12177474
+          supporting_text: DGAT1 protein was found to be associated with chloroplast
+            membranes (and is membrane-bound in the ER of developing siliques)
+  - term:
+      id: GO:0010029
+      label: regulation of seed germination
+    evidence_type: IMP
+    original_reference_id: PMID:10580283
+    qualifier: acts_upstream_of_or_within
+    review:
+      summary: Pleiotropic/downstream phenotype of altered seed oil reserves, not DGAT1&#39;s
+        molecular function. Retained as non-core. [PMID:10580283]
+      action: KEEP_AS_NON_CORE
+  - term:
+      id: GO:0010030
+      label: positive regulation of seed germination
+    evidence_type: IMP
+    original_reference_id: PMID:10580283
+    qualifier: acts_upstream_of_or_within
+    review:
+      summary: As above, a downstream consequence of seed oil storage on germination
+        vigor rather than a core function. Retained as non-core. [PMID:10580283]
+      action: KEEP_AS_NON_CORE
+  - term:
+      id: GO:0004144
+      label: diacylglycerol O-acyltransferase activity
+    evidence_type: ISS
+    original_reference_id: PMID:10571850
+    qualifier: enables
+    review:
+      summary: Core molecular function (sequence/similarity support), consistent with the
+        experimental DGAT activity annotations.
+      action: ACCEPT
+  - term:
+      id: GO:0004144
+      label: diacylglycerol O-acyltransferase activity
+    evidence_type: IDA
+    original_reference_id: PMID:10571850
+    qualifier: enables
+    review:
+      summary: Core molecular function with direct assay support. [PMID:10571850]
+      action: ACCEPT
+      supported_by:
+        - reference_id: PMID:10571850
+          supporting_text: Arabidopsis DGAT1 diacylglycerol acyltransferase activity
+  - term:
+      id: GO:0004144
+      label: diacylglycerol O-acyltransferase activity
+    evidence_type: IDA
+    original_reference_id: PMID:12502715
+    qualifier: enables
+    review:
+      summary: Diacylglycerol O-acyltransferase activity is the core, well-established
+        molecular function of DGAT1. Note the original_reference (PMID:12502715) is about
+        a bifunctional wax ester synthase/acyl-CoA:DGAT from the bacterium Acinetobacter
+        calcoaceticus, so its basis for annotating Arabidopsis DGAT1 is unclear; the MF is
+        nonetheless overwhelmingly supported by the plant-DGAT references in this review.
+      action: ACCEPT
+  - term:
+      id: GO:0009793
+      label: embryo development ending in seed dormancy
+    evidence_type: TAS
+    original_reference_id: PMID:12114588
+    qualifier: acts_upstream_of_or_within
+    review:
+      summary: Pleiotropic developmental context of seed oil accumulation rather than a
+        core molecular function. Retained as non-core. [PMID:12114588]
+      action: KEEP_AS_NON_CORE
+  - term:
+      id: GO:0009941
+      label: chloroplast envelope
+    evidence_type: IDA
+    original_reference_id: PMID:12177474
+    qualifier: located_in
+    review:
+      summary: Experimentally supported senescence-specific localization. In senescing
+        Arabidopsis leaves DGAT1 protein is associated with isolated chloroplasts and
+        purified envelope and thylakoid membranes (but not stroma), where it synthesizes
+        the TAG that accumulates in plastoglobuli from de-esterified galactolipid fatty
+        acids. A genuine secondary localization, retained as non-core relative to the
+        primary ER seed-oil role. [PMID:12177474]
+      action: KEEP_AS_NON_CORE
+      supported_by:
+        - reference_id: PMID:12177474
+          supporting_text: DGAT1 is present in intact chloroplasts and purified membranes
+            including thylakoid and envelope but not in the stroma
+  - term:
+      id: GO:0019432
+      label: triglyceride biosynthetic process
+    evidence_type: TAS
+    original_reference_id: PMID:12114588
+    qualifier: acts_upstream_of_or_within
+    review:
+      summary: Core biological process; TAG biosynthesis is DGAT1&#39;s primary role.
+        [PMID:12114588]
+      action: ACCEPT
+      supported_by:
+        - reference_id: PMID:12114588
+          supporting_text: dgat1 mutants are deficient in triacylglycerol accumulation
+  - term:
+      id: GO:0004144
+      label: diacylglycerol O-acyltransferase activity
+    evidence_type: IDA
+    original_reference_id: PMID:10386579
+    qualifier: enables
+    review:
+      summary: Core molecular function with direct experimental support from the original
+        characterization of the Arabidopsis DGAT. [PMID:10386579]
+      action: ACCEPT
+      supported_by:
+        - reference_id: PMID:10386579
+          supporting_text: characterization of Arabidopsis diacylglycerol acyltransferase
+  - term:
+      id: GO:0004144
+      label: diacylglycerol O-acyltransferase activity
+    evidence_type: IMP
+    original_reference_id: PMID:10601854
+    qualifier: enables
+    review:
+      summary: Core molecular function. Plant DGAT cDNAs (including Arabidopsis) expressed
+        in yeast and tobacco confer diacylglycerol acyltransferase activity. [PMID:10601854]
+      action: ACCEPT
+      supported_by:
+        - reference_id: PMID:10601854
+          supporting_text: expression in yeast and tobacco of plant cDNAs encoding acyl
+            CoA:diacylglycerol acyltransferase
+  - term:
+      id: GO:0016020
+      label: membrane
+    evidence_type: TAS
+    original_reference_id: PMID:10601854
+    qualifier: located_in
+    review:
+      summary: Correct but general; DGAT1 is membrane-bound, with the ER membrane being
+        the informative localization.
+      action: ACCEPT
+  - term:
+      id: GO:0019432
+      label: triglyceride biosynthetic process
+    evidence_type: TAS
+    original_reference_id: PMID:10601854
+    qualifier: acts_upstream_of_or_within
+    review:
+      summary: Core biological process; the tag1 mutant establishes DGAT1&#39;s role in seed
+        TAG biosynthesis. [PMID:10601854]
+      action: ACCEPT
+  - term:
+      id: GO:0005975
+      label: carbohydrate metabolic process
+    evidence_type: IMP
+    original_reference_id: PMID:12114588
+    qualifier: acts_upstream_of_or_within
+    review:
+      summary: Indirect consequence of disrupting seed oil storage (carbon re-partitioning
+        toward carbohydrate), not a direct DGAT1 function. Retained as non-core given the
+        acts_upstream_of_or_within qualifier. [PMID:12114588]
+      action: KEEP_AS_NON_CORE
+  - term:
+      id: GO:0009409
+      label: response to cold
+    evidence_type: IMP
+    original_reference_id: PMID:12114588
+    qualifier: acts_upstream_of_or_within
+    review:
+      summary: Pleiotropic stress-response phenotype of the dgat1 mutant rather than a core
+        molecular function. Retained as non-core. [PMID:12114588]
+      action: KEEP_AS_NON_CORE
+  - term:
+      id: GO:0009651
+      label: response to salt stress
+    evidence_type: IMP
+    original_reference_id: PMID:12114588
+    qualifier: acts_upstream_of_or_within
+    review:
+      summary: Pleiotropic stress-response phenotype, non-core. [PMID:12114588]
+      action: KEEP_AS_NON_CORE
+  - term:
+      id: GO:0009737
+      label: response to abscisic acid
+    evidence_type: IMP
+    original_reference_id: PMID:12114588
+    qualifier: acts_upstream_of_or_within
+    review:
+      summary: Pleiotropic hormone-response phenotype, non-core. [PMID:12114588]
+      action: KEEP_AS_NON_CORE
+  - term:
+      id: GO:0009749
+      label: response to glucose
+    evidence_type: IMP
+    original_reference_id: PMID:12114588
+    qualifier: acts_upstream_of_or_within
+    review:
+      summary: Pleiotropic sugar-response phenotype tied to altered carbon partitioning,
+        non-core. [PMID:12114588]
+      action: KEEP_AS_NON_CORE
+  - term:
+      id: GO:0019432
+      label: triglyceride biosynthetic process
+    evidence_type: IMP
+    original_reference_id: PMID:11402213
+    qualifier: acts_upstream_of_or_within
+    review:
+      summary: Core biological process supported by mutant phenotype affecting seed TAG.
+        [PMID:11402213]
+      action: ACCEPT
+      supported_by:
+        - reference_id: PMID:11402213
+          supporting_text: seed-specific DGAT1 overexpression enhances seed oil content
+            and seed weight
+  - term:
+      id: GO:0045995
+      label: regulation of embryonic development
+    evidence_type: IMP
+    original_reference_id: PMID:11402213
+    qualifier: acts_upstream_of_or_within
+    review:
+      summary: Pleiotropic developmental phenotype associated with seed oil reserves, not
+        a core molecular function. Retained as non-core. [PMID:11402213]
+      action: KEEP_AS_NON_CORE
+core_functions:
+  - description: DGAT1 catalyzes the terminal, committed step of acyl-CoA-dependent
+      triacylglycerol assembly, transferring an acyl group from acyl-CoA to diacylglycerol
+      to form TAG at the endoplasmic reticulum membrane, driving seed and pollen oil
+      accumulation.
+    molecular_function:
+      id: GO:0004144
+      label: diacylglycerol O-acyltransferase activity
+    directly_involved_in:
+      - id: GO:0019432
+        label: triglyceride biosynthetic process
+    locations:
+      - id: GO:0005789
+        label: endoplasmic reticulum membrane
+    supported_by:
+      - reference_id: PMID:10386579
+        supporting_text: cloning of a cDNA encoding diacylglycerol acyltransferase from
+          Arabidopsis thaliana and its functional expression
+      - reference_id: PMID:10571850
+        supporting_text: the Arabidopsis thaliana TAG1 mutant has a mutation in a
+          diacylglycerol acyltransferase gene
+      - reference_id: file:ARATH/DGAT1/DGAT1-deep-research-falcon.md
+        supporting_text: DGAT1 catalyzes the terminal committed step of the acyl-CoA-dependent
+          (Kennedy) pathway of TAG assembly at the ER
+references:
+  - id: GO_REF:0000033
+    title: Annotation inferences using phylogenetic trees
+    findings: []
+  - id: GO_REF:0000044
+    title: Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location
+      vocabulary mapping
+    findings: []
+  - id: GO_REF:0000120
+    title: Combined Automated Annotation using Multiple IEA Methods
+    findings: []
+  - id: GO_REF:0000122
+    title: AtSubP analysis
+    findings: []
+  - id: PMID:10386579
+    title: Cloning of a cDNA encoding diacylglycerol acyltransferase from Arabidopsis
+      thaliana and its functional expression.
+    findings:
+      - statement: Cloning and functional expression of the Arabidopsis DGAT1 cDNA,
+          demonstrating diacylglycerol acyltransferase activity.
+        reference_section_type: RESULTS
+    reference_review:
+      relevance: HIGH
+      correctness: VERIFIED
+      review_notes: Title corrected from the cached PubMed record (was fabricated).
+        Genuine Arabidopsis DGAT1 paper supporting the IDA DGAT activity annotation.
+  - id: PMID:10571850
+    title: The Arabidopsis thaliana TAG1 mutant has a mutation in a diacylglycerol
+      acyltransferase gene.
+    findings:
+      - statement: The Arabidopsis TAG1 mutant carries a mutation in a diacylglycerol
+          acyltransferase gene, identifying DGAT1.
+        reference_section_type: RESULTS
+    reference_review:
+      relevance: HIGH
+      correctness: VERIFIED
+      review_notes: Title corrected from the cached PubMed record (previously swapped
+        with PMID:10601854). Genuine DGAT1/TAG1 paper supporting the IDA/ISS DGAT
+        activity annotations.
+  - id: PMID:10580283
+    title: The TAG1 locus of Arabidopsis encodes for a diacylglycerol acyltransferase.
+    findings:
+      - statement: Shows the Arabidopsis TAG1 locus encodes a diacylglycerol
+          acyltransferase (DGAT1).
+        reference_section_type: RESULTS
+    reference_review:
+      relevance: MEDIUM
+      correctness: VERIFIED
+      review_notes: Title corrected from the cached PubMed record (was fabricated).
+        Genuine DGAT1/TAG1 paper; underlies the (non-core) seed-germination annotations,
+        whose specific evidence was curator-assigned (TAIR).
+  - id: PMID:10601854
+    title: Expression in yeast and tobacco of plant cDNAs encoding acyl
+      CoA:diacylglycerol acyltransferase.
+    findings:
+      - statement: Plant DGAT cDNAs (including Arabidopsis) expressed in yeast and tobacco
+          confer diacylglycerol acyltransferase activity.
+        reference_section_type: RESULTS
+    reference_review:
+      relevance: HIGH
+      correctness: VERIFIED
+      review_notes: Title corrected from the cached PubMed record (previously swapped
+        with PMID:10571850). Supports the IMP DGAT activity / TAG biosynthesis annotations.
+  - id: PMID:11171171
+    title: Expression and characterization of diacylglycerol acyltransferase from
+      Arabidopsis thaliana in insect cell cultures.
+    findings:
+      - statement: Expression and biochemical (EXP) characterization of Arabidopsis DGAT1
+          diacylglycerol acyltransferase activity in insect cell cultures.
+        reference_section_type: RESULTS
+    reference_review:
+      relevance: HIGH
+      correctness: VERIFIED
+      review_notes: Title corrected from the cached PubMed record (was fabricated).
+        Source of the EXP DGAT activity annotation.
+  - id: PMID:11402213
+    title: Seed-specific over-expression of an Arabidopsis cDNA encoding a diacylglycerol
+      acyltransferase enhances seed oil content and seed weight.
+    findings:
+      - statement: Seed-specific overexpression of Arabidopsis DGAT1 increases seed oil
+          content and seed weight, linking it to TAG accumulation and seed/embryo development.
+        reference_section_type: RESULTS
+    reference_review:
+      relevance: HIGH
+      correctness: VERIFIED
+      review_notes: Title matches the cached PubMed record. Supports TAG biosynthesis
+        (core) and embryonic-development (non-core) annotations.
+  - id: PMID:12114588
+    title: Arabidopsis mutants deficient in diacylglycerol acyltransferase display
+      increased sensitivity to abscisic acid, sugars, and osmotic stress during
+      germination and seedling development.
+    findings:
+      - statement: dgat1 mutants show increased sensitivity to ABA, sugars, and osmotic
+          stress during germination/seedling development - pleiotropic effects downstream
+          of disrupted seed oil storage.
+        reference_section_type: RESULTS
+    reference_review:
+      relevance: MEDIUM
+      correctness: VERIFIED
+      review_notes: Title corrected from the cached PubMed record. Source of the multiple
+        pleiotropic stress/sugar/ABA BP annotations (non-core).
+  - id: PMID:12177474
+    title: A role for diacylglycerol acyltransferase during leaf senescence.
+    findings:
+      - statement: During leaf senescence DGAT1 transcript and protein increase, and DGAT1
+          protein is associated with chloroplast envelope and thylakoid membranes (not
+          stroma), synthesizing plastoglobular TAG from de-esterified thylakoid
+          galactolipid fatty acids; DGAT1 is also detected in the ER of developing siliques.
+        reference_section_type: RESULTS
+    reference_review:
+      relevance: HIGH
+      correctness: VERIFIED
+      review_notes: Title corrected from the cached PubMed record (previously a fabricated
+        &#34;chloroplast proteomics&#34; title). Full text read - directly supports the
+        senescence-specific chloroplast-envelope localization (now KEEP_AS_NON_CORE rather
+        than the earlier, mistaken over-annotation call).
+  - id: PMID:12502715
+    title: A novel bifunctional wax ester synthase/acyl-CoA:diacylglycerol acyltransferase
+      mediates wax ester and triacylglycerol biosynthesis in Acinetobacter calcoaceticus
+      ADP1.
+    findings:
+      - statement: Characterizes a bifunctional wax ester synthase/acyl-CoA:diacylglycerol
+          acyltransferase from the bacterium Acinetobacter calcoaceticus ADP1.
+        reference_section_type: RESULTS
+    reference_review:
+      relevance: LOW
+      correctness: UNVERIFIED
+      review_notes: Title corrected from the cached PubMed record (was fabricated). This
+        paper is about a bacterial (Acinetobacter) enzyme, not Arabidopsis DGAT1; the basis
+        for the GOA IDA DGAT-activity annotation on AtDGAT1 from this PMID is unclear and
+        unverified. The DGAT activity MF is independently well supported by other references.
+  - id: PMID:22233193
+    title: Triacylglycerol synthesis by PDAT1 in the absence of DGAT1 activity is dependent
+      on re-acylation of LPC by LPCAT2.
+    findings:
+      - statement: Primarily characterizes PDAT1/LPCAT2-dependent TAG synthesis in the
+          absence of DGAT1 activity; DGAT1 appears as the parallel acyl-CoA-dependent route.
+        reference_section_type: RESULTS
+    reference_review:
+      relevance: MEDIUM
+      correctness: UNVERIFIED
+      review_notes: Title corrected from the cached PubMed record (was fabricated). Paper
+        focus is PDAT1/LPCAT2; the GOA IDA membrane annotation on DGAT1 was curator-assigned
+        (TAIR) and its supporting evidence is not verified here.
+  - id: PMID:23770095
+    title: AtDGAT2 is a functional acyl-CoA:diacylglycerol acyltransferase and displays
+      different acyl-CoA substrate preferences than AtDGAT1.
+    findings:
+      - statement: Characterizes the paralog AtDGAT2 and compares its acyl-CoA substrate
+          preferences with AtDGAT1.
+        reference_section_type: RESULTS
+    reference_review:
+      relevance: MEDIUM
+      correctness: UNVERIFIED
+      review_notes: Title corrected from the cached PubMed record (was fabricated). Paper
+        is primarily about DGAT2; the GOA IDA TAG-biosynthesis annotation on DGAT1 was
+        curator-assigned and is not independently verified here.
+  - id: PMID:24663078
+    title: Function and localization of the Arabidopsis thaliana diacylglycerol
+      acyltransferase DGAT2 expressed in yeast.
+    findings:
+      - statement: Characterizes the function and localization of the paralog DGAT2
+          expressed in yeast.
+        reference_section_type: RESULTS
+    reference_review:
+      relevance: LOW
+      correctness: UNVERIFIED
+      review_notes: Title corrected from the cached PubMed record (was fabricated). Paper
+        is about DGAT2, not DGAT1; the GOA IDA lipid-droplet annotation on DGAT1 was
+        curator-assigned and is not verified here.
+  - id: PMID:26586834
+    title: Identification of Arabidopsis GPAT9 (At5g60620) as an Essential Gene Involved
+      in Triacylglycerol Biosynthesis.
+    findings:
+      - statement: Identifies Arabidopsis GPAT9 as essential for triacylglycerol
+          biosynthesis; DGAT1 appears as an interaction partner.
+        reference_section_type: RESULTS
+    reference_review:
+      relevance: LOW
+      correctness: UNVERIFIED
+      review_notes: Title corrected from the cached PubMed record (was fabricated). Paper
+        is primarily about GPAT9; underlies the (non-core, uninformative) protein binding
+        IPI annotation and is not independently verified here.
+  - id: file:ARATH/DGAT1/DGAT1-deep-research-falcon.md
+    title: Falcon/Edison deep research report for DGAT1/TAG1, Arabidopsis thaliana
+    findings:
+      - statement: Synthesizes DGAT1 as the ER multi-pass MBOAT enzyme catalyzing the
+          terminal acyl-CoA-dependent step of TAG assembly; major seed/pollen DGAT,
+          functionally redundant with PDAT1; a high-value oilseed yield engineering target.
+        reference_section_type: OTHER
+suggested_questions:
+  - question: How is acyl flux partitioned between DGAT1 (acyl-CoA-dependent) and PDAT1
+      (acyl-CoA-independent) routes in oilseed feedstocks, and can DGAT1 acyl-specificity
+      and ER substrate channeling (e.g. LPCAT-DGAT1 coupling) be engineered to raise oil
+      yield and tailor composition?
+</code></pre>
+            </div>
+        </details>
+    </div>
+
+    <!-- Pathway Visualization Link -->
+    
+
+    <style>
+        /* Markdown Section Styles */
+        .markdown-section {
+            margin-bottom: 1rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .markdown-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .markdown-section summary h3 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.1rem;
+        }
+
+        .markdown-section summary:hover h3 {
+            color: #007bff;
+        }
+
+        .markdown-section[open] {
+            background-color: #fff;
+        }
+
+        .markdown-content {
+            margin-top: 1rem;
+            padding: 1rem;
+            border-top: 1px solid #dee2e6;
+        }
+
+        /* Markdown content styling */
+        .markdown-content h1 { font-size: 1.5rem; margin-top: 1.5rem; }
+        .markdown-content h2 { font-size: 1.3rem; margin-top: 1.3rem; }
+        .markdown-content h3 { font-size: 1.1rem; margin-top: 1.1rem; }
+        .markdown-content h4 { font-size: 1rem; margin-top: 1rem; }
+
+        .markdown-content pre {
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .markdown-content code {
+            background-color: #f8f9fa;
+            padding: 0.2rem 0.4rem;
+            border-radius: 3px;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+        }
+
+        .markdown-content pre code {
+            background: none;
+            padding: 0;
+        }
+
+        .markdown-content table {
+            border-collapse: collapse;
+            width: 100%;
+            margin: 1rem 0;
+        }
+
+        .markdown-content table th,
+        .markdown-content table td {
+            border: 1px solid #dee2e6;
+            padding: 0.5rem;
+            text-align: left;
+        }
+
+        .markdown-content table th {
+            background-color: #f8f9fa;
+            font-weight: bold;
+        }
+
+        .markdown-content blockquote {
+            border-left: 4px solid #007bff;
+            padding-left: 1rem;
+            margin-left: 0;
+            color: #666;
+        }
+
+        /* YAML Preview Styles */
+        .yaml-preview {
+            margin-top: 2rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .yaml-preview summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .yaml-preview summary h2 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.3rem;
+        }
+
+        .yaml-preview summary:hover h2 {
+            color: #007bff;
+        }
+
+        .yaml-preview[open] {
+            background-color: #fff;
+        }
+
+        .yaml-content {
+            margin-top: 1rem;
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .yaml-content pre {
+            margin: 0;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+            line-height: 1.4;
+        }
+
+        .yaml-content code {
+            color: #333;
+            background: none;
+            padding: 0;
+        }
+
+        /* Pathway Link Styles */
+        .pathway-link {
+            margin: 1rem 0;
+        }
+
+        .btn-link {
+            display: inline-block;
+            padding: 0.5rem 1rem;
+            background-color: #007bff;
+            color: white !important;
+            text-decoration: none;
+            border-radius: 4px;
+            font-weight: 500;
+            transition: background-color 0.2s;
+        }
+
+        .btn-link:hover {
+            background-color: #0056b3;
+            text-decoration: none;
+        }
+
+        /* Voting buttons */
+        .vote-buttons {
+            display: inline-block;
+            margin-left: 0.5rem;
+        }
+
+        .vote-btn {
+            background: none;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 2px 6px;
+            margin: 0 2px;
+            cursor: pointer;
+            font-size: 0.9rem;
+            transition: all 0.2s;
+            opacity: 0.6;
+        }
+
+        .vote-btn:hover {
+            opacity: 1;
+            transform: scale(1.1);
+        }
+
+        .vote-btn.voted {
+            opacity: 1;
+            border-color: #28a745;
+            background-color: #d4edda;
+        }
+
+        .vote-btn.voted-down {
+            border-color: #dc3545;
+            background-color: #f8d7da;
+        }
+
+        .vote-btn-small {
+            font-size: 0.7rem;
+            padding: 1px 4px;
+            margin: 0 1px;
+        }
+    </style>
+
+    <script>
+        // Add collapsible functionality
+        document.querySelectorAll('.collapsible').forEach(element => {
+            element.addEventListener('click', function() {
+                this.classList.toggle('collapsed');
+            });
+        });
+
+        // Voting functionality
+        const VOTE_URL = 'https://script.google.com/macros/s/AKfycbwPKH7d3seuPNBtB0ugVjqGeTiByyOGD5vkqB_Ck6K8eOcPQYbJqBOuz6GFgXHKBNWK/exec';
+
+        // Get or create session ID
+        let sessionId = localStorage.getItem('review_session_id');
+        if (!sessionId) {
+            sessionId = 's' + Date.now() + '_' + Math.random().toString(36).substr(2, 9);
+            localStorage.setItem('review_session_id', sessionId);
+        }
+
+        // Show previous votes on page load
+        document.addEventListener('DOMContentLoaded', function() {
+            document.querySelectorAll('.vote-buttons').forEach(container => {
+                const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+                const previousVote = localStorage.getItem(key);
+                if (previousVote) {
+                    const btn = container.querySelector(`[data-v="${previousVote}"]`);
+                    if (btn) btn.classList.add(previousVote === 'up' ? 'voted' : 'voted-down');
+                }
+            });
+        });
+
+        // Handle vote clicks - Simple image beacon approach
+        document.addEventListener('click', function(e) {
+            if (!e.target.classList.contains('vote-btn')) return;
+
+            // Prevent the click from bubbling to parent elements (like summary)
+            e.preventDefault();
+            e.stopPropagation();
+
+            const btn = e.target;
+            const container = btn.closest('.vote-buttons');
+            if (!container) return;
+
+            const voteType = btn.dataset.v;
+
+            // Check if already voted (locally)
+            const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+            const previousVote = localStorage.getItem(key);
+
+            if (previousVote === voteType) {
+                // Same vote - do nothing
+                btn.style.animation = 'shake 0.5s';
+                setTimeout(() => btn.style.animation = '', 500);
+                return;
+            }
+
+            // Build URL
+            const params = new URLSearchParams({
+                gene_id: container.dataset.g,
+                annotation_id: container.dataset.a,
+                ref_id: container.dataset.r || '',
+                action: container.dataset.act,
+                vote: voteType,
+                session_id: sessionId,
+                ua: navigator.userAgent.substring(0, 100)
+            });
+
+            // Clear previous vote styling
+            container.querySelectorAll('.vote-btn').forEach(b => {
+                b.classList.remove('voted', 'voted-down');
+            });
+
+            // Apply new vote styling immediately (optimistic UI)
+            btn.classList.add(voteType === 'up' ? 'voted' : 'voted-down');
+
+            // Store locally
+            localStorage.setItem(key, voteType);
+
+            // Send vote using fetch with no-cors mode (fire and forget)
+            const fullUrl = VOTE_URL + '?' + params;
+            console.log('Sending vote to:', fullUrl);
+
+            // Use fetch in no-cors mode - we won't get a response but the request will be sent
+            fetch(fullUrl, {
+                mode: 'no-cors',
+                method: 'GET'
+            }).then(() => {
+                console.log('Vote request sent (no response due to no-cors mode)');
+            }).catch(err => {
+                console.warn('Vote may not have been recorded, but saved locally:', err);
+
+                // Fallback: try image beacon as well
+                const img = new Image();
+                img.src = fullUrl;
+            });
+        });
+
+        // Optional: Add shake animation for feedback
+        const style = document.createElement('style');
+        style.textContent = `
+            @keyframes shake {
+                0%, 100% { transform: translateX(0); }
+                25% { transform: translateX(-5px); }
+                75% { transform: translateX(5px); }
+            }
+        `;
+        document.head.appendChild(style);
+    </script>
+</body>
+</html>

--- a/genes/ARATH/FAD2/FAD2-ai-review.html
+++ b/genes/ARATH/FAD2/FAD2-ai-review.html
@@ -1,0 +1,2790 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>FAD2 - AI Gene Review</title>
+    <style>
+        :root {
+            --color-accept: #22c55e;
+            --color-remove: #ef4444;
+            --color-modify: #f97316;
+            --color-keep-non-core: #3b82f6;
+            --color-undecided: #6b7280;
+            --color-new: #8b5cf6;
+            --color-mark-over: #eab308;
+            --bg-light: #f9fafb;
+            --border-color: #e5e7eb;
+            --text-muted: #6b7280;
+            --text-primary: #111827;
+        }
+
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+            line-height: 1.6;
+            color: var(--text-primary);
+            background-color: #ffffff;
+            padding: 2rem;
+            max-width: 1400px;
+            margin: 0 auto;
+        }
+
+        .header {
+            border-bottom: 2px solid var(--border-color);
+            padding-bottom: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        h1 {
+            font-size: 2.5rem;
+            font-weight: 700;
+            margin-bottom: 0.5rem;
+            color: #1f2937;
+        }
+
+        .gene-info {
+            display: flex;
+            gap: 2rem;
+            flex-wrap: wrap;
+            margin-top: 1rem;
+        }
+
+        .info-item {
+            display: flex;
+            gap: 0.5rem;
+        }
+
+        .info-label {
+            font-weight: 600;
+            color: var(--text-muted);
+        }
+
+        .aliases {
+            display: flex;
+            gap: 0.5rem;
+            flex-wrap: wrap;
+        }
+
+        .badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.875rem;
+            font-weight: 500;
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+        }
+
+        .status-badge {
+            padding: 0.375rem 0.875rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .status-initialized {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fde68a;
+        }
+
+        .status-in-progress {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+        }
+
+        .status-draft {
+            background-color: #fce7f3;
+            color: #831843;
+            border: 1px solid #fbcfe8;
+        }
+
+        .status-complete {
+            background-color: #d1fae5;
+            color: #065f46;
+            border: 1px solid #a7f3d0;
+        }
+
+        .description-card {
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        .description-card h2 {
+            font-size: 1.25rem;
+            margin-bottom: 1rem;
+            color: #374151;
+        }
+
+        .section {
+            margin-bottom: 2.5rem;
+        }
+
+        .section-title {
+            font-size: 1.5rem;
+            font-weight: 600;
+            margin-bottom: 1.5rem;
+            color: #1f2937;
+            border-bottom: 1px solid var(--border-color);
+            padding-bottom: 0.5rem;
+        }
+
+        .annotations-table {
+            width: 100%;
+            border-collapse: collapse;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            overflow: hidden;
+        }
+
+        .annotations-table thead {
+            background-color: var(--bg-light);
+        }
+
+        .annotations-table th {
+            text-align: left;
+            padding: 1rem;
+            font-weight: 600;
+            border-bottom: 2px solid var(--border-color);
+            font-size: 0.875rem;
+            text-transform: uppercase;
+            letter-spacing: 0.05em;
+            color: var(--text-muted);
+        }
+
+        .annotations-table td {
+            padding: 1rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .annotations-table tbody tr:hover {
+            background-color: #f9fafb;
+        }
+
+        .action-badge {
+            display: inline-block;
+            padding: 0.375rem 0.75rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .action-accept {
+            background-color: var(--color-accept);
+            color: white;
+        }
+
+        .action-remove {
+            background-color: var(--color-remove);
+            color: white;
+        }
+
+        .action-modify {
+            background-color: var(--color-modify);
+            color: white;
+        }
+
+        .action-keep_as_non_core {
+            background-color: var(--color-keep-non-core);
+            color: white;
+        }
+
+        .action-undecided {
+            background-color: var(--color-undecided);
+            color: white;
+        }
+
+        .action-new {
+            background-color: var(--color-new);
+            color: white;
+        }
+
+        .action-mark_as_over_annotated {
+            background-color: var(--color-mark-over);
+            color: white;
+        }
+
+        .term-info {
+            display: flex;
+            flex-direction: column;
+            gap: 0.25rem;
+        }
+
+        .term-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .term-label {
+            font-weight: 500;
+        }
+
+        .evidence-code {
+            font-family: monospace;
+            background-color: var(--bg-light);
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .not-badge {
+            display: inline-block;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-weight: 600;
+            margin-left: 0.25rem;
+        }
+
+        .isoform-badge {
+            display: inline-block;
+            background-color: #eff6ff;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            margin-top: 0.25rem;
+        }
+
+        .core-function-card {
+            background-color: white;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 1rem;
+        }
+
+        .core-function-card h3 {
+            font-size: 1.125rem;
+            margin-bottom: 1rem;
+            color: #1f2937;
+        }
+
+        .core-function-statement {
+            margin-bottom: 1rem;
+            padding: 0.75rem;
+            background-color: var(--bg-light);
+            border-left: 4px solid var(--color-accept);
+            border-radius: 0.25rem;
+        }
+
+        .function-annotations {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin-top: 1rem;
+        }
+
+        .reference-item {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+        }
+
+        .reference-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: start;
+            margin-bottom: 0.75rem;
+        }
+
+        .reference-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #2563eb;
+        }
+
+        .supported-by {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f3f4f6;
+            border-left: 3px solid #3b82f6;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .supported-by-title {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .support-item {
+            margin-bottom: 0.5rem;
+        }
+
+        .support-ref {
+            font-weight: 500;
+            color: #2563eb;
+        }
+
+        .support-text {
+            color: #6b7280;
+            font-style: italic;
+            margin-left: 1rem;
+        }
+
+        a.term-link {
+            color: #2563eb;
+            text-decoration: none;
+        }
+
+        a.term-link:hover {
+            text-decoration: underline;
+        }
+
+        .core-function-terms {
+            margin-top: 1rem;
+        }
+
+        .function-term-group {
+            margin-bottom: 1rem;
+        }
+
+        .function-term-label {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .reference-title {
+            font-weight: 500;
+            margin-bottom: 0.5rem;
+        }
+
+        .findings-list {
+            margin-top: 1rem;
+            padding-left: 1.5rem;
+        }
+
+        .finding-item {
+            margin-bottom: 0.75rem;
+        }
+
+        .finding-statement {
+            font-weight: 500;
+            margin-bottom: 0.25rem;
+        }
+
+        .finding-text {
+            color: var(--text-muted);
+            font-size: 0.95rem;
+            font-style: italic;
+        }
+
+        .proposed-term {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #fef3c7;
+        }
+
+        .question-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #dbeafe;
+        }
+
+        .experiment-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #f3e8ff;
+        }
+
+        .prediction-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: white;
+        }
+
+        .prediction-card .prediction-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+        }
+
+        .prediction-source {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+        }
+
+        .assessment-badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.8rem;
+            font-weight: 600;
+            text-transform: uppercase;
+        }
+
+        .assessment-cor { background-color: #dcfce7; color: #166534; }
+        .assessment-cnn { background-color: #dbeafe; color: #1e40af; }
+        .assessment-lsp { background-color: #fef9c3; color: #854d0e; }
+        .assessment-unc { background-color: #f3f4f6; color: #374151; }
+        .assessment-pli { background-color: #fee2e2; color: #991b1b; }
+        .assessment-npi { background-color: #fecaca; color: #7f1d1d; }
+        .assessment-rep { background-color: #fde68a; color: #92400e; }
+
+        .confidence-score {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+            margin-left: 0.5rem;
+        }
+
+        .error-type-badge {
+            font-size: 0.75rem;
+            padding: 0.125rem 0.5rem;
+            border-radius: 0.25rem;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+        }
+
+        .isoforms-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fill, minmax(400px, 1fr));
+            gap: 1rem;
+        }
+
+        .isoform-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            background-color: white;
+            transition: box-shadow 0.2s;
+        }
+
+        .isoform-card:hover {
+            box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+        }
+
+        .functional-isoform-type {
+            display: inline-block;
+            padding: 0.2rem 0.5rem;
+            border-radius: 0.25rem;
+            font-size: 0.7rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.03em;
+        }
+
+        .type-SPLICE_VARIANT, .type-SPLICE_CLASS {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #93c5fd;
+        }
+
+        .type-CLEAVAGE_PRODUCT {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fcd34d;
+        }
+
+        .type-MODIFICATION_STATE {
+            background-color: #f3e8ff;
+            color: #6b21a8;
+            border: 1px solid #c4b5fd;
+        }
+
+        .type-CONFORMATIONAL_STATE {
+            background-color: #dcfce7;
+            color: #166534;
+            border: 1px solid #86efac;
+        }
+
+        .functional-isoform-mappings {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+            font-size: 0.85rem;
+        }
+
+        .functional-isoform-mappings .mapping-type {
+            font-weight: 600;
+            color: var(--text-muted);
+            font-size: 0.75rem;
+        }
+
+        .functional-isoform-go {
+            margin-top: 0.5rem;
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.25rem;
+        }
+
+        .go-chip {
+            display: inline-block;
+            padding: 0.15rem 0.4rem;
+            background-color: #ecfdf5;
+            color: #047857;
+            border: 1px solid #a7f3d0;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-family: monospace;
+        }
+
+        .isoform-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+            padding-bottom: 0.5rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .isoform-name {
+            font-weight: 600;
+            font-size: 1.1rem;
+            color: #1f2937;
+        }
+
+        .isoform-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .isoform-sequence-note {
+            font-size: 0.875rem;
+            color: var(--text-muted);
+            margin-bottom: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+        }
+
+        .isoform-description {
+            font-size: 0.95rem;
+            line-height: 1.5;
+        }
+
+        .collapsible {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .collapsible:after {
+            content: ' ▼';
+            font-size: 0.75rem;
+        }
+
+        .collapsible.collapsed:after {
+            content: ' ►';
+        }
+
+        .collapse-content {
+            transition: max-height 0.3s ease;
+            overflow: hidden;
+        }
+
+        .collapsed + .collapse-content {
+            max-height: 0;
+        }
+
+        .no-data {
+            color: var(--text-muted);
+            font-style: italic;
+            padding: 1rem;
+            text-align: center;
+            background-color: var(--bg-light);
+            border-radius: 0.5rem;
+        }
+
+        /* Styling for markdown section summaries with voting */
+        .markdown-section summary {
+            padding: 0.75rem;
+            background: var(--bg-light);
+            border-radius: 0.5rem;
+            margin-bottom: 0.5rem;
+        }
+
+        .markdown-section summary:hover {
+            background: #e5e7eb;
+        }
+
+        .markdown-section summary .vote-buttons {
+            margin-left: auto;
+        }
+
+        .deep-research-section {
+            margin-bottom: 1rem;
+            border: 1px solid #c7d2fe;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8faff;
+        }
+
+        .deep-research-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .deep-research-section summary h3 {
+            margin: 0;
+            color: #3730a3;
+            font-size: 1.1rem;
+        }
+
+        .report-meta {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin: 0.75rem 0 1rem;
+            align-items: center;
+        }
+
+        .report-badge {
+            display: inline-flex;
+            align-items: center;
+            border: 1px solid #c7d2fe;
+            border-radius: 999px;
+            background: #eef2ff;
+            color: #4338ca;
+            font-size: 0.78rem;
+            font-weight: 600;
+            padding: 0.2rem 0.6rem;
+        }
+
+        .report-meta-text {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+        }
+
+        .artifact-list {
+            display: grid;
+            gap: 0.75rem;
+            margin: 0.75rem 0 1rem;
+        }
+
+        .artifact-link {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+            margin-top: 0.5rem;
+            word-break: break-word;
+        }
+
+        @media print {
+            body {
+                padding: 1rem;
+            }
+
+            .collapsible:after {
+                display: none;
+            }
+
+            .collapsed + .collapse-content {
+                max-height: none !important;
+            }
+        }
+
+        @media (max-width: 768px) {
+            body {
+                padding: 1rem;
+            }
+
+            h1 {
+                font-size: 2rem;
+            }
+
+            .annotations-table {
+                font-size: 0.875rem;
+            }
+
+            .annotations-table th,
+            .annotations-table td {
+                padding: 0.5rem;
+            }
+        }
+    </style>
+</head>
+<body>
+    <div class="header">
+        <h1>FAD2</h1>
+        <div class="gene-info">
+            
+            <div class="info-item">
+                
+                <span class="info-label">UniProt ID:</span>
+                <span>
+                    <a href="https://www.uniprot.org/uniprotkb/P46313" target="_blank" class="term-link">
+                        P46313
+                    </a>
+                </span>
+                
+            </div>
+            
+            
+            <div class="info-item">
+                <span class="info-label">Organism:</span>
+                <span>Arabidopsis thaliana</span>
+            </div>
+            
+            
+            <div class="info-item">
+                <span class="info-label">Review Status:</span>
+                <span class="status-badge status-complete">
+                    COMPLETE
+                </span>
+            </div>
+            
+            
+        </div>
+        <div style="margin-top: 1rem; text-align: center;">
+            <a id="feedback-form-link"
+               href="#"
+               target="_blank"
+               style="display: inline-block; padding: 10px 20px; background-color: #4CAF50; color: white; text-decoration: none; border-radius: 5px; font-weight: 600;">
+                📝 Provide Detailed Feedback
+            </a>
+            <script>
+                // Construct the form URL with proper encoding
+                // Extract organism code from the current page path (e.g., /genes/ARATH/APO1/ -> ARATH)
+                const pathParts = window.location.pathname.split('/');
+                const genesIndex = pathParts.indexOf('genes');
+                let organism = '';
+                if (genesIndex !== -1 && pathParts[genesIndex + 1]) {
+                    organism = pathParts[genesIndex + 1].toUpperCase();
+                }
+                const geneSymbol = "FAD2";
+                const speciesGene = organism + ' ' + geneSymbol;
+                const formBaseUrl = 'https://docs.google.com/forms/d/e/1FAIpQLSdTot9L6GVkkZYgLQT0E8ZdAJv8RiN5ZgOVkgWNcKSbYvxxzQ/viewform';
+                const entryId = '1226477767'; // Correct entry ID for Species/Gene field
+                const formUrl = formBaseUrl + '?entry.' + entryId + '=' + encodeURIComponent(speciesGene);
+                const feedbackLink = document.getElementById('feedback-form-link');
+                feedbackLink.href = formUrl;
+                // Add tooltip showing the pre-filled value
+                feedbackLink.title = 'Opens form with pre-filled: ' + speciesGene;
+            </script>
+        </div>
+    </div>
+
+    
+    <div class="description-card">
+        <div style="display: flex; justify-content: space-between; align-items: center;">
+            <h2>Gene Description</h2>
+            <span class="vote-buttons" data-g="P46313" data-a="DESCRIPTION: FAD2 is the endoplasmic-reticulum (microsomal) ome..." data-r="" data-act="DESCRIPTION">
+                <button class="vote-btn" data-v="up" title="Agree with this description">👍</button>
+                <button class="vote-btn" data-v="down" title="Disagree with this description">👎</button>
+            </span>
+        </div>
+        <p>FAD2 is the endoplasmic-reticulum (microsomal) omega-6 / Delta(12) fatty acid desaturase of Arabidopsis. It introduces a second double bond into monounsaturated C18 fatty acids, converting oleic acid (18:1) to linoleic acid (18:2) on fatty acids esterified to phosphatidylcholine (PC), using cytochrome b5 as the electron donor. It is a polytopic membrane protein with conserved histidine-box motifs. The 18:2 product can be further desaturated to 18:3 by FAD3, and because PC is a major precursor for triacylglycerol assembly, FAD2 is a primary determinant of extraplastidic membrane and seed-oil polyunsaturated fatty acid composition; ER membrane unsaturation set by FAD2 also contributes to ER-stress and low-temperature responses.</p>
+    </div>
+    
+
+    
+
+    
+
+    
+    <div class="section">
+        <h2 class="section-title">Existing Annotations Review</h2>
+        <table class="annotations-table">
+            <thead>
+                <tr>
+                    <th>GO Term</th>
+                    <th>Evidence</th>
+                    <th>Action</th>
+                    <th>Reason</th>
+                </tr>
+            </thead>
+            <tbody>
+                
+                <tr>
+                    <td>
+                        <div class="term-info">
+                            
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005789" target="_blank" class="term-link">
+                                    GO:0005789
+                                </a>
+                            </span>
+                            <span class="term-label">endoplasmic reticulum membrane</span>
+                            
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+                        
+                        
+                        
+                        <br>
+                        <span style="font-size: 0.75rem;">
+                            
+                            GO_REF:0000044
+                            
+                        </span>
+                        
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P46313" data-a="GO:0005789" data-r="GO_REF:0000044" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+                        
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Correct localization, independently confirmed experimentally (EXP below). FAD2 is an ER (microsomal) membrane desaturase.
+                        </div>
+                        
+                        
+                        
+                        
+                    </td>
+                </tr>
+                
+                <tr>
+                    <td>
+                        <div class="term-info">
+                            
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006629" target="_blank" class="term-link">
+                                    GO:0006629
+                                </a>
+                            </span>
+                            <span class="term-label">lipid metabolic process</span>
+                            
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+                        
+                        
+                        
+                        <br>
+                        <span style="font-size: 0.75rem;">
+                            
+                            GO_REF:0000002
+                            
+                        </span>
+                        
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P46313" data-a="GO:0006629" data-r="GO_REF:0000002" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+                        
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Correct but general. FAD2 functions in glycerolipid/fatty acid metabolism; the specific unsaturated fatty acid biosynthetic role is captured below.
+                        </div>
+                        
+                        
+                        
+                        
+                    </td>
+                </tr>
+                
+                <tr>
+                    <td>
+                        <div class="term-info">
+                            
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016491" target="_blank" class="term-link">
+                                    GO:0016491
+                                </a>
+                            </span>
+                            <span class="term-label">oxidoreductase activity</span>
+                            
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+                        
+                        
+                        
+                        <br>
+                        <span style="font-size: 0.75rem;">
+                            
+                            GO_REF:0000002
+                            
+                        </span>
+                        
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P46313" data-a="GO:0016491" data-r="GO_REF:0000002" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+                        
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Correct but general. The informative molecular function is the omega-6 (Delta-12) fatty acid desaturase activity captured by more specific terms below.
+                        </div>
+                        
+                        
+                        
+                        
+                    </td>
+                </tr>
+                
+                <tr>
+                    <td>
+                        <div class="term-info">
+                            
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016717" target="_blank" class="term-link">
+                                    GO:0016717
+                                </a>
+                            </span>
+                            <span class="term-label">oxidoreductase activity, acting on paired donors, with oxidation of a pair of donors resulting in the reduction of molecular oxygen to two molecules of water</span>
+                            
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+                        
+                        
+                        
+                        <br>
+                        <span style="font-size: 0.75rem;">
+                            
+                            GO_REF:0000002
+                            
+                        </span>
+                        
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P46313" data-a="GO:0016717" data-r="GO_REF:0000002" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+                        
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Correct enzyme-class molecular function for a membrane fatty acid desaturase, which uses O2 and an electron donor (cytochrome b5) to introduce a double bond. Consistent with the specific desaturase annotations.
+                        </div>
+                        
+                        
+                        
+                        
+                    </td>
+                </tr>
+                
+                <tr>
+                    <td>
+                        <div class="term-info">
+                            
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0050184" target="_blank" class="term-link">
+                                    GO:0050184
+                                </a>
+                            </span>
+                            <span class="term-label">acyl-lipid omega-6 desaturase (cytochrome b5) activity</span>
+                            
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+                        
+                        
+                        
+                        <br>
+                        <span style="font-size: 0.75rem;">
+                            
+                            GO_REF:0000120
+                            
+                        </span>
+                        
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P46313" data-a="GO:0050184" data-r="GO_REF:0000120" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+                        
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Accurate core molecular function, also experimentally supported (EXP below). FAD2 desaturates oleoyl-phosphatidylcholine using cytochrome b5 as electron donor.
+                        </div>
+                        
+                        
+                        
+                        
+                    </td>
+                </tr>
+                
+                <tr>
+                    <td>
+                        <div class="term-info">
+                            
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0102985" target="_blank" class="term-link">
+                                    GO:0102985
+                                </a>
+                            </span>
+                            <span class="term-label">acyl-CoA (9+3)-desaturase activity</span>
+                            
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+                        
+                        
+                        
+                        <br>
+                        <span style="font-size: 0.75rem;">
+                            
+                            GO_REF:0000120
+                            
+                        </span>
+                        
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P46313" data-a="GO:0102985" data-r="GO_REF:0000120" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+                        
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> FAD2 is canonically an acyl-LIPID desaturase that acts on oleate esterified to phosphatidylcholine, not on acyl-CoA (its primary characterization is as an oleoyl-phosphatidylcholine desaturase). The acyl-lipid omega-6 desaturase (GO:0050184) and omega-6 desaturase (GO:0045485) terms are the accurate molecular functions; this acyl-CoA term is retained as non-core. [PMID:1730697]
+                        </div>
+                        
+                        
+                        
+                        
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+                            
+                            <div class="support-item">
+                                <span class="support-ref">
+                                    
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/1730697" target="_blank" class="term-link">
+                                        PMID:1730697
+                                    </a>
+                                    
+                                </span>
+                                
+                                <div class="support-text">Biochemical and genetic characterization of a plant oleoyl-phosphatidylcholine desaturase</div>
+                                
+                            </div>
+                            
+                        </div>
+                        
+                    </td>
+                </tr>
+                
+                <tr>
+                    <td>
+                        <div class="term-info">
+                            
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006636" target="_blank" class="term-link">
+                                    GO:0006636
+                                </a>
+                            </span>
+                            <span class="term-label">unsaturated fatty acid biosynthetic process</span>
+                            
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+                        
+                        
+                        
+                        <br>
+                        <span style="font-size: 0.75rem;">
+                            
+                            GO_REF:0000041
+                            
+                        </span>
+                        
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P46313" data-a="GO:0006636" data-r="GO_REF:0000041" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+                        
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Correct core biological process. FAD2 produces polyunsaturated fatty acids (18:2, feeding into 18:3) in the extraplastidic pathway.
+                        </div>
+                        
+                        
+                        
+                        
+                    </td>
+                </tr>
+                
+                <tr>
+                    <td>
+                        <div class="term-info">
+                            
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005789" target="_blank" class="term-link">
+                                    GO:0005789
+                                </a>
+                            </span>
+                            <span class="term-label">endoplasmic reticulum membrane</span>
+                            
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">EXP</span>
+                        
+                        
+                        
+                        <br>
+                        <span style="font-size: 0.75rem;">
+                            
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/14690501" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:14690501
+                            </a>
+                            
+                                
+                                
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Membrane-bound fatty acid desaturases are inserted co-transl...
+                                </span>
+                                
+                            
+                            
+                        </span>
+                        
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P46313" data-a="GO:0005789" data-r="PMID:14690501" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+                        
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Experimentally supported ER membrane localization. Membrane-bound fatty acid desaturases including FAD2 are co-translationally inserted into the ER and carry C-terminal ER-retrieval motifs. [PMID:14690501]
+                        </div>
+                        
+                        
+                        
+                        
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+                            
+                            <div class="support-item">
+                                <span class="support-ref">
+                                    
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/14690501" target="_blank" class="term-link">
+                                        PMID:14690501
+                                    </a>
+                                    
+                                </span>
+                                
+                                <div class="support-text">Membrane-bound fatty acid desaturases are inserted co-translationally into the ER and contain ER retrieval motifs at their carboxy termini</div>
+                                
+                            </div>
+                            
+                        </div>
+                        
+                    </td>
+                </tr>
+                
+                <tr>
+                    <td>
+                        <div class="term-info">
+                            
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0050184" target="_blank" class="term-link">
+                                    GO:0050184
+                                </a>
+                            </span>
+                            <span class="term-label">acyl-lipid omega-6 desaturase (cytochrome b5) activity</span>
+                            
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">EXP</span>
+                        
+                        
+                        
+                        <br>
+                        <span style="font-size: 0.75rem;">
+                            
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/1730697" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:1730697
+                            </a>
+                            
+                                
+                                
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Arabidopsis mutants deficient in polyunsaturated fatty acid ...
+                                </span>
+                                
+                            
+                            
+                        </span>
+                        
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P46313" data-a="GO:0050184" data-r="PMID:1730697" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+                        
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Core molecular function with direct experimental support. FAD2 is the plant oleoyl-phosphatidylcholine (acyl-lipid) omega-6 desaturase; fad2 mutants are deficient in polyunsaturated fatty acid synthesis. [PMID:1730697]
+                        </div>
+                        
+                        
+                        
+                        
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+                            
+                            <div class="support-item">
+                                <span class="support-ref">
+                                    
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/1730697" target="_blank" class="term-link">
+                                        PMID:1730697
+                                    </a>
+                                    
+                                </span>
+                                
+                                <div class="support-text">Arabidopsis mutants deficient in polyunsaturated fatty acid synthesis; characterization of a plant oleoyl-phosphatidylcholine desaturase</div>
+                                
+                            </div>
+                            
+                        </div>
+                        
+                    </td>
+                </tr>
+                
+                <tr>
+                    <td>
+                        <div class="term-info">
+                            
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0102985" target="_blank" class="term-link">
+                                    GO:0102985
+                                </a>
+                            </span>
+                            <span class="term-label">acyl-CoA (9+3)-desaturase activity</span>
+                            
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">EXP</span>
+                        
+                        
+                        
+                        <br>
+                        <span style="font-size: 0.75rem;">
+                            
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/8685264" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:8685264
+                            </a>
+                            
+                                
+                                
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Functional expression of the extraplastidial Arabidopsis tha...
+                                </span>
+                                
+                            
+                            
+                        </span>
+                        
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P46313" data-a="GO:0102985" data-r="PMID:8685264" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+                        
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Same substrate-class caveat as the IEA instance above. FAD2 functionally expressed in yeast desaturates oleate to linoleate, but its physiological substrate is PC-esterified oleate (acyl-lipid), so the acyl-lipid omega-6 desaturase term is the accurate core function; retained as non-core. [PMID:8685264]
+                        </div>
+                        
+                        
+                        
+                        
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+                            
+                            <div class="support-item">
+                                <span class="support-ref">
+                                    
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/8685264" target="_blank" class="term-link">
+                                        PMID:8685264
+                                    </a>
+                                    
+                                </span>
+                                
+                                <div class="support-text">Functional expression of the extraplastidial Arabidopsis FAD2 oleate desaturase gene in Saccharomyces cerevisiae</div>
+                                
+                            </div>
+                            
+                        </div>
+                        
+                    </td>
+                </tr>
+                
+                <tr>
+                    <td>
+                        <div class="term-info">
+                            
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005634" target="_blank" class="term-link">
+                                    GO:0005634
+                                </a>
+                            </span>
+                            <span class="term-label">nucleus</span>
+                            
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">ISM</span>
+                        
+                        
+                        
+                        <br>
+                        <span style="font-size: 0.75rem;">
+                            
+                            GO_REF:0000122
+                            
+                        </span>
+                        
+                    </td>
+                    <td>
+                        <span class="action-badge action-remove">
+                            REMOVE
+                        </span>
+                        <span class="vote-buttons" data-g="P46313" data-a="GO:0005634" data-r="GO_REF:0000122" data-act="REMOVE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+                        
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Spurious computational (AtSubP sequence-model) prediction that contradicts the experimentally established ER membrane localization. FAD2 is a polytopic ER membrane desaturase; there is no evidence for nuclear localization.
+                        </div>
+                        
+                        
+                        
+                        
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+                            
+                            <div class="support-item">
+                                <span class="support-ref">
+                                    
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/14690501" target="_blank" class="term-link">
+                                        PMID:14690501
+                                    </a>
+                                    
+                                </span>
+                                
+                                <div class="support-text">membrane-bound fatty acid desaturases are inserted into the ER</div>
+                                
+                            </div>
+                            
+                        </div>
+                        
+                    </td>
+                </tr>
+                
+                <tr>
+                    <td>
+                        <div class="term-info">
+                            
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0045485" target="_blank" class="term-link">
+                                    GO:0045485
+                                </a>
+                            </span>
+                            <span class="term-label">omega-6 fatty acid desaturase activity</span>
+                            
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+                        
+                        
+                        
+                        <br>
+                        <span style="font-size: 0.75rem;">
+                            
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/8685264" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:8685264
+                            </a>
+                            
+                                
+                                
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Functional expression of the extraplastidial Arabidopsis tha...
+                                </span>
+                                
+                            
+                            
+                        </span>
+                        
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P46313" data-a="GO:0045485" data-r="PMID:8685264" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+                        
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Core molecular function, directly demonstrated. Functional expression of FAD2 confers omega-6 (Delta-12) desaturase activity, converting oleate to linoleate. [PMID:8685264]
+                        </div>
+                        
+                        
+                        
+                        
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+                            
+                            <div class="support-item">
+                                <span class="support-ref">
+                                    
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/8685264" target="_blank" class="term-link">
+                                        PMID:8685264
+                                    </a>
+                                    
+                                </span>
+                                
+                                <div class="support-text">Functional expression of the Arabidopsis oleate desaturase gene (FAD2) conferring omega-6 desaturation</div>
+                                
+                            </div>
+                            
+                        </div>
+                        
+                    </td>
+                </tr>
+                
+            </tbody>
+        </table>
+    </div>
+    
+
+    
+    <div class="section">
+        <h2 class="section-title">Core Functions</h2>
+        
+        <div class="core-function-card">
+            
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+                <h3>FAD2 is the ER omega-6 (Delta-12) fatty acid desaturase that converts oleoyl-phosphatidylcholine (18:1) to linoleoyl-phosphatidylcholine (18:2) using cytochrome b5 as electron donor, the committed step of extraplastidic polyunsaturated fatty acid synthesis that shapes membrane and seed-oil composition.</h3>
+                <span class="vote-buttons" data-g="P46313" data-a="FUNCTION: FAD2 is the ER omega-6 (Delta-12) fatty acid desat..." data-r="" data-act="CORE_FUNCTION">
+                    <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
+                    <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
+                </span>
+            </div>
+            
+
+            <div class="core-function-terms">
+                
+                <div class="function-term-group">
+                    <div class="function-term-label">Molecular Function:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0050184" target="_blank" class="term-link">
+                            acyl-lipid omega-6 desaturase (cytochrome b5) activity
+                        </a>
+                    </span>
+                </div>
+                
+
+                
+                <div class="function-term-group">
+                    <div class="function-term-label">Directly Involved In:</div>
+                    <div class="function-annotations">
+                        
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006636" target="_blank" class="term-link">
+                                unsaturated fatty acid biosynthetic process
+                            </a>
+                        </span>
+                        
+                    </div>
+                </div>
+                
+
+                
+                <div class="function-term-group">
+                    <div class="function-term-label">Cellular Locations:</div>
+                    <div class="function-annotations">
+                        
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005789" target="_blank" class="term-link">
+                                endoplasmic reticulum membrane
+                            </a>
+                        </span>
+                        
+                    </div>
+                </div>
+                
+
+                
+
+                
+            </div>
+
+            
+            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
+                <strong>Supporting Evidence:</strong>
+                <ul class="findings-list">
+                    
+                    <li class="finding-item">
+                        <span class="reference-id">
+                            
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/1730697" target="_blank" class="term-link">
+                                PMID:1730697
+                            </a>
+                            
+                        </span>
+                        
+                        <div class="finding-text">plant oleoyl-phosphatidylcholine (omega-6) desaturase; fad2 mutants deficient in polyunsaturated fatty acid synthesis</div>
+                        
+                    </li>
+                    
+                    <li class="finding-item">
+                        <span class="reference-id">
+                            
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/8685264" target="_blank" class="term-link">
+                                PMID:8685264
+                            </a>
+                            
+                        </span>
+                        
+                        <div class="finding-text">FAD2 confers oleate (18:1) to linoleate (18:2) omega-6 desaturation</div>
+                        
+                    </li>
+                    
+                    <li class="finding-item">
+                        <span class="reference-id">
+                            
+                            file:ARATH/FAD2/FAD2-deep-research-falcon.md
+                            
+                        </span>
+                        
+                        <div class="finding-text">FAD2 is the ER Delta-12 step controlling oleate to linoleate conversion on phosphatidylcholine</div>
+                        
+                    </li>
+                    
+                </ul>
+            </div>
+            
+        </div>
+        
+    </div>
+    
+
+    
+    <div class="section">
+        <h2 class="section-title collapsible">References</h2>
+        <div class="collapse-content">
+            
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+                        
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000002.md" target="_blank" class="term-link">
+                            GO_REF:0000002
+                        </a>
+                        
+                    </span>
+                </div>
+                
+                <div class="reference-title">Gene Ontology annotation through association of InterPro records with GO terms</div>
+                
+                
+            </div>
+            
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+                        
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000041.md" target="_blank" class="term-link">
+                            GO_REF:0000041
+                        </a>
+                        
+                    </span>
+                </div>
+                
+                <div class="reference-title">Gene Ontology annotation based on UniPathway vocabulary mapping</div>
+                
+                
+            </div>
+            
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+                        
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000044.md" target="_blank" class="term-link">
+                            GO_REF:0000044
+                        </a>
+                        
+                    </span>
+                </div>
+                
+                <div class="reference-title">Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location vocabulary mapping, accompanied by conservative changes to GO terms applied by UniProt</div>
+                
+                
+            </div>
+            
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+                        
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000120.md" target="_blank" class="term-link">
+                            GO_REF:0000120
+                        </a>
+                        
+                    </span>
+                </div>
+                
+                <div class="reference-title">Combined Automated Annotation using Multiple IEA Methods</div>
+                
+                
+            </div>
+            
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+                        
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000122.md" target="_blank" class="term-link">
+                            GO_REF:0000122
+                        </a>
+                        
+                    </span>
+                </div>
+                
+                <div class="reference-title">AtSubP analysis</div>
+                
+                
+            </div>
+            
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+                        
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/14690501" target="_blank" class="term-link">
+                            PMID:14690501
+                        </a>
+                        
+                    </span>
+                </div>
+                
+                <div class="reference-title">Membrane-bound fatty acid desaturases are inserted co-translationally into the ER and contain different ER retrieval motifs at their carboxy termini.</div>
+                
+                
+                <ul class="findings-list">
+                    
+                    <li class="finding-item">
+                        <div class="finding-statement">Membrane fatty acid desaturases including FAD2 are co-translationally inserted into the ER membrane and carry C-terminal ER-retrieval motifs.</div>
+                        
+                    </li>
+                    
+                </ul>
+                
+            </div>
+            
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+                        
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/1730697" target="_blank" class="term-link">
+                            PMID:1730697
+                        </a>
+                        
+                    </span>
+                </div>
+                
+                <div class="reference-title">Arabidopsis mutants deficient in polyunsaturated fatty acid synthesis. Biochemical and genetic characterization of a plant oleoyl-phosphatidylcholine desaturase.</div>
+                
+                
+                <ul class="findings-list">
+                    
+                    <li class="finding-item">
+                        <div class="finding-statement">Characterizes FAD2 as the plant oleoyl-phosphatidylcholine (acyl-lipid) omega-6 desaturase; fad2 mutants are deficient in polyunsaturated fatty acids.</div>
+                        
+                    </li>
+                    
+                </ul>
+                
+            </div>
+            
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+                        
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/8685264" target="_blank" class="term-link">
+                            PMID:8685264
+                        </a>
+                        
+                    </span>
+                </div>
+                
+                <div class="reference-title">Functional expression of the extraplastidial Arabidopsis thaliana oleate desaturase gene (FAD2) in Saccharomyces cerevisiae.</div>
+                
+                
+                <ul class="findings-list">
+                    
+                    <li class="finding-item">
+                        <div class="finding-statement">FAD2 expressed in yeast confers omega-6 (Delta-12) desaturase activity, converting oleate (18:1) to linoleate (18:2).</div>
+                        
+                    </li>
+                    
+                </ul>
+                
+            </div>
+            
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+                        
+                        file:ARATH/FAD2/FAD2-deep-research-falcon.md
+                        
+                    </span>
+                </div>
+                
+                <div class="reference-title">Falcon/Edison deep research report for FAD2, Arabidopsis thaliana</div>
+                
+                
+                <ul class="findings-list">
+                    
+                    <li class="finding-item">
+                        <div class="finding-statement">Synthesizes FAD2 as the ER omega-6/Delta-12 desaturase acting on PC-esterified oleate via cytochrome b5; central to seed-oil PUFA content and ER membrane unsaturation (ER-stress, cold responses); a canonical high-oleic oilseed engineering target.</div>
+                        
+                    </li>
+                    
+                </ul>
+                
+            </div>
+            
+        </div>
+    </div>
+    
+
+
+    
+    <div class="section">
+        <h2 class="section-title">Suggested Questions for Experts</h2>
+        
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> How is FAD2 activity and stability regulated post-translationally (e.g. temperature-dependent turnover) to tune the membrane 18:1/18:2 ratio, and how can this be exploited to stabilize high-oleic oils in oilseed feedstocks?</p>
+                    
+                </div>
+                <span class="vote-buttons" data-g="P46313" data-a="Q: How is FAD2 activity and stability regulated post-..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+        
+    </div>
+    
+
+    
+
+    
+
+    <!-- Computational Predictions Section -->
+    
+
+    <!-- Deep Research Sections -->
+    
+    <div class="section">
+        <h2 class="section-title">Deep Research</h2>
+        
+        <details class="deep-research-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; gap: 1rem;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Falcon</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(FAD2-deep-research-falcon.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="P46313" data-a="DEEP_RESEARCH: Falcon" data-r="" data-act="DEEP_RESEARCH" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This deep research is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This deep research needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+                
+                <div class="report-meta">
+                    
+                    <span class="report-meta-text">this with annotations you find in gene/protein databases, but these can be outdated or inaccurate.</span>
+                    
+                    
+                    <span class="report-badge">Falcon</span>
+                    
+                    
+                    <span class="report-badge">Edison Scientific Literature</span>
+                    
+                    
+                    <span class="report-badge">28 citations</span>
+                    
+                    
+                    <span class="report-badge">2 artifacts</span>
+                    
+                    
+                    <span class="report-meta-text">2026-06-11T17:58:33.202965</span>
+                    
+                    
+                    
+                </div>
+                
+                
+                <div class="artifact-list">
+                    
+                    
+                    
+                    <div class="artifact-link">
+                        <a href="FAD2-deep-research-falcon_artifacts/artifact-00.md" class="term-link">Edison artifact artifact-00</a>
+                        <span>(text/markdown)</span>
+                    </div>
+                    
+                    
+                    
+                    
+                    <div class="artifact-link">
+                        <a href="FAD2-deep-research-falcon_artifacts/image-1.png" class="term-link">## Context ID: pqac-00000011 Table 1 on page 5 provides the fatty acid composition percentages for wild-type camelina (WT) and various genetically engineered li</a>
+                        <span>(image/png)</span>
+                    </div>
+                    
+                    
+                </div>
+                
+                <p>The research report should be a detailed narrative explaining the function, biological processes, and localization of the gene product. Citations should be given for all claims.</p>
+<p>You should prioritize authoritative reviews and primary scientific literature when conducting research. You can supplement<br />
+this with annotations you find in gene/protein databases, but these can be outdated or inaccurate.</p>
+<p>We are specifically interested in the primary function of the gene - for enzymes, what reaction is catalyzed, and what is the substrate specificity? For transporters, what is the substrate? For structural proteins or adapters, what is the broader structural role? For signaling molecules, what is the role in the pathway.</p>
+<p>We are interested in where in or outside the cell the gene product carries out its function.</p>
+<p>We are also interested in the signaling or biochemical pathways in which the gene functions. We are less interested in broad pleiotropic effects, except where these elucidate the precise role.</p>
+<p>Include evidence where possible. We are interested in both experimental evidence as well as inference from structure, evolution, or bioinformatic analysis. Precise studies should be prioritized over high-throughput, where available.</p>
+<h2 id="research-report-arabidopsis-thaliana-fad2-uniprot-p46313-gene-fad2-agi-at3g12120-functional-annotation">Research report: Arabidopsis thaliana <strong>FAD2</strong> (UniProt <strong>P46313</strong>; gene <strong>FAD2</strong>, AGI <strong>At3g12120</strong>) — functional annotation</h2>
+<h3 id="0-identity-verification-critical">0) Identity verification (critical)</h3>
+<p>The target in scope is <strong>Arabidopsis thaliana</strong> fatty-acid desaturase <strong>FAD2</strong>, described in the user-provided UniProt record (P46313) as an <strong>endoplasmic reticulum (ER) omega-6 / Δ12 desaturase</strong> (fatty acid desaturase type 1 family). The primary literature retrieved here consistently uses “<strong>FAD2</strong>/fad2” to refer to the <strong>Arabidopsis ER/microsomal ω-6 desaturase</strong> that converts <strong>18:1 to 18:2</strong>, matching the UniProt description and excluding unrelated “FAD2” usage in other organisms (e.g., safflower/soybean/camelina paralogs used for comparison or engineering). (nguyen2019membranelipidpolyunsaturation pages 2-4, menard2017genomewideanalysis pages 1-4)</p>
+<p><em>Evidence limitation:</em> within the retrieved full-text snippets, <strong>the explicit string “At3g12120” was not captured</strong>; the At3g12120↔P46313↔FAD2 mapping is therefore treated as <strong>verified via the user-provided UniProt context</strong>, while functional claims are supported by the cited Arabidopsis experimental literature below. (nguyen2019membranelipidpolyunsaturation pages 2-4)</p>
+<h3 id="1-key-concepts-definitions-and-current-understanding">1) Key concepts, definitions, and current understanding</h3>
+<h4 id="11-what-fad2-is">1.1 What FAD2 is</h4>
+<p><strong>FAD2</strong> is a <strong>microsomal/ER-localized ω-6 (Δ12) fatty acid desaturase</strong> that introduces a double bond into monounsaturated C18 fatty acids in extraplastidic glycerolipids. (menard2017genomewideanalysis pages 1-4, nguyen2019membranelipidpolyunsaturation pages 2-4)</p>
+<h4 id="12-reaction-catalyzed-and-substrate-context-substrate-specificity-at-pathway-level">1.2 Reaction catalyzed and substrate context (substrate specificity at pathway level)</h4>
+<p>Across Arabidopsis-focused sources and cross-plant comparative work, FAD2 is defined by the reaction:<br />
+- <strong>oleic acid (18:1) → linoleic acid (18:2)</strong> (Δ12 desaturation / ω-6 desaturation). (nguyen2019membranelipidpolyunsaturation pages 2-4, gishini2020endoplasmicreticulumretention pages 1-2)</p>
+<p>In the canonical seed/oil pathway framing, FAD2 acts in the <strong>ER “microsomal” desaturation pathway</strong> on fatty acids <strong>esterified to phosphatidylcholine (PC)</strong>, producing 18:2 that can subsequently be desaturated to 18:3 by FAD3; PC is also a major precursor feeding triacylglycerol (TAG) assembly in seeds, linking FAD2 activity directly to seed oil composition. (menard2017genomewideanalysis pages 1-4)</p>
+<h4 id="13-subcellular-localization">1.3 Subcellular localization</h4>
+<p>An in vivo reporter assay using <strong>functional FAD2 fluorescent fusion constructs</strong> supports that Arabidopsis FAD2 localizes to the <strong>endoplasmic reticulum</strong> (no overlap with chloroplast autofluorescence, and not consistent with plasma membrane marker patterns). (nguyen2019membranelipidpolyunsaturation pages 2-4)</p>
+<h4 id="14-structuraltopological-features-familydomain-informed">1.4 Structural/topological features (family/domain-informed)</h4>
+<p>Plant membrane-bound desaturases of the FAD2 class are characterized by <strong>conserved histidine-box motifs</strong> and typically <strong>four transmembrane domains</strong> supporting catalysis in membranes. In Arabidopsis ω-6 desaturase comparisons, ER ω-6 desaturase features are discussed alongside conserved histidine motifs and predicted transmembrane segments. (lusk2022lipidomicanalysisof pages 5-5)</p>
+<p>More generally, membrane-bound desaturases are described as methyl-end desaturases with <strong>three conserved histidine boxes</strong> and <strong>four membrane-spanning domains</strong>, and (in this cited review context) as typically <strong>lacking an N-terminal fused cytochrome b5 domain</strong>, instead relying on electron transfer partners (e.g., cytochrome b5). (gishini2020endoplasmicreticulumretention pages 1-2)</p>
+<h3 id="2-experimental-evidence-for-biological-roles-in-arabidopsis">2) Experimental evidence for biological roles in Arabidopsis</h3>
+<h4 id="21-er-membrane-polyunsaturation-and-er-stress-tolerance">2.1 ER membrane polyunsaturation and ER stress tolerance</h4>
+<p>A systematic screen of fatty acid desaturase mutants identified <strong>fad2</strong> as <strong>hypersensitive to tunicamycin-induced ER stress</strong>, supporting that FAD2-dependent ER lipid polyunsaturation is required for robust ER stress responses. The authors link the phenotype to the <strong>balance between 18:1 and 18:2 species</strong> in ER glycerolipids. (Plant Journal; Aug 2019; https://doi.org/10.1111/tpj.14338) (nguyen2019membranelipidpolyunsaturation pages 2-4)</p>
+<h4 id="22-low-temperature-extraplastidic-pufa-metabolism-interactions">2.2 Low-temperature / extraplastidic PUFA metabolism interactions</h4>
+<p>Genetic interaction evidence in Arabidopsis places <strong>fad2</strong> in extraplastidic PUFA metabolism relevant to low temperature responses: introducing the <strong>ER fatty acid desaturase mutation fad2</strong> into a tocopherol-deficient background suppressed low-temperature-induced phenotypes, implicating ER-derived polyunsaturated lipid metabolism in the observed physiology. (Plant Cell; Feb 2008; https://doi.org/10.1105/tpc.107.054718) (maeda2008tocopherolsmodulateextraplastidic pages 1-2)</p>
+<h4 id="23-seed-oil-composition-context-and-temperature-responsive-regulation-framework">2.3 Seed-oil composition context and temperature-responsive regulation framework</h4>
+<p>A genome-wide analysis of desaturation in Arabidopsis describes <strong>FAD2 and FAD3</strong> as <strong>microsomal (ER) desaturases</strong> acting sequentially in the PC-linked pathway producing polyunsaturated fatty acids important for seed TAG composition, and discusses temperature dependence of these pathways. (Plant Physiology; Jan 2017; https://doi.org/10.1104/pp.16.01907) (menard2017genomewideanalysis pages 1-4)</p>
+<h3 id="3-recent-developments-prioritizing-20232024">3) Recent developments (prioritizing 2023–2024)</h3>
+<h4 id="31-mechanisticcellular-physiology-framing-arabidopsis-baseline-used-by-recent-work">3.1 Mechanistic/cellular physiology framing (Arabidopsis baseline used by recent work)</h4>
+<p>While the most direct mechanistic evidence retrieved here is from 2017–2019 Arabidopsis studies, these continue to anchor recent research: the 2019 work explicitly ties <strong>ER-localized FAD2 activity</strong> and <strong>ER membrane fatty-acid unsaturation</strong> to ER stress tolerance, a concept now broadly integrated into discussions of lipid homeostasis and stress resilience. (nguyen2019membranelipidpolyunsaturation pages 2-4)</p>
+<p>A 2023 Arabidopsis pollen/TAG study (DGAT1 mutant) notes altered expression of lipid-pathway genes and explicitly refers to <strong>FAD2 as encoding ER-localized desaturases</strong> in the context of reproductive lipid metabolism (supporting continued integration of FAD2 into ER lipid assembly frameworks). (AoB Plants; Feb 2023; https://doi.org/10.1093/aobpla/plad012) (nguyen2019membranelipidpolyunsaturation pages 2-4)</p>
+<p><em>Important 2024 primary development not accessible in this run:</em> a 2024 Plant Journal paper on <strong>sub-ER localization of FAD2 at ER–Golgi exit sites</strong> was identified by search metadata but not retrievable in full text here, so it cannot be used as evidence in this report. (unobtainable listing in tool output)</p>
+<h4 id="32-translationalbiotechnology-advances-2024">3.2 Translational/biotechnology advances (2024)</h4>
+<p>A 2024 review on <strong>Camelina</strong> biotechnology highlights FAD2 as a primary lever for tailoring oil composition (high-oleic/low-PUFA oils), emphasizing that Camelina’s allohexaploidy necessitates <strong>multi-homeolog targeting</strong> and supports a <strong>gene-dosage</strong> model (silencing one/two/three copies gives intermediate phenotypes). Methods include <strong>CRISPR-Cas9 editing</strong>, <strong>antisense RNA</strong>, and <strong>miRNA-mediated silencing</strong> (miRNA described as more specific than antisense in this context). (OCL; Jan 2024; https://doi.org/10.1051/ocl/2024007) (clavijobernal2024biotechnologicalcamelinaplatform pages 4-6)</p>
+<p>A 2024 genome-wide Camelina study similarly highlights FAD2 as a common editing target; it emphasizes high conservation among homeologs and concludes that subfunctionalization is largely via transcriptional balancing—supporting rational design for “dosage-tuned” editing strategies. (BMC Biotechnology; Dec 2024; https://doi.org/10.1186/s12896-024-00936-4) (blume2024genomewideidentificationand pages 1-2)</p>
+<p>A 2024 oil-biosynthesis review (broad plant scope) cites FAD2 silencing approaches (e.g., RNAi/amiRNA) as a route to generate “high-stearic and high-oleic” cottonseed oils, reinforcing FAD2 as a canonical target for oil-quality improvement (though the excerpted portion does not provide quantitative effect sizes). (Genes; Aug 2024; https://doi.org/10.3390/genes15091125) (zhou2024regulationofoil pages 13-14)</p>
+<h3 id="4-current-applications-and-real-world-implementations">4) Current applications and real-world implementations</h3>
+<p>FAD2 modification is widely deployed in <strong>oilseed engineering</strong> to increase <strong>oleic acid</strong> (18:1) and reduce <strong>linoleic/linolenic acids</strong> (18:2/18:3), improving oxidative stability and tailoring oils for food and industrial oleochemicals. Recent Camelina-focused biotechnology work explicitly positions this as a platform for sustainable oleochemical feedstocks, leveraging Arabidopsis as the mechanistic reference model. (clavijobernal2024biotechnologicalcamelinaplatform pages 4-6)</p>
+<h4 id="quantitative-example-2024-camelina-platform">Quantitative example (2024; Camelina platform)</h4>
+<p>A 2024 review reports fatty-acid composition shifts in engineered Camelina lines consistent with FAD2-targeted strategies, with oleic acid rising from ~11.5% to as high as 70% (and concomitant reductions in linoleic/linolenic acids): WT <strong>18:1 = 11.50%</strong> vs “High 18:1” <strong>18:1 = 70.00%</strong> (with <strong>18:2 = 4.00%</strong>, <strong>18:3 = 10.00%</strong>), and a “Low PUFA” line showing <strong>18:1 = 50.00%</strong>, <strong>18:2 = 4.50%</strong>, <strong>18:3 = 13.00%</strong>. (clavijobernal2024biotechnologicalcamelinaplatform pages 4-6, clavijobernal2024biotechnologicalcamelinaplatform media 605d3362)</p>
+<h3 id="5-expert-opinions-authoritative-analysis-interpretation-anchored-in-sources">5) Expert opinions / authoritative analysis (interpretation anchored in sources)</h3>
+<p>Across authoritative peer-reviewed sources, expert consensus framing is that:<br />
+1) <strong>FAD2 is the key ER Δ12 step</strong> controlling the oleate→linoleate conversion in extraplastidic lipid metabolism, thereby strongly influencing downstream PUFA content and TAG composition. (menard2017genomewideanalysis pages 1-4, gishini2020endoplasmicreticulumretention pages 1-2)<br />
+2) The physiological importance extends beyond storage oils: <strong>ER membrane unsaturation state</strong> (notably the 18:1/18:2 ratio) is implicated as a functional variable in <strong>ER stress tolerance</strong>, supporting a biophysical/homeostatic role of desaturation beyond nutrient storage. (nguyen2019membranelipidpolyunsaturation pages 2-4)<br />
+3) Because altering FAD2 can drive very large compositional shifts, FAD2 is repeatedly emphasized in 2024 biotechnology syntheses as a premier target for “designer oils,” with polyploid species requiring explicit multi-copy dosage strategies. (clavijobernal2024biotechnologicalcamelinaplatform pages 4-6, blume2024genomewideidentificationand pages 1-2)</p>
+<h3 id="6-summary-artifact-functional-annotation-at-a-glance">6) Summary artifact (functional annotation at a glance)</h3>
+<table>
+<thead>
+<tr>
+<th>Aspect</th>
+<th>Summary</th>
+<th>Evidence/Citation</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>Identity / aliases</td>
+<td><strong>Arabidopsis thaliana FAD2</strong> corresponds to the ER/extraplastidic <strong>fatty acid desaturase 2</strong>, functionally defined as the enzyme converting <strong>18:1 to 18:2</strong> in Arabidopsis. The user-supplied identifiers map this protein to <strong>UniProt P46313 / AGI At3g12120</strong>; literature consistently refers to Arabidopsis <strong>FAD2/fad2</strong> as the ER-localized oleate desaturase.</td>
+<td>(nguyen2019membranelipidpolyunsaturation pages 2-4, nguyen2019membranelipidpolyunsaturation pages 1-2)</td>
+</tr>
+<tr>
+<td>Enzyme class &amp; EC</td>
+<td>Membrane-bound <strong>ω-6 / Δ12 fatty acid desaturase</strong> acting in extraplastidic glycerolipid desaturation; literature describes it as a <strong>microsomal/ER ω-6 desaturase</strong>. UniProt annotation supplied by the user lists <strong>EC 1.14.19.22</strong> and <strong>EC 1.14.19.6</strong>.</td>
+<td>(menard2017genomewideanalysis pages 1-4, cao2013alargeand pages 1-2, gishini2020endoplasmicreticulumretention pages 1-2)</td>
+</tr>
+<tr>
+<td>Reaction and substrate context</td>
+<td>Core reaction: <strong>oleic acid (18:1) → linoleic acid (18:2)</strong>. In plants, FAD2 introduces a <strong>Δ12 double bond</strong> into <strong>oleoyl phosphatidylcholine (PC)</strong> in the ER/microsomal pathway; FAD3 can then further desaturate 18:2 to 18:3. PC is both a desaturation substrate and a major precursor for TAG assembly, linking FAD2 directly to seed-oil composition.</td>
+<td>(nguyen2019membranelipidpolyunsaturation pages 2-4, menard2017genomewideanalysis pages 1-4, cao2013alargeand pages 1-2, gishini2020endoplasmicreticulumretention pages 1-2)</td>
+</tr>
+<tr>
+<td>Subcellular localization</td>
+<td>Arabidopsis FAD2 is experimentally localized to the <strong>endoplasmic reticulum (ER)</strong>. Functional <strong>FAD2-Venus</strong> reporters complemented the mutant phenotype and showed ER localization, with no chloroplast overlap. Multiple studies also describe FAD2 as <strong>microsomal/ER-localized</strong>.</td>
+<td>(nguyen2019membranelipidpolyunsaturation pages 2-4, nguyen2019membranelipidpolyunsaturation pages 1-2)</td>
+</tr>
+<tr>
+<td>Structural / topology features</td>
+<td>FAD2 belongs to the membrane desaturase group characterized by <strong>conserved histidine-box motifs</strong> and typically <strong>four membrane-spanning segments</strong>. Comparative analyses of Arabidopsis ω-6 desaturases support <strong>four predicted transmembrane domains</strong> and conserved catalytic histidines. General membrane-bound desaturase reviews note these enzymes typically <strong>lack an N-terminal fused cytochrome b5 domain</strong> and instead use external electron-transfer partners.</td>
+<td>(lusk2022lipidomicanalysisof pages 5-5, gishini2020endoplasmicreticulumretention pages 1-2)</td>
+</tr>
+<tr>
+<td>Biological role: seed oil PUFA synthesis</td>
+<td>FAD2 is the major ER entry point from <strong>18:1 to 18:2</strong> in the extraplastidic pathway, thereby controlling the <strong>oleic/linoleic balance</strong> and influencing downstream <strong>18:3</strong> synthesis and TAG composition in seeds. Temperature-responsive desaturation analyses identify <strong>FAD2 and FAD3</strong> as the microsomal enzymes shaping Arabidopsis seed TAG polyunsaturation.</td>
+<td>(menard2017genomewideanalysis pages 1-4, cao2013alargeand pages 1-2)</td>
+</tr>
+<tr>
+<td>Biological role: ER stress tolerance</td>
+<td>Loss of Arabidopsis FAD2 causes <strong>hypersensitivity to tunicamycin-induced ER stress</strong>, supporting a direct role for <strong>ER membrane polyunsaturation</strong> in coping with proteotoxic stress. The relevant biophysical variable appears to be the <strong>18:1/18:2 balance</strong> in ER glycerolipids.</td>
+<td>(nguyen2019membranelipidpolyunsaturation pages 2-4, nguyen2019membranelipidpolyunsaturation pages 1-2)</td>
+</tr>
+<tr>
+<td>Biological role: low-temperature / extraplastidic PUFA responses</td>
+<td>Genetic evidence places <strong>fad2</strong> in ER PUFA metabolism required for low-temperature membrane responses: introducing <strong>fad2</strong> into the tocopherol-deficient <strong>vte2</strong> background suppressed the low-temperature phenotype, implicating ER-derived polyunsaturated lipids in acclimation/phenotype expression.</td>
+<td>(maeda2008tocopherolsmodulateextraplastidic pages 1-2)</td>
+</tr>
+<tr>
+<td>2023–2024 mechanistic developments relevant to Arabidopsis</td>
+<td>Recent Arabidopsis work continued to connect ER desaturation with cell physiology: a 2023 pollen/TAG study noted altered <strong>FAD2</strong> expression in a <strong>dgat1</strong> mutant background, consistent with coupling between ER lipid assembly and desaturation; 2024–2025 literature also continued emphasizing FAD2 as a reference ER ω-6 desaturase for comparative/engineering studies.</td>
+<td>(nguyen2019membranelipidpolyunsaturation pages 2-4)</td>
+</tr>
+<tr>
+<td>2023–2024 applications: high-oleic oil engineering</td>
+<td>Recent reviews identify <strong>FAD2</strong> as a premier engineering target to increase <strong>oleic acid</strong> and reduce <strong>linoleic/linolenic acids</strong> in oilseeds. In <strong>Camelina sativa</strong>, strategies include <strong>CRISPR-Cas9</strong>, <strong>antisense RNA</strong>, and <strong>miRNA-mediated silencing</strong>; because camelina is allohexaploid, outcomes reflect <strong>gene-dosage effects</strong> when one, two, or three FAD2 homoeologs are targeted.</td>
+<td>(clavijobernal2024biotechnologicalcamelinaplatform pages 4-6, blume2024genomewideidentificationand pages 1-2, zhou2024regulationofoil pages 13-14)</td>
+</tr>
+<tr>
+<td>Quantitative implementation data from Camelina</td>
+<td>Reported Camelina seed-oil profiles show strong compositional shifts after FAD2-targeted engineering: <strong>WT</strong> oleic <strong>11.50%</strong>, linoleic <strong>16.80%</strong>, linolenic <strong>30.90%</strong>; engineered <strong>High 18:1</strong> line oleic <strong>70.00%</strong>, linoleic <strong>4.00%</strong>, linolenic <strong>10.00%</strong>; engineered <strong>Low PUFA</strong> line oleic <strong>50.00%</strong>, linoleic <strong>4.50%</strong>, linolenic <strong>13.00%</strong>. These data illustrate practical control of oil quality via FAD2 dosage/silencing.</td>
+<td>(clavijobernal2024biotechnologicalcamelinaplatform pages 4-6, clavijobernal2024biotechnologicalcamelinaplatform media 605d3362)</td>
+</tr>
+</tbody>
+</table>
+<p><em>Table: This table condenses the key functional annotation for Arabidopsis thaliana FAD2 (UniProt P46313; At3g12120), covering reaction chemistry, localization, structural features, biological roles, and recent translational applications. It also includes quantitative 2024 Camelina engineering data illustrating how FAD2 targeting changes seed-oil composition.</em></p>
+<h3 id="7-key-takeaways-functional-annotation">7) Key takeaways (functional annotation)</h3>
+<ul>
+<li><strong>Molecular function:</strong> ER/microsomal ω-6 (Δ12) fatty acid desaturase; converts <strong>18:1 → 18:2</strong> in extraplastidic lipid metabolism. (nguyen2019membranelipidpolyunsaturation pages 2-4, menard2017genomewideanalysis pages 1-4)</li>
+<li><strong>Cellular location:</strong> <strong>Endoplasmic reticulum</strong> (supported by functional fluorescent fusion localization). (nguyen2019membranelipidpolyunsaturation pages 2-4)</li>
+<li><strong>Pathway role:</strong> central step in ER PUFA synthesis on PC, influencing TAG fatty-acid composition and broader lipid homeostasis. (menard2017genomewideanalysis pages 1-4)</li>
+<li><strong>Physiological roles with direct evidence:</strong> contributes to <strong>ER stress tolerance</strong> via membrane polyunsaturation and participates in extraplastidic PUFA-dependent phenotypes (including low-temperature-related genetic interactions). (nguyen2019membranelipidpolyunsaturation pages 2-4, maeda2008tocopherolsmodulateextraplastidic pages 1-2)</li>
+<li><strong>Applications (2024):</strong> widely used engineering target (CRISPR/miRNA/antisense; dosage approaches in polyploids) for high-oleic oils; recent Camelina examples show <strong>multi-fold</strong> increases in oleic acid percentage (11.5%→70%). (clavijobernal2024biotechnologicalcamelinaplatform pages 4-6, clavijobernal2024biotechnologicalcamelinaplatform media 605d3362)</li>
+</ul>
+<p>References</p>
+<ol>
+<li>
+<p>(nguyen2019membranelipidpolyunsaturation pages 2-4): Van Cam Nguyen, Yuki Nakamura, and Kazue Kanehara. Membrane lipid polyunsaturation mediated by fatty acid desaturase 2 (fad2) is involved in endoplasmic reticulum stress tolerance in arabidopsis thaliana. The Plant journal : for cell and molecular biology, 99:478-493, Aug 2019. URL: https://doi.org/10.1111/tpj.14338, doi:10.1111/tpj.14338. This article has 70 citations.</p>
+</li>
+<li>
+<p>(menard2017genomewideanalysis pages 1-4): Guillaume N. Menard, Jose Martin Moreno, Fiona M. Bryant, Olaya Munoz-Azcarate, Amélie A. Kelly, Keywan Hassani-Pak, Smita Kurup, and Peter J. Eastmond. Genome wide analysis of fatty acid desaturation and its response to temperature1[open]. Plant Physiology, 173:1594-1605, Jan 2017. URL: https://doi.org/10.1104/pp.16.01907, doi:10.1104/pp.16.01907. This article has 77 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(gishini2020endoplasmicreticulumretention pages 1-2): Mohammad Fazel Soltani Gishini, Alireza Zebarjadi, Maryam Abdoli-nasab, Mokhtar Jalali Javaran, Danial Kahrizi, and David Hildebrand. Endoplasmic reticulum retention signaling and transmembrane channel proteins predicted for oilseed ω3 fatty acid desaturase 3 (fad3) genes. Functional &amp; Integrative Genomics, 20:433-458, Nov 2020. URL: https://doi.org/10.1007/s10142-019-00718-8, doi:10.1007/s10142-019-00718-8. This article has 13 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(lusk2022lipidomicanalysisof pages 5-5): Hannah J Lusk, Nicholas Neumann, Madeline Colter, Mary R Roth, Pamela Tamura, Libin Yao, Sunitha Shiva, Jyoti Shah, Kathrin Schrick, Timothy P Durrett, and Ruth Welti. Lipidomic analysis of arabidopsis t-dna insertion lines leads to identification and characterization of c-terminal alterations in fatty acid desaturase 6. Plant and Cell Physiology, 63:1193-1204, Jun 2022. URL: https://doi.org/10.1093/pcp/pcac088, doi:10.1093/pcp/pcac088. This article has 13 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(maeda2008tocopherolsmodulateextraplastidic pages 1-2): Hiroshi A. Maeda, T. Sage, G. Isaac, R. Welti, and D. DellaPenna. Tocopherols modulate extraplastidic polyunsaturated fatty acid metabolism in arabidopsis at low temperature[w]. The Plant Cell Online, 20:452-470, Feb 2008. URL: https://doi.org/10.1105/tpc.107.054718, doi:10.1105/tpc.107.054718. This article has 150 citations.</p>
+</li>
+<li>
+<p>(clavijobernal2024biotechnologicalcamelinaplatform pages 4-6): Enrique J. Clavijo-Bernal, Enrique Martínez-Force, Rafael Garcés, Joaquín J Salas, and Mónica Venegas-Calerón. Biotechnological camelina platform for green sustainable oleochemicals production. OCL, 31:11, Jan 2024. URL: https://doi.org/10.1051/ocl/2024007, doi:10.1051/ocl/2024007. This article has 7 citations.</p>
+</li>
+<li>
+<p>(blume2024genomewideidentificationand pages 1-2): Rostyslav Y. Blume, Vitaliy Y. Hotsuliak, Tara J. Nazarenus, Edgar B. Cahoon, and Yaroslav B. Blume. Genome-wide identification and diversity of fad2, fad3 and fae1 genes in terms of biotechnological importance in camelina species. BMC Biotechnology, Dec 2024. URL: https://doi.org/10.1186/s12896-024-00936-4, doi:10.1186/s12896-024-00936-4. This article has 9 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(zhou2024regulationofoil pages 13-14): Lixia Zhou, Qiufei Wu, Yaodong Yang, Qihong Li, Rui Li, and Jianqiu Ye. Regulation of oil biosynthesis and genetic improvement in plants: advances and prospects. Genes, 15:1125, Aug 2024. URL: https://doi.org/10.3390/genes15091125, doi:10.3390/genes15091125. This article has 23 citations.</p>
+</li>
+<li>
+<p>(clavijobernal2024biotechnologicalcamelinaplatform media 605d3362): Enrique J. Clavijo-Bernal, Enrique Martínez-Force, Rafael Garcés, Joaquín J Salas, and Mónica Venegas-Calerón. Biotechnological camelina platform for green sustainable oleochemicals production. OCL, 31:11, Jan 2024. URL: https://doi.org/10.1051/ocl/2024007, doi:10.1051/ocl/2024007. This article has 7 citations.</p>
+</li>
+<li>
+<p>(nguyen2019membranelipidpolyunsaturation pages 1-2): Van Cam Nguyen, Yuki Nakamura, and Kazue Kanehara. Membrane lipid polyunsaturation mediated by fatty acid desaturase 2 (fad2) is involved in endoplasmic reticulum stress tolerance in arabidopsis thaliana. The Plant journal : for cell and molecular biology, 99:478-493, Aug 2019. URL: https://doi.org/10.1111/tpj.14338, doi:10.1111/tpj.14338. This article has 70 citations.</p>
+</li>
+<li>
+<p>(cao2013alargeand pages 1-2): Shijiang Cao, Xue-Rong Zhou, Craig C Wood, Allan G Green, Surinder P Singh, Lixia Liu, and Qing Liu. A large and functionally diverse family of fad2 genes in safflower (carthamus tinctoriusl.). BMC Plant Biology, Jan 2013. URL: https://doi.org/10.1186/1471-2229-13-5, doi:10.1186/1471-2229-13-5. This article has 124 citations and is from a peer-reviewed journal.</p>
+</li>
+</ol>
+<h2 id="artifacts">Artifacts</h2>
+<ul>
+<li><a href="FAD2-deep-research-falcon_artifacts/artifact-00.md">Edison artifact artifact-00</a><br />
+<img alt="## Context ID: pqac-00000011 Table 1 on page 5 provides the fatty acid composition percentages for wild-type camelina (WT) and various genetically engineered li" src="FAD2-deep-research-falcon_artifacts/image-1.png" /></li>
+</ul>
+<h2 id="citations">Citations</h2>
+<ol>
+<li>nguyen2019membranelipidpolyunsaturation pages 2-4</li>
+<li>menard2017genomewideanalysis pages 1-4</li>
+<li>lusk2022lipidomicanalysisof pages 5-5</li>
+<li>gishini2020endoplasmicreticulumretention pages 1-2</li>
+<li>maeda2008tocopherolsmodulateextraplastidic pages 1-2</li>
+<li>clavijobernal2024biotechnologicalcamelinaplatform pages 4-6</li>
+<li>blume2024genomewideidentificationand pages 1-2</li>
+<li>zhou2024regulationofoil pages 13-14</li>
+<li>nguyen2019membranelipidpolyunsaturation pages 1-2</li>
+<li>cao2013alargeand pages 1-2</li>
+<li>open</li>
+<li>w</li>
+<li>https://doi.org/10.1111/tpj.14338</li>
+<li>https://doi.org/10.1105/tpc.107.054718</li>
+<li>https://doi.org/10.1104/pp.16.01907</li>
+<li>https://doi.org/10.1093/aobpla/plad012</li>
+<li>https://doi.org/10.1051/ocl/2024007</li>
+<li>https://doi.org/10.1186/s12896-024-00936-4</li>
+<li>https://doi.org/10.3390/genes15091125</li>
+<li>https://doi.org/10.1111/tpj.14338,</li>
+<li>https://doi.org/10.1104/pp.16.01907,</li>
+<li>https://doi.org/10.1007/s10142-019-00718-8,</li>
+<li>https://doi.org/10.1093/pcp/pcac088,</li>
+<li>https://doi.org/10.1105/tpc.107.054718,</li>
+<li>https://doi.org/10.1051/ocl/2024007,</li>
+<li>https://doi.org/10.1186/s12896-024-00936-4,</li>
+<li>https://doi.org/10.3390/genes15091125,</li>
+<li>https://doi.org/10.1186/1471-2229-13-5,</li>
+</ol>
+            </div>
+        </details>
+        
+    </div>
+    
+
+    <!-- Additional Documentation Sections -->
+    
+    <div class="section">
+        <h2 class="section-title">📚 Additional Documentation</h2>
+        
+        <details class="markdown-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; cursor: pointer;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Notes</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(FAD2-notes.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="P46313" data-a="DOC: Notes" data-r="" data-act="DOCUMENTATION" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This documentation is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This documentation needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+                <h1 id="fad2-delta-12-omega-6-oleate-desaturase-arabidopsis-thaliana-review-notes">FAD2 (Delta-12 / omega-6 oleate desaturase) — Arabidopsis thaliana — review notes</h1>
+<p>UniProt: P46313 · At3g12120 · EC 1.14.19.6 / 1.14.19.22 · Taxon 3702<br />
+Relevance: primary lever for seed-oil quality (oleic vs polyunsaturated content) — a<br />
+canonical DOE/BER oilseed engineering target (high-oleic oils for fuel/oleochemical use).</p>
+<h2 id="core-function">Core function</h2>
+<ul>
+<li>ER (microsomal) <strong>omega-6 / Delta-12 fatty acid desaturase</strong>: converts <strong>oleic acid<br />
+  (18:1) -&gt; linoleic acid (18:2)</strong> by introducing a second double bond. Acts on fatty<br />
+  acids <strong>esterified to phosphatidylcholine (PC)</strong> (acyl-lipid desaturase), using<br />
+<strong>cytochrome b5</strong> as electron donor; product 18:2 is further desaturated to 18:3 by<br />
+  FAD3. [UniProt P46313 FUNCTION; file:ARATH/FAD2/FAD2-deep-research-falcon.md;<br />
+  PMID:1730697; PMID:8685264]</li>
+<li>Membrane-bound desaturase: conserved histidine-box motifs, ~four transmembrane<br />
+  domains; no fused cytochrome b5 (uses separate electron-transfer partner).<br />
+  [file:ARATH/FAD2/FAD2-deep-research-falcon.md]</li>
+<li>PC is both the desaturation substrate and a major precursor for seed TAG assembly, so<br />
+  FAD2 directly shapes seed-oil fatty-acid composition. [PMID:14690501 context;<br />
+  file:ARATH/FAD2/FAD2-deep-research-falcon.md]</li>
+</ul>
+<h2 id="localization">Localization</h2>
+<ul>
+<li><strong>Endoplasmic reticulum membrane</strong>, experimentally confirmed (EXP PMID:14690501;<br />
+  in vivo FAD2-fluorescent fusion shows ER, no chloroplast/PM overlap).</li>
+<li>The GOA <strong>nucleus (ISM, GO_REF:0000122 AtSubP)</strong> annotation contradicts this and is a<br />
+  spurious sequence-model prediction -&gt; REMOVE. (Same AtSubP artifact as FAE1's bogus<br />
+  chloroplast call.)</li>
+</ul>
+<h2 id="substrate-class-nuance">Substrate-class nuance</h2>
+<ul>
+<li>Two EXP annotations assign <strong>GO:0102985 acyl-CoA (9+3)-desaturase activity</strong>. FAD2 is<br />
+  canonically an <strong>acyl-LIPID</strong> (PC-bound) desaturase, not an acyl-CoA desaturase, so the<br />
+  acyl-lipid omega-6 desaturase term (GO:0050184) and omega-6 desaturase (GO:0045485) are<br />
+  the accurate core MFs. Per curation guidance I do not REMOVE the EXP acyl-CoA term but<br />
+  mark it KEEP_AS_NON_CORE and note the preferred acyl-lipid framing.</li>
+</ul>
+<h2 id="annotation-review-decisions">Annotation review decisions</h2>
+<ul>
+<li>GO:0050184 acyl-lipid omega-6 desaturase (cytochrome b5) (IEA+EXP) -&gt; ACCEPT (core MF)</li>
+<li>GO:0045485 omega-6 fatty acid desaturase activity (IDA) -&gt; ACCEPT (core MF)</li>
+<li>GO:0016717 oxidoreductase, paired donors, O2-&gt;2 H2O (IEA) -&gt; ACCEPT (desaturase class)</li>
+<li>GO:0016491 oxidoreductase activity (IEA) -&gt; ACCEPT (general)</li>
+<li>GO:0102985 acyl-CoA (9+3)-desaturase activity (IEA+EXP) -&gt; KEEP_AS_NON_CORE (acyl-lipid<br />
+  is the accurate substrate class)</li>
+<li>GO:0006636 unsaturated fatty acid biosynthetic process (IEA) -&gt; ACCEPT (core BP)</li>
+<li>GO:0006629 lipid metabolic process (IEA) -&gt; ACCEPT (general)</li>
+<li>GO:0005789 endoplasmic reticulum membrane (IEA+EXP) -&gt; ACCEPT (core location)</li>
+<li>GO:0005634 nucleus (ISM) -&gt; REMOVE (spurious AtSubP prediction)</li>
+</ul>
+<h2 id="doeber-relevance">DOE/BER relevance</h2>
+<p>FAD2 silencing/knockout raises oleic acid and lowers PUFA (e.g. Camelina 18:1 ~11.5% -&gt;<br />
+~70%), improving oxidative stability for fuel/oleochemical feedstocks. Allohexaploid crops<br />
+(Camelina) need multi-homeolog targeting (gene-dosage model).</p>
+            </div>
+        </details>
+        
+    </div>
+    
+
+    <!-- YAML Preview Section -->
+    <div class="section">
+        <details class="yaml-preview">
+            <summary>
+                <h2 style="display: inline;">📄 View Raw YAML</h2>
+            </summary>
+            <div class="yaml-content">
+                <pre><code>id: P46313
+gene_symbol: FAD2
+product_type: PROTEIN
+status: COMPLETE
+taxon:
+  id: NCBITaxon:3702
+  label: Arabidopsis thaliana
+description: FAD2 is the endoplasmic-reticulum (microsomal) omega-6 / Delta(12) fatty
+  acid desaturase of Arabidopsis. It introduces a second double bond into monounsaturated
+  C18 fatty acids, converting oleic acid (18:1) to linoleic acid (18:2) on fatty acids
+  esterified to phosphatidylcholine (PC), using cytochrome b5 as the electron donor. It
+  is a polytopic membrane protein with conserved histidine-box motifs. The 18:2 product
+  can be further desaturated to 18:3 by FAD3, and because PC is a major precursor for
+  triacylglycerol assembly, FAD2 is a primary determinant of extraplastidic membrane and
+  seed-oil polyunsaturated fatty acid composition; ER membrane unsaturation set by FAD2
+  also contributes to ER-stress and low-temperature responses.
+existing_annotations:
+  - term:
+      id: GO:0005789
+      label: endoplasmic reticulum membrane
+    evidence_type: IEA
+    original_reference_id: GO_REF:0000044
+    qualifier: located_in
+    review:
+      summary: Correct localization, independently confirmed experimentally (EXP below).
+        FAD2 is an ER (microsomal) membrane desaturase.
+      action: ACCEPT
+  - term:
+      id: GO:0006629
+      label: lipid metabolic process
+    evidence_type: IEA
+    original_reference_id: GO_REF:0000002
+    qualifier: involved_in
+    review:
+      summary: Correct but general. FAD2 functions in glycerolipid/fatty acid metabolism;
+        the specific unsaturated fatty acid biosynthetic role is captured below.
+      action: ACCEPT
+  - term:
+      id: GO:0016491
+      label: oxidoreductase activity
+    evidence_type: IEA
+    original_reference_id: GO_REF:0000002
+    qualifier: enables
+    review:
+      summary: Correct but general. The informative molecular function is the omega-6
+        (Delta-12) fatty acid desaturase activity captured by more specific terms below.
+      action: ACCEPT
+  - term:
+      id: GO:0016717
+      label: oxidoreductase activity, acting on paired donors, with oxidation of a pair
+        of donors resulting in the reduction of molecular oxygen to two molecules of water
+    evidence_type: IEA
+    original_reference_id: GO_REF:0000002
+    qualifier: enables
+    review:
+      summary: Correct enzyme-class molecular function for a membrane fatty acid
+        desaturase, which uses O2 and an electron donor (cytochrome b5) to introduce a
+        double bond. Consistent with the specific desaturase annotations.
+      action: ACCEPT
+  - term:
+      id: GO:0050184
+      label: acyl-lipid omega-6 desaturase (cytochrome b5) activity
+    evidence_type: IEA
+    original_reference_id: GO_REF:0000120
+    qualifier: enables
+    review:
+      summary: Accurate core molecular function, also experimentally supported (EXP below).
+        FAD2 desaturates oleoyl-phosphatidylcholine using cytochrome b5 as electron donor.
+      action: ACCEPT
+  - term:
+      id: GO:0102985
+      label: acyl-CoA (9+3)-desaturase activity
+    evidence_type: IEA
+    original_reference_id: GO_REF:0000120
+    qualifier: enables
+    review:
+      summary: FAD2 is canonically an acyl-LIPID desaturase that acts on oleate esterified
+        to phosphatidylcholine, not on acyl-CoA (its primary characterization is as an
+        oleoyl-phosphatidylcholine desaturase). The acyl-lipid omega-6 desaturase
+        (GO:0050184) and omega-6 desaturase (GO:0045485) terms are the accurate molecular
+        functions; this acyl-CoA term is retained as non-core. [PMID:1730697]
+      action: KEEP_AS_NON_CORE
+      supported_by:
+        - reference_id: PMID:1730697
+          supporting_text: Biochemical and genetic characterization of a plant
+            oleoyl-phosphatidylcholine desaturase
+  - term:
+      id: GO:0006636
+      label: unsaturated fatty acid biosynthetic process
+    evidence_type: IEA
+    original_reference_id: GO_REF:0000041
+    qualifier: involved_in
+    review:
+      summary: Correct core biological process. FAD2 produces polyunsaturated fatty acids
+        (18:2, feeding into 18:3) in the extraplastidic pathway.
+      action: ACCEPT
+  - term:
+      id: GO:0005789
+      label: endoplasmic reticulum membrane
+    evidence_type: EXP
+    original_reference_id: PMID:14690501
+    qualifier: located_in
+    review:
+      summary: Experimentally supported ER membrane localization. Membrane-bound fatty
+        acid desaturases including FAD2 are co-translationally inserted into the ER and
+        carry C-terminal ER-retrieval motifs. [PMID:14690501]
+      action: ACCEPT
+      supported_by:
+        - reference_id: PMID:14690501
+          supporting_text: Membrane-bound fatty acid desaturases are inserted
+            co-translationally into the ER and contain ER retrieval motifs at their
+            carboxy termini
+  - term:
+      id: GO:0050184
+      label: acyl-lipid omega-6 desaturase (cytochrome b5) activity
+    evidence_type: EXP
+    original_reference_id: PMID:1730697
+    qualifier: enables
+    review:
+      summary: Core molecular function with direct experimental support. FAD2 is the plant
+        oleoyl-phosphatidylcholine (acyl-lipid) omega-6 desaturase; fad2 mutants are
+        deficient in polyunsaturated fatty acid synthesis. [PMID:1730697]
+      action: ACCEPT
+      supported_by:
+        - reference_id: PMID:1730697
+          supporting_text: Arabidopsis mutants deficient in polyunsaturated fatty acid
+            synthesis; characterization of a plant oleoyl-phosphatidylcholine desaturase
+  - term:
+      id: GO:0102985
+      label: acyl-CoA (9+3)-desaturase activity
+    evidence_type: EXP
+    original_reference_id: PMID:8685264
+    qualifier: enables
+    review:
+      summary: Same substrate-class caveat as the IEA instance above. FAD2 functionally
+        expressed in yeast desaturates oleate to linoleate, but its physiological
+        substrate is PC-esterified oleate (acyl-lipid), so the acyl-lipid omega-6
+        desaturase term is the accurate core function; retained as non-core. [PMID:8685264]
+      action: KEEP_AS_NON_CORE
+      supported_by:
+        - reference_id: PMID:8685264
+          supporting_text: Functional expression of the extraplastidial Arabidopsis FAD2
+            oleate desaturase gene in Saccharomyces cerevisiae
+  - term:
+      id: GO:0005634
+      label: nucleus
+    evidence_type: ISM
+    original_reference_id: GO_REF:0000122
+    qualifier: located_in
+    review:
+      summary: Spurious computational (AtSubP sequence-model) prediction that contradicts
+        the experimentally established ER membrane localization. FAD2 is a polytopic ER
+        membrane desaturase; there is no evidence for nuclear localization.
+      action: REMOVE
+      supported_by:
+        - reference_id: PMID:14690501
+          supporting_text: membrane-bound fatty acid desaturases are inserted into the ER
+  - term:
+      id: GO:0045485
+      label: omega-6 fatty acid desaturase activity
+    evidence_type: IDA
+    original_reference_id: PMID:8685264
+    qualifier: enables
+    review:
+      summary: Core molecular function, directly demonstrated. Functional expression of
+        FAD2 confers omega-6 (Delta-12) desaturase activity, converting oleate to
+        linoleate. [PMID:8685264]
+      action: ACCEPT
+      supported_by:
+        - reference_id: PMID:8685264
+          supporting_text: Functional expression of the Arabidopsis oleate desaturase gene
+            (FAD2) conferring omega-6 desaturation
+core_functions:
+  - description: FAD2 is the ER omega-6 (Delta-12) fatty acid desaturase that converts
+      oleoyl-phosphatidylcholine (18:1) to linoleoyl-phosphatidylcholine (18:2) using
+      cytochrome b5 as electron donor, the committed step of extraplastidic
+      polyunsaturated fatty acid synthesis that shapes membrane and seed-oil composition.
+    molecular_function:
+      id: GO:0050184
+      label: acyl-lipid omega-6 desaturase (cytochrome b5) activity
+    directly_involved_in:
+      - id: GO:0006636
+        label: unsaturated fatty acid biosynthetic process
+    locations:
+      - id: GO:0005789
+        label: endoplasmic reticulum membrane
+    supported_by:
+      - reference_id: PMID:1730697
+        supporting_text: plant oleoyl-phosphatidylcholine (omega-6) desaturase; fad2
+          mutants deficient in polyunsaturated fatty acid synthesis
+      - reference_id: PMID:8685264
+        supporting_text: FAD2 confers oleate (18:1) to linoleate (18:2) omega-6
+          desaturation
+      - reference_id: file:ARATH/FAD2/FAD2-deep-research-falcon.md
+        supporting_text: FAD2 is the ER Delta-12 step controlling oleate to linoleate
+          conversion on phosphatidylcholine
+references:
+  - id: GO_REF:0000002
+    title: Gene Ontology annotation through association of InterPro records with GO terms
+    findings: []
+  - id: GO_REF:0000041
+    title: Gene Ontology annotation based on UniPathway vocabulary mapping
+    findings: []
+  - id: GO_REF:0000044
+    title: Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location
+      vocabulary mapping, accompanied by conservative changes to GO terms applied by
+      UniProt
+    findings: []
+  - id: GO_REF:0000120
+    title: Combined Automated Annotation using Multiple IEA Methods
+    findings: []
+  - id: GO_REF:0000122
+    title: AtSubP analysis
+    findings: []
+  - id: PMID:14690501
+    title: Membrane-bound fatty acid desaturases are inserted co-translationally into the
+      ER and contain different ER retrieval motifs at their carboxy termini.
+    findings:
+      - statement: Membrane fatty acid desaturases including FAD2 are co-translationally
+          inserted into the ER membrane and carry C-terminal ER-retrieval motifs.
+        reference_section_type: RESULTS
+    reference_review:
+      relevance: HIGH
+      correctness: VERIFIED
+      review_notes: Source of EXP ER membrane localization.
+  - id: PMID:1730697
+    title: Arabidopsis mutants deficient in polyunsaturated fatty acid synthesis.
+      Biochemical and genetic characterization of a plant oleoyl-phosphatidylcholine
+      desaturase.
+    findings:
+      - statement: Characterizes FAD2 as the plant oleoyl-phosphatidylcholine (acyl-lipid)
+          omega-6 desaturase; fad2 mutants are deficient in polyunsaturated fatty acids.
+        reference_section_type: RESULTS
+    reference_review:
+      relevance: HIGH
+      correctness: VERIFIED
+      review_notes: Establishes the acyl-lipid (PC) substrate; supports core MF and the
+        acyl-CoA caveat.
+  - id: PMID:8685264
+    title: Functional expression of the extraplastidial Arabidopsis thaliana oleate
+      desaturase gene (FAD2) in Saccharomyces cerevisiae.
+    findings:
+      - statement: FAD2 expressed in yeast confers omega-6 (Delta-12) desaturase activity,
+          converting oleate (18:1) to linoleate (18:2).
+        reference_section_type: RESULTS
+    reference_review:
+      relevance: HIGH
+      correctness: VERIFIED
+      review_notes: Source of the IDA omega-6 desaturase activity and EXP desaturase
+        annotations.
+  - id: file:ARATH/FAD2/FAD2-deep-research-falcon.md
+    title: Falcon/Edison deep research report for FAD2, Arabidopsis thaliana
+    findings:
+      - statement: Synthesizes FAD2 as the ER omega-6/Delta-12 desaturase acting on
+          PC-esterified oleate via cytochrome b5; central to seed-oil PUFA content and ER
+          membrane unsaturation (ER-stress, cold responses); a canonical high-oleic
+          oilseed engineering target.
+        reference_section_type: OTHER
+suggested_questions:
+  - question: How is FAD2 activity and stability regulated post-translationally (e.g.
+      temperature-dependent turnover) to tune the membrane 18:1/18:2 ratio, and how can
+      this be exploited to stabilize high-oleic oils in oilseed feedstocks?
+</code></pre>
+            </div>
+        </details>
+    </div>
+
+    <!-- Pathway Visualization Link -->
+    
+
+    <style>
+        /* Markdown Section Styles */
+        .markdown-section {
+            margin-bottom: 1rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .markdown-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .markdown-section summary h3 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.1rem;
+        }
+
+        .markdown-section summary:hover h3 {
+            color: #007bff;
+        }
+
+        .markdown-section[open] {
+            background-color: #fff;
+        }
+
+        .markdown-content {
+            margin-top: 1rem;
+            padding: 1rem;
+            border-top: 1px solid #dee2e6;
+        }
+
+        /* Markdown content styling */
+        .markdown-content h1 { font-size: 1.5rem; margin-top: 1.5rem; }
+        .markdown-content h2 { font-size: 1.3rem; margin-top: 1.3rem; }
+        .markdown-content h3 { font-size: 1.1rem; margin-top: 1.1rem; }
+        .markdown-content h4 { font-size: 1rem; margin-top: 1rem; }
+
+        .markdown-content pre {
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .markdown-content code {
+            background-color: #f8f9fa;
+            padding: 0.2rem 0.4rem;
+            border-radius: 3px;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+        }
+
+        .markdown-content pre code {
+            background: none;
+            padding: 0;
+        }
+
+        .markdown-content table {
+            border-collapse: collapse;
+            width: 100%;
+            margin: 1rem 0;
+        }
+
+        .markdown-content table th,
+        .markdown-content table td {
+            border: 1px solid #dee2e6;
+            padding: 0.5rem;
+            text-align: left;
+        }
+
+        .markdown-content table th {
+            background-color: #f8f9fa;
+            font-weight: bold;
+        }
+
+        .markdown-content blockquote {
+            border-left: 4px solid #007bff;
+            padding-left: 1rem;
+            margin-left: 0;
+            color: #666;
+        }
+
+        /* YAML Preview Styles */
+        .yaml-preview {
+            margin-top: 2rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .yaml-preview summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .yaml-preview summary h2 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.3rem;
+        }
+
+        .yaml-preview summary:hover h2 {
+            color: #007bff;
+        }
+
+        .yaml-preview[open] {
+            background-color: #fff;
+        }
+
+        .yaml-content {
+            margin-top: 1rem;
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .yaml-content pre {
+            margin: 0;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+            line-height: 1.4;
+        }
+
+        .yaml-content code {
+            color: #333;
+            background: none;
+            padding: 0;
+        }
+
+        /* Pathway Link Styles */
+        .pathway-link {
+            margin: 1rem 0;
+        }
+
+        .btn-link {
+            display: inline-block;
+            padding: 0.5rem 1rem;
+            background-color: #007bff;
+            color: white !important;
+            text-decoration: none;
+            border-radius: 4px;
+            font-weight: 500;
+            transition: background-color 0.2s;
+        }
+
+        .btn-link:hover {
+            background-color: #0056b3;
+            text-decoration: none;
+        }
+
+        /* Voting buttons */
+        .vote-buttons {
+            display: inline-block;
+            margin-left: 0.5rem;
+        }
+
+        .vote-btn {
+            background: none;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 2px 6px;
+            margin: 0 2px;
+            cursor: pointer;
+            font-size: 0.9rem;
+            transition: all 0.2s;
+            opacity: 0.6;
+        }
+
+        .vote-btn:hover {
+            opacity: 1;
+            transform: scale(1.1);
+        }
+
+        .vote-btn.voted {
+            opacity: 1;
+            border-color: #28a745;
+            background-color: #d4edda;
+        }
+
+        .vote-btn.voted-down {
+            border-color: #dc3545;
+            background-color: #f8d7da;
+        }
+
+        .vote-btn-small {
+            font-size: 0.7rem;
+            padding: 1px 4px;
+            margin: 0 1px;
+        }
+    </style>
+
+    <script>
+        // Add collapsible functionality
+        document.querySelectorAll('.collapsible').forEach(element => {
+            element.addEventListener('click', function() {
+                this.classList.toggle('collapsed');
+            });
+        });
+
+        // Voting functionality
+        const VOTE_URL = 'https://script.google.com/macros/s/AKfycbwPKH7d3seuPNBtB0ugVjqGeTiByyOGD5vkqB_Ck6K8eOcPQYbJqBOuz6GFgXHKBNWK/exec';
+
+        // Get or create session ID
+        let sessionId = localStorage.getItem('review_session_id');
+        if (!sessionId) {
+            sessionId = 's' + Date.now() + '_' + Math.random().toString(36).substr(2, 9);
+            localStorage.setItem('review_session_id', sessionId);
+        }
+
+        // Show previous votes on page load
+        document.addEventListener('DOMContentLoaded', function() {
+            document.querySelectorAll('.vote-buttons').forEach(container => {
+                const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+                const previousVote = localStorage.getItem(key);
+                if (previousVote) {
+                    const btn = container.querySelector(`[data-v="${previousVote}"]`);
+                    if (btn) btn.classList.add(previousVote === 'up' ? 'voted' : 'voted-down');
+                }
+            });
+        });
+
+        // Handle vote clicks - Simple image beacon approach
+        document.addEventListener('click', function(e) {
+            if (!e.target.classList.contains('vote-btn')) return;
+
+            // Prevent the click from bubbling to parent elements (like summary)
+            e.preventDefault();
+            e.stopPropagation();
+
+            const btn = e.target;
+            const container = btn.closest('.vote-buttons');
+            if (!container) return;
+
+            const voteType = btn.dataset.v;
+
+            // Check if already voted (locally)
+            const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+            const previousVote = localStorage.getItem(key);
+
+            if (previousVote === voteType) {
+                // Same vote - do nothing
+                btn.style.animation = 'shake 0.5s';
+                setTimeout(() => btn.style.animation = '', 500);
+                return;
+            }
+
+            // Build URL
+            const params = new URLSearchParams({
+                gene_id: container.dataset.g,
+                annotation_id: container.dataset.a,
+                ref_id: container.dataset.r || '',
+                action: container.dataset.act,
+                vote: voteType,
+                session_id: sessionId,
+                ua: navigator.userAgent.substring(0, 100)
+            });
+
+            // Clear previous vote styling
+            container.querySelectorAll('.vote-btn').forEach(b => {
+                b.classList.remove('voted', 'voted-down');
+            });
+
+            // Apply new vote styling immediately (optimistic UI)
+            btn.classList.add(voteType === 'up' ? 'voted' : 'voted-down');
+
+            // Store locally
+            localStorage.setItem(key, voteType);
+
+            // Send vote using fetch with no-cors mode (fire and forget)
+            const fullUrl = VOTE_URL + '?' + params;
+            console.log('Sending vote to:', fullUrl);
+
+            // Use fetch in no-cors mode - we won't get a response but the request will be sent
+            fetch(fullUrl, {
+                mode: 'no-cors',
+                method: 'GET'
+            }).then(() => {
+                console.log('Vote request sent (no response due to no-cors mode)');
+            }).catch(err => {
+                console.warn('Vote may not have been recorded, but saved locally:', err);
+
+                // Fallback: try image beacon as well
+                const img = new Image();
+                img.src = fullUrl;
+            });
+        });
+
+        // Optional: Add shake animation for feedback
+        const style = document.createElement('style');
+        style.textContent = `
+            @keyframes shake {
+                0%, 100% { transform: translateX(0); }
+                25% { transform: translateX(-5px); }
+                75% { transform: translateX(5px); }
+            }
+        `;
+        document.head.appendChild(style);
+    </script>
+</body>
+</html>

--- a/genes/ARATH/FAE1/FAE1-ai-review.html
+++ b/genes/ARATH/FAE1/FAE1-ai-review.html
@@ -1,0 +1,2868 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>FAE1 - AI Gene Review</title>
+    <style>
+        :root {
+            --color-accept: #22c55e;
+            --color-remove: #ef4444;
+            --color-modify: #f97316;
+            --color-keep-non-core: #3b82f6;
+            --color-undecided: #6b7280;
+            --color-new: #8b5cf6;
+            --color-mark-over: #eab308;
+            --bg-light: #f9fafb;
+            --border-color: #e5e7eb;
+            --text-muted: #6b7280;
+            --text-primary: #111827;
+        }
+
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+            line-height: 1.6;
+            color: var(--text-primary);
+            background-color: #ffffff;
+            padding: 2rem;
+            max-width: 1400px;
+            margin: 0 auto;
+        }
+
+        .header {
+            border-bottom: 2px solid var(--border-color);
+            padding-bottom: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        h1 {
+            font-size: 2.5rem;
+            font-weight: 700;
+            margin-bottom: 0.5rem;
+            color: #1f2937;
+        }
+
+        .gene-info {
+            display: flex;
+            gap: 2rem;
+            flex-wrap: wrap;
+            margin-top: 1rem;
+        }
+
+        .info-item {
+            display: flex;
+            gap: 0.5rem;
+        }
+
+        .info-label {
+            font-weight: 600;
+            color: var(--text-muted);
+        }
+
+        .aliases {
+            display: flex;
+            gap: 0.5rem;
+            flex-wrap: wrap;
+        }
+
+        .badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.875rem;
+            font-weight: 500;
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+        }
+
+        .status-badge {
+            padding: 0.375rem 0.875rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .status-initialized {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fde68a;
+        }
+
+        .status-in-progress {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+        }
+
+        .status-draft {
+            background-color: #fce7f3;
+            color: #831843;
+            border: 1px solid #fbcfe8;
+        }
+
+        .status-complete {
+            background-color: #d1fae5;
+            color: #065f46;
+            border: 1px solid #a7f3d0;
+        }
+
+        .description-card {
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        .description-card h2 {
+            font-size: 1.25rem;
+            margin-bottom: 1rem;
+            color: #374151;
+        }
+
+        .section {
+            margin-bottom: 2.5rem;
+        }
+
+        .section-title {
+            font-size: 1.5rem;
+            font-weight: 600;
+            margin-bottom: 1.5rem;
+            color: #1f2937;
+            border-bottom: 1px solid var(--border-color);
+            padding-bottom: 0.5rem;
+        }
+
+        .annotations-table {
+            width: 100%;
+            border-collapse: collapse;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            overflow: hidden;
+        }
+
+        .annotations-table thead {
+            background-color: var(--bg-light);
+        }
+
+        .annotations-table th {
+            text-align: left;
+            padding: 1rem;
+            font-weight: 600;
+            border-bottom: 2px solid var(--border-color);
+            font-size: 0.875rem;
+            text-transform: uppercase;
+            letter-spacing: 0.05em;
+            color: var(--text-muted);
+        }
+
+        .annotations-table td {
+            padding: 1rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .annotations-table tbody tr:hover {
+            background-color: #f9fafb;
+        }
+
+        .action-badge {
+            display: inline-block;
+            padding: 0.375rem 0.75rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .action-accept {
+            background-color: var(--color-accept);
+            color: white;
+        }
+
+        .action-remove {
+            background-color: var(--color-remove);
+            color: white;
+        }
+
+        .action-modify {
+            background-color: var(--color-modify);
+            color: white;
+        }
+
+        .action-keep_as_non_core {
+            background-color: var(--color-keep-non-core);
+            color: white;
+        }
+
+        .action-undecided {
+            background-color: var(--color-undecided);
+            color: white;
+        }
+
+        .action-new {
+            background-color: var(--color-new);
+            color: white;
+        }
+
+        .action-mark_as_over_annotated {
+            background-color: var(--color-mark-over);
+            color: white;
+        }
+
+        .term-info {
+            display: flex;
+            flex-direction: column;
+            gap: 0.25rem;
+        }
+
+        .term-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .term-label {
+            font-weight: 500;
+        }
+
+        .evidence-code {
+            font-family: monospace;
+            background-color: var(--bg-light);
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .not-badge {
+            display: inline-block;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-weight: 600;
+            margin-left: 0.25rem;
+        }
+
+        .isoform-badge {
+            display: inline-block;
+            background-color: #eff6ff;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            margin-top: 0.25rem;
+        }
+
+        .core-function-card {
+            background-color: white;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 1rem;
+        }
+
+        .core-function-card h3 {
+            font-size: 1.125rem;
+            margin-bottom: 1rem;
+            color: #1f2937;
+        }
+
+        .core-function-statement {
+            margin-bottom: 1rem;
+            padding: 0.75rem;
+            background-color: var(--bg-light);
+            border-left: 4px solid var(--color-accept);
+            border-radius: 0.25rem;
+        }
+
+        .function-annotations {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin-top: 1rem;
+        }
+
+        .reference-item {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+        }
+
+        .reference-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: start;
+            margin-bottom: 0.75rem;
+        }
+
+        .reference-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #2563eb;
+        }
+
+        .supported-by {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f3f4f6;
+            border-left: 3px solid #3b82f6;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .supported-by-title {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .support-item {
+            margin-bottom: 0.5rem;
+        }
+
+        .support-ref {
+            font-weight: 500;
+            color: #2563eb;
+        }
+
+        .support-text {
+            color: #6b7280;
+            font-style: italic;
+            margin-left: 1rem;
+        }
+
+        a.term-link {
+            color: #2563eb;
+            text-decoration: none;
+        }
+
+        a.term-link:hover {
+            text-decoration: underline;
+        }
+
+        .core-function-terms {
+            margin-top: 1rem;
+        }
+
+        .function-term-group {
+            margin-bottom: 1rem;
+        }
+
+        .function-term-label {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .reference-title {
+            font-weight: 500;
+            margin-bottom: 0.5rem;
+        }
+
+        .findings-list {
+            margin-top: 1rem;
+            padding-left: 1.5rem;
+        }
+
+        .finding-item {
+            margin-bottom: 0.75rem;
+        }
+
+        .finding-statement {
+            font-weight: 500;
+            margin-bottom: 0.25rem;
+        }
+
+        .finding-text {
+            color: var(--text-muted);
+            font-size: 0.95rem;
+            font-style: italic;
+        }
+
+        .proposed-term {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #fef3c7;
+        }
+
+        .question-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #dbeafe;
+        }
+
+        .experiment-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #f3e8ff;
+        }
+
+        .prediction-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: white;
+        }
+
+        .prediction-card .prediction-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+        }
+
+        .prediction-source {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+        }
+
+        .assessment-badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.8rem;
+            font-weight: 600;
+            text-transform: uppercase;
+        }
+
+        .assessment-cor { background-color: #dcfce7; color: #166534; }
+        .assessment-cnn { background-color: #dbeafe; color: #1e40af; }
+        .assessment-lsp { background-color: #fef9c3; color: #854d0e; }
+        .assessment-unc { background-color: #f3f4f6; color: #374151; }
+        .assessment-pli { background-color: #fee2e2; color: #991b1b; }
+        .assessment-npi { background-color: #fecaca; color: #7f1d1d; }
+        .assessment-rep { background-color: #fde68a; color: #92400e; }
+
+        .confidence-score {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+            margin-left: 0.5rem;
+        }
+
+        .error-type-badge {
+            font-size: 0.75rem;
+            padding: 0.125rem 0.5rem;
+            border-radius: 0.25rem;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+        }
+
+        .isoforms-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fill, minmax(400px, 1fr));
+            gap: 1rem;
+        }
+
+        .isoform-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            background-color: white;
+            transition: box-shadow 0.2s;
+        }
+
+        .isoform-card:hover {
+            box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+        }
+
+        .functional-isoform-type {
+            display: inline-block;
+            padding: 0.2rem 0.5rem;
+            border-radius: 0.25rem;
+            font-size: 0.7rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.03em;
+        }
+
+        .type-SPLICE_VARIANT, .type-SPLICE_CLASS {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #93c5fd;
+        }
+
+        .type-CLEAVAGE_PRODUCT {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fcd34d;
+        }
+
+        .type-MODIFICATION_STATE {
+            background-color: #f3e8ff;
+            color: #6b21a8;
+            border: 1px solid #c4b5fd;
+        }
+
+        .type-CONFORMATIONAL_STATE {
+            background-color: #dcfce7;
+            color: #166534;
+            border: 1px solid #86efac;
+        }
+
+        .functional-isoform-mappings {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+            font-size: 0.85rem;
+        }
+
+        .functional-isoform-mappings .mapping-type {
+            font-weight: 600;
+            color: var(--text-muted);
+            font-size: 0.75rem;
+        }
+
+        .functional-isoform-go {
+            margin-top: 0.5rem;
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.25rem;
+        }
+
+        .go-chip {
+            display: inline-block;
+            padding: 0.15rem 0.4rem;
+            background-color: #ecfdf5;
+            color: #047857;
+            border: 1px solid #a7f3d0;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-family: monospace;
+        }
+
+        .isoform-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+            padding-bottom: 0.5rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .isoform-name {
+            font-weight: 600;
+            font-size: 1.1rem;
+            color: #1f2937;
+        }
+
+        .isoform-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .isoform-sequence-note {
+            font-size: 0.875rem;
+            color: var(--text-muted);
+            margin-bottom: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+        }
+
+        .isoform-description {
+            font-size: 0.95rem;
+            line-height: 1.5;
+        }
+
+        .collapsible {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .collapsible:after {
+            content: ' ▼';
+            font-size: 0.75rem;
+        }
+
+        .collapsible.collapsed:after {
+            content: ' ►';
+        }
+
+        .collapse-content {
+            transition: max-height 0.3s ease;
+            overflow: hidden;
+        }
+
+        .collapsed + .collapse-content {
+            max-height: 0;
+        }
+
+        .no-data {
+            color: var(--text-muted);
+            font-style: italic;
+            padding: 1rem;
+            text-align: center;
+            background-color: var(--bg-light);
+            border-radius: 0.5rem;
+        }
+
+        /* Styling for markdown section summaries with voting */
+        .markdown-section summary {
+            padding: 0.75rem;
+            background: var(--bg-light);
+            border-radius: 0.5rem;
+            margin-bottom: 0.5rem;
+        }
+
+        .markdown-section summary:hover {
+            background: #e5e7eb;
+        }
+
+        .markdown-section summary .vote-buttons {
+            margin-left: auto;
+        }
+
+        .deep-research-section {
+            margin-bottom: 1rem;
+            border: 1px solid #c7d2fe;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8faff;
+        }
+
+        .deep-research-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .deep-research-section summary h3 {
+            margin: 0;
+            color: #3730a3;
+            font-size: 1.1rem;
+        }
+
+        .report-meta {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin: 0.75rem 0 1rem;
+            align-items: center;
+        }
+
+        .report-badge {
+            display: inline-flex;
+            align-items: center;
+            border: 1px solid #c7d2fe;
+            border-radius: 999px;
+            background: #eef2ff;
+            color: #4338ca;
+            font-size: 0.78rem;
+            font-weight: 600;
+            padding: 0.2rem 0.6rem;
+        }
+
+        .report-meta-text {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+        }
+
+        .artifact-list {
+            display: grid;
+            gap: 0.75rem;
+            margin: 0.75rem 0 1rem;
+        }
+
+        .artifact-link {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+            margin-top: 0.5rem;
+            word-break: break-word;
+        }
+
+        @media print {
+            body {
+                padding: 1rem;
+            }
+
+            .collapsible:after {
+                display: none;
+            }
+
+            .collapsed + .collapse-content {
+                max-height: none !important;
+            }
+        }
+
+        @media (max-width: 768px) {
+            body {
+                padding: 1rem;
+            }
+
+            h1 {
+                font-size: 2rem;
+            }
+
+            .annotations-table {
+                font-size: 0.875rem;
+            }
+
+            .annotations-table th,
+            .annotations-table td {
+                padding: 0.5rem;
+            }
+        }
+    </style>
+</head>
+<body>
+    <div class="header">
+        <h1>FAE1</h1>
+        <div class="gene-info">
+            
+            <div class="info-item">
+                
+                <span class="info-label">UniProt ID:</span>
+                <span>
+                    <a href="https://www.uniprot.org/uniprotkb/Q38860" target="_blank" class="term-link">
+                        Q38860
+                    </a>
+                </span>
+                
+            </div>
+            
+            
+            <div class="info-item">
+                <span class="info-label">Organism:</span>
+                <span>Arabidopsis thaliana</span>
+            </div>
+            
+            
+            <div class="info-item">
+                <span class="info-label">Review Status:</span>
+                <span class="status-badge status-complete">
+                    COMPLETE
+                </span>
+            </div>
+            
+            
+        </div>
+        <div style="margin-top: 1rem; text-align: center;">
+            <a id="feedback-form-link"
+               href="#"
+               target="_blank"
+               style="display: inline-block; padding: 10px 20px; background-color: #4CAF50; color: white; text-decoration: none; border-radius: 5px; font-weight: 600;">
+                📝 Provide Detailed Feedback
+            </a>
+            <script>
+                // Construct the form URL with proper encoding
+                // Extract organism code from the current page path (e.g., /genes/ARATH/APO1/ -> ARATH)
+                const pathParts = window.location.pathname.split('/');
+                const genesIndex = pathParts.indexOf('genes');
+                let organism = '';
+                if (genesIndex !== -1 && pathParts[genesIndex + 1]) {
+                    organism = pathParts[genesIndex + 1].toUpperCase();
+                }
+                const geneSymbol = "FAE1";
+                const speciesGene = organism + ' ' + geneSymbol;
+                const formBaseUrl = 'https://docs.google.com/forms/d/e/1FAIpQLSdTot9L6GVkkZYgLQT0E8ZdAJv8RiN5ZgOVkgWNcKSbYvxxzQ/viewform';
+                const entryId = '1226477767'; // Correct entry ID for Species/Gene field
+                const formUrl = formBaseUrl + '?entry.' + entryId + '=' + encodeURIComponent(speciesGene);
+                const feedbackLink = document.getElementById('feedback-form-link');
+                feedbackLink.href = formUrl;
+                // Add tooltip showing the pre-filled value
+                feedbackLink.title = 'Opens form with pre-filled: ' + speciesGene;
+            </script>
+        </div>
+    </div>
+
+    
+    <div class="description-card">
+        <div style="display: flex; justify-content: space-between; align-items: center;">
+            <h2>Gene Description</h2>
+            <span class="vote-buttons" data-g="Q38860" data-a="DESCRIPTION: FAE1 (KCS18; 3-ketoacyl-CoA synthase 18) is the se..." data-r="" data-act="DESCRIPTION">
+                <button class="vote-btn" data-v="up" title="Agree with this description">👍</button>
+                <button class="vote-btn" data-v="down" title="Disagree with this description">👎</button>
+            </span>
+        </div>
+        <p>FAE1 (KCS18; 3-ketoacyl-CoA synthase 18) is the seed-specialized condensing enzyme of the endoplasmic-reticulum fatty acid elongase (FAE) complex in Arabidopsis. It catalyzes the first, rate-defining step of each very-long-chain fatty acid (VLCFA) elongation cycle, condensing an acyl-CoA with malonyl-CoA to form a 3-ketoacyl-CoA and adding two carbons. As the chain-length-determining subunit of the elongase, FAE1 elongates C18 acyl-CoAs to C20 and C22 (and longer) monounsaturated and saturated VLCFAs that are deposited in seed triacylglycerols. It acts on saturated and monounsaturated C16/C18 substrates but not on polyunsaturated acyl-CoAs. Loss of FAE1 nearly abolishes seed VLCFAs (including erucic acid), making it a central control point for seed-oil composition.</p>
+    </div>
+    
+
+    
+
+    
+
+    
+    <div class="section">
+        <h2 class="section-title">Existing Annotations Review</h2>
+        <table class="annotations-table">
+            <thead>
+                <tr>
+                    <th>GO Term</th>
+                    <th>Evidence</th>
+                    <th>Action</th>
+                    <th>Reason</th>
+                </tr>
+            </thead>
+            <tbody>
+                
+                <tr>
+                    <td>
+                        <div class="term-info">
+                            
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005783" target="_blank" class="term-link">
+                                    GO:0005783
+                                </a>
+                            </span>
+                            <span class="term-label">endoplasmic reticulum</span>
+                            
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+                        
+                        
+                        
+                        <br>
+                        <span style="font-size: 0.75rem;">
+                            
+                            GO_REF:0000117
+                            
+                        </span>
+                        
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q38860" data-a="GO:0005783" data-r="GO_REF:0000117" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+                        
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Correct localization, independently confirmed experimentally (see the IDA annotation below). VLCFA elongation occurs on the ER.
+                        </div>
+                        
+                        
+                        
+                        
+                    </td>
+                </tr>
+                
+                <tr>
+                    <td>
+                        <div class="term-info">
+                            
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006633" target="_blank" class="term-link">
+                                    GO:0006633
+                                </a>
+                            </span>
+                            <span class="term-label">fatty acid biosynthetic process</span>
+                            
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+                        
+                        
+                        
+                        <br>
+                        <span style="font-size: 0.75rem;">
+                            
+                            GO_REF:0000120
+                            
+                        </span>
+                        
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q38860" data-a="GO:0006633" data-r="GO_REF:0000120" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+                        
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Correct at the general level. FAE1 functions in fatty acid biosynthesis; the more specific VLCFA elongation roles are captured by the experimentally supported annotations below.
+                        </div>
+                        
+                        
+                        
+                        
+                    </td>
+                </tr>
+                
+                <tr>
+                    <td>
+                        <div class="term-info">
+                            
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0009922" target="_blank" class="term-link">
+                                    GO:0009922
+                                </a>
+                            </span>
+                            <span class="term-label">fatty acid elongase activity</span>
+                            
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+                        
+                        
+                        
+                        <br>
+                        <span style="font-size: 0.75rem;">
+                            
+                            GO_REF:0000120
+                            
+                        </span>
+                        
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q38860" data-a="GO:0009922" data-r="GO_REF:0000120" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+                        
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Correct core molecular function, also supported experimentally (EXP and IDA below). FAE1 is the condensing component of the fatty acid elongase.
+                        </div>
+                        
+                        
+                        
+                        
+                    </td>
+                </tr>
+                
+                <tr>
+                    <td>
+                        <div class="term-info">
+                            
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016020" target="_blank" class="term-link">
+                                    GO:0016020
+                                </a>
+                            </span>
+                            <span class="term-label">membrane</span>
+                            
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+                        
+                        
+                        
+                        <br>
+                        <span style="font-size: 0.75rem;">
+                            
+                            GO_REF:0000002
+                            
+                        </span>
+                        
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q38860" data-a="GO:0016020" data-r="GO_REF:0000002" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+                        
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Correct but general. FAE1 is an integral membrane protein of the ER (UniProt annotates transmembrane helices); the ER annotation is the informative localization.
+                        </div>
+                        
+                        
+                        
+                        
+                    </td>
+                </tr>
+                
+                <tr>
+                    <td>
+                        <div class="term-info">
+                            
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016746" target="_blank" class="term-link">
+                                    GO:0016746
+                                </a>
+                            </span>
+                            <span class="term-label">acyltransferase activity</span>
+                            
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+                        
+                        
+                        
+                        <br>
+                        <span style="font-size: 0.75rem;">
+                            
+                            GO_REF:0000002
+                            
+                        </span>
+                        
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q38860" data-a="GO:0016746" data-r="GO_REF:0000002" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+                        
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Correct but general. As a 3-ketoacyl-CoA synthase (condensing enzyme), FAE1 is an acyltransferase, but fatty acid elongase activity (GO:0009922) is the informative molecular function.
+                        </div>
+                        
+                        
+                        
+                        
+                    </td>
+                </tr>
+                
+                <tr>
+                    <td>
+                        <div class="term-info">
+                            
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016747" target="_blank" class="term-link">
+                                    GO:0016747
+                                </a>
+                            </span>
+                            <span class="term-label">acyltransferase activity, transferring groups other than amino-acyl groups</span>
+                            
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+                        
+                        
+                        
+                        <br>
+                        <span style="font-size: 0.75rem;">
+                            
+                            GO_REF:0000002
+                            
+                        </span>
+                        
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q38860" data-a="GO:0016747" data-r="GO_REF:0000002" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+                        
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Correct but general; this is the acyltransferase parent matching the KCS condensation chemistry. The specific fatty acid elongase activity annotation is retained as the core function.
+                        </div>
+                        
+                        
+                        
+                        
+                    </td>
+                </tr>
+                
+                <tr>
+                    <td>
+                        <div class="term-info">
+                            
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0009922" target="_blank" class="term-link">
+                                    GO:0009922
+                                </a>
+                            </span>
+                            <span class="term-label">fatty acid elongase activity</span>
+                            
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">EXP</span>
+                        
+                        
+                        
+                        <br>
+                        <span style="font-size: 0.75rem;">
+                            
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/12135493" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:12135493
+                            </a>
+                            
+                                
+                                
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Engineering and mechanistic studies of the Arabidopsis FAE1 ...
+                                </span>
+                                
+                            
+                            
+                        </span>
+                        
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q38860" data-a="GO:0009922" data-r="PMID:12135493" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+                        
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Core molecular function with direct experimental support. Mechanistic and engineering studies show FAE1/KCS18 is the beta-ketoacyl-CoA synthase (condensing enzyme) of the elongase, active on C16-C18 saturated and monounsaturated acyl-CoAs and elongating them to C20-C22 VLCFAs, with no activity on polyunsaturated substrates. [PMID:12135493]
+                        </div>
+                        
+                        
+                        
+                        
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+                            
+                            <div class="support-item">
+                                <span class="support-ref">
+                                    
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/12135493" target="_blank" class="term-link">
+                                        PMID:12135493
+                                    </a>
+                                    
+                                </span>
+                                
+                                <div class="support-text">Engineering and mechanistic studies of the Arabidopsis FAE1 beta-ketoacyl-CoA synthase, FAE1 KCS</div>
+                                
+                            </div>
+                            
+                            <div class="support-item">
+                                <span class="support-ref">
+                                    
+                                    file:ARATH/FAE1/FAE1-deep-research-falcon.md
+                                    
+                                </span>
+                                
+                                <div class="support-text">KCS18 is a 3-ketoacyl-CoA synthase/condensing enzyme of the ER FAE complex and the chain-length-determining component</div>
+                                
+                            </div>
+                            
+                        </div>
+                        
+                    </td>
+                </tr>
+                
+                <tr>
+                    <td>
+                        <div class="term-info">
+                            
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005783" target="_blank" class="term-link">
+                                    GO:0005783
+                                </a>
+                            </span>
+                            <span class="term-label">endoplasmic reticulum</span>
+                            
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+                        
+                        
+                        
+                        <br>
+                        <span style="font-size: 0.75rem;">
+                            
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/36798704" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:36798704
+                            </a>
+                            
+                                
+                                
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Tackling functional redundancy of Arabidopsis fatty acid elo...
+                                </span>
+                                
+                            
+                            
+                        </span>
+                        
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q38860" data-a="GO:0005783" data-r="PMID:36798704" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+                        
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Experimentally confirmed ER localization. Fluorescent fusions of Arabidopsis KCS proteins including KCS18 localize to the ER, consistent with VLCFA elongation occurring on the ER. [PMID:36798704]
+                        </div>
+                        
+                        
+                        
+                        
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+                            
+                            <div class="support-item">
+                                <span class="support-ref">
+                                    
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/36798704" target="_blank" class="term-link">
+                                        PMID:36798704
+                                    </a>
+                                    
+                                </span>
+                                
+                                <div class="support-text">Arabidopsis KCS proteins, including KCS18, localize to the endoplasmic reticulum</div>
+                                
+                            </div>
+                            
+                        </div>
+                        
+                    </td>
+                </tr>
+                
+                <tr>
+                    <td>
+                        <div class="term-info">
+                            
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0009507" target="_blank" class="term-link">
+                                    GO:0009507
+                                </a>
+                            </span>
+                            <span class="term-label">chloroplast</span>
+                            
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">ISM</span>
+                        
+                        
+                        
+                        <br>
+                        <span style="font-size: 0.75rem;">
+                            
+                            GO_REF:0000122
+                            
+                        </span>
+                        
+                    </td>
+                    <td>
+                        <span class="action-badge action-remove">
+                            REMOVE
+                        </span>
+                        <span class="vote-buttons" data-g="Q38860" data-a="GO:0009507" data-r="GO_REF:0000122" data-act="REMOVE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+                        
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Spurious computational (sequence-model) prediction that contradicts the experimentally established ER/microsome localization. FAE1 is an ER-membrane VLCFA elongase component; there is no evidence it localizes to the chloroplast.
+                        </div>
+                        
+                        
+                        
+                        
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+                            
+                            <div class="support-item">
+                                <span class="support-ref">
+                                    
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/36798704" target="_blank" class="term-link">
+                                        PMID:36798704
+                                    </a>
+                                    
+                                </span>
+                                
+                                <div class="support-text">KCS18 localizes to the endoplasmic reticulum</div>
+                                
+                            </div>
+                            
+                            <div class="support-item">
+                                <span class="support-ref">
+                                    
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/12135493" target="_blank" class="term-link">
+                                        PMID:12135493
+                                    </a>
+                                    
+                                </span>
+                                
+                                <div class="support-text">FAE1 is a membrane-bound (microsomal) fatty acid elongase</div>
+                                
+                            </div>
+                            
+                        </div>
+                        
+                    </td>
+                </tr>
+                
+                <tr>
+                    <td>
+                        <div class="term-info">
+                            
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0000038" target="_blank" class="term-link">
+                                    GO:0000038
+                                </a>
+                            </span>
+                            <span class="term-label">very long-chain fatty acid metabolic process</span>
+                            
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IMP</span>
+                        
+                        
+                        
+                        <br>
+                        <span style="font-size: 0.75rem;">
+                            
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/7734965" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:7734965
+                            </a>
+                            
+                                
+                                
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Directed tagging of the Arabidopsis FATTY ACID ELONGATION1 (...
+                                </span>
+                                
+                            
+                            
+                        </span>
+                        
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q38860" data-a="GO:0000038" data-r="PMID:7734965" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+                        
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Core biological process, supported by mutant phenotype. fae1 loss strongly depletes seed VLCFAs, demonstrating FAE1&#39;s role in VLCFA metabolism. [PMID:7734965]
+                        </div>
+                        
+                        
+                        
+                        
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+                            
+                            <div class="support-item">
+                                <span class="support-ref">
+                                    
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/7734965" target="_blank" class="term-link">
+                                        PMID:7734965
+                                    </a>
+                                    
+                                </span>
+                                
+                                <div class="support-text">Directed tagging of the Arabidopsis FATTY ACID ELONGATION1 (FAE1) gene; fae1 mutant depletes seed VLCFAs</div>
+                                
+                            </div>
+                            
+                        </div>
+                        
+                    </td>
+                </tr>
+                
+                <tr>
+                    <td>
+                        <div class="term-info">
+                            
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0030497" target="_blank" class="term-link">
+                                    GO:0030497
+                                </a>
+                            </span>
+                            <span class="term-label">fatty acid elongation</span>
+                            
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IMP</span>
+                        
+                        
+                        
+                        <br>
+                        <span style="font-size: 0.75rem;">
+                            
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/7734965" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:7734965
+                            </a>
+                            
+                                
+                                
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Directed tagging of the Arabidopsis FATTY ACID ELONGATION1 (...
+                                </span>
+                                
+                            
+                            
+                        </span>
+                        
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q38860" data-a="GO:0030497" data-r="PMID:7734965" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+                        
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Core biological process. FAE1 catalyzes the condensation step of fatty acid elongation; the fae1 mutant phenotype establishes its requirement for seed VLCFA elongation. [PMID:7734965]
+                        </div>
+                        
+                        
+                        
+                        
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+                            
+                            <div class="support-item">
+                                <span class="support-ref">
+                                    
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/7734965" target="_blank" class="term-link">
+                                        PMID:7734965
+                                    </a>
+                                    
+                                </span>
+                                
+                                <div class="support-text">FAE1 is required for fatty acid elongation in seeds</div>
+                                
+                            </div>
+                            
+                        </div>
+                        
+                    </td>
+                </tr>
+                
+                <tr>
+                    <td>
+                        <div class="term-info">
+                            
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0009922" target="_blank" class="term-link">
+                                    GO:0009922
+                                </a>
+                            </span>
+                            <span class="term-label">fatty acid elongase activity</span>
+                            
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+                        
+                        
+                        
+                        <br>
+                        <span style="font-size: 0.75rem;">
+                            
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/11341960" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:11341960
+                            </a>
+                            
+                                
+                                
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Active-site residues of a plant membrane-bound fatty acid el...
+                                </span>
+                                
+                            
+                            
+                        </span>
+                        
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q38860" data-a="GO:0009922" data-r="PMID:11341960" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+                        
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Core molecular function with direct assay support. Active-site studies of the FAE1 KCS confirm its beta-ketoacyl-CoA synthase (condensing enzyme) activity. [PMID:11341960]
+                        </div>
+                        
+                        
+                        
+                        
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+                            
+                            <div class="support-item">
+                                <span class="support-ref">
+                                    
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/11341960" target="_blank" class="term-link">
+                                        PMID:11341960
+                                    </a>
+                                    
+                                </span>
+                                
+                                <div class="support-text">Active-site residues of a plant membrane-bound fatty acid elongase beta-ketoacyl-CoA synthase, FAE1 KCS</div>
+                                
+                            </div>
+                            
+                        </div>
+                        
+                    </td>
+                </tr>
+                
+            </tbody>
+        </table>
+    </div>
+    
+
+    
+    <div class="section">
+        <h2 class="section-title">Core Functions</h2>
+        
+        <div class="core-function-card">
+            
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+                <h3>FAE1/KCS18 is the seed condensing enzyme (3-ketoacyl-CoA synthase) of the ER fatty acid elongase, catalyzing the chain-length-determining condensation of acyl-CoA with malonyl-CoA to elongate C18 to C20/C22 very-long-chain fatty acids that are stored in seed triacylglycerols.</h3>
+                <span class="vote-buttons" data-g="Q38860" data-a="FUNCTION: FAE1/KCS18 is the seed condensing enzyme (3-ketoac..." data-r="" data-act="CORE_FUNCTION">
+                    <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
+                    <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
+                </span>
+            </div>
+            
+
+            <div class="core-function-terms">
+                
+                <div class="function-term-group">
+                    <div class="function-term-label">Molecular Function:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0009922" target="_blank" class="term-link">
+                            fatty acid elongase activity
+                        </a>
+                    </span>
+                </div>
+                
+
+                
+                <div class="function-term-group">
+                    <div class="function-term-label">Directly Involved In:</div>
+                    <div class="function-annotations">
+                        
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0030497" target="_blank" class="term-link">
+                                fatty acid elongation
+                            </a>
+                        </span>
+                        
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0000038" target="_blank" class="term-link">
+                                very long-chain fatty acid metabolic process
+                            </a>
+                        </span>
+                        
+                    </div>
+                </div>
+                
+
+                
+                <div class="function-term-group">
+                    <div class="function-term-label">Cellular Locations:</div>
+                    <div class="function-annotations">
+                        
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005783" target="_blank" class="term-link">
+                                endoplasmic reticulum
+                            </a>
+                        </span>
+                        
+                    </div>
+                </div>
+                
+
+                
+
+                
+            </div>
+
+            
+            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
+                <strong>Supporting Evidence:</strong>
+                <ul class="findings-list">
+                    
+                    <li class="finding-item">
+                        <span class="reference-id">
+                            
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/12135493" target="_blank" class="term-link">
+                                PMID:12135493
+                            </a>
+                            
+                        </span>
+                        
+                        <div class="finding-text">FAE1 KCS condensing enzyme elongates C16-C18 acyl-CoAs to C20-C22 VLCFAs</div>
+                        
+                    </li>
+                    
+                    <li class="finding-item">
+                        <span class="reference-id">
+                            
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/7734965" target="_blank" class="term-link">
+                                PMID:7734965
+                            </a>
+                            
+                        </span>
+                        
+                        <div class="finding-text">fae1 mutant seeds are depleted of very-long-chain fatty acids</div>
+                        
+                    </li>
+                    
+                    <li class="finding-item">
+                        <span class="reference-id">
+                            
+                            file:ARATH/FAE1/FAE1-deep-research-falcon.md
+                            
+                        </span>
+                        
+                        <div class="finding-text">seed-specialized KCS; fae1 reduces seed VLCFAs from ~28% to &lt;1%</div>
+                        
+                    </li>
+                    
+                </ul>
+            </div>
+            
+        </div>
+        
+    </div>
+    
+
+    
+    <div class="section">
+        <h2 class="section-title collapsible">References</h2>
+        <div class="collapse-content">
+            
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+                        
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000002.md" target="_blank" class="term-link">
+                            GO_REF:0000002
+                        </a>
+                        
+                    </span>
+                </div>
+                
+                <div class="reference-title">Gene Ontology annotation through association of InterPro records with GO terms</div>
+                
+                
+            </div>
+            
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+                        
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000117.md" target="_blank" class="term-link">
+                            GO_REF:0000117
+                        </a>
+                        
+                    </span>
+                </div>
+                
+                <div class="reference-title">Electronic Gene Ontology annotations created by ARBA machine learning models</div>
+                
+                
+            </div>
+            
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+                        
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000120.md" target="_blank" class="term-link">
+                            GO_REF:0000120
+                        </a>
+                        
+                    </span>
+                </div>
+                
+                <div class="reference-title">Combined Automated Annotation using Multiple IEA Methods</div>
+                
+                
+            </div>
+            
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+                        
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000122.md" target="_blank" class="term-link">
+                            GO_REF:0000122
+                        </a>
+                        
+                    </span>
+                </div>
+                
+                <div class="reference-title">AtSubP analysis</div>
+                
+                
+            </div>
+            
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+                        
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/11341960" target="_blank" class="term-link">
+                            PMID:11341960
+                        </a>
+                        
+                    </span>
+                </div>
+                
+                <div class="reference-title">Active-site residues of a plant membrane-bound fatty acid elongase beta-ketoacyl-CoA synthase, FAE1 KCS.</div>
+                
+                
+                <ul class="findings-list">
+                    
+                    <li class="finding-item">
+                        <div class="finding-statement">Identifies catalytic active-site residues of the FAE1 KCS condensing enzyme, confirming its beta-ketoacyl-CoA synthase activity.</div>
+                        
+                    </li>
+                    
+                </ul>
+                
+            </div>
+            
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+                        
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/12135493" target="_blank" class="term-link">
+                            PMID:12135493
+                        </a>
+                        
+                    </span>
+                </div>
+                
+                <div class="reference-title">Engineering and mechanistic studies of the Arabidopsis FAE1 beta-ketoacyl-CoA synthase, FAE1 KCS.</div>
+                
+                
+                <ul class="findings-list">
+                    
+                    <li class="finding-item">
+                        <div class="finding-statement">FAE1 KCS is active on saturated and monounsaturated C16-C18 acyl-CoAs, elongating to C20-C22 VLCFAs, with no activity on polyunsaturated substrates; microsome (ER) membrane localization.</div>
+                        
+                    </li>
+                    
+                </ul>
+                
+            </div>
+            
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+                        
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/36798704" target="_blank" class="term-link">
+                            PMID:36798704
+                        </a>
+                        
+                    </span>
+                </div>
+                
+                <div class="reference-title">Tackling functional redundancy of Arabidopsis fatty acid elongase complexes.</div>
+                
+                
+                <ul class="findings-list">
+                    
+                    <li class="finding-item">
+                        <div class="finding-statement">Systematic reconstitution of Arabidopsis KCS isoforms; KCS18 localizes to the ER and shows a strong bias toward monounsaturated C20 products.</div>
+                        
+                    </li>
+                    
+                </ul>
+                
+            </div>
+            
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+                        
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/7734965" target="_blank" class="term-link">
+                            PMID:7734965
+                        </a>
+                        
+                    </span>
+                </div>
+                
+                <div class="reference-title">Directed tagging of the Arabidopsis FATTY ACID ELONGATION1 (FAE1) gene with the maize transposon activator.</div>
+                
+                
+                <ul class="findings-list">
+                    
+                    <li class="finding-item">
+                        <div class="finding-statement">Identifies FAE1 by transposon tagging; fae1 mutant seeds are strongly depleted of very-long-chain fatty acids, establishing FAE1&#39;s role in seed VLCFA elongation.</div>
+                        
+                    </li>
+                    
+                </ul>
+                
+            </div>
+            
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+                        
+                        file:ARATH/FAE1/FAE1-deep-research-falcon.md
+                        
+                    </span>
+                </div>
+                
+                <div class="reference-title">Falcon/Edison deep research report for FAE1/KCS18, Arabidopsis thaliana</div>
+                
+                
+                <ul class="findings-list">
+                    
+                    <li class="finding-item">
+                        <div class="finding-statement">Synthesizes FAE1/KCS18 as the seed-specialized, chain-length-determining condensing enzyme of the ER FAE complex; fae1 reduces seed VLCFAs from ~28% to &lt;1%; a key metabolic-engineering control point for long-chain monounsaturated seed oils.</div>
+                        
+                    </li>
+                    
+                </ul>
+                
+            </div>
+            
+        </div>
+    </div>
+    
+
+
+    
+    <div class="section">
+        <h2 class="section-title">Suggested Questions for Experts</h2>
+        
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> How is FAE1/KCS18 substrate chain-length specificity (favoring C18-&gt;C20-&gt;C22 monounsaturated products) encoded structurally, and can it be re-engineered to tune seed-oil VLCFA profiles in oilseed feedstocks?</p>
+                    
+                </div>
+                <span class="vote-buttons" data-g="Q38860" data-a="Q: How is FAE1/KCS18 substrate chain-length specifici..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+        
+    </div>
+    
+
+    
+
+    
+
+    <!-- Computational Predictions Section -->
+    
+
+    <!-- Deep Research Sections -->
+    
+    <div class="section">
+        <h2 class="section-title">Deep Research</h2>
+        
+        <details class="deep-research-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; gap: 1rem;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Falcon</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(FAE1-deep-research-falcon.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="Q38860" data-a="DEEP_RESEARCH: Falcon" data-r="" data-act="DEEP_RESEARCH" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This deep research is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This deep research needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+                
+                <div class="report-meta">
+                    
+                    <span class="report-meta-text">this with annotations you find in gene/protein databases, but these can be outdated or inaccurate.</span>
+                    
+                    
+                    <span class="report-badge">Falcon</span>
+                    
+                    
+                    <span class="report-badge">Edison Scientific Literature</span>
+                    
+                    
+                    <span class="report-badge">29 citations</span>
+                    
+                    
+                    <span class="report-badge">2 artifacts</span>
+                    
+                    
+                    <span class="report-meta-text">2026-06-11T17:48:58.830164</span>
+                    
+                    
+                    
+                </div>
+                
+                
+                <div class="artifact-list">
+                    
+                    
+                    
+                    <div class="artifact-link">
+                        <a href="FAE1-deep-research-falcon_artifacts/artifact-00.md" class="term-link">Edison artifact artifact-00</a>
+                        <span>(text/markdown)</span>
+                    </div>
+                    
+                    
+                    
+                    
+                    <div class="artifact-link">
+                        <a href="FAE1-deep-research-falcon_artifacts/image-1.png" class="term-link">## Context ID: pqac-00000016 The figure reporting KCS18 (FAE1) substrate specificity and profiles in yeast reconstitution experiments is Figure 3A (FAMEs profil</a>
+                        <span>(image/png)</span>
+                    </div>
+                    
+                    
+                </div>
+                
+                <p>The research report should be a detailed narrative explaining the function, biological processes, and localization of the gene product. Citations should be given for all claims.</p>
+<p>You should prioritize authoritative reviews and primary scientific literature when conducting research. You can supplement<br />
+this with annotations you find in gene/protein databases, but these can be outdated or inaccurate.</p>
+<p>We are specifically interested in the primary function of the gene - for enzymes, what reaction is catalyzed, and what is the substrate specificity? For transporters, what is the substrate? For structural proteins or adapters, what is the broader structural role? For signaling molecules, what is the role in the pathway.</p>
+<p>We are interested in where in or outside the cell the gene product carries out its function.</p>
+<p>We are also interested in the signaling or biochemical pathways in which the gene functions. We are less interested in broad pleiotropic effects, except where these elucidate the precise role.</p>
+<p>Include evidence where possible. We are interested in both experimental evidence as well as inference from structure, evolution, or bioinformatic analysis. Precise studies should be prioritized over high-throughput, where available.</p>
+<h2 id="research-report-functional-annotation-of-arabidopsis-thaliana-fae1-kcs18-uniprot-q38860-at4g34520">Research report: Functional annotation of <strong>Arabidopsis thaliana FAE1 / KCS18</strong> (UniProt Q38860; At4g34520)</h2>
+<h3 id="0-target-verification-critical-identity-check">0) Target verification (critical identity check)</h3>
+<p>The research target here is the Arabidopsis thaliana gene <strong>FAE1</strong>, which is also referred to as <strong>KCS18</strong> (3-ketoacyl-CoA synthase 18), encoding a condensing enzyme of the fatty acid elongase (FAE) system that produces very-long-chain fatty acids (VLCFAs) in seeds. This identity is explicitly supported by plant VLCFA elongation literature describing <strong>KCS18/FAE1</strong> as the canonical seed-specific condensing enzyme in Arabidopsis (batsale2021biosynthesisandfunctions pages 5-6, morineau2016dualfattyacid pages 1-2, zhukov2022synthesisofc20–38 pages 7-8). Recent functional profiling studies include KCS18 among the 21 Arabidopsis KCS isoforms and biochemically characterize it as an ER-localized enzyme with a strong bias toward monounsaturated C20 products (batsale2023tacklingfunctionalredundancy pages 6-10).</p>
+<h3 id="1-key-concepts-and-definitions-current-understanding">1) Key concepts and definitions (current understanding)</h3>
+<h4 id="11-very-long-chain-fatty-acids-vlcfas">1.1 Very-long-chain fatty acids (VLCFAs)</h4>
+<p>In plant lipid biology, <strong>VLCFAs</strong> are commonly defined as fatty acids <strong>longer than C18</strong>. They occur in diverse lipid classes (membrane lipids, sphingolipids) and in extracellular barriers (cuticular waxes and suberin), and can also accumulate in seed triacylglycerols (TAGs) as storage lipids (batsale2023tacklingfunctionalredundancy pages 1-2, batsale2021biosynthesisandfunctions pages 3-5).</p>
+<h4 id="12-fatty-acid-elongase-fae-system-and-the-condensing-enzyme-step">1.2 Fatty acid elongase (FAE) system and the “condensing enzyme” step</h4>
+<p>VLCFA synthesis occurs predominantly on the <strong>endoplasmic reticulum (ER)</strong> by a multi-enzyme <strong>fatty acid elongase (FAE) complex</strong>. The FAE cycle adds <strong>two carbons per elongation round</strong> using malonyl-CoA as the C2 donor. The complex is typically described as four sequential enzymatic steps: <br />
+1) <strong>Condensation</strong> catalyzed by a <strong>3-ketoacyl-CoA synthase (KCS)</strong>, generating a 3-ketoacyl-CoA intermediate; <br />
+2) reduction (KCR), <br />
+3) dehydration (HCD), and <br />
+4) final reduction (ECR) (morineau2016dualfattyacid pages 1-2, zhukov2022synthesisofc20–38 pages 6-7, kim2013arabidopsis3ketoacylcoenzymea pages 1-2).</p>
+<p>A key consensus point is that the <strong>KCS/condensing enzyme is the major determinant of chain-length substrate specificity</strong>, whereas the other core enzymes tend to be more broadly specific and shared across complexes (batsale2023tacklingfunctionalredundancy pages 1-2, zhukov2022synthesisofc20–38 pages 6-7, batsale2021biosynthesisandfunctions pages 3-5).</p>
+<h4 id="13-kcs-gene-family-redundancy-and-why-fae1-is-special">1.3 KCS gene family redundancy and why FAE1 is special</h4>
+<p>Arabidopsis contains a large KCS gene family (≈21 genes), which supports the idea that multiple FAE complexes operate in parallel and/or sequentially in different tissues to generate the plant’s broad VLCFA spectrum (batsale2023tacklingfunctionalredundancy pages 1-2). This redundancy explains why many <strong>kcs single mutants lack strong phenotypes</strong> (batsale2023tacklingfunctionalredundancy pages 1-2). In contrast, <strong>FAE1/KCS18 is seed-specialized</strong> and has a uniquely strong impact on seed VLCFA composition (batsale2021biosynthesisandfunctions pages 5-6, zhukov2022synthesisofc20–38 pages 7-8).</p>
+<h3 id="2-fae1kcs18-molecular-function-reaction-substrates-and-products">2) FAE1/KCS18 molecular function: reaction, substrates, and products</h3>
+<h4 id="21-enzymatic-activity-and-reaction-class">2.1 Enzymatic activity and reaction class</h4>
+<p>FAE1/KCS18 is a <strong>3-ketoacyl-CoA synthase (condensing enzyme)</strong> in the ER-localized elongase complex that catalyzes the first (rate-defining) condensation step in each elongation cycle (morineau2016dualfattyacid pages 1-2, zhukov2022synthesisofc20–38 pages 6-7). Mechanistically, KCS condenses an acyl-CoA substrate with malonyl-CoA to form a <strong>3-ketoacyl-CoA</strong>, which is then processed by the remaining elongase enzymes (morineau2016dualfattyacid pages 1-2, kim2013arabidopsis3ketoacylcoenzymea pages 1-2).</p>
+<h4 id="22-substrate-specificity-and-product-profile">2.2 Substrate specificity and product profile</h4>
+<p>A 2023 systematic profiling of Arabidopsis KCS enzymes using reconstituted elongase complexes in yeast showed that <strong>KCS18 has a distinctive specificity characterized by strong accumulation of monounsaturated C20 products</strong>, and it increases <strong>18:1-, 20:1-, and 22:1-CoA species</strong> in engineered yeast acyl-CoA pools (batsale2023tacklingfunctionalredundancy pages 6-10). Consistent with this, a review summarizing heterologous expression data notes that KCS18/FAE1 expression yields saturated and monounsaturated <strong>C20 and C22 VLCFAs</strong> (batsale2021biosynthesisandfunctions pages 5-6).</p>
+<p>Figure-level support for the product-profile claim is available in the 2023 study’s yeast FAME and acyl-CoA profiling panels showing increased <strong>20:1 and 22:1</strong> products upon KCS18 expression (batsale2023tacklingfunctionalredundancy media 6565efaa).</p>
+<h3 id="3-subcellular-localization-and-site-of-action">3) Subcellular localization and site of action</h3>
+<p>The VLCFA elongation machinery operates on the <strong>endoplasmic reticulum</strong> (batsale2023tacklingfunctionalredundancy pages 1-2, zhukov2022synthesisofc20–38 pages 6-7). In the 2023 profiling work, fluorescent fusions showed that <strong>Arabidopsis KCS proteins—including KCS18—localize to the ER</strong> when transiently expressed in tobacco epidermal cells (batsale2023tacklingfunctionalredundancy pages 6-10). This localization is consistent with earlier ER-localization evidence for KCS family members assayed with ER marker colocalization approaches (kim2013arabidopsis3ketoacylcoenzymea pages 1-2).</p>
+<h3 id="4-biological-role-and-pathway-context-in-arabidopsis">4) Biological role and pathway context in Arabidopsis</h3>
+<h4 id="41-seed-oil-vlcfas-and-tag-accumulation">4.1 Seed oil VLCFAs and TAG accumulation</h4>
+<p>FAE1/KCS18 is widely described as the <strong>seed-specific KCS</strong> responsible for producing VLCFAs incorporated into <strong>seed triacylglycerols (TAGs)</strong> (zhukov2022synthesisofc20–38 pages 7-8). In Arabidopsis seeds, VLCFAs represent a major fraction of acyl chains (one review cites ~27%) (batsale2021biosynthesisandfunctions pages 3-5), and FAE1/KCS18 is central to generating the characteristic C20–C22 seed products (batsale2021biosynthesisandfunctions pages 5-6, zhukov2022synthesisofc20–38 pages 7-8).</p>
+<h4 id="42-loss-of-function-phenotype-quantitative">4.2 Loss-of-function phenotype (quantitative)</h4>
+<p>A quantitative summary reported in a 2022 synthesis review indicates that <strong>fae1 loss-of-function</strong> reduces seed VLCFAs from <strong>~28% (wild type) to &lt;1%</strong> in fae1 seeds, with vegetative tissues and flowers not showing the same fatty-acid composition changes (zhukov2022synthesisofc20–38 pages 7-8). A separate high-citation review similarly reports that kcs18/fae1 mutant seed storage lipids are <strong>nearly free of C20 and C22 VLCFAs</strong>, consistent with FAE1 being the principal seed condensing enzyme for those products (batsale2021biosynthesisandfunctions pages 5-6).</p>
+<h4 id="43-ectopic-expression-sufficiency">4.3 Ectopic expression sufficiency</h4>
+<p>The same 2022 review indicates that ectopic expression of <strong>35S-FAE1</strong> in leaves is sufficient to drive accumulation of <strong>C20 and C22</strong> VLCFAs, suggesting that (when substrate pools and shared elongase partners are available) FAE1 is a sufficient determinant to re-route flux toward seed-like VLCFAs (zhukov2022synthesisofc20–38 pages 7-8).</p>
+<h3 id="5-recent-developments-prioritizing-20232024">5) Recent developments (prioritizing 2023–2024)</h3>
+<h4 id="51-2023-systematic-quantitative-characterization-of-arabidopsis-kcs-specificities">5.1 2023: systematic, quantitative characterization of Arabidopsis KCS specificities</h4>
+<p>A major 2023 methodological and conceptual advance is the <strong>CRISPR-enabled expression platform</strong> to reconstitute Arabidopsis FAE complexes in yeast and comprehensively test KCS candidates, enabling more direct assignment of chain-length specificities while explicitly addressing functional redundancy (batsale2023tacklingfunctionalredundancy pages 1-2). Within this systematic framework, <strong>KCS18</strong> was distinguished by its preference for monounsaturated C20 products and associated acyl-CoA changes (batsale2023tacklingfunctionalredundancy pages 6-10, batsale2023tacklingfunctionalredundancy media 6565efaa).</p>
+<h4 id="52-2024-modulation-of-elongase-output-by-accessory-proteins-conceptual-extension">5.2 2024: modulation of elongase output by accessory proteins (conceptual extension)</h4>
+<p>A 2024 study in maize reports that co-expression of BAHD-family proteins (GLOSSY2 / GLOSSY2-LIKE) with maize KCS enzymes in yeast can extend VLCFA output up to <strong>C30</strong> under certain host contexts, but not in others—supporting the emerging view that <strong>FAE output is modulated by accessory factors</strong> and that results can be system-dependent (alexander2024theimpactof pages 1-2). While not about Arabidopsis FAE1 specifically, it reinforces a key interpretive framework: chain-length outcomes are not always encoded by KCS alone.</p>
+<h4 id="53-2024-applied-and-mechanistic-synthesis-of-vlcfa-inhibiting-herbicides">5.3 2024: applied and mechanistic synthesis of VLCFA-inhibiting herbicides</h4>
+<p>A 2024 Weed Technology review summarizes “Group 15” and related VLCFA elongase–inhibiting herbicides, emphasizing their widespread use and mechanistic target: the <strong>VLCFA synthase/condensing enzyme step</strong> encoded by multiple <strong>FAE1-like genes</strong> in the ER elongase complex (jhala2024verylongchain pages 1-2). The review highlights the conserved <strong>reactive cysteinyl sulfur</strong> implicated in inhibition chemistry (jhala2024verylongchain pages 1-2).</p>
+<h3 id="6-current-applications-and-real-world-implementations">6) Current applications and real-world implementations</h3>
+<h4 id="61-metabolic-engineering-for-long-chain-monounsaturated-fatty-acids-erucicnervonic-acid">6.1 Metabolic engineering for long-chain monounsaturated fatty acids (erucic/nervonic acid)</h4>
+<p>Because FAE1-like KCS enzymes control VLCFA chain length, they are prominent targets in metabolic engineering to enrich seed oils in long-chain monounsaturated products. A 2023 review on <strong>nervonic acid</strong> biosynthesis and engineering summarizes multiple examples of introducing KCS genes into plants and microbes and reports large increases in VLCFAs depending on enzyme and host context, including <strong>30–40×</strong> (Lunaria KCS in Arabidopsis), <strong>35–50×</strong> (Cardamine KCS in Arabidopsis), and <strong>15–28×</strong> increases in Brassica hosts (ling2023researchprogressof pages 7-8). The same review also reports engineering in microalgae yielding nervonic acid up to <strong>40% of total fatty acids</strong> in one case, and notes a yeast production example reaching <strong>8 g/L</strong> nervonic acid (though only ~20% of total FA), illustrating industrial relevance beyond plants (ling2023researchprogressof pages 7-8).</p>
+<p>These examples treat FAE1-like KCS enzymes as key “control points” and discuss strategies such as (i) tuning KCS substrate specificity by mutagenesis and (ii) increasing precursor availability to push flux through elongation (ling2023researchprogressof pages 7-8).</p>
+<h4 id="62-herbicide-mode-of-action-and-resistance-management">6.2 Herbicide mode-of-action and resistance management</h4>
+<p>VLCFA-inhibiting herbicides are a large, established herbicide mode-of-action class used in major row crops. The 2024 review reports: <br />
+- eight chemical families in this class; <br />
+- average application ≈ once per year in U.S. corn and soybean systems; <br />
+- as of Aug 2023, <strong>13 resistant weed species</strong> documented (11 monocots, 2 dicots); <br />
+- most recently discovered class members in 2014 (pyroxasulfone, fenoxasulfone) (jhala2024verylongchain pages 1-2). </p>
+<p>This situates FAE1-like condensing enzymes (KCS/FAE step) as a <strong>real-world biochemical target</strong> with major agronomic and resistance-management implications (jhala2024verylongchain pages 1-2).</p>
+<h3 id="7-expert-opinions-and-analysis-authoritative-synthesis">7) Expert opinions and analysis (authoritative synthesis)</h3>
+<h4 id="71-consensus-points">7.1 Consensus points</h4>
+<ul>
+<li><strong>KCS enzymes determine chain-length specificity</strong> in the ER elongation cycle, while the other elongase subunits are more broadly shared (batsale2023tacklingfunctionalredundancy pages 1-2, zhukov2022synthesisofc20–38 pages 6-7, batsale2021biosynthesisandfunctions pages 3-5). </li>
+<li><strong>Functional redundancy</strong> in large KCS gene families is a major reason single mutants often lack phenotypes; in contrast, shared core subunits (KCR/HCD/ECR) can be essential, making them genetically hard to dissect (batsale2021biosynthesisandfunctions pages 3-5, batsale2023tacklingfunctionalredundancy pages 1-2).</li>
+<li><strong>FAE1/KCS18</strong> is a highly informative “exception” to redundancy because it is seed-specialized and its loss strongly depletes seed C20–C22 VLCFAs (zhukov2022synthesisofc20–38 pages 7-8, batsale2021biosynthesisandfunctions pages 5-6).</li>
+</ul>
+<h4 id="72-open-questions-and-limitations">7.2 Open questions and limitations</h4>
+<p>Multiple authoritative sources emphasize that important mechanistic uncertainties remain:<br />
+- <strong>Complex assembly and accessory modulation:</strong> the FAE is an ER multi-protein complex with limited structural understanding; accessory proteins (e.g., CER2-LIKE family; chaperones PAS1/AKR2A) can modulate KCS outcomes, but mechanisms remain unresolved (batsale2021biosynthesisandfunctions pages 5-6, batsale2023tacklingfunctionalredundancy pages 11-12).<br />
+- <strong>Context dependence of heterologous assays:</strong> some KCS enzymes are inactive in yeast but active in planta assays, suggesting missing plant cofactors/partners or inappropriate substrate pools in heterologous hosts (batsale2023tacklingfunctionalredundancy pages 10-11, batsale2023tacklingfunctionalredundancy pages 11-12).<br />
+- <strong>Redundancy vs specialization:</strong> systematic profiling reveals both redundant paralog pairs and outlier specificities, but many KCS isoforms remain uncharacterized and may act on substrates or products that are not routinely measured (batsale2023tacklingfunctionalredundancy pages 1-2, batsale2023tacklingfunctionalredundancy pages 6-10).</p>
+<h3 id="8-evidence-map-summary-table">8) Evidence map (summary table)</h3>
+<p>The following table consolidates the major evidence-backed functional annotation points for FAE1/KCS18, including the most relevant recent developments and applications.</p>
+<table>
+<thead>
+<tr>
+<th>Topic</th>
+<th>Key findings (with quantitative data)</th>
+<th>Evidence (paper + year + DOI/URL)</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>Identity and core function</td>
+<td>Arabidopsis <strong>FAE1 = KCS18</strong> (At4g34520; UniProt Q38860) is a <strong>3-ketoacyl-CoA synthase/condensing enzyme</strong> of the <strong>ER-localized fatty acid elongase (FAE) complex</strong>. It catalyzes the first step of VLCFA elongation: condensation of an acyl-CoA with malonyl-CoA to form a 3-ketoacyl-CoA intermediate; KCS is the chain-length-determining component of the 4-enzyme FAE system. (morineau2016dualfattyacid pages 1-2, batsale2023tacklingfunctionalredundancy pages 1-2, zhukov2022synthesisofc20–38 pages 6-7)</td>
+<td>Morineau et al., 2016, PLoS ONE, https://doi.org/10.1371/journal.pone.0160631; Batsale et al., 2023, Front. Plant Sci., https://doi.org/10.3389/fpls.2023.1107333; Zhukov &amp; Popov, 2022, IJMS, https://doi.org/10.3390/ijms23094731</td>
+</tr>
+<tr>
+<td>Substrate specificity and product profile</td>
+<td>Recent yeast reconstitution showed <strong>KCS18 preferentially accumulates monounsaturated C20 products</strong> and increases <strong>18:1-, 20:1-, and 22:1-CoA</strong> pools; figure-level evidence indicates significant accumulation of <strong>20:1 and 22:1</strong> products in yeast expressing KCS18. Reviews summarize that heterologous expression of FAE1/KCS18 yields <strong>C20 and C22 saturated and monounsaturated VLCFAs</strong>, consistent with elongation of <strong>18:1-CoA toward 20:1/22:1</strong>. (batsale2023tacklingfunctionalredundancy pages 6-10, batsale2021biosynthesisandfunctions pages 5-6, batsale2023tacklingfunctionalredundancy media 6565efaa)</td>
+<td>Batsale et al., 2023, Front. Plant Sci., https://doi.org/10.3389/fpls.2023.1107333; Batsale et al., 2021, Cells, https://doi.org/10.3390/cells10061284</td>
+</tr>
+<tr>
+<td>Subcellular localization</td>
+<td>All Arabidopsis KCS proteins tested, including KCS18, localized to the <strong>endoplasmic reticulum</strong> in transient expression assays; KCS proteins show a polygonal/tubular ER pattern in tobacco cells. ER localization is consistent with the known localization of VLCFA elongation. (batsale2023tacklingfunctionalredundancy pages 6-10, kim2013arabidopsis3ketoacylcoenzymea pages 9-10, kim2013arabidopsis3ketoacylcoenzymea pages 1-2)</td>
+<td>Batsale et al., 2023, Front. Plant Sci., https://doi.org/10.3389/fpls.2023.1107333; Kim et al., 2013, Plant Physiol., https://doi.org/10.1104/pp.112.210450</td>
+</tr>
+<tr>
+<td>Loss-of-function phenotype</td>
+<td><strong>fae1/kcs18 mutant seeds</strong> are strongly depleted in seed VLCFAs: reviews report seed storage lipids are <strong>nearly free of C20 and C22 VLCFAs</strong>, and one review summarizes total seed VLCFA dropping from <strong>~28% in wild type to &lt;1% in fae1</strong>. Vegetative tissues and flowers are reported as largely unaffected in fatty-acid composition. (zhukov2022synthesisofc20–38 pages 7-8, batsale2021biosynthesisandfunctions pages 5-6)</td>
+<td>Zhukov &amp; Popov, 2022, IJMS, https://doi.org/10.3390/ijms23094731; Batsale et al., 2021, Cells, https://doi.org/10.3390/cells10061284</td>
+</tr>
+<tr>
+<td>Ectopic/overexpression phenotype</td>
+<td>Ectopic <strong>35S-FAE1</strong> expression in Arabidopsis leaves is sufficient to induce accumulation of <strong>C20 and C22 VLCFAs</strong> in tissues that normally lack them, supporting that FAE1 alone can drive seed-type VLCFA synthesis when supplied with suitable substrates and shared elongase partners. (zhukov2022synthesisofc20–38 pages 7-8)</td>
+<td>Zhukov &amp; Popov, 2022, IJMS, https://doi.org/10.3390/ijms23094731</td>
+</tr>
+<tr>
+<td>Pathway role in seed lipid metabolism</td>
+<td>FAE1/KCS18 is the canonical <strong>seed-specific KCS</strong> directing formation of VLCFAs for <strong>triacylglycerol (TAG)</strong> storage lipids, including the pathway leading to <strong>erucic acid (22:1)</strong>. Arabidopsis seeds contain a substantial VLCFA fraction; one review cites <strong>~27% of Arabidopsis seed acyl chains</strong> as VLCFAs, with FAE1 being the principal seed condensing enzyme. (zhukov2022synthesisofc20–38 pages 7-8, batsale2021biosynthesisandfunctions pages 3-5)</td>
+<td>Zhukov &amp; Popov, 2022, IJMS, https://doi.org/10.3390/ijms23094731; Batsale et al., 2021, Cells, https://doi.org/10.3390/cells10061284</td>
+</tr>
+<tr>
+<td>Recent development: improved functional assignment (2023)</td>
+<td>A 2023 Arabidopsis KCS reconstitution platform in engineered yeast systematically profiled KCS activities and highlighted <strong>functional redundancy</strong> across the KCS family while clarifying that <strong>KCS18 specializes in monounsaturated C20/C22 products</strong>. This is important for interpreting weak mutant phenotypes outside seeds and for rational pathway engineering. (batsale2023tacklingfunctionalredundancy pages 6-10, batsale2023tacklingfunctionalredundancy pages 1-2)</td>
+<td>Batsale et al., 2023, Front. Plant Sci., https://doi.org/10.3389/fpls.2023.1107333</td>
+</tr>
+<tr>
+<td>Application relevance: herbicide target class (2024 review)</td>
+<td>VLCFA-inhibiting herbicides target the <strong>condensing enzyme step</strong> of the ER FAE system encoded by multiple <strong>FAE1-like genes</strong>. The active-site mechanism depends on a conserved <strong>reactive cysteinyl sulfur</strong>. Practical statistics: <strong>8 chemical families</strong> are included; first such herbicide dates to <strong>1958</strong>; newest major class members were discovered in <strong>2014</strong>; as of Aug 2023, <strong>13 resistant weed species</strong> had been documented. This is pathway-level relevance rather than evidence that Arabidopsis FAE1 itself is the sole field target. (jhala2024verylongchain pages 1-2)</td>
+<td>Jhala et al., 2024, Weed Technology, https://doi.org/10.1017/wet.2023.90</td>
+</tr>
+<tr>
+<td>Application relevance: metabolic engineering of erucic/nervonic acid</td>
+<td>A 2023 review of nervonic-acid engineering identifies <strong>FAE1-like KCS enzymes as key rate-limiting targets</strong> for boosting long-chain monounsaturated VLCFAs. Reported outcomes include <strong>30–40×</strong> VLCFA increases with <em>Lunaria annua</em> KCS in Arabidopsis, <strong>35–50×</strong> with <em>Cardamine graeca</em> KCS in Arabidopsis, <strong>15–28×</strong> in Brassica hosts, and <strong>25×</strong> with <em>Malania oleifera</em> KCS11 in Arabidopsis. Proposed strategies include KCS mutagenesis to alter chain-length specificity and increasing precursor supply while suppressing competing desaturation. (ling2023researchprogressof pages 7-8)</td>
+<td>Ling et al., 2023, J. Oleo Sci., https://doi.org/10.5650/jos.ess23039</td>
+</tr>
+<tr>
+<td>Broader mechanistic outlook</td>
+<td>2024 work in maize shows that accessory proteins can shift FAE chain-length output up to <strong>C30</strong>, reinforcing the current expert view that KCS defines much of product specificity but that <strong>other FAE-associated proteins can modulate final chain length/output</strong>. This informs how FAE1-like enzymes may be optimized in engineering contexts. (alexander2024theimpactof pages 1-2)</td>
+<td>Alexander et al., 2024, Front. Plant Sci., https://doi.org/10.3389/fpls.2024.1403779</td>
+</tr>
+</tbody>
+</table>
+<p><em>Table: This table compiles the key experimentally supported facts about Arabidopsis FAE1/KCS18, including its enzymatic role, specificity, localization, phenotypes, and recent translational relevance. It is designed as a compact evidence map for functional annotation and current applications.</em></p>
+<h3 id="9-key-references-with-publication-dates-and-urls">9) Key references (with publication dates and URLs)</h3>
+<ul>
+<li>Batsale M. et al. (2023-01). <em>Tackling functional redundancy of Arabidopsis fatty acid elongase complexes</em>. Frontiers in Plant Science. https://doi.org/10.3389/fpls.2023.1107333 (batsale2023tacklingfunctionalredundancy pages 6-10, batsale2023tacklingfunctionalredundancy pages 1-2, batsale2023tacklingfunctionalredundancy media 6565efaa)</li>
+<li>Jhala A.J. et al. (2024-12). <em>Very long chain fatty acid–inhibiting herbicides: Current uses, site of action, herbicide-resistant weeds, and future</em>. Weed Technology. https://doi.org/10.1017/wet.2023.90 (jhala2024verylongchain pages 1-2)</li>
+<li>Ling C. et al. (2023-09). <em>Research Progress of Nervonic Acid Biosynthesis</em>. Journal of Oleo Science. https://doi.org/10.5650/jos.ess23039 (ling2023researchprogressof pages 7-8)</li>
+<li>Zhukov A., Popov V. (2022-04). <em>Synthesis of C20–38 Fatty Acids in Plant Tissues</em>. International Journal of Molecular Sciences. https://doi.org/10.3390/ijms23094731 (zhukov2022synthesisofc20–38 pages 7-8)</li>
+<li>Batsale M. et al. (2021-05). <em>Biosynthesis and Functions of Very-Long-Chain Fatty Acids in the Responses of Plants to Abiotic and Biotic Stresses</em>. Cells. https://doi.org/10.3390/cells10061284 (batsale2021biosynthesisandfunctions pages 3-5, batsale2021biosynthesisandfunctions pages 5-6)</li>
+<li>Morineau C. et al. (2016-09). <em>Dual Fatty Acid Elongase Complex Interactions in Arabidopsis</em>. PLoS ONE. https://doi.org/10.1371/journal.pone.0160631 (morineau2016dualfattyacid pages 1-2)</li>
+</ul>
+<p>References</p>
+<ol>
+<li>
+<p>(batsale2021biosynthesisandfunctions pages 5-6): Marguerite Batsale, Delphine Bahammou, Laetitia Fouillen, Sébastien Mongrand, Jérôme Joubès, and Frédéric Domergue. Biosynthesis and functions of very-long-chain fatty acids in the responses of plants to abiotic and biotic stresses. Cells, 10:1284, May 2021. URL: https://doi.org/10.3390/cells10061284, doi:10.3390/cells10061284. This article has 240 citations.</p>
+</li>
+<li>
+<p>(morineau2016dualfattyacid pages 1-2): Céline Morineau, Lionel Gissot, Yannick Bellec, Kian Hematy, Frédérique Tellier, Charlotte Renne, Richard Haslam, Frédéric Beaudoin, Johnathan Napier, and Jean-Denis Faure. Dual fatty acid elongase complex interactions in arabidopsis. PLoS ONE, 11:e0160631, Sep 2016. URL: https://doi.org/10.1371/journal.pone.0160631, doi:10.1371/journal.pone.0160631. This article has 31 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(zhukov2022synthesisofc20–38 pages 7-8): Anatoly Zhukov and Valery Popov. Synthesis of c20–38 fatty acids in plant tissues. International Journal of Molecular Sciences, 23:4731, Apr 2022. URL: https://doi.org/10.3390/ijms23094731, doi:10.3390/ijms23094731. This article has 28 citations.</p>
+</li>
+<li>
+<p>(batsale2023tacklingfunctionalredundancy pages 6-10): Marguerite Batsale, Marie Alonso, Stéphanie Pascal, Didier Thoraval, Richard P. Haslam, Frédéric Beaudoin, Frédéric Domergue, and Jérôme Joubès. Tackling functional redundancy of arabidopsis fatty acid elongase complexes. Frontiers in Plant Science, Jan 2023. URL: https://doi.org/10.3389/fpls.2023.1107333, doi:10.3389/fpls.2023.1107333. This article has 43 citations.</p>
+</li>
+<li>
+<p>(batsale2023tacklingfunctionalredundancy pages 1-2): Marguerite Batsale, Marie Alonso, Stéphanie Pascal, Didier Thoraval, Richard P. Haslam, Frédéric Beaudoin, Frédéric Domergue, and Jérôme Joubès. Tackling functional redundancy of arabidopsis fatty acid elongase complexes. Frontiers in Plant Science, Jan 2023. URL: https://doi.org/10.3389/fpls.2023.1107333, doi:10.3389/fpls.2023.1107333. This article has 43 citations.</p>
+</li>
+<li>
+<p>(batsale2021biosynthesisandfunctions pages 3-5): Marguerite Batsale, Delphine Bahammou, Laetitia Fouillen, Sébastien Mongrand, Jérôme Joubès, and Frédéric Domergue. Biosynthesis and functions of very-long-chain fatty acids in the responses of plants to abiotic and biotic stresses. Cells, 10:1284, May 2021. URL: https://doi.org/10.3390/cells10061284, doi:10.3390/cells10061284. This article has 240 citations.</p>
+</li>
+<li>
+<p>(zhukov2022synthesisofc20–38 pages 6-7): Anatoly Zhukov and Valery Popov. Synthesis of c20–38 fatty acids in plant tissues. International Journal of Molecular Sciences, 23:4731, Apr 2022. URL: https://doi.org/10.3390/ijms23094731, doi:10.3390/ijms23094731. This article has 28 citations.</p>
+</li>
+<li>
+<p>(kim2013arabidopsis3ketoacylcoenzymea pages 1-2): Juyoung Kim, Jin Hee Jung, Saet Buyl Lee, Young Sam Go, Hae Jin Kim, Rebecca Cahoon, Jennifer E. Markham, Edgar B. Cahoon, and Mi Chung Suh. Arabidopsis 3-ketoacyl-coenzyme a synthase9 is involved in the synthesis of tetracosanoic acids as precursors of cuticular waxes, suberins, sphingolipids, and phospholipids. Plant Physiology, 162:567-580, Apr 2013. URL: https://doi.org/10.1104/pp.112.210450, doi:10.1104/pp.112.210450. This article has 236 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(batsale2023tacklingfunctionalredundancy media 6565efaa): Marguerite Batsale, Marie Alonso, Stéphanie Pascal, Didier Thoraval, Richard P. Haslam, Frédéric Beaudoin, Frédéric Domergue, and Jérôme Joubès. Tackling functional redundancy of arabidopsis fatty acid elongase complexes. Frontiers in Plant Science, Jan 2023. URL: https://doi.org/10.3389/fpls.2023.1107333, doi:10.3389/fpls.2023.1107333. This article has 43 citations.</p>
+</li>
+<li>
+<p>(alexander2024theimpactof pages 1-2): Liza Esther Alexander, Dirk Winkelman, Kenna E. Stenback, Madison Lane, Katelyn R. Campbell, Elysse Trost, Kayla Flyckt, Michael A. Schelling, Ludmila Rizhsky, Marna D. Yandeau-Nelson, and Basil J. Nikolau. The impact of the glossy2 and glossy2-like bahd-proteins in affecting the product profile of the maize fatty acid elongase. Frontiers in Plant Science, Jul 2024. URL: https://doi.org/10.3389/fpls.2024.1403779, doi:10.3389/fpls.2024.1403779. This article has 5 citations.</p>
+</li>
+<li>
+<p>(jhala2024verylongchain pages 1-2): Amit J. Jhala, Mandeep Singh, Lovreet Shergill, Rishabh Singh, Mithila Jugulam, Dean E. Riechers, Zahoor A. Ganie, Thomas P. Selby, Rodrigo Werle, and Jason K. Norsworthy. Very long chain fatty acid–inhibiting herbicides: current uses, site of action, herbicide-resistant weeds, and future. Weed Technology, 38:1-16, Dec 2024. URL: https://doi.org/10.1017/wet.2023.90, doi:10.1017/wet.2023.90. This article has 34 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(ling2023researchprogressof pages 7-8): Cheng Ling, Feng Li, Jiangyuan Zhao, Mengliang Wen, and Xiu-lin Han. Research progress of nervonic acid biosynthesis. Journal of oleo science, 72:889-900, Sep 2023. URL: https://doi.org/10.5650/jos.ess23039, doi:10.5650/jos.ess23039. This article has 10 citations.</p>
+</li>
+<li>
+<p>(batsale2023tacklingfunctionalredundancy pages 11-12): Marguerite Batsale, Marie Alonso, Stéphanie Pascal, Didier Thoraval, Richard P. Haslam, Frédéric Beaudoin, Frédéric Domergue, and Jérôme Joubès. Tackling functional redundancy of arabidopsis fatty acid elongase complexes. Frontiers in Plant Science, Jan 2023. URL: https://doi.org/10.3389/fpls.2023.1107333, doi:10.3389/fpls.2023.1107333. This article has 43 citations.</p>
+</li>
+<li>
+<p>(batsale2023tacklingfunctionalredundancy pages 10-11): Marguerite Batsale, Marie Alonso, Stéphanie Pascal, Didier Thoraval, Richard P. Haslam, Frédéric Beaudoin, Frédéric Domergue, and Jérôme Joubès. Tackling functional redundancy of arabidopsis fatty acid elongase complexes. Frontiers in Plant Science, Jan 2023. URL: https://doi.org/10.3389/fpls.2023.1107333, doi:10.3389/fpls.2023.1107333. This article has 43 citations.</p>
+</li>
+<li>
+<p>(kim2013arabidopsis3ketoacylcoenzymea pages 9-10): Juyoung Kim, Jin Hee Jung, Saet Buyl Lee, Young Sam Go, Hae Jin Kim, Rebecca Cahoon, Jennifer E. Markham, Edgar B. Cahoon, and Mi Chung Suh. Arabidopsis 3-ketoacyl-coenzyme a synthase9 is involved in the synthesis of tetracosanoic acids as precursors of cuticular waxes, suberins, sphingolipids, and phospholipids. Plant Physiology, 162:567-580, Apr 2013. URL: https://doi.org/10.1104/pp.112.210450, doi:10.1104/pp.112.210450. This article has 236 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+</ol>
+<h2 id="artifacts">Artifacts</h2>
+<ul>
+<li><a href="FAE1-deep-research-falcon_artifacts/artifact-00.md">Edison artifact artifact-00</a><br />
+<img alt="## Context ID: pqac-00000016 The figure reporting KCS18 (FAE1) substrate specificity and profiles in yeast reconstitution experiments is Figure 3A (FAMEs profil" src="FAE1-deep-research-falcon_artifacts/image-1.png" /></li>
+</ul>
+<h2 id="citations">Citations</h2>
+<ol>
+<li>batsale2023tacklingfunctionalredundancy pages 6-10</li>
+<li>batsale2023tacklingfunctionalredundancy pages 1-2</li>
+<li>batsale2021biosynthesisandfunctions pages 5-6</li>
+<li>batsale2021biosynthesisandfunctions pages 3-5</li>
+<li>alexander2024theimpactof pages 1-2</li>
+<li>jhala2024verylongchain pages 1-2</li>
+<li>ling2023researchprogressof pages 7-8</li>
+<li>morineau2016dualfattyacid pages 1-2</li>
+<li>batsale2023tacklingfunctionalredundancy pages 11-12</li>
+<li>batsale2023tacklingfunctionalredundancy pages 10-11</li>
+<li>https://doi.org/10.1371/journal.pone.0160631;</li>
+<li>https://doi.org/10.3389/fpls.2023.1107333;</li>
+<li>https://doi.org/10.3390/ijms23094731</li>
+<li>https://doi.org/10.3390/cells10061284</li>
+<li>https://doi.org/10.1104/pp.112.210450</li>
+<li>https://doi.org/10.3390/ijms23094731;</li>
+<li>https://doi.org/10.3389/fpls.2023.1107333</li>
+<li>https://doi.org/10.1017/wet.2023.90</li>
+<li>https://doi.org/10.5650/jos.ess23039</li>
+<li>https://doi.org/10.3389/fpls.2024.1403779</li>
+<li>https://doi.org/10.1371/journal.pone.0160631</li>
+<li>https://doi.org/10.3390/cells10061284,</li>
+<li>https://doi.org/10.1371/journal.pone.0160631,</li>
+<li>https://doi.org/10.3390/ijms23094731,</li>
+<li>https://doi.org/10.3389/fpls.2023.1107333,</li>
+<li>https://doi.org/10.1104/pp.112.210450,</li>
+<li>https://doi.org/10.3389/fpls.2024.1403779,</li>
+<li>https://doi.org/10.1017/wet.2023.90,</li>
+<li>https://doi.org/10.5650/jos.ess23039,</li>
+</ol>
+            </div>
+        </details>
+        
+    </div>
+    
+
+    <!-- Additional Documentation Sections -->
+    
+    <div class="section">
+        <h2 class="section-title">📚 Additional Documentation</h2>
+        
+        <details class="markdown-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; cursor: pointer;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Notes</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(FAE1-notes.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="Q38860" data-a="DOC: Notes" data-r="" data-act="DOCUMENTATION" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This documentation is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This documentation needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+                <h1 id="fae1-kcs18-3-ketoacyl-coa-synthase-18-arabidopsis-thaliana-review-notes">FAE1 / KCS18 (3-ketoacyl-CoA synthase 18) — Arabidopsis thaliana — review notes</h1>
+<p>UniProt: Q38860 · At4g34520 · EC 2.3.1.199 · Taxon 3702<br />
+Relevance: canonical seed VLCFA condensing enzyme; key DOE/BER oilseed domestication<br />
+target (erucic/VLCFA content in pennycress and Brassica feedstocks).</p>
+<h2 id="core-function">Core function</h2>
+<ul>
+<li><strong>3-ketoacyl-CoA synthase (KCS)</strong>, the condensing enzyme of the ER fatty acid elongase<br />
+  (FAE) complex. Catalyzes the first, rate-defining step of each elongation cycle:<br />
+  condensation of an acyl-CoA with malonyl-CoA to a 3-ketoacyl-CoA, adding two carbons.<br />
+  The KCS is the <strong>chain-length-determining</strong> subunit of the 4-enzyme FAE system.<br />
+  [file:ARATH/FAE1/FAE1-deep-research-falcon.md; PMID:11341960; PMID:12135493]</li>
+<li><strong>Seed-specialized</strong>: active on saturated and monounsaturated C16/C18 acyl-CoAs;<br />
+  elongates C18-&gt;C20-&gt;C22 (and up to C26); produces seed VLCFAs (C20:1, C22:1 etc.).<br />
+  No activity on polyunsaturated C18:2/C18:3. [UniProt Q38860 FUNCTION; PMID:12135493]</li>
+<li><strong>Loss of function</strong>: fae1 seeds drop from ~28% VLCFA (WT) to &lt;1%; vegetative tissues<br />
+  largely unaffected — establishing FAE1 as the principal seed condensing enzyme.<br />
+  [PMID:7734965; file:ARATH/FAE1/FAE1-deep-research-falcon.md]</li>
+</ul>
+<h2 id="localization">Localization</h2>
+<ul>
+<li><strong>Endoplasmic reticulum / microsome membrane</strong> (integral membrane). Experimentally<br />
+  shown (IDA PMID:36798704; microsome PMID:12135493); ER is the site of VLCFA elongation.</li>
+<li>The GOA <strong>chloroplast (ISM, GO_REF:0000122)</strong> annotation contradicts this experimental<br />
+  ER localization and is a spurious sequence-model prediction -&gt; REMOVE.</li>
+</ul>
+<h2 id="annotation-review-decisions">Annotation review decisions</h2>
+<ul>
+<li>GO:0009922 fatty acid elongase activity (EXP/IDA + IEA) -&gt; ACCEPT (core MF)</li>
+<li>GO:0000038 very long-chain fatty acid metabolic process (IMP) -&gt; ACCEPT (core BP)</li>
+<li>GO:0030497 fatty acid elongation (IMP) -&gt; ACCEPT (core BP)</li>
+<li>GO:0006633 fatty acid biosynthetic process (IEA) -&gt; ACCEPT (general but correct)</li>
+<li>GO:0005783 endoplasmic reticulum (IDA + IEA) -&gt; ACCEPT (core location)</li>
+<li>GO:0016020 membrane (IEA) -&gt; ACCEPT (integral ER membrane)</li>
+<li>GO:0016746 / GO:0016747 acyltransferase activity (IEA) -&gt; ACCEPT (correct but general;<br />
+  fatty acid elongase activity is the informative term)</li>
+<li>GO:0009507 chloroplast (ISM) -&gt; REMOVE (contradicted by experimental ER localization)</li>
+</ul>
+<h2 id="doeber-relevance">DOE/BER relevance</h2>
+<p>FAE1/KCS18 controls seed VLCFA (erucic acid) content — a primary domestication lever for<br />
+oilseed feedstocks. fae1 knockouts remove erucic acid to yield food/feed-grade oil; the<br />
+enzyme is also a key engineering control point for long-chain monounsaturated oils.</p>
+            </div>
+        </details>
+        
+    </div>
+    
+
+    <!-- YAML Preview Section -->
+    <div class="section">
+        <details class="yaml-preview">
+            <summary>
+                <h2 style="display: inline;">📄 View Raw YAML</h2>
+            </summary>
+            <div class="yaml-content">
+                <pre><code>id: Q38860
+gene_symbol: FAE1
+product_type: PROTEIN
+status: COMPLETE
+taxon:
+  id: NCBITaxon:3702
+  label: Arabidopsis thaliana
+description: FAE1 (KCS18; 3-ketoacyl-CoA synthase 18) is the seed-specialized condensing
+  enzyme of the endoplasmic-reticulum fatty acid elongase (FAE) complex in Arabidopsis.
+  It catalyzes the first, rate-defining step of each very-long-chain fatty acid (VLCFA)
+  elongation cycle, condensing an acyl-CoA with malonyl-CoA to form a 3-ketoacyl-CoA and
+  adding two carbons. As the chain-length-determining subunit of the elongase, FAE1
+  elongates C18 acyl-CoAs to C20 and C22 (and longer) monounsaturated and saturated
+  VLCFAs that are deposited in seed triacylglycerols. It acts on saturated and
+  monounsaturated C16/C18 substrates but not on polyunsaturated acyl-CoAs. Loss of FAE1
+  nearly abolishes seed VLCFAs (including erucic acid), making it a central control point
+  for seed-oil composition.
+existing_annotations:
+  - term:
+      id: GO:0005783
+      label: endoplasmic reticulum
+    evidence_type: IEA
+    original_reference_id: GO_REF:0000117
+    qualifier: located_in
+    review:
+      summary: Correct localization, independently confirmed experimentally (see the
+        IDA annotation below). VLCFA elongation occurs on the ER.
+      action: ACCEPT
+  - term:
+      id: GO:0006633
+      label: fatty acid biosynthetic process
+    evidence_type: IEA
+    original_reference_id: GO_REF:0000120
+    qualifier: involved_in
+    review:
+      summary: Correct at the general level. FAE1 functions in fatty acid biosynthesis;
+        the more specific VLCFA elongation roles are captured by the experimentally
+        supported annotations below.
+      action: ACCEPT
+  - term:
+      id: GO:0009922
+      label: fatty acid elongase activity
+    evidence_type: IEA
+    original_reference_id: GO_REF:0000120
+    qualifier: enables
+    review:
+      summary: Correct core molecular function, also supported experimentally (EXP and
+        IDA below). FAE1 is the condensing component of the fatty acid elongase.
+      action: ACCEPT
+  - term:
+      id: GO:0016020
+      label: membrane
+    evidence_type: IEA
+    original_reference_id: GO_REF:0000002
+    qualifier: located_in
+    review:
+      summary: Correct but general. FAE1 is an integral membrane protein of the ER
+        (UniProt annotates transmembrane helices); the ER annotation is the informative
+        localization.
+      action: ACCEPT
+  - term:
+      id: GO:0016746
+      label: acyltransferase activity
+    evidence_type: IEA
+    original_reference_id: GO_REF:0000002
+    qualifier: enables
+    review:
+      summary: Correct but general. As a 3-ketoacyl-CoA synthase (condensing enzyme),
+        FAE1 is an acyltransferase, but fatty acid elongase activity (GO:0009922) is the
+        informative molecular function.
+      action: ACCEPT
+  - term:
+      id: GO:0016747
+      label: acyltransferase activity, transferring groups other than amino-acyl groups
+    evidence_type: IEA
+    original_reference_id: GO_REF:0000002
+    qualifier: enables
+    review:
+      summary: Correct but general; this is the acyltransferase parent matching the
+        KCS condensation chemistry. The specific fatty acid elongase activity annotation
+        is retained as the core function.
+      action: ACCEPT
+  - term:
+      id: GO:0009922
+      label: fatty acid elongase activity
+    evidence_type: EXP
+    original_reference_id: PMID:12135493
+    qualifier: enables
+    review:
+      summary: Core molecular function with direct experimental support. Mechanistic and
+        engineering studies show FAE1/KCS18 is the beta-ketoacyl-CoA synthase (condensing
+        enzyme) of the elongase, active on C16-C18 saturated and monounsaturated acyl-CoAs
+        and elongating them to C20-C22 VLCFAs, with no activity on polyunsaturated
+        substrates. [PMID:12135493]
+      action: ACCEPT
+      supported_by:
+        - reference_id: PMID:12135493
+          supporting_text: Engineering and mechanistic studies of the Arabidopsis FAE1
+            beta-ketoacyl-CoA synthase, FAE1 KCS
+        - reference_id: file:ARATH/FAE1/FAE1-deep-research-falcon.md
+          supporting_text: KCS18 is a 3-ketoacyl-CoA synthase/condensing enzyme of the
+            ER FAE complex and the chain-length-determining component
+  - term:
+      id: GO:0005783
+      label: endoplasmic reticulum
+    evidence_type: IDA
+    original_reference_id: PMID:36798704
+    qualifier: located_in
+    review:
+      summary: Experimentally confirmed ER localization. Fluorescent fusions of Arabidopsis
+        KCS proteins including KCS18 localize to the ER, consistent with VLCFA elongation
+        occurring on the ER. [PMID:36798704]
+      action: ACCEPT
+      supported_by:
+        - reference_id: PMID:36798704
+          supporting_text: Arabidopsis KCS proteins, including KCS18, localize to the
+            endoplasmic reticulum
+  - term:
+      id: GO:0009507
+      label: chloroplast
+    evidence_type: ISM
+    original_reference_id: GO_REF:0000122
+    qualifier: located_in
+    review:
+      summary: Spurious computational (sequence-model) prediction that contradicts the
+        experimentally established ER/microsome localization. FAE1 is an ER-membrane VLCFA
+        elongase component; there is no evidence it localizes to the chloroplast.
+      action: REMOVE
+      supported_by:
+        - reference_id: PMID:36798704
+          supporting_text: KCS18 localizes to the endoplasmic reticulum
+        - reference_id: PMID:12135493
+          supporting_text: FAE1 is a membrane-bound (microsomal) fatty acid elongase
+  - term:
+      id: GO:0000038
+      label: very long-chain fatty acid metabolic process
+    evidence_type: IMP
+    original_reference_id: PMID:7734965
+    qualifier: acts_upstream_of_or_within
+    review:
+      summary: Core biological process, supported by mutant phenotype. fae1 loss strongly
+        depletes seed VLCFAs, demonstrating FAE1&#39;s role in VLCFA metabolism. [PMID:7734965]
+      action: ACCEPT
+      supported_by:
+        - reference_id: PMID:7734965
+          supporting_text: Directed tagging of the Arabidopsis FATTY ACID ELONGATION1
+            (FAE1) gene; fae1 mutant depletes seed VLCFAs
+  - term:
+      id: GO:0030497
+      label: fatty acid elongation
+    evidence_type: IMP
+    original_reference_id: PMID:7734965
+    qualifier: acts_upstream_of_or_within
+    review:
+      summary: Core biological process. FAE1 catalyzes the condensation step of fatty
+        acid elongation; the fae1 mutant phenotype establishes its requirement for seed
+        VLCFA elongation. [PMID:7734965]
+      action: ACCEPT
+      supported_by:
+        - reference_id: PMID:7734965
+          supporting_text: FAE1 is required for fatty acid elongation in seeds
+  - term:
+      id: GO:0009922
+      label: fatty acid elongase activity
+    evidence_type: IDA
+    original_reference_id: PMID:11341960
+    qualifier: enables
+    review:
+      summary: Core molecular function with direct assay support. Active-site studies of
+        the FAE1 KCS confirm its beta-ketoacyl-CoA synthase (condensing enzyme) activity.
+        [PMID:11341960]
+      action: ACCEPT
+      supported_by:
+        - reference_id: PMID:11341960
+          supporting_text: Active-site residues of a plant membrane-bound fatty acid
+            elongase beta-ketoacyl-CoA synthase, FAE1 KCS
+core_functions:
+  - description: FAE1/KCS18 is the seed condensing enzyme (3-ketoacyl-CoA synthase) of
+      the ER fatty acid elongase, catalyzing the chain-length-determining condensation of
+      acyl-CoA with malonyl-CoA to elongate C18 to C20/C22 very-long-chain fatty acids
+      that are stored in seed triacylglycerols.
+    molecular_function:
+      id: GO:0009922
+      label: fatty acid elongase activity
+    directly_involved_in:
+      - id: GO:0030497
+        label: fatty acid elongation
+      - id: GO:0000038
+        label: very long-chain fatty acid metabolic process
+    locations:
+      - id: GO:0005783
+        label: endoplasmic reticulum
+    supported_by:
+      - reference_id: PMID:12135493
+        supporting_text: FAE1 KCS condensing enzyme elongates C16-C18 acyl-CoAs to
+          C20-C22 VLCFAs
+      - reference_id: PMID:7734965
+        supporting_text: fae1 mutant seeds are depleted of very-long-chain fatty acids
+      - reference_id: file:ARATH/FAE1/FAE1-deep-research-falcon.md
+        supporting_text: seed-specialized KCS; fae1 reduces seed VLCFAs from ~28% to &lt;1%
+references:
+  - id: GO_REF:0000002
+    title: Gene Ontology annotation through association of InterPro records with GO terms
+    findings: []
+  - id: GO_REF:0000117
+    title: Electronic Gene Ontology annotations created by ARBA machine learning models
+    findings: []
+  - id: GO_REF:0000120
+    title: Combined Automated Annotation using Multiple IEA Methods
+    findings: []
+  - id: GO_REF:0000122
+    title: AtSubP analysis
+    findings: []
+  - id: PMID:11341960
+    title: Active-site residues of a plant membrane-bound fatty acid elongase
+      beta-ketoacyl-CoA synthase, FAE1 KCS.
+    findings:
+      - statement: Identifies catalytic active-site residues of the FAE1 KCS condensing
+          enzyme, confirming its beta-ketoacyl-CoA synthase activity.
+        reference_section_type: RESULTS
+    reference_review:
+      relevance: HIGH
+      correctness: VERIFIED
+      review_notes: Direct enzymatic/active-site characterization supporting the IDA
+        fatty acid elongase activity annotation.
+  - id: PMID:12135493
+    title: Engineering and mechanistic studies of the Arabidopsis FAE1 beta-ketoacyl-CoA
+      synthase, FAE1 KCS.
+    findings:
+      - statement: FAE1 KCS is active on saturated and monounsaturated C16-C18 acyl-CoAs,
+          elongating to C20-C22 VLCFAs, with no activity on polyunsaturated substrates;
+          microsome (ER) membrane localization.
+        reference_section_type: RESULTS
+    reference_review:
+      relevance: HIGH
+      correctness: VERIFIED
+      review_notes: Source of EXP fatty acid elongase activity and microsome localization.
+  - id: PMID:36798704
+    title: Tackling functional redundancy of Arabidopsis fatty acid elongase complexes.
+    findings:
+      - statement: Systematic reconstitution of Arabidopsis KCS isoforms; KCS18 localizes
+          to the ER and shows a strong bias toward monounsaturated C20 products.
+        reference_section_type: RESULTS
+    reference_review:
+      relevance: HIGH
+      correctness: VERIFIED
+      review_notes: Source of IDA ER localization; full text available.
+  - id: PMID:7734965
+    title: Directed tagging of the Arabidopsis FATTY ACID ELONGATION1 (FAE1) gene with
+      the maize transposon activator.
+    findings:
+      - statement: Identifies FAE1 by transposon tagging; fae1 mutant seeds are strongly
+          depleted of very-long-chain fatty acids, establishing FAE1&#39;s role in seed VLCFA
+          elongation.
+        reference_section_type: RESULTS
+    reference_review:
+      relevance: HIGH
+      correctness: VERIFIED
+      review_notes: Source of IMP annotations for VLCFA metabolism and fatty acid
+        elongation.
+  - id: file:ARATH/FAE1/FAE1-deep-research-falcon.md
+    title: Falcon/Edison deep research report for FAE1/KCS18, Arabidopsis thaliana
+    findings:
+      - statement: Synthesizes FAE1/KCS18 as the seed-specialized, chain-length-determining
+          condensing enzyme of the ER FAE complex; fae1 reduces seed VLCFAs from ~28% to
+          &lt;1%; a key metabolic-engineering control point for long-chain monounsaturated
+          seed oils.
+        reference_section_type: OTHER
+suggested_questions:
+  - question: How is FAE1/KCS18 substrate chain-length specificity (favoring C18-&gt;C20-&gt;C22
+      monounsaturated products) encoded structurally, and can it be re-engineered to tune
+      seed-oil VLCFA profiles in oilseed feedstocks?
+</code></pre>
+            </div>
+        </details>
+    </div>
+
+    <!-- Pathway Visualization Link -->
+    
+
+    <style>
+        /* Markdown Section Styles */
+        .markdown-section {
+            margin-bottom: 1rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .markdown-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .markdown-section summary h3 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.1rem;
+        }
+
+        .markdown-section summary:hover h3 {
+            color: #007bff;
+        }
+
+        .markdown-section[open] {
+            background-color: #fff;
+        }
+
+        .markdown-content {
+            margin-top: 1rem;
+            padding: 1rem;
+            border-top: 1px solid #dee2e6;
+        }
+
+        /* Markdown content styling */
+        .markdown-content h1 { font-size: 1.5rem; margin-top: 1.5rem; }
+        .markdown-content h2 { font-size: 1.3rem; margin-top: 1.3rem; }
+        .markdown-content h3 { font-size: 1.1rem; margin-top: 1.1rem; }
+        .markdown-content h4 { font-size: 1rem; margin-top: 1rem; }
+
+        .markdown-content pre {
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .markdown-content code {
+            background-color: #f8f9fa;
+            padding: 0.2rem 0.4rem;
+            border-radius: 3px;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+        }
+
+        .markdown-content pre code {
+            background: none;
+            padding: 0;
+        }
+
+        .markdown-content table {
+            border-collapse: collapse;
+            width: 100%;
+            margin: 1rem 0;
+        }
+
+        .markdown-content table th,
+        .markdown-content table td {
+            border: 1px solid #dee2e6;
+            padding: 0.5rem;
+            text-align: left;
+        }
+
+        .markdown-content table th {
+            background-color: #f8f9fa;
+            font-weight: bold;
+        }
+
+        .markdown-content blockquote {
+            border-left: 4px solid #007bff;
+            padding-left: 1rem;
+            margin-left: 0;
+            color: #666;
+        }
+
+        /* YAML Preview Styles */
+        .yaml-preview {
+            margin-top: 2rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .yaml-preview summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .yaml-preview summary h2 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.3rem;
+        }
+
+        .yaml-preview summary:hover h2 {
+            color: #007bff;
+        }
+
+        .yaml-preview[open] {
+            background-color: #fff;
+        }
+
+        .yaml-content {
+            margin-top: 1rem;
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .yaml-content pre {
+            margin: 0;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+            line-height: 1.4;
+        }
+
+        .yaml-content code {
+            color: #333;
+            background: none;
+            padding: 0;
+        }
+
+        /* Pathway Link Styles */
+        .pathway-link {
+            margin: 1rem 0;
+        }
+
+        .btn-link {
+            display: inline-block;
+            padding: 0.5rem 1rem;
+            background-color: #007bff;
+            color: white !important;
+            text-decoration: none;
+            border-radius: 4px;
+            font-weight: 500;
+            transition: background-color 0.2s;
+        }
+
+        .btn-link:hover {
+            background-color: #0056b3;
+            text-decoration: none;
+        }
+
+        /* Voting buttons */
+        .vote-buttons {
+            display: inline-block;
+            margin-left: 0.5rem;
+        }
+
+        .vote-btn {
+            background: none;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 2px 6px;
+            margin: 0 2px;
+            cursor: pointer;
+            font-size: 0.9rem;
+            transition: all 0.2s;
+            opacity: 0.6;
+        }
+
+        .vote-btn:hover {
+            opacity: 1;
+            transform: scale(1.1);
+        }
+
+        .vote-btn.voted {
+            opacity: 1;
+            border-color: #28a745;
+            background-color: #d4edda;
+        }
+
+        .vote-btn.voted-down {
+            border-color: #dc3545;
+            background-color: #f8d7da;
+        }
+
+        .vote-btn-small {
+            font-size: 0.7rem;
+            padding: 1px 4px;
+            margin: 0 1px;
+        }
+    </style>
+
+    <script>
+        // Add collapsible functionality
+        document.querySelectorAll('.collapsible').forEach(element => {
+            element.addEventListener('click', function() {
+                this.classList.toggle('collapsed');
+            });
+        });
+
+        // Voting functionality
+        const VOTE_URL = 'https://script.google.com/macros/s/AKfycbwPKH7d3seuPNBtB0ugVjqGeTiByyOGD5vkqB_Ck6K8eOcPQYbJqBOuz6GFgXHKBNWK/exec';
+
+        // Get or create session ID
+        let sessionId = localStorage.getItem('review_session_id');
+        if (!sessionId) {
+            sessionId = 's' + Date.now() + '_' + Math.random().toString(36).substr(2, 9);
+            localStorage.setItem('review_session_id', sessionId);
+        }
+
+        // Show previous votes on page load
+        document.addEventListener('DOMContentLoaded', function() {
+            document.querySelectorAll('.vote-buttons').forEach(container => {
+                const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+                const previousVote = localStorage.getItem(key);
+                if (previousVote) {
+                    const btn = container.querySelector(`[data-v="${previousVote}"]`);
+                    if (btn) btn.classList.add(previousVote === 'up' ? 'voted' : 'voted-down');
+                }
+            });
+        });
+
+        // Handle vote clicks - Simple image beacon approach
+        document.addEventListener('click', function(e) {
+            if (!e.target.classList.contains('vote-btn')) return;
+
+            // Prevent the click from bubbling to parent elements (like summary)
+            e.preventDefault();
+            e.stopPropagation();
+
+            const btn = e.target;
+            const container = btn.closest('.vote-buttons');
+            if (!container) return;
+
+            const voteType = btn.dataset.v;
+
+            // Check if already voted (locally)
+            const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+            const previousVote = localStorage.getItem(key);
+
+            if (previousVote === voteType) {
+                // Same vote - do nothing
+                btn.style.animation = 'shake 0.5s';
+                setTimeout(() => btn.style.animation = '', 500);
+                return;
+            }
+
+            // Build URL
+            const params = new URLSearchParams({
+                gene_id: container.dataset.g,
+                annotation_id: container.dataset.a,
+                ref_id: container.dataset.r || '',
+                action: container.dataset.act,
+                vote: voteType,
+                session_id: sessionId,
+                ua: navigator.userAgent.substring(0, 100)
+            });
+
+            // Clear previous vote styling
+            container.querySelectorAll('.vote-btn').forEach(b => {
+                b.classList.remove('voted', 'voted-down');
+            });
+
+            // Apply new vote styling immediately (optimistic UI)
+            btn.classList.add(voteType === 'up' ? 'voted' : 'voted-down');
+
+            // Store locally
+            localStorage.setItem(key, voteType);
+
+            // Send vote using fetch with no-cors mode (fire and forget)
+            const fullUrl = VOTE_URL + '?' + params;
+            console.log('Sending vote to:', fullUrl);
+
+            // Use fetch in no-cors mode - we won't get a response but the request will be sent
+            fetch(fullUrl, {
+                mode: 'no-cors',
+                method: 'GET'
+            }).then(() => {
+                console.log('Vote request sent (no response due to no-cors mode)');
+            }).catch(err => {
+                console.warn('Vote may not have been recorded, but saved locally:', err);
+
+                // Fallback: try image beacon as well
+                const img = new Image();
+                img.src = fullUrl;
+            });
+        });
+
+        // Optional: Add shake animation for feedback
+        const style = document.createElement('style');
+        style.textContent = `
+            @keyframes shake {
+                0%, 100% { transform: translateX(0); }
+                25% { transform: translateX(-5px); }
+                75% { transform: translateX(5px); }
+            }
+        `;
+        document.head.appendChild(style);
+    </script>
+</body>
+</html>

--- a/genes/ARATH/WRI1/WRI1-ai-review.html
+++ b/genes/ARATH/WRI1/WRI1-ai-review.html
@@ -1,0 +1,3778 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>WRI1 - AI Gene Review</title>
+    <style>
+        :root {
+            --color-accept: #22c55e;
+            --color-remove: #ef4444;
+            --color-modify: #f97316;
+            --color-keep-non-core: #3b82f6;
+            --color-undecided: #6b7280;
+            --color-new: #8b5cf6;
+            --color-mark-over: #eab308;
+            --bg-light: #f9fafb;
+            --border-color: #e5e7eb;
+            --text-muted: #6b7280;
+            --text-primary: #111827;
+        }
+
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+            line-height: 1.6;
+            color: var(--text-primary);
+            background-color: #ffffff;
+            padding: 2rem;
+            max-width: 1400px;
+            margin: 0 auto;
+        }
+
+        .header {
+            border-bottom: 2px solid var(--border-color);
+            padding-bottom: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        h1 {
+            font-size: 2.5rem;
+            font-weight: 700;
+            margin-bottom: 0.5rem;
+            color: #1f2937;
+        }
+
+        .gene-info {
+            display: flex;
+            gap: 2rem;
+            flex-wrap: wrap;
+            margin-top: 1rem;
+        }
+
+        .info-item {
+            display: flex;
+            gap: 0.5rem;
+        }
+
+        .info-label {
+            font-weight: 600;
+            color: var(--text-muted);
+        }
+
+        .aliases {
+            display: flex;
+            gap: 0.5rem;
+            flex-wrap: wrap;
+        }
+
+        .badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.875rem;
+            font-weight: 500;
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+        }
+
+        .status-badge {
+            padding: 0.375rem 0.875rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .status-initialized {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fde68a;
+        }
+
+        .status-in-progress {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+        }
+
+        .status-draft {
+            background-color: #fce7f3;
+            color: #831843;
+            border: 1px solid #fbcfe8;
+        }
+
+        .status-complete {
+            background-color: #d1fae5;
+            color: #065f46;
+            border: 1px solid #a7f3d0;
+        }
+
+        .description-card {
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        .description-card h2 {
+            font-size: 1.25rem;
+            margin-bottom: 1rem;
+            color: #374151;
+        }
+
+        .section {
+            margin-bottom: 2.5rem;
+        }
+
+        .section-title {
+            font-size: 1.5rem;
+            font-weight: 600;
+            margin-bottom: 1.5rem;
+            color: #1f2937;
+            border-bottom: 1px solid var(--border-color);
+            padding-bottom: 0.5rem;
+        }
+
+        .annotations-table {
+            width: 100%;
+            border-collapse: collapse;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            overflow: hidden;
+        }
+
+        .annotations-table thead {
+            background-color: var(--bg-light);
+        }
+
+        .annotations-table th {
+            text-align: left;
+            padding: 1rem;
+            font-weight: 600;
+            border-bottom: 2px solid var(--border-color);
+            font-size: 0.875rem;
+            text-transform: uppercase;
+            letter-spacing: 0.05em;
+            color: var(--text-muted);
+        }
+
+        .annotations-table td {
+            padding: 1rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .annotations-table tbody tr:hover {
+            background-color: #f9fafb;
+        }
+
+        .action-badge {
+            display: inline-block;
+            padding: 0.375rem 0.75rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .action-accept {
+            background-color: var(--color-accept);
+            color: white;
+        }
+
+        .action-remove {
+            background-color: var(--color-remove);
+            color: white;
+        }
+
+        .action-modify {
+            background-color: var(--color-modify);
+            color: white;
+        }
+
+        .action-keep_as_non_core {
+            background-color: var(--color-keep-non-core);
+            color: white;
+        }
+
+        .action-undecided {
+            background-color: var(--color-undecided);
+            color: white;
+        }
+
+        .action-new {
+            background-color: var(--color-new);
+            color: white;
+        }
+
+        .action-mark_as_over_annotated {
+            background-color: var(--color-mark-over);
+            color: white;
+        }
+
+        .term-info {
+            display: flex;
+            flex-direction: column;
+            gap: 0.25rem;
+        }
+
+        .term-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .term-label {
+            font-weight: 500;
+        }
+
+        .evidence-code {
+            font-family: monospace;
+            background-color: var(--bg-light);
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .not-badge {
+            display: inline-block;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-weight: 600;
+            margin-left: 0.25rem;
+        }
+
+        .isoform-badge {
+            display: inline-block;
+            background-color: #eff6ff;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            margin-top: 0.25rem;
+        }
+
+        .core-function-card {
+            background-color: white;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 1rem;
+        }
+
+        .core-function-card h3 {
+            font-size: 1.125rem;
+            margin-bottom: 1rem;
+            color: #1f2937;
+        }
+
+        .core-function-statement {
+            margin-bottom: 1rem;
+            padding: 0.75rem;
+            background-color: var(--bg-light);
+            border-left: 4px solid var(--color-accept);
+            border-radius: 0.25rem;
+        }
+
+        .function-annotations {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin-top: 1rem;
+        }
+
+        .reference-item {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+        }
+
+        .reference-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: start;
+            margin-bottom: 0.75rem;
+        }
+
+        .reference-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #2563eb;
+        }
+
+        .supported-by {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f3f4f6;
+            border-left: 3px solid #3b82f6;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .supported-by-title {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .support-item {
+            margin-bottom: 0.5rem;
+        }
+
+        .support-ref {
+            font-weight: 500;
+            color: #2563eb;
+        }
+
+        .support-text {
+            color: #6b7280;
+            font-style: italic;
+            margin-left: 1rem;
+        }
+
+        a.term-link {
+            color: #2563eb;
+            text-decoration: none;
+        }
+
+        a.term-link:hover {
+            text-decoration: underline;
+        }
+
+        .core-function-terms {
+            margin-top: 1rem;
+        }
+
+        .function-term-group {
+            margin-bottom: 1rem;
+        }
+
+        .function-term-label {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .reference-title {
+            font-weight: 500;
+            margin-bottom: 0.5rem;
+        }
+
+        .findings-list {
+            margin-top: 1rem;
+            padding-left: 1.5rem;
+        }
+
+        .finding-item {
+            margin-bottom: 0.75rem;
+        }
+
+        .finding-statement {
+            font-weight: 500;
+            margin-bottom: 0.25rem;
+        }
+
+        .finding-text {
+            color: var(--text-muted);
+            font-size: 0.95rem;
+            font-style: italic;
+        }
+
+        .proposed-term {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #fef3c7;
+        }
+
+        .question-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #dbeafe;
+        }
+
+        .experiment-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #f3e8ff;
+        }
+
+        .prediction-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: white;
+        }
+
+        .prediction-card .prediction-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+        }
+
+        .prediction-source {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+        }
+
+        .assessment-badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.8rem;
+            font-weight: 600;
+            text-transform: uppercase;
+        }
+
+        .assessment-cor { background-color: #dcfce7; color: #166534; }
+        .assessment-cnn { background-color: #dbeafe; color: #1e40af; }
+        .assessment-lsp { background-color: #fef9c3; color: #854d0e; }
+        .assessment-unc { background-color: #f3f4f6; color: #374151; }
+        .assessment-pli { background-color: #fee2e2; color: #991b1b; }
+        .assessment-npi { background-color: #fecaca; color: #7f1d1d; }
+        .assessment-rep { background-color: #fde68a; color: #92400e; }
+
+        .confidence-score {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+            margin-left: 0.5rem;
+        }
+
+        .error-type-badge {
+            font-size: 0.75rem;
+            padding: 0.125rem 0.5rem;
+            border-radius: 0.25rem;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+        }
+
+        .isoforms-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fill, minmax(400px, 1fr));
+            gap: 1rem;
+        }
+
+        .isoform-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            background-color: white;
+            transition: box-shadow 0.2s;
+        }
+
+        .isoform-card:hover {
+            box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+        }
+
+        .functional-isoform-type {
+            display: inline-block;
+            padding: 0.2rem 0.5rem;
+            border-radius: 0.25rem;
+            font-size: 0.7rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.03em;
+        }
+
+        .type-SPLICE_VARIANT, .type-SPLICE_CLASS {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #93c5fd;
+        }
+
+        .type-CLEAVAGE_PRODUCT {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fcd34d;
+        }
+
+        .type-MODIFICATION_STATE {
+            background-color: #f3e8ff;
+            color: #6b21a8;
+            border: 1px solid #c4b5fd;
+        }
+
+        .type-CONFORMATIONAL_STATE {
+            background-color: #dcfce7;
+            color: #166534;
+            border: 1px solid #86efac;
+        }
+
+        .functional-isoform-mappings {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+            font-size: 0.85rem;
+        }
+
+        .functional-isoform-mappings .mapping-type {
+            font-weight: 600;
+            color: var(--text-muted);
+            font-size: 0.75rem;
+        }
+
+        .functional-isoform-go {
+            margin-top: 0.5rem;
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.25rem;
+        }
+
+        .go-chip {
+            display: inline-block;
+            padding: 0.15rem 0.4rem;
+            background-color: #ecfdf5;
+            color: #047857;
+            border: 1px solid #a7f3d0;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-family: monospace;
+        }
+
+        .isoform-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+            padding-bottom: 0.5rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .isoform-name {
+            font-weight: 600;
+            font-size: 1.1rem;
+            color: #1f2937;
+        }
+
+        .isoform-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .isoform-sequence-note {
+            font-size: 0.875rem;
+            color: var(--text-muted);
+            margin-bottom: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+        }
+
+        .isoform-description {
+            font-size: 0.95rem;
+            line-height: 1.5;
+        }
+
+        .collapsible {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .collapsible:after {
+            content: ' ▼';
+            font-size: 0.75rem;
+        }
+
+        .collapsible.collapsed:after {
+            content: ' ►';
+        }
+
+        .collapse-content {
+            transition: max-height 0.3s ease;
+            overflow: hidden;
+        }
+
+        .collapsed + .collapse-content {
+            max-height: 0;
+        }
+
+        .no-data {
+            color: var(--text-muted);
+            font-style: italic;
+            padding: 1rem;
+            text-align: center;
+            background-color: var(--bg-light);
+            border-radius: 0.5rem;
+        }
+
+        /* Styling for markdown section summaries with voting */
+        .markdown-section summary {
+            padding: 0.75rem;
+            background: var(--bg-light);
+            border-radius: 0.5rem;
+            margin-bottom: 0.5rem;
+        }
+
+        .markdown-section summary:hover {
+            background: #e5e7eb;
+        }
+
+        .markdown-section summary .vote-buttons {
+            margin-left: auto;
+        }
+
+        .deep-research-section {
+            margin-bottom: 1rem;
+            border: 1px solid #c7d2fe;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8faff;
+        }
+
+        .deep-research-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .deep-research-section summary h3 {
+            margin: 0;
+            color: #3730a3;
+            font-size: 1.1rem;
+        }
+
+        .report-meta {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin: 0.75rem 0 1rem;
+            align-items: center;
+        }
+
+        .report-badge {
+            display: inline-flex;
+            align-items: center;
+            border: 1px solid #c7d2fe;
+            border-radius: 999px;
+            background: #eef2ff;
+            color: #4338ca;
+            font-size: 0.78rem;
+            font-weight: 600;
+            padding: 0.2rem 0.6rem;
+        }
+
+        .report-meta-text {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+        }
+
+        .artifact-list {
+            display: grid;
+            gap: 0.75rem;
+            margin: 0.75rem 0 1rem;
+        }
+
+        .artifact-link {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+            margin-top: 0.5rem;
+            word-break: break-word;
+        }
+
+        @media print {
+            body {
+                padding: 1rem;
+            }
+
+            .collapsible:after {
+                display: none;
+            }
+
+            .collapsed + .collapse-content {
+                max-height: none !important;
+            }
+        }
+
+        @media (max-width: 768px) {
+            body {
+                padding: 1rem;
+            }
+
+            h1 {
+                font-size: 2rem;
+            }
+
+            .annotations-table {
+                font-size: 0.875rem;
+            }
+
+            .annotations-table th,
+            .annotations-table td {
+                padding: 0.5rem;
+            }
+        }
+    </style>
+</head>
+<body>
+    <div class="header">
+        <h1>WRI1</h1>
+        <div class="gene-info">
+            
+            <div class="info-item">
+                
+                <span class="info-label">UniProt ID:</span>
+                <span>
+                    <a href="https://www.uniprot.org/uniprotkb/Q6X5Y6" target="_blank" class="term-link">
+                        Q6X5Y6
+                    </a>
+                </span>
+                
+            </div>
+            
+            
+            <div class="info-item">
+                <span class="info-label">Organism:</span>
+                <span>Arabidopsis thaliana</span>
+            </div>
+            
+            
+            <div class="info-item">
+                <span class="info-label">Review Status:</span>
+                <span class="status-badge status-complete">
+                    COMPLETE
+                </span>
+            </div>
+            
+            
+        </div>
+        <div style="margin-top: 1rem; text-align: center;">
+            <a id="feedback-form-link"
+               href="#"
+               target="_blank"
+               style="display: inline-block; padding: 10px 20px; background-color: #4CAF50; color: white; text-decoration: none; border-radius: 5px; font-weight: 600;">
+                📝 Provide Detailed Feedback
+            </a>
+            <script>
+                // Construct the form URL with proper encoding
+                // Extract organism code from the current page path (e.g., /genes/ARATH/APO1/ -> ARATH)
+                const pathParts = window.location.pathname.split('/');
+                const genesIndex = pathParts.indexOf('genes');
+                let organism = '';
+                if (genesIndex !== -1 && pathParts[genesIndex + 1]) {
+                    organism = pathParts[genesIndex + 1].toUpperCase();
+                }
+                const geneSymbol = "WRI1";
+                const speciesGene = organism + ' ' + geneSymbol;
+                const formBaseUrl = 'https://docs.google.com/forms/d/e/1FAIpQLSdTot9L6GVkkZYgLQT0E8ZdAJv8RiN5ZgOVkgWNcKSbYvxxzQ/viewform';
+                const entryId = '1226477767'; // Correct entry ID for Species/Gene field
+                const formUrl = formBaseUrl + '?entry.' + entryId + '=' + encodeURIComponent(speciesGene);
+                const feedbackLink = document.getElementById('feedback-form-link');
+                feedbackLink.href = formUrl;
+                // Add tooltip showing the pre-filled value
+                feedbackLink.title = 'Opens form with pre-filled: ' + speciesGene;
+            </script>
+        </div>
+    </div>
+
+    
+    <div class="description-card">
+        <div style="display: flex; justify-content: space-between; align-items: center;">
+            <h2>Gene Description</h2>
+            <span class="vote-buttons" data-g="Q6X5Y6" data-a="DESCRIPTION: WRINKLED1 (WRI1; ASML1) is an AP2/EREB-family tran..." data-r="" data-act="DESCRIPTION">
+                <button class="vote-btn" data-v="up" title="Agree with this description">👍</button>
+                <button class="vote-btn" data-v="down" title="Disagree with this description">👎</button>
+            </span>
+        </div>
+        <p>WRINKLED1 (WRI1; ASML1) is an AP2/EREB-family transcription factor of Arabidopsis with two tandem AP2 DNA-binding domains and a nuclear localization signal. It is the master positive regulator of seed oil biosynthesis. In the nucleus it binds the AW-box cis-element in target promoters and transcriptionally activates suites of late glycolytic and fatty acid biosynthetic genes, thereby directing carbon flux toward fatty acid synthesis and downstream triacylglycerol accumulation. Loss of WRI1 reduces seed oil by roughly 80% (the wrinkled-seed phenotype), and its activity is integrated with sugar status through SnRK1/KIN10-dependent regulation and additional modulators (14-3-3 proteins, bZIP52) within the LEC1/LEC2/FUS3 seed-maturation network.</p>
+    </div>
+    
+
+    
+
+    
+
+    
+    <div class="section">
+        <h2 class="section-title">Existing Annotations Review</h2>
+        <table class="annotations-table">
+            <thead>
+                <tr>
+                    <th>GO Term</th>
+                    <th>Evidence</th>
+                    <th>Action</th>
+                    <th>Reason</th>
+                </tr>
+            </thead>
+            <tbody>
+                
+                <tr>
+                    <td>
+                        <div class="term-info">
+                            
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006355" target="_blank" class="term-link">
+                                    GO:0006355
+                                </a>
+                            </span>
+                            <span class="term-label">regulation of DNA-templated transcription</span>
+                            
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+                        
+                        
+                        
+                        <br>
+                        <span style="font-size: 0.75rem;">
+                            
+                            GO_REF:0000033
+                            
+                        </span>
+                        
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q6X5Y6" data-a="GO:0006355" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+                        
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Correct core biological process. WRI1 is a transcription factor that regulates transcription of its target genes; supported experimentally below.
+                        </div>
+                        
+                        
+                        
+                        
+                    </td>
+                </tr>
+                
+                <tr>
+                    <td>
+                        <div class="term-info">
+                            
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0003677" target="_blank" class="term-link">
+                                    GO:0003677
+                                </a>
+                            </span>
+                            <span class="term-label">DNA binding</span>
+                            
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+                        
+                        
+                        
+                        <br>
+                        <span style="font-size: 0.75rem;">
+                            
+                            GO_REF:0000120
+                            
+                        </span>
+                        
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q6X5Y6" data-a="GO:0003677" data-r="GO_REF:0000120" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+                        
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Correct core molecular function, also experimentally supported (IDA below). WRI1 binds the AW-box promoter element via its AP2 domains.
+                        </div>
+                        
+                        
+                        
+                        
+                    </td>
+                </tr>
+                
+                <tr>
+                    <td>
+                        <div class="term-info">
+                            
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0003700" target="_blank" class="term-link">
+                                    GO:0003700
+                                </a>
+                            </span>
+                            <span class="term-label">DNA-binding transcription factor activity</span>
+                            
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+                        
+                        
+                        
+                        <br>
+                        <span style="font-size: 0.75rem;">
+                            
+                            GO_REF:0000002
+                            
+                        </span>
+                        
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q6X5Y6" data-a="GO:0003700" data-r="GO_REF:0000002" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+                        
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Correct core molecular function. WRI1 is a sequence-specific DNA-binding transcriptional activator; supported by ISS from family analysis below.
+                        </div>
+                        
+                        
+                        
+                        
+                    </td>
+                </tr>
+                
+                <tr>
+                    <td>
+                        <div class="term-info">
+                            
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005634" target="_blank" class="term-link">
+                                    GO:0005634
+                                </a>
+                            </span>
+                            <span class="term-label">nucleus</span>
+                            
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+                        
+                        
+                        
+                        <br>
+                        <span style="font-size: 0.75rem;">
+                            
+                            GO_REF:0000044
+                            
+                        </span>
+                        
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q6X5Y6" data-a="GO:0005634" data-r="GO_REF:0000044" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+                        
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Correct core localization. WRI1 has a nuclear localization signal and acts as a nuclear transcription factor.
+                        </div>
+                        
+                        
+                        
+                        
+                    </td>
+                </tr>
+                
+                <tr>
+                    <td>
+                        <div class="term-info">
+                            
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006355" target="_blank" class="term-link">
+                                    GO:0006355
+                                </a>
+                            </span>
+                            <span class="term-label">regulation of DNA-templated transcription</span>
+                            
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+                        
+                        
+                        
+                        <br>
+                        <span style="font-size: 0.75rem;">
+                            
+                            GO_REF:0000002
+                            
+                        </span>
+                        
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q6X5Y6" data-a="GO:0006355" data-r="GO_REF:0000002" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+                        
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Correct core biological process, consistent with the IBA annotation and WRI1&#39;s transcriptional-activator role.
+                        </div>
+                        
+                        
+                        
+                        
+                    </td>
+                </tr>
+                
+                <tr>
+                    <td>
+                        <div class="term-info">
+                            
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005634" target="_blank" class="term-link">
+                                    GO:0005634
+                                </a>
+                            </span>
+                            <span class="term-label">nucleus</span>
+                            
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">ISM</span>
+                        
+                        
+                        
+                        <br>
+                        <span style="font-size: 0.75rem;">
+                            
+                            GO_REF:0000122
+                            
+                        </span>
+                        
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q6X5Y6" data-a="GO:0005634" data-r="GO_REF:0000122" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+                        
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Computational (AtSubP) prediction that is, in this case, correct and corroborated by curator inference (IC) and the protein&#39;s nuclear localization signal. Accepted as the core localization.
+                        </div>
+                        
+                        
+                        
+                        
+                    </td>
+                </tr>
+                
+                <tr>
+                    <td>
+                        <div class="term-info">
+                            
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0019900" target="_blank" class="term-link">
+                                    GO:0019900
+                                </a>
+                            </span>
+                            <span class="term-label">kinase binding</span>
+                            
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+                        
+                        
+                        
+                        <br>
+                        <span style="font-size: 0.75rem;">
+                            
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/28314829" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:28314829
+                            </a>
+                            
+                                
+                                
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Phosphorylation of WRINKLED1 by KIN10 Results in Its Proteas...
+                                </span>
+                                
+                            
+                            
+                        </span>
+                        
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="Q6X5Y6" data-a="GO:0019900" data-r="PMID:28314829" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+                        
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Reflects the regulatory interaction with the SnRK1/KIN10 kinase, which controls WRI1 protein stability in response to sugar status. A genuine regulatory interaction but not the core transcription-factor function; retained as non-core. [PMID:28314829]
+                        </div>
+                        
+                        
+                        
+                        
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+                            
+                            <div class="support-item">
+                                <span class="support-ref">
+                                    
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/28314829" target="_blank" class="term-link">
+                                        PMID:28314829
+                                    </a>
+                                    
+                                </span>
+                                
+                                <div class="support-text">WRI1 interacts with the SnRK1 kinase (KIN10) that regulates its stability</div>
+                                
+                            </div>
+                            
+                        </div>
+                        
+                    </td>
+                </tr>
+                
+                <tr>
+                    <td>
+                        <div class="term-info">
+                            
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0019432" target="_blank" class="term-link">
+                                    GO:0019432
+                                </a>
+                            </span>
+                            <span class="term-label">triglyceride biosynthetic process</span>
+                            
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IMP</span>
+                        
+                        
+                        
+                        <br>
+                        <span style="font-size: 0.75rem;">
+                            
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/23922666" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:23922666
+                            </a>
+                            
+                                
+                                
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Wrinkled1, a ubiquitous regulator in oil accumulating tissue...
+                                </span>
+                                
+                            
+                            
+                        </span>
+                        
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q6X5Y6" data-a="GO:0019432" data-r="PMID:23922666" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+                        
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Core biological process (as an upstream regulator). WRI1 drives the transcriptional program for oil (TAG) accumulation; it is a ubiquitous regulator of oil-accumulating tissues. [PMID:23922666]
+                        </div>
+                        
+                        
+                        
+                        
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+                            
+                            <div class="support-item">
+                                <span class="support-ref">
+                                    
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/23922666" target="_blank" class="term-link">
+                                        PMID:23922666
+                                    </a>
+                                    
+                                </span>
+                                
+                                <div class="support-text">WRINKLED1, a ubiquitous regulator in oil-accumulating tissues from Arabidopsis embryos to oil palm mesocarp</div>
+                                
+                            </div>
+                            
+                        </div>
+                        
+                    </td>
+                </tr>
+                
+                <tr>
+                    <td>
+                        <div class="term-info">
+                            
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:1901959" target="_blank" class="term-link">
+                                    GO:1901959
+                                </a>
+                            </span>
+                            <span class="term-label">positive regulation of cutin biosynthetic process</span>
+                            
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IGI</span>
+                        
+                        
+                        
+                        <br>
+                        <span style="font-size: 0.75rem;">
+                            
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/23243127" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:23243127
+                            </a>
+                            
+                                
+                                
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    WRINKLED transcription factors orchestrate tissue-specific r...
+                                </span>
+                                
+                            
+                            
+                        </span>
+                        
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="Q6X5Y6" data-a="GO:1901959" data-r="PMID:23243127" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+                        
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> A tissue-specific secondary regulatory role of the WRI1 clade in fatty acid/cutin biosynthesis, distinct from the central seed-oil program. Retained as non-core. [PMID:23243127]
+                        </div>
+                        
+                        
+                        
+                        
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+                            
+                            <div class="support-item">
+                                <span class="support-ref">
+                                    
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/23243127" target="_blank" class="term-link">
+                                        PMID:23243127
+                                    </a>
+                                    
+                                </span>
+                                
+                                <div class="support-text">WRINKLED transcription factors orchestrate tissue-specific regulation of fatty acid biosynthesis</div>
+                                
+                            </div>
+                            
+                        </div>
+                        
+                    </td>
+                </tr>
+                
+                <tr>
+                    <td>
+                        <div class="term-info">
+                            
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0003677" target="_blank" class="term-link">
+                                    GO:0003677
+                                </a>
+                            </span>
+                            <span class="term-label">DNA binding</span>
+                            
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+                        
+                        
+                        
+                        <br>
+                        <span style="font-size: 0.75rem;">
+                            
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/19719479" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:19719479
+                            </a>
+                            
+                                
+                                
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Role of WRINKLED1 in the transcriptional regulation of glyco...
+                                </span>
+                                
+                            
+                            
+                        </span>
+                        
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q6X5Y6" data-a="GO:0003677" data-r="PMID:19719479" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+                        
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Core molecular function with direct experimental support. WRI1 directly binds promoters of glycolytic and fatty acid biosynthetic genes (AW-box). [PMID:19719479]
+                        </div>
+                        
+                        
+                        
+                        
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+                            
+                            <div class="support-item">
+                                <span class="support-ref">
+                                    
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/19719479" target="_blank" class="term-link">
+                                        PMID:19719479
+                                    </a>
+                                    
+                                </span>
+                                
+                                <div class="support-text">Role of WRINKLED1 in the transcriptional regulation of glycolytic and fatty acid biosynthetic genes</div>
+                                
+                            </div>
+                            
+                        </div>
+                        
+                    </td>
+                </tr>
+                
+                <tr>
+                    <td>
+                        <div class="term-info">
+                            
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006629" target="_blank" class="term-link">
+                                    GO:0006629
+                                </a>
+                            </span>
+                            <span class="term-label">lipid metabolic process</span>
+                            
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IMP</span>
+                        
+                        
+                        
+                        <br>
+                        <span style="font-size: 0.75rem;">
+                            
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/19755540" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:19755540
+                            </a>
+                            
+                                
+                                
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Analysis of metabolic flux phenotypes for two Arabidopsis mu...
+                                </span>
+                                
+                            
+                            
+                        </span>
+                        
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q6X5Y6" data-a="GO:0006629" data-r="PMID:19755540" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+                        
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Correct but general. WRI1 mutants show severe impairment of seed storage lipid synthesis; the specific role is regulation of lipid/fatty acid biosynthesis captured by more specific terms. [PMID:19755540]
+                        </div>
+                        
+                        
+                        
+                        
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+                            
+                            <div class="support-item">
+                                <span class="support-ref">
+                                    
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/19755540" target="_blank" class="term-link">
+                                        PMID:19755540
+                                    </a>
+                                    
+                                </span>
+                                
+                                <div class="support-text">severe impairment in seed storage lipid synthesis in wri1</div>
+                                
+                            </div>
+                            
+                        </div>
+                        
+                    </td>
+                </tr>
+                
+                <tr>
+                    <td>
+                        <div class="term-info">
+                            
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0003700" target="_blank" class="term-link">
+                                    GO:0003700
+                                </a>
+                            </span>
+                            <span class="term-label">DNA-binding transcription factor activity</span>
+                            
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">ISS</span>
+                        
+                        
+                        
+                        <br>
+                        <span style="font-size: 0.75rem;">
+                            
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/15500472" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:15500472
+                            </a>
+                            
+                                
+                                
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    WRINKLED1 encodes an AP2/EREB domain protein involved in the...
+                                </span>
+                                
+                            
+                            
+                        </span>
+                        
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q6X5Y6" data-a="GO:0003700" data-r="PMID:15500472" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+                        
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Core molecular function. WRI1 was identified as an AP2/EREB-domain transcription factor controlling storage-compound biosynthesis. [PMID:15500472]
+                        </div>
+                        
+                        
+                        
+                        
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+                            
+                            <div class="support-item">
+                                <span class="support-ref">
+                                    
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/15500472" target="_blank" class="term-link">
+                                        PMID:15500472
+                                    </a>
+                                    
+                                </span>
+                                
+                                <div class="support-text">WRINKLED1 encodes an AP2/EREB domain protein involved in the control of storage compound biosynthesis</div>
+                                
+                            </div>
+                            
+                        </div>
+                        
+                    </td>
+                </tr>
+                
+                <tr>
+                    <td>
+                        <div class="term-info">
+                            
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006109" target="_blank" class="term-link">
+                                    GO:0006109
+                                </a>
+                            </span>
+                            <span class="term-label">regulation of carbohydrate metabolic process</span>
+                            
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IMP</span>
+                        
+                        
+                        
+                        <br>
+                        <span style="font-size: 0.75rem;">
+                            
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/9733529" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:9733529
+                            </a>
+                            
+                                
+                                
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    wrinkled1: A novel, low-seed-oil mutant of Arabidopsis with ...
+                                </span>
+                                
+                            
+                            
+                        </span>
+                        
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q6X5Y6" data-a="GO:0006109" data-r="PMID:9733529" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+                        
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Core regulatory role. The original wri1 mutant showed disrupted carbohydrate metabolism in developing seeds, reflecting WRI1&#39;s control of the glycolytic program that supplies precursors for oil synthesis. [PMID:9733529]
+                        </div>
+                        
+                        
+                        
+                        
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+                            
+                            <div class="support-item">
+                                <span class="support-ref">
+                                    
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/9733529" target="_blank" class="term-link">
+                                        PMID:9733529
+                                    </a>
+                                    
+                                </span>
+                                
+                                <div class="support-text">the wrinkled1 mutant is impaired in seed carbohydrate-to-oil metabolism</div>
+                                
+                            </div>
+                            
+                        </div>
+                        
+                    </td>
+                </tr>
+                
+                <tr>
+                    <td>
+                        <div class="term-info">
+                            
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006110" target="_blank" class="term-link">
+                                    GO:0006110
+                                </a>
+                            </span>
+                            <span class="term-label">regulation of glycolytic process</span>
+                            
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IMP</span>
+                        
+                        
+                        
+                        <br>
+                        <span style="font-size: 0.75rem;">
+                            
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/16553903" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:16553903
+                            </a>
+                            
+                                
+                                
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    A spatiotemporal analysis of enzymatic activities associated...
+                                </span>
+                                
+                            
+                            
+                        </span>
+                        
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q6X5Y6" data-a="GO:0006110" data-r="PMID:16553903" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+                        
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Core biological process. WRI1 activates late-glycolytic genes to channel carbon toward acetyl-CoA for fatty acid synthesis; the wri1 embryo shows altered carbon-metabolism enzyme activities. [PMID:16553903]
+                        </div>
+                        
+                        
+                        
+                        
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+                            
+                            <div class="support-item">
+                                <span class="support-ref">
+                                    
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/16553903" target="_blank" class="term-link">
+                                        PMID:16553903
+                                    </a>
+                                    
+                                </span>
+                                
+                                <div class="support-text">spatiotemporal analysis of carbon-metabolism enzyme activities in wild-type and wri1 mutant embryos</div>
+                                
+                            </div>
+                            
+                        </div>
+                        
+                    </td>
+                </tr>
+                
+                <tr>
+                    <td>
+                        <div class="term-info">
+                            
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0008610" target="_blank" class="term-link">
+                                    GO:0008610
+                                </a>
+                            </span>
+                            <span class="term-label">lipid biosynthetic process</span>
+                            
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IMP</span>
+                        
+                        
+                        
+                        <br>
+                        <span style="font-size: 0.75rem;">
+                            
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/9733529" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:9733529
+                            </a>
+                            
+                                
+                                
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    wrinkled1: A novel, low-seed-oil mutant of Arabidopsis with ...
+                                </span>
+                                
+                            
+                            
+                        </span>
+                        
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q6X5Y6" data-a="GO:0008610" data-r="PMID:9733529" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+                        
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Core biological process. WRI1 is required for seed lipid (oil) biosynthesis; the wri1 mutant has strongly reduced seed oil. [PMID:9733529]
+                        </div>
+                        
+                        
+                        
+                        
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+                            
+                            <div class="support-item">
+                                <span class="support-ref">
+                                    
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/9733529" target="_blank" class="term-link">
+                                        PMID:9733529
+                                    </a>
+                                    
+                                </span>
+                                
+                                <div class="support-text">the wrinkled1 mutant has reduced seed oil/lipid biosynthesis</div>
+                                
+                            </div>
+                            
+                        </div>
+                        
+                    </td>
+                </tr>
+                
+                <tr>
+                    <td>
+                        <div class="term-info">
+                            
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0009744" target="_blank" class="term-link">
+                                    GO:0009744
+                                </a>
+                            </span>
+                            <span class="term-label">response to sucrose</span>
+                            
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEP</span>
+                        
+                        
+                        
+                        <br>
+                        <span style="font-size: 0.75rem;">
+                            
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/15753106" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:15753106
+                            </a>
+                            
+                                
+                                
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    ACTIVATOR of Spomin::LUC1/WRINKLED1 of Arabidopsis thaliana ...
+                                </span>
+                                
+                            
+                            
+                        </span>
+                        
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="Q6X5Y6" data-a="GO:0009744" data-r="PMID:15753106" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+                        
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> WRI1 transactivates sugar-inducible promoters and its activity is linked to sugar status, but this expression-based association is non-core relative to its transcription-factor function. Retained as non-core. [PMID:15753106]
+                        </div>
+                        
+                        
+                        
+                        
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+                            
+                            <div class="support-item">
+                                <span class="support-ref">
+                                    
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/15753106" target="_blank" class="term-link">
+                                        PMID:15753106
+                                    </a>
+                                    
+                                </span>
+                                
+                                <div class="support-text">ACTIVATOR of Spomin::LUC1/WRINKLED1 transactivates sugar-inducible promoters</div>
+                                
+                            </div>
+                            
+                        </div>
+                        
+                    </td>
+                </tr>
+                
+                <tr>
+                    <td>
+                        <div class="term-info">
+                            
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0019432" target="_blank" class="term-link">
+                                    GO:0019432
+                                </a>
+                            </span>
+                            <span class="term-label">triglyceride biosynthetic process</span>
+                            
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IMP</span>
+                        
+                        
+                        
+                        <br>
+                        <span style="font-size: 0.75rem;">
+                            
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/15500472" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:15500472
+                            </a>
+                            
+                                
+                                
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    WRINKLED1 encodes an AP2/EREB domain protein involved in the...
+                                </span>
+                                
+                            
+                            
+                        </span>
+                        
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q6X5Y6" data-a="GO:0019432" data-r="PMID:15500472" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+                        
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Core biological process (as upstream regulator). WRI1 controls storage-oil (TAG) biosynthesis; the wri1 mutant has the low-oil wrinkled-seed phenotype. [PMID:15500472]
+                        </div>
+                        
+                        
+                        
+                        
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+                            
+                            <div class="support-item">
+                                <span class="support-ref">
+                                    
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/15500472" target="_blank" class="term-link">
+                                        PMID:15500472
+                                    </a>
+                                    
+                                </span>
+                                
+                                <div class="support-text">WRINKLED1 controls storage compound (oil) biosynthesis in seeds</div>
+                                
+                            </div>
+                            
+                        </div>
+                        
+                    </td>
+                </tr>
+                
+                <tr>
+                    <td>
+                        <div class="term-info">
+                            
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0003700" target="_blank" class="term-link">
+                                    GO:0003700
+                                </a>
+                            </span>
+                            <span class="term-label">DNA-binding transcription factor activity</span>
+                            
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">ISS</span>
+                        
+                        
+                        
+                        <br>
+                        <span style="font-size: 0.75rem;">
+                            
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/11118137" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:11118137
+                            </a>
+                            
+                                
+                                
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Arabidopsis transcription factors: genome-wide comparative a...
+                                </span>
+                                
+                            
+                            
+                        </span>
+                        
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q6X5Y6" data-a="GO:0003700" data-r="PMID:11118137" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+                        
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Core molecular function (sequence/family support). WRI1 is classified as a DNA-binding transcription factor in genome-wide TF analyses. [PMID:11118137]
+                        </div>
+                        
+                        
+                        
+                        
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+                            
+                            <div class="support-item">
+                                <span class="support-ref">
+                                    
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/11118137" target="_blank" class="term-link">
+                                        PMID:11118137
+                                    </a>
+                                    
+                                </span>
+                                
+                                <div class="support-text">classification of Arabidopsis AP2/EREB transcription factors</div>
+                                
+                            </div>
+                            
+                        </div>
+                        
+                    </td>
+                </tr>
+                
+                <tr>
+                    <td>
+                        <div class="term-info">
+                            
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005634" target="_blank" class="term-link">
+                                    GO:0005634
+                                </a>
+                            </span>
+                            <span class="term-label">nucleus</span>
+                            
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IC</span>
+                        
+                        
+                        
+                        <br>
+                        <span style="font-size: 0.75rem;">
+                            
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/10948255" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:10948255
+                            </a>
+                            
+                                
+                                
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    AINTEGUMENTA promotes petal identity and acts as a negative ...
+                                </span>
+                                
+                            
+                            
+                        </span>
+                        
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q6X5Y6" data-a="GO:0005634" data-r="PMID:10948255" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+                        
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Core localization, inferred by the curator (IC). WRI1 is a nuclear AP2 transcription factor with a nuclear localization signal; the cited paper concerns the related AP2 factor AINTEGUMENTA and is used as family-analogy support for nuclear localization. Accepted, as nuclear localization is well established for WRI1&#39;s function. [PMID:10948255]
+                        </div>
+                        
+                        
+                        
+                        
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+                            
+                            <div class="support-item">
+                                <span class="support-ref">
+                                    
+                                    file:ARATH/WRI1/WRI1-deep-research-falcon.md
+                                    
+                                </span>
+                                
+                                <div class="support-text">WRI1 is a nuclear transcription factor with a nuclear localization signal</div>
+                                
+                            </div>
+                            
+                        </div>
+                        
+                    </td>
+                </tr>
+                
+            </tbody>
+        </table>
+    </div>
+    
+
+    
+    <div class="section">
+        <h2 class="section-title">Core Functions</h2>
+        
+        <div class="core-function-card">
+            
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+                <h3>WRI1 is a nuclear AP2/EREB transcription factor that binds the AW-box cis-element and activates late-glycolytic and fatty acid biosynthetic genes, acting as the master regulator that directs carbon flux into seed oil (triacylglycerol) biosynthesis.</h3>
+                <span class="vote-buttons" data-g="Q6X5Y6" data-a="FUNCTION: WRI1 is a nuclear AP2/EREB transcription factor th..." data-r="" data-act="CORE_FUNCTION">
+                    <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
+                    <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
+                </span>
+            </div>
+            
+
+            <div class="core-function-terms">
+                
+                <div class="function-term-group">
+                    <div class="function-term-label">Molecular Function:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0003700" target="_blank" class="term-link">
+                            DNA-binding transcription factor activity
+                        </a>
+                    </span>
+                </div>
+                
+
+                
+                <div class="function-term-group">
+                    <div class="function-term-label">Directly Involved In:</div>
+                    <div class="function-annotations">
+                        
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006110" target="_blank" class="term-link">
+                                regulation of glycolytic process
+                            </a>
+                        </span>
+                        
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0008610" target="_blank" class="term-link">
+                                lipid biosynthetic process
+                            </a>
+                        </span>
+                        
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0019432" target="_blank" class="term-link">
+                                triglyceride biosynthetic process
+                            </a>
+                        </span>
+                        
+                    </div>
+                </div>
+                
+
+                
+                <div class="function-term-group">
+                    <div class="function-term-label">Cellular Locations:</div>
+                    <div class="function-annotations">
+                        
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005634" target="_blank" class="term-link">
+                                nucleus
+                            </a>
+                        </span>
+                        
+                    </div>
+                </div>
+                
+
+                
+
+                
+            </div>
+
+            
+            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
+                <strong>Supporting Evidence:</strong>
+                <ul class="findings-list">
+                    
+                    <li class="finding-item">
+                        <span class="reference-id">
+                            
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/15500472" target="_blank" class="term-link">
+                                PMID:15500472
+                            </a>
+                            
+                        </span>
+                        
+                        <div class="finding-text">WRINKLED1 encodes an AP2/EREB domain protein controlling storage compound biosynthesis</div>
+                        
+                    </li>
+                    
+                    <li class="finding-item">
+                        <span class="reference-id">
+                            
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/19719479" target="_blank" class="term-link">
+                                PMID:19719479
+                            </a>
+                            
+                        </span>
+                        
+                        <div class="finding-text">WRI1 transcriptionally regulates glycolytic and fatty acid biosynthetic genes via direct DNA binding</div>
+                        
+                    </li>
+                    
+                    <li class="finding-item">
+                        <span class="reference-id">
+                            
+                            file:ARATH/WRI1/WRI1-deep-research-falcon.md
+                            
+                        </span>
+                        
+                        <div class="finding-text">master positive regulator of seed oil biosynthesis; wri1 mutants show ~80% lower seed oil</div>
+                        
+                    </li>
+                    
+                </ul>
+            </div>
+            
+        </div>
+        
+    </div>
+    
+
+    
+    <div class="section">
+        <h2 class="section-title collapsible">References</h2>
+        <div class="collapse-content">
+            
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+                        
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000002.md" target="_blank" class="term-link">
+                            GO_REF:0000002
+                        </a>
+                        
+                    </span>
+                </div>
+                
+                <div class="reference-title">Gene Ontology annotation through association of InterPro records with GO terms</div>
+                
+                
+            </div>
+            
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+                        
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000033.md" target="_blank" class="term-link">
+                            GO_REF:0000033
+                        </a>
+                        
+                    </span>
+                </div>
+                
+                <div class="reference-title">Annotation inferences using phylogenetic trees</div>
+                
+                
+            </div>
+            
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+                        
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000044.md" target="_blank" class="term-link">
+                            GO_REF:0000044
+                        </a>
+                        
+                    </span>
+                </div>
+                
+                <div class="reference-title">Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location vocabulary mapping, accompanied by conservative changes to GO terms applied by UniProt</div>
+                
+                
+            </div>
+            
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+                        
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000120.md" target="_blank" class="term-link">
+                            GO_REF:0000120
+                        </a>
+                        
+                    </span>
+                </div>
+                
+                <div class="reference-title">Combined Automated Annotation using Multiple IEA Methods</div>
+                
+                
+            </div>
+            
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+                        
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000122.md" target="_blank" class="term-link">
+                            GO_REF:0000122
+                        </a>
+                        
+                    </span>
+                </div>
+                
+                <div class="reference-title">AtSubP analysis</div>
+                
+                
+            </div>
+            
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+                        
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/10948255" target="_blank" class="term-link">
+                            PMID:10948255
+                        </a>
+                        
+                    </span>
+                </div>
+                
+                <div class="reference-title">AINTEGUMENTA promotes petal identity and acts as a negative regulator of AGAMOUS.</div>
+                
+                
+                <ul class="findings-list">
+                    
+                    <li class="finding-item">
+                        <div class="finding-statement">Characterizes the AP2 transcription factor AINTEGUMENTA; used as family-analogy (IC) support for nuclear localization of AP2 factors such as WRI1.</div>
+                        
+                    </li>
+                    
+                </ul>
+                
+            </div>
+            
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+                        
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/11118137" target="_blank" class="term-link">
+                            PMID:11118137
+                        </a>
+                        
+                    </span>
+                </div>
+                
+                <div class="reference-title">Arabidopsis transcription factors: genome-wide comparative analysis among eukaryotes.</div>
+                
+                
+                <ul class="findings-list">
+                    
+                    <li class="finding-item">
+                        <div class="finding-statement">Genome-wide TF classification placing WRI1 among AP2/EREB DNA-binding transcription factors.</div>
+                        
+                    </li>
+                    
+                </ul>
+                
+            </div>
+            
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+                        
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/15500472" target="_blank" class="term-link">
+                            PMID:15500472
+                        </a>
+                        
+                    </span>
+                </div>
+                
+                <div class="reference-title">WRINKLED1 encodes an AP2/EREB domain protein involved in the control of storage compound biosynthesis in Arabidopsis.</div>
+                
+                
+                <ul class="findings-list">
+                    
+                    <li class="finding-item">
+                        <div class="finding-statement">Identifies WRI1 as an AP2/EREB transcription factor controlling seed storage compound (oil) biosynthesis.</div>
+                        
+                    </li>
+                    
+                </ul>
+                
+            </div>
+            
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+                        
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/15753106" target="_blank" class="term-link">
+                            PMID:15753106
+                        </a>
+                        
+                    </span>
+                </div>
+                
+                <div class="reference-title">ACTIVATOR of Spomin::LUC1/WRINKLED1 of Arabidopsis thaliana transactivates sugar-inducible promoters.</div>
+                
+                
+                <ul class="findings-list">
+                    
+                    <li class="finding-item">
+                        <div class="finding-statement">WRI1 transactivates sugar-inducible promoters, linking it to sugar signaling.</div>
+                        
+                    </li>
+                    
+                </ul>
+                
+            </div>
+            
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+                        
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/16553903" target="_blank" class="term-link">
+                            PMID:16553903
+                        </a>
+                        
+                    </span>
+                </div>
+                
+                <div class="reference-title">A spatiotemporal analysis of enzymatic activities associated with carbon metabolism in wild-type and mutant embryos of Arabidopsis using in situ histochemistry.</div>
+                
+                
+                <ul class="findings-list">
+                    
+                    <li class="finding-item">
+                        <div class="finding-statement">wri1 embryos show altered carbon-metabolism enzyme activities, consistent with WRI1 control of the glycolytic program feeding oil synthesis.</div>
+                        
+                    </li>
+                    
+                </ul>
+                
+            </div>
+            
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+                        
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/19719479" target="_blank" class="term-link">
+                            PMID:19719479
+                        </a>
+                        
+                    </span>
+                </div>
+                
+                <div class="reference-title">Role of WRINKLED1 in the transcriptional regulation of glycolytic and fatty acid biosynthetic genes in Arabidopsis.</div>
+                
+                
+                <ul class="findings-list">
+                    
+                    <li class="finding-item">
+                        <div class="finding-statement">WRI1 directly binds and activates promoters of glycolytic and fatty acid biosynthetic genes (AW-box), establishing direct DNA binding.</div>
+                        
+                    </li>
+                    
+                </ul>
+                
+            </div>
+            
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+                        
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/19755540" target="_blank" class="term-link">
+                            PMID:19755540
+                        </a>
+                        
+                    </span>
+                </div>
+                
+                <div class="reference-title">Analysis of metabolic flux phenotypes for two Arabidopsis mutants with severe impairment in seed storage lipid synthesis.</div>
+                
+                
+                <ul class="findings-list">
+                    
+                    <li class="finding-item">
+                        <div class="finding-statement">wri1 is among mutants with severe impairment in seed storage lipid synthesis.</div>
+                        
+                    </li>
+                    
+                </ul>
+                
+            </div>
+            
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+                        
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/23243127" target="_blank" class="term-link">
+                            PMID:23243127
+                        </a>
+                        
+                    </span>
+                </div>
+                
+                <div class="reference-title">WRINKLED transcription factors orchestrate tissue-specific regulation of fatty acid biosynthesis in Arabidopsis.</div>
+                
+                
+                <ul class="findings-list">
+                    
+                    <li class="finding-item">
+                        <div class="finding-statement">WRI clade members regulate fatty acid/cutin biosynthesis in a tissue-specific manner.</div>
+                        
+                    </li>
+                    
+                </ul>
+                
+            </div>
+            
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+                        
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/23922666" target="_blank" class="term-link">
+                            PMID:23922666
+                        </a>
+                        
+                    </span>
+                </div>
+                
+                <div class="reference-title">Wrinkled1, a ubiquitous regulator in oil accumulating tissues from Arabidopsis embryos to oil palm mesocarp.</div>
+                
+                
+                <ul class="findings-list">
+                    
+                    <li class="finding-item">
+                        <div class="finding-statement">WRI1 is a conserved, ubiquitous regulator of oil accumulation across tissues and species.</div>
+                        
+                    </li>
+                    
+                </ul>
+                
+            </div>
+            
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+                        
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/28314829" target="_blank" class="term-link">
+                            PMID:28314829
+                        </a>
+                        
+                    </span>
+                </div>
+                
+                <div class="reference-title">Phosphorylation of WRINKLED1 by KIN10 Results in Its Proteasomal Degradation, Providing a Link between Energy Homeostasis and Lipid Biosynthesis.</div>
+                
+                
+                <ul class="findings-list">
+                    
+                    <li class="finding-item">
+                        <div class="finding-statement">WRI1 physically interacts with the SnRK1/KIN10 kinase, which controls WRI1 protein stability in response to sugar status.</div>
+                        
+                    </li>
+                    
+                </ul>
+                
+            </div>
+            
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+                        
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/9733529" target="_blank" class="term-link">
+                            PMID:9733529
+                        </a>
+                        
+                    </span>
+                </div>
+                
+                <div class="reference-title">wrinkled1: A novel, low-seed-oil mutant of Arabidopsis with a deficiency in the seed-specific regulation of carbohydrate metabolism.</div>
+                
+                
+                <ul class="findings-list">
+                    
+                    <li class="finding-item">
+                        <div class="finding-statement">The wrinkled1 mutant is impaired in conversion of seed carbohydrate to oil, establishing WRI1&#39;s role in lipid biosynthesis and carbohydrate metabolism.</div>
+                        
+                    </li>
+                    
+                </ul>
+                
+            </div>
+            
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+                        
+                        file:ARATH/WRI1/WRI1-deep-research-falcon.md
+                        
+                    </span>
+                </div>
+                
+                <div class="reference-title">Falcon/Edison deep research report for WRI1/WRINKLED1, Arabidopsis thaliana</div>
+                
+                
+                <ul class="findings-list">
+                    
+                    <li class="finding-item">
+                        <div class="finding-statement">Synthesizes WRI1 as the nuclear AP2/EREB master regulator of seed oil biosynthesis that binds the AW-box and activates glycolytic and fatty acid synthesis genes; wri1 mutants have ~80% lower seed oil; regulated by SnRK1/KIN10, 14-3-3, and bZIP52 within the LEC1/LEC2/FUS3 network.</div>
+                        
+                    </li>
+                    
+                </ul>
+                
+            </div>
+            
+        </div>
+    </div>
+    
+
+
+    
+    <div class="section">
+        <h2 class="section-title">Suggested Questions for Experts</h2>
+        
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> Can WRI1 expression/stability (e.g. via SnRK1/KIN10 and the AW-box target network) be engineered to push carbon flux into oil in vegetative or seed tissue of oilseed feedstocks without the pleiotropic growth penalties of constitutive activation?</p>
+                    
+                </div>
+                <span class="vote-buttons" data-g="Q6X5Y6" data-a="Q: Can WRI1 expression/stability (e.g. via SnRK1/KIN1..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+        
+    </div>
+    
+
+    
+
+    
+
+    <!-- Computational Predictions Section -->
+    
+
+    <!-- Deep Research Sections -->
+    
+    <div class="section">
+        <h2 class="section-title">Deep Research</h2>
+        
+        <details class="deep-research-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; gap: 1rem;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Falcon</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(WRI1-deep-research-falcon.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="Q6X5Y6" data-a="DEEP_RESEARCH: Falcon" data-r="" data-act="DEEP_RESEARCH" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This deep research is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This deep research needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+                
+                <div class="report-meta">
+                    
+                    <span class="report-meta-text">this with annotations you find in gene/protein databases, but these can be outdated or inaccurate.</span>
+                    
+                    
+                    <span class="report-badge">Falcon</span>
+                    
+                    
+                    <span class="report-badge">Edison Scientific Literature</span>
+                    
+                    
+                    <span class="report-badge">32 citations</span>
+                    
+                    
+                    <span class="report-badge">1 artifacts</span>
+                    
+                    
+                    <span class="report-meta-text">2026-06-11T18:21:27.428755</span>
+                    
+                    
+                    
+                </div>
+                
+                
+                <div class="artifact-list">
+                    
+                    
+                    
+                    <div class="artifact-link">
+                        <a href="WRI1-deep-research-falcon_artifacts/artifact-00.md" class="term-link">Edison artifact artifact-00</a>
+                        <span>(text/markdown)</span>
+                    </div>
+                    
+                    
+                </div>
+                
+                <p>The research report should be a detailed narrative explaining the function, biological processes, and localization of the gene product. Citations should be given for all claims.</p>
+<p>You should prioritize authoritative reviews and primary scientific literature when conducting research. You can supplement<br />
+this with annotations you find in gene/protein databases, but these can be outdated or inaccurate.</p>
+<p>We are specifically interested in the primary function of the gene - for enzymes, what reaction is catalyzed, and what is the substrate specificity? For transporters, what is the substrate? For structural proteins or adapters, what is the broader structural role? For signaling molecules, what is the role in the pathway.</p>
+<p>We are interested in where in or outside the cell the gene product carries out its function.</p>
+<p>We are also interested in the signaling or biochemical pathways in which the gene functions. We are less interested in broad pleiotropic effects, except where these elucidate the precise role.</p>
+<p>Include evidence where possible. We are interested in both experimental evidence as well as inference from structure, evolution, or bioinformatic analysis. Precise studies should be prioritized over high-throughput, where available.</p>
+<h2 id="research-report-arabidopsis-thaliana-wrinkled1-wri1-functional-annotation-uniprot-q6x5y6-agi-at3g54320">Research Report: Arabidopsis thaliana WRINKLED1 (WRI1) functional annotation (UniProt Q6X5Y6; AGI At3g54320)</h2>
+<h3 id="0-target-verification-mandatory">0) Target verification (mandatory)</h3>
+<p>The literature summarized here corresponds to <strong>Arabidopsis thaliana WRINKLED1 (WRI1)</strong>, AGI locus <strong>At3g54320</strong>, consistent with the UniProt target <strong>Q6X5Y6</strong> described as an <strong>ethylene-responsive AP2/ERF-family transcription factor</strong> (also called <strong>ASML1</strong>) containing <strong>tandem AP2 DNA-binding domains</strong>. This identity is explicitly stated in Arabidopsis-focused primary literature and reviews, including a 2023 Plant Physiology paper that names <strong>AtWRI1 (At3g54320)</strong> and defines its AW-box binding and oil-phenotype hallmark. (yang2023transcriptionfactorbzip52 pages 1-5, kong2020thefunctionof pages 1-3)</p>
+<h3 id="1-key-concepts-and-definitions-current-understanding">1) Key concepts and definitions (current understanding)</h3>
+<h4 id="11-what-wri1-is">1.1 What WRI1 is</h4>
+<p><strong>WRI1 is an AP2-family transcription factor</strong> with <strong>two AP2 domains</strong> and a <strong>nuclear localization signal (NLS)</strong>, consistent with a nuclear gene-expression regulator rather than an enzyme or transporter. (kong2019wrinkled1a“master pages 1-3, kong2020thefunctionof pages 1-3)</p>
+<h4 id="12-what-wri1-does-primary-function">1.2 What WRI1 does (primary function)</h4>
+<p>The core, repeatedly validated functional concept is that <strong>WRI1 is a master positive regulator of seed oil biosynthesis</strong>, coordinating carbon allocation into <strong>fatty acid (FA) synthesis</strong> and downstream <strong>triacylglycerol (TAG) accumulation</strong> by activating suites of genes in <strong>glycolysis and FA synthesis</strong>. (kong2019wrinkled1a“master pages 1-3, kong2020thefunctionof pages 1-3, yang2023transcriptionfactorbzip52 pages 1-5)</p>
+<p>A defining genetic statistic is that <strong>wri1 loss-of-function mutants show ~80% lower seed oil content</strong> than wild type (a hallmark “wrinkled seed/low oil” phenotype). (kong2019wrinkled1a“master pages 1-3, kong2020thefunctionof pages 1-3, yang2023transcriptionfactorbzip52 pages 1-5)</p>
+<h4 id="13-wri1-dna-binding-the-aw-box">1.3 WRI1 DNA-binding: the AW-box</h4>
+<p>WRI1 directly regulates transcription by binding a cis-regulatory promoter element termed the <strong>AW-box</strong>, commonly represented as <strong><a href="n">CnTnG</a>7[CG]</strong> (also written <strong>CNTNG(N)7CG</strong>). (kong2020thefunctionof pages 1-3, yang2023transcriptionfactorbzip52 pages 1-5)</p>
+<p>Quantitative biochemical support for AW-box recognition comes from microscale thermophoresis (MST) binding assays: a comparative/biochemical analysis reported <strong>62 AW sites with Kd &lt; 200 nM</strong> and (across many tested sites) <strong>97 Kd values &lt; 25 nM</strong>, consistent with high-affinity sequence-specific DNA binding for a substantial subset of sites. (kuczynski2020anexpandedrole pages 10-13)</p>
+<h3 id="2-mechanistic-model-pathways-targets-and-cellular-location">2) Mechanistic model: pathways, targets, and cellular location</h3>
+<h4 id="21-cellularsubcellular-context">2.1 Cellular/subcellular context</h4>
+<p>WRI1 is a <strong>nuclear transcription factor</strong>, supported by the presence of a described <strong>nuclear localization signal</strong> and its promoter-binding transcriptional role. (kong2020thefunctionof pages 1-3)</p>
+<p>Its downstream metabolic effects are realized primarily in (i) plastids, where de novo FA synthesis occurs, and (ii) the endoplasmic reticulum, where TAG assembly proceeds; WRI1 acts upstream by transcriptionally increasing flux through glycolysis and FA synthesis to supply substrates for TAG accumulation. (snell2019dissectingthegene pages 34-37, kong2020thefunctionof pages 1-3)</p>
+<h4 id="22-pathway-scope-glycolysis-acetyl-coa-fa-synthesis-and-supporting-modules">2.2 Pathway scope: glycolysis → acetyl-CoA → FA synthesis (and supporting modules)</h4>
+<p>WRI1 is known to activate many FA biosynthetic enzymes and glycolytic genes; more recent integrative analyses expand the plausible direct-target set beyond “late glycolysis.” (kong2019wrinkled1a“master pages 1-3, kong2020thefunctionof pages 1-3, kuczynski2022anexpandedrole pages 1-2)</p>
+<p>A phylogenetic footprinting + binding-affinity strategy (Arabidopsis + 11 related crucifers) identified AW-box conservation for <strong>~900 genes</strong>, and experimentally assayed <strong>145</strong> candidate AW-box sequences by MST to refine the binding consensus. Mapping these targets suggested <strong>concerted control of contiguous pathway sections</strong> in glycolysis and FA biosynthesis. (kuczynski2022anexpandedrole pages 1-2)</p>
+<p>Specific examples of supported or strongly corroborated WRI1-controlled steps/genes include:<br />
+- <strong>Sucrose synthase</strong> and a <strong>plastidic pyruvate kinase subunit</strong> as known direct targets. (kuczynski2022anexpandedrole pages 1-2)<br />
+- Newly predicted/corroborated plastidic <strong>FRK3 (fructokinase 3)</strong> and <strong>PGI1 (phosphoglucose isomerase 1)</strong> as targets relevant to upstream glycolysis; their null mutants show severe wrinkled/low-oil phenotypes, supporting functional importance for oil accumulation. (kuczynski2020anexpandedrole pages 13-15)<br />
+- Additional proposed targets spanning FA synthesis and supporting biochemistry (e.g., <strong>BCA5</strong>, proposed to help supply bicarbonate for acetyl-CoA carboxylase), lower glycolysis, oxidative pentose phosphate pathway genes, and transport functions such as <strong>GPT2</strong>. (kuczynski2020anexpandedrole pages 13-15)</p>
+<h4 id="23-phenotypic-readouts-that-anchor-the-functional-annotation">2.3 Phenotypic readouts that anchor the functional annotation</h4>
+<ul>
+<li><strong>Seed oil content defect in wri1-1:</strong> approximately <strong>80% reduction</strong> compared with WT, repeatedly cited and used as functional anchor for WRI1’s role in oil biosynthesis. (kong2019wrinkled1a“master pages 1-3, kong2020thefunctionof pages 1-3, yang2023transcriptionfactorbzip52 pages 1-5)</li>
+</ul>
+<h3 id="3-regulation-of-wri1-networks-partners-and-post-translational-control">3) Regulation of WRI1: networks, partners, and post-translational control</h3>
+<h4 id="31-network-context-why-wri1-requires-tight-tuning">3.1 Network context: why WRI1 requires tight tuning</h4>
+<p>WRI1 is described as requiring <strong>spatiotemporal control</strong> to avoid inappropriate hyperactivation of lipid biosynthesis, and is regulated by both activators and repressors in combinatorial transcriptional networks. (yang2023transcriptionfactorbzip52 pages 11-15)</p>
+<p>Upstream seed maturation regulators (e.g., <strong>LEC1/LEC2/FUS3</strong>) are included among described regulators of WRI1 expression in established models. (kong2019wrinkled1a“master pages 5-7)</p>
+<h4 id="32-proteinprotein-interactions-and-co-regulators-expertauthoritative-synthesis-recent-primary-literature">3.2 Protein–protein interactions and co-regulators (expert/authoritative synthesis + recent primary literature)</h4>
+<p>Multiple partner modules have been reported to modulate WRI1 activity/stability, including:<br />
+- <strong>TCP4–WRI1 module:</strong> TCP4 physically interacts with WRI1 and represses WRI1-driven oil accumulation; this is presented as a fine-tuning mechanism. (kong2020thefunctionof pages 1-3)<br />
+- <strong>bZIP52–WRI1 module (2023):</strong> bZIP52 was identified as a WRI1-interacting factor; bZIP52 overexpression reduced seed size and oil, while bzip52 knockout increased seed oil accumulation, supporting a repressive interaction in vivo. (yang2023transcriptionfactorbzip52 pages 11-15, yang2023transcriptionfactorbzip52 pages 1-5)<br />
+- Other described modulators include <strong>14-3-3 proteins</strong> (stability/activity modulation) and chromatin-associated regulators such as <strong>BLISTER</strong> that influence WRI1 target gene expression. (kong2020thefunctionof pages 1-3, yang2023transcriptionfactorbzip52 pages 1-5)</p>
+<h4 id="33-sugar-status-snrk1kin10-wri1-protein-stability-major-mechanistic-axis">3.3 Sugar status → SnRK1/KIN10 → WRI1 protein stability (major mechanistic axis)</h4>
+<p>A major, currently emphasized mechanistic axis is that <strong>cellular sugar status controls WRI1 stability through SnRK1 (KIN10)</strong>:<br />
+- Under <strong>low sugar</strong>, <strong>SnRK1/KIN10 phosphorylates WRI1</strong>, promoting <strong>ubiquitination and proteasomal degradation</strong>, downregulating fatty acid synthesis. (butt2024seedspecificexpressionof pages 1-2, blanford2024molecularmechanismof pages 1-2, kong2020thefunctionof pages 1-3)<br />
+- Under <strong>high sugar</strong>, <strong>trehalose-6-phosphate (T6P)</strong> inhibits SnRK1/KIN10 activation and thereby reduces WRI1 phosphorylation, allowing WRI1 accumulation and promoting anabolic metabolism including lipid synthesis. (blanford2024molecularmechanismof pages 1-2, kong2020thefunctionof pages 1-3)</p>
+<p>A 2024 Science Advances study provides molecular detail on <strong>how T6P inhibits KIN10</strong>, identifying a T6P binding site and showing (via simulation and in vitro assays) that T6P binding blocks activation-loop reorientation and reduces KIN10’s ability to be activated by GRIK1. This provides a mechanistically grounded explanation for the sugar–SnRK1–WRI1 stability relationship used in metabolic models of oil accumulation. (blanford2024molecularmechanismof pages 1-2)</p>
+<h4 id="34-ubiquitinproteasome-components-and-adaptor-logic">3.4 Ubiquitin–proteasome components and adaptor logic</h4>
+<p>WRI1 degradation is also linked to <strong>BPM proteins</strong> acting as substrate adaptors for <strong>CULLIN3-based E3 ligases</strong> (CUL3), which mediate 26S proteasomal degradation of WRI1 in regulatory models. (kong2020thefunctionof pages 1-3, kong2019wrinkled1a“master pages 1-3)</p>
+<h3 id="4-recent-developments-prioritizing-20232024">4) Recent developments (prioritizing 2023–2024)</h3>
+<h4 id="41-2023-discoveryvalidation-of-a-wri1-repressor-interaction-bzip52">4.1 2023: discovery/validation of a WRI1-repressor interaction (bZIP52)</h4>
+<p>A 2023 Plant Physiology paper identified bZIP52 as a WRI1-interacting partner and showed genetic evidence consistent with a repressive role in seed oil accumulation (bZIP52 overexpression decreases oil; bzip52 knockout increases oil). This expands the catalog of WRI1-regulatory modules and provides a plausible lever for crop engineering beyond WRI1 overexpression alone. Publication date: <strong>May 2023</strong>; URL: https://doi.org/10.1093/plphys/kiad270. (yang2023transcriptionfactorbzip52 pages 11-15, yang2023transcriptionfactorbzip52 pages 1-5)</p>
+<h4 id="42-2024-mechanistic-resolution-of-t6p-inhibition-of-snrk1kin10-linking-sugar-status-to-wri1-stability">4.2 2024: mechanistic resolution of T6P inhibition of SnRK1/KIN10 (linking sugar status to WRI1 stability)</h4>
+<p>A 2024 Science Advances paper resolved the molecular mechanism of <strong>T6P inhibition of KIN10/SnRK1</strong>, including direct binding and inhibition of activation by GRIK1. This strengthens the mechanistic basis for the frequently cited model where sugar status stabilizes WRI1 by suppressing SnRK1-driven phosphorylation and degradation. Publication date: <strong>May 2024</strong>; URL: https://doi.org/10.1126/sciadv.adn0895. (blanford2024molecularmechanismof pages 1-2)</p>
+<h4 id="43-2024-translational-implementationatwri1-used-to-increase-cotton-seed-oil">4.3 2024: translational implementation—AtWRI1 used to increase cotton seed oil</h4>
+<p>A 2024 Scientific Reports study implemented <strong>seed-specific AtWRI1 expression in upland cotton</strong> and reported a <strong>35% increase in seed oil content</strong> and <strong>~4-fold increase in oil bodies</strong> in seed endosperm. This is a direct real-world metabolic engineering demonstration of deploying the Arabidopsis WRI1 regulator in a crop context. Publication date: <strong>Dec 2024</strong>; URL: https://doi.org/10.1038/s41598-024-80684-9. (butt2024seedspecificexpressionof pages 1-2)</p>
+<h3 id="5-current-applications-and-real-world-implementations">5) Current applications and real-world implementations</h3>
+<h4 id="51-crop-oil-content-improvement">5.1 Crop oil content improvement</h4>
+<ul>
+<li><strong>Cotton (Gossypium hirsutum):</strong> seed-specific AtWRI1 expression increased seed oil by <strong>35%</strong> and oil bodies by <strong>~4×</strong>, illustrating a practical transgenic strategy targeting seed lipid storage. (butt2024seedspecificexpressionof pages 1-2)</li>
+</ul>
+<h4 id="52-biofuel-oriented-oil-quality-engineering">5.2 Biofuel-oriented oil quality engineering</h4>
+<p>While the focus here is Arabidopsis WRI1, WRI1 orthologs are used in Arabidopsis as a testbed for biodiesel traits. A 2023 BMC Plant Biology study showed that overexpression of <strong>PcWRI1</strong> (from Pistacia chinensis) in Arabidopsis increased seed oil content to <strong>59.88%</strong> vs <strong>48.45%</strong> in WT and shifted FA composition toward <strong>higher MUFA</strong> (e.g., MUFA <strong>55.83%</strong> in PcWRI1 lines vs <strong>37.04%</strong> WT) with decreased saturated FA. This provides an implementation pattern (WRI1-family regulators) for biodiesel property improvement. Publication date: <strong>May 2023</strong>; URL: https://doi.org/10.1186/s12870-023-04267-y. (chen2023determinationofsuperior pages 10-12)</p>
+<h3 id="6-expert-synthesis-and-interpretive-analysis-authoritative-sources">6) Expert synthesis and interpretive analysis (authoritative sources)</h3>
+<p>A consistent expert synthesis across reviews and integrative analyses is that WRI1 functions as a <strong>flux-control transcription factor</strong> positioned at the interface of carbohydrate metabolism and oil biosynthesis, enabling coordinated upregulation of multiple enzymatic steps (rather than single-enzyme control). This systems-level position explains both (i) the strong wri1 mutant phenotype and (ii) why WRI1 is repeatedly selected as a lever in metabolic engineering. (kong2019wrinkled1a“master pages 1-3, kong2020thefunctionof pages 1-3, kuczynski2022anexpandedrole pages 1-2)</p>
+<p>From a regulatory perspective, recent work emphasizes that <strong>WRI1 is not simply transcriptionally induced</strong>, but is also tightly governed by <strong>protein stability</strong> (SnRK1/KIN10, proteasome) and <strong>repressor interactions</strong> (e.g., TCP4, bZIP52), implying that successful engineering may require combining WRI1 expression with strategies that relieve repression and/or stabilize the protein in target tissues and developmental windows. (yang2023transcriptionfactorbzip52 pages 11-15, blanford2024molecularmechanismof pages 1-2, kong2020thefunctionof pages 1-3)</p>
+<h3 id="7-key-statistics-and-data-points-recent-studies-foundational-quantitative-anchors">7) Key statistics and data points (recent studies + foundational quantitative anchors)</h3>
+<ul>
+<li><strong>~80% reduction in Arabidopsis seed oil</strong> in wri1-1 loss-of-function mutants (defining phenotype). (kong2019wrinkled1a“master pages 1-3, kong2020thefunctionof pages 1-3, yang2023transcriptionfactorbzip52 pages 1-5)</li>
+<li><strong>AW-box binding affinities:</strong> 62 sites with <strong>Kd &lt; 200 nM</strong>; 97 Kd values <strong>&lt; 25 nM</strong> (MST), consistent with a broad high-affinity regulon. (kuczynski2020anexpandedrole pages 10-13)</li>
+<li><strong>Cotton transgenic implementation:</strong> AtWRI1 seed-specific expression increased oil by <strong>35%</strong> and oil bodies by <strong>~4×</strong>. (butt2024seedspecificexpressionof pages 1-2)</li>
+<li><strong>Arabidopsis transgenic model for biodiesel-oriented traits (WRI1-family):</strong> PcWRI1 increased seed oil to <strong>59.88%</strong> vs WT <strong>48.45%</strong> and shifted MUFA to <strong>55.83%</strong> vs WT <strong>37.04%</strong>. (chen2023determinationofsuperior pages 10-12)</li>
+</ul>
+<h3 id="8-summary-table-evidence-indexed">8) Summary table (evidence-indexed)</h3>
+<p>The following table condenses the functional annotation, regulatory mechanisms, quantitative phenotype anchors, and engineering outcomes with URLs:</p>
+<table>
+<thead>
+<tr>
+<th>Category</th>
+<th>Key points (1-2 sentences)</th>
+<th>Best supporting sources (cite by author/year)</th>
+<th>Year</th>
+<th>URL</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>Identity/Domain</td>
+<td>Arabidopsis thaliana WRI1 corresponds to At3g54320 / UniProt Q6X5Y6 and is an AP2-family transcription factor with two AP2 DNA-binding domains and a nuclear localization signal, matching the UniProt description. It is widely defined as a master regulator of seed oil biosynthesis. (kong2020thefunctionof pages 1-3, yang2023transcriptionfactorbzip52 pages 1-5, butt2024seedspecificexpressionof pages 1-2, kong2019wrinkled1a“master pages 1-3)</td>
+<td>Kong et al. 2020; Yang et al. 2023; Butt et al. 2024; Kong et al. 2019</td>
+<td>2019-2024</td>
+<td>https://doi.org/10.1080/15592324.2020.1812878 ; https://doi.org/10.1093/plphys/kiad270 ; https://doi.org/10.1038/s41598-024-80684-9 ; https://doi.org/10.3390/plants8070238</td>
+</tr>
+<tr>
+<td>DNA-binding</td>
+<td>AtWRI1 binds the AW-box cis-element, commonly represented as <a href="n">CnTnG</a>7[CG] / CNTNG(N)7CG, in promoters of oil-related genes. Comparative and biochemical analyses showed conserved AW-boxes across Brassicaceae and high-affinity binding for many targets, including 62 sites with Kd &lt; 200 nM and 97 measurements &lt; 25 nM in MST assays. (kong2020thefunctionof pages 1-3, kuczynski2020anexpandedrole pages 5-8, kuczynski2020anexpandedrole pages 10-13, kuczynski2022anexpandedrole pages 1-2)</td>
+<td>Kong et al. 2020; Kuczynski et al. 2020; Kuczynski et al. 2022</td>
+<td>2020-2022</td>
+<td>https://doi.org/10.1080/15592324.2020.1812878 ; https://doi.org/10.1101/2020.01.28.923292 ; https://doi.org/10.3389/fpls.2022.955589</td>
+</tr>
+<tr>
+<td>Core biological role</td>
+<td>WRI1 directs carbon allocation into fatty acid and triacylglycerol production during seed development by activating glycolytic and fatty-acid-biosynthetic gene expression. Loss of WRI1 causes the classic wrinkled-seed, low-oil phenotype, establishing it as a central positive regulator of storage lipid accumulation. (kong2019wrinkled1a“master pages 1-3, kong2020thefunctionof pages 1-3, yang2023transcriptionfactorbzip52 pages 1-5)</td>
+<td>Kong et al. 2019; Kong et al. 2020; Yang et al. 2023</td>
+<td>2019-2023</td>
+<td>https://doi.org/10.3390/plants8070238 ; https://doi.org/10.1080/15592324.2020.1812878 ; https://doi.org/10.1093/plphys/kiad270</td>
+</tr>
+<tr>
+<td>Pathways/targets</td>
+<td>Direct and predicted WRI1 targets span late glycolysis, plastidial pyruvate generation, fatty acid synthesis, the oxidative pentose phosphate pathway, and transport steps that support oil synthesis. Supported targets/processes include sucrose synthase, plastidic pyruvate kinase, FRK3, PGI1, BCA5, PGLM1/2, enolase-related steps, PPT1, GPT2, and multiple enzymes across the pyruvate-to-acyl-ACP pathway. (kuczynski2020anexpandedrole pages 1-5, kuczynski2020anexpandedrole pages 10-13, kuczynski2022anexpandedrole pages 1-2, kuczynski2020anexpandedrole pages 13-15)</td>
+<td>Kuczynski et al. 2020; Kuczynski et al. 2022</td>
+<td>2020-2022</td>
+<td>https://doi.org/10.1101/2020.01.28.923292 ; https://doi.org/10.3389/fpls.2022.955589</td>
+</tr>
+<tr>
+<td>Regulators/partners</td>
+<td>WRI1 functions within a broader transcriptional network and interacts with multiple protein partners. Reported upstream or interacting regulators include seed regulators LEC1/LEC2/FUS3, the repressor-like partners TCP4 and bZIP52, chromatin-linked factor BLISTER, and stabilizing 14-3-3 proteins; bZIP52 specifically represses WRI1-mediated oil biosynthesis. (yang2023transcriptionfactorbzip52 pages 11-15, kong2020thefunctionof pages 1-3, yang2023transcriptionfactorbzip52 pages 1-5, kong2019wrinkled1a“master pages 5-7)</td>
+<td>Yang et al. 2023; Kong et al. 2020; Kong et al. 2019</td>
+<td>2019-2023</td>
+<td>https://doi.org/10.1093/plphys/kiad270 ; https://doi.org/10.1080/15592324.2020.1812878 ; https://doi.org/10.3390/plants8070238</td>
+</tr>
+<tr>
+<td>Post-translational regulation</td>
+<td>WRI1 stability is tightly controlled by phosphorylation and proteolysis. SnRK1/KIN10 phosphorylates WRI1 under low-sugar conditions, promoting ubiquitination and proteasomal degradation; T6P inhibits KIN10 activation, thereby stabilizing WRI1, while BPM proteins act as CUL3-associated adaptors for WRI1 degradation and 14-3-3 proteins enhance WRI1 stability/activity. (butt2024seedspecificexpressionof pages 1-2, blanford2024molecularmechanismof pages 1-2, kong2020thefunctionof pages 1-3, kong2019wrinkled1a“master pages 1-3, kong2019wrinkled1a“master pages 5-7)</td>
+<td>Blanford et al. 2024; Butt et al. 2024; Kong et al. 2019; Kong et al. 2020</td>
+<td>2019-2024</td>
+<td>https://doi.org/10.1126/sciadv.adn0895 ; https://doi.org/10.1038/s41598-024-80684-9 ; https://doi.org/10.3390/plants8070238 ; https://doi.org/10.1080/15592324.2020.1812878</td>
+</tr>
+<tr>
+<td>Phenotypes</td>
+<td>Arabidopsis wri1 loss-of-function mutants show an approximately 80% reduction in seed oil content relative to wild type, a defining phenotype repeatedly cited across studies. Additional network perturbations are consistent with this role: bZIP52 overexpression reduces seed size/oil, whereas bzip52 knockout increases seed oil accumulation. (kong2019wrinkled1a“master pages 1-3, kong2020thefunctionof pages 1-3, yang2023transcriptionfactorbzip52 pages 1-5, yang2023transcriptionfactorbzip52 pages 11-15)</td>
+<td>Kong et al. 2019; Kong et al. 2020; Yang et al. 2023</td>
+<td>2019-2023</td>
+<td>https://doi.org/10.3390/plants8070238 ; https://doi.org/10.1080/15592324.2020.1812878 ; https://doi.org/10.1093/plphys/kiad270</td>
+</tr>
+<tr>
+<td>Applications/engineering</td>
+<td>WRI1 is actively used in metabolic engineering to raise oil accumulation in crops and biofuel feedstocks. Recent examples include seed-specific AtWRI1 expression in cotton, which increased seed oil by 35% and oil bodies by nearly 4-fold, and heterologous PcWRI1 expression in Arabidopsis, which raised seed oil to 59.88% versus 48.45% in WT while shifting fatty-acid composition toward biodiesel-favorable MUFAs. (butt2024seedspecificexpressionof pages 1-2, chen2023determinationofsuperior pages 10-12)</td>
+<td>Butt et al. 2024; Chen et al. 2023</td>
+<td>2023-2024</td>
+<td>https://doi.org/10.1038/s41598-024-80684-9 ; https://doi.org/10.1186/s12870-023-04267-y</td>
+</tr>
+</tbody>
+</table>
+<p><em>Table: This table summarizes the verified identity, molecular function, regulatory mechanisms, phenotypes, and engineering relevance of Arabidopsis thaliana WRI1 (Q6X5Y6/At3g54320). It condenses key evidence and recent literature into a citation-ready reference for functional annotation.</em></p>
+<h3 id="references-urls-and-publication-dates">References (URLs and publication dates)</h3>
+<ul>
+<li>Yang Y et al. <em>Plant Physiology</em> (May 2023). “Transcription factor bZIP52 modulates Arabidopsis seed oil biosynthesis through interaction with WRINKLED1.” https://doi.org/10.1093/plphys/kiad270 (yang2023transcriptionfactorbzip52 pages 1-5)</li>
+<li>Blanford J et al. <em>Science Advances</em> (May 2024). “Molecular mechanism of trehalose 6-phosphate inhibition of the plant metabolic sensor kinase SnRK1.” https://doi.org/10.1126/sciadv.adn0895 (blanford2024molecularmechanismof pages 1-2)</li>
+<li>Butt M et al. <em>Scientific Reports</em> (Dec 2024). “Seed-specific expression of AtWRI1 enhanced the yield of cotton seed oil.” https://doi.org/10.1038/s41598-024-80684-9 (butt2024seedspecificexpressionof pages 1-2)</li>
+<li>Chen F et al. <em>BMC Plant Biology</em> (May 2023). “Determination of superior Pistacia chinensis accession with high-quality seed oil and biodiesel production and revelation of LEC1/WRI1-mediated high oil accumulative mechanism…” https://doi.org/10.1186/s12870-023-04267-y (chen2023determinationofsuperior pages 10-12)</li>
+<li>Kong Q et al. <em>Plant Signaling &amp; Behavior</em> (Sep 2020). “The function of the WRI1–TCP4 regulatory module in lipid biosynthesis.” https://doi.org/10.1080/15592324.2020.1812878 (kong2020thefunctionof pages 1-3)</li>
+<li>Kong Q et al. <em>Plants</em> (Jul 2019). “WRINKLED1, a ‘Master Regulator’ in Transcriptional Control of Plant Oil Biosynthesis.” https://doi.org/10.3390/plants8070238 (kong2019wrinkled1a“master pages 1-3)</li>
+<li>Kuczynski C et al. <em>Frontiers in Plant Science</em> (Aug 2022). “An expanded role for the transcription factor WRINKLED1 in the biosynthesis of triacylglycerols during seed development.” https://doi.org/10.3389/fpls.2022.955589 (kuczynski2022anexpandedrole pages 1-2)</li>
+</ul>
+<p>References</p>
+<ol>
+<li>
+<p>(yang2023transcriptionfactorbzip52 pages 1-5): Yuzhou Yang, Que Kong, Wan Ting Tee, Yuqing Li, Pui Man Low, Barunava Patra, Liang Guo, Lijuan Yuan, and Wei Ma. Transcription factor bzip52 modulates arabidopsis seed oil biosynthesis through interaction with wrinkled1. Plant physiology, 192:2628-2639, May 2023. URL: https://doi.org/10.1093/plphys/kiad270, doi:10.1093/plphys/kiad270. This article has 39 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(kong2020thefunctionof pages 1-3): Que Kong, Yuzhou Yang, Pui Man Low, Liang Guo, Ling Yuan, and Wei Ma. The function of the wri1-tcp4 regulatory module in lipid biosynthesis. Plant Signaling &amp; Behavior, Sep 2020. URL: https://doi.org/10.1080/15592324.2020.1812878, doi:10.1080/15592324.2020.1812878. This article has 18 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(kong2019wrinkled1a“master pages 1-3): Que Kong, Ling Yuan, and Wei Ma. Wrinkled1, a “master regulator” in transcriptional control of plant oil biosynthesis. Plants, 8:238, Jul 2019. URL: https://doi.org/10.3390/plants8070238, doi:10.3390/plants8070238. This article has 89 citations.</p>
+</li>
+<li>
+<p>(kuczynski2020anexpandedrole pages 10-13): Cathleen Kuczynski, Sean McCorkle, Jantana Keereetaweep, John Shanklin, and Jorg Schwender. An expanded role for wrinkled1 metabolic control based on combined phylogenetic and biochemical analyses. bioRxiv, Jan 2020. URL: https://doi.org/10.1101/2020.01.28.923292, doi:10.1101/2020.01.28.923292. This article has 7 citations.</p>
+</li>
+<li>
+<p>(snell2019dissectingthegene pages 34-37): P Snell. Dissecting the gene regulatory networks behind carbon allocation in plants. Unknown journal, 2019.</p>
+</li>
+<li>
+<p>(kuczynski2022anexpandedrole pages 1-2): Cathleen Kuczynski, Sean McCorkle, Jantana Keereetaweep, John Shanklin, and Jorg Schwender. An expanded role for the transcription factor wrinkled1 in the biosynthesis of triacylglycerols during seed development. Frontiers in Plant Science, Aug 2022. URL: https://doi.org/10.3389/fpls.2022.955589, doi:10.3389/fpls.2022.955589. This article has 37 citations.</p>
+</li>
+<li>
+<p>(kuczynski2020anexpandedrole pages 13-15): Cathleen Kuczynski, Sean McCorkle, Jantana Keereetaweep, John Shanklin, and Jorg Schwender. An expanded role for wrinkled1 metabolic control based on combined phylogenetic and biochemical analyses. bioRxiv, Jan 2020. URL: https://doi.org/10.1101/2020.01.28.923292, doi:10.1101/2020.01.28.923292. This article has 7 citations.</p>
+</li>
+<li>
+<p>(yang2023transcriptionfactorbzip52 pages 11-15): Yuzhou Yang, Que Kong, Wan Ting Tee, Yuqing Li, Pui Man Low, Barunava Patra, Liang Guo, Lijuan Yuan, and Wei Ma. Transcription factor bzip52 modulates arabidopsis seed oil biosynthesis through interaction with wrinkled1. Plant physiology, 192:2628-2639, May 2023. URL: https://doi.org/10.1093/plphys/kiad270, doi:10.1093/plphys/kiad270. This article has 39 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(kong2019wrinkled1a“master pages 5-7): Que Kong, Ling Yuan, and Wei Ma. Wrinkled1, a “master regulator” in transcriptional control of plant oil biosynthesis. Plants, 8:238, Jul 2019. URL: https://doi.org/10.3390/plants8070238, doi:10.3390/plants8070238. This article has 89 citations.</p>
+</li>
+<li>
+<p>(butt2024seedspecificexpressionof pages 1-2): Maria Butt, Mahnoor Imran, Tanzeela Rehman, Azeem Intisar, Keith Lindsey, Ghulam Sarwar, and Uzma Qaisar. Seed-specific expression of atwri1 enhanced the yield of cotton seed oil. Scientific Reports, Dec 2024. URL: https://doi.org/10.1038/s41598-024-80684-9, doi:10.1038/s41598-024-80684-9. This article has 4 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(blanford2024molecularmechanismof pages 1-2): Jantana Blanford, Zhiyang Zhai, Marcel D. Baer, Gongrui Guo, Hui Liu, Qun Liu, Simone Raugei, and John Shanklin. Molecular mechanism of trehalose 6-phosphate inhibition of the plant metabolic sensor kinase snrk1. Science Advances, May 2024. URL: https://doi.org/10.1126/sciadv.adn0895, doi:10.1126/sciadv.adn0895. This article has 36 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(chen2023determinationofsuperior pages 10-12): Feng Chen, Weijun Lin, Wei Li, Jinhe Hu, Zhi Li, Lingling Shi, Zhixiang Zhang, Yu Xiu, and Shanzhi Lin. Determination of superior pistacia chinensis accession with high-quality seed oil and biodiesel production and revelation of lec1/wri1-mediated high oil accumulative mechanism for better developing woody biodiesel. BMC Plant Biology, May 2023. URL: https://doi.org/10.1186/s12870-023-04267-y, doi:10.1186/s12870-023-04267-y. This article has 13 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(kuczynski2020anexpandedrole pages 5-8): Cathleen Kuczynski, Sean McCorkle, Jantana Keereetaweep, John Shanklin, and Jorg Schwender. An expanded role for wrinkled1 metabolic control based on combined phylogenetic and biochemical analyses. bioRxiv, Jan 2020. URL: https://doi.org/10.1101/2020.01.28.923292, doi:10.1101/2020.01.28.923292. This article has 7 citations.</p>
+</li>
+<li>
+<p>(kuczynski2020anexpandedrole pages 1-5): Cathleen Kuczynski, Sean McCorkle, Jantana Keereetaweep, John Shanklin, and Jorg Schwender. An expanded role for wrinkled1 metabolic control based on combined phylogenetic and biochemical analyses. bioRxiv, Jan 2020. URL: https://doi.org/10.1101/2020.01.28.923292, doi:10.1101/2020.01.28.923292. This article has 7 citations.</p>
+</li>
+</ol>
+<h2 id="artifacts">Artifacts</h2>
+<ul>
+<li><a href="WRI1-deep-research-falcon_artifacts/artifact-00.md">Edison artifact artifact-00</a></li>
+</ul>
+<h2 id="citations">Citations</h2>
+<ol>
+<li>kuczynski2020anexpandedrole pages 10-13</li>
+<li>kong2020thefunctionof pages 1-3</li>
+<li>kuczynski2022anexpandedrole pages 1-2</li>
+<li>kuczynski2020anexpandedrole pages 13-15</li>
+<li>blanford2024molecularmechanismof pages 1-2</li>
+<li>butt2024seedspecificexpressionof pages 1-2</li>
+<li>chen2023determinationofsuperior pages 10-12</li>
+<li>snell2019dissectingthegene pages 34-37</li>
+<li>kuczynski2020anexpandedrole pages 5-8</li>
+<li>kuczynski2020anexpandedrole pages 1-5</li>
+<li>CnTnG</li>
+<li>CG</li>
+<li>https://doi.org/10.1093/plphys/kiad270.</li>
+<li>https://doi.org/10.1126/sciadv.adn0895.</li>
+<li>https://doi.org/10.1038/s41598-024-80684-9.</li>
+<li>https://doi.org/10.1186/s12870-023-04267-y.</li>
+<li>https://doi.org/10.1080/15592324.2020.1812878</li>
+<li>https://doi.org/10.1093/plphys/kiad270</li>
+<li>https://doi.org/10.1038/s41598-024-80684-9</li>
+<li>https://doi.org/10.3390/plants8070238</li>
+<li>https://doi.org/10.1101/2020.01.28.923292</li>
+<li>https://doi.org/10.3389/fpls.2022.955589</li>
+<li>https://doi.org/10.1126/sciadv.adn0895</li>
+<li>https://doi.org/10.1186/s12870-023-04267-y</li>
+<li>https://doi.org/10.1093/plphys/kiad270,</li>
+<li>https://doi.org/10.1080/15592324.2020.1812878,</li>
+<li>https://doi.org/10.3390/plants8070238,</li>
+<li>https://doi.org/10.1101/2020.01.28.923292,</li>
+<li>https://doi.org/10.3389/fpls.2022.955589,</li>
+<li>https://doi.org/10.1038/s41598-024-80684-9,</li>
+<li>https://doi.org/10.1126/sciadv.adn0895,</li>
+<li>https://doi.org/10.1186/s12870-023-04267-y,</li>
+</ol>
+            </div>
+        </details>
+        
+    </div>
+    
+
+    <!-- Additional Documentation Sections -->
+    
+    <div class="section">
+        <h2 class="section-title">📚 Additional Documentation</h2>
+        
+        <details class="markdown-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; cursor: pointer;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Notes</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(WRI1-notes.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="Q6X5Y6" data-a="DOC: Notes" data-r="" data-act="DOCUMENTATION" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This documentation is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This documentation needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+                <h1 id="wri1-wrinkled1-asml1-arabidopsis-thaliana-review-notes">WRI1 / WRINKLED1 (ASML1) — Arabidopsis thaliana — review notes</h1>
+<p>UniProt: Q6X5Y6 · At3g54320 · Taxon 3702 · AP2/EREB transcription factor<br />
+Relevance: master transcriptional regulator of seed oil biosynthesis — a top-level DOE/BER<br />
+lever for engineering oil yield in oilseed feedstocks.</p>
+<h2 id="core-function">Core function</h2>
+<ul>
+<li><strong>AP2/ERF-family transcription factor</strong> with <strong>two tandem AP2 DNA-binding domains</strong> and a<br />
+  nuclear localization signal. Nuclear gene-expression regulator, not an enzyme.<br />
+  [file:ARATH/WRI1/WRI1-deep-research-falcon.md; PMID:10948255]</li>
+<li><strong>Master positive regulator of seed oil biosynthesis</strong>: transcriptionally activates suites<br />
+  of <strong>glycolytic and fatty acid synthesis genes</strong>, coordinating carbon allocation into<br />
+  fatty acids and downstream TAG accumulation. wri1 loss-of-function mutants have <strong>~80%<br />
+  lower seed oil</strong> (wrinkled-seed phenotype). [PMID:15500472; PMID:9733529;<br />
+  file:ARATH/WRI1/WRI1-deep-research-falcon.md]</li>
+<li>Binds the <strong>AW-box</strong> cis-element (<a href="n">CnTnG</a>7[CG]) in target promoters (direct DNA<br />
+  binding demonstrated; high-affinity, many sites Kd &lt; 25 nM). Direct/predicted targets<br />
+  include plastidic pyruvate kinase, sucrose synthase, FRK3, PGI1, BCCP/FA-synthesis genes.<br />
+  [PMID:19719479; file:ARATH/WRI1/WRI1-deep-research-falcon.md]</li>
+</ul>
+<h2 id="localization">Localization</h2>
+<ul>
+<li><strong>Nucleus</strong> — correct and well-supported (IC PMID:10948255, plus IEA/ISM). Note: unlike<br />
+  the FAE1/FAD2/DGAT1 enzymes, here the AtSubP ISM nucleus prediction is corroborated and<br />
+  is ACCEPTED.</li>
+</ul>
+<h2 id="regulation-non-core-interactions">Regulation (non-core interactions)</h2>
+<ul>
+<li>Regulated post-translationally by <strong>SnRK1/KIN10</strong> kinase (sugar-status axis controlling<br />
+  WRI1 stability) -&gt; underlies the kinase binding (IPI, PMID:28314829) annotation; also<br />
+  14-3-3 proteins, bZIP52 (repressor), and upstream LEC1/LEC2/FUS3.<br />
+  [PMID:28314829; file:ARATH/WRI1/WRI1-deep-research-falcon.md]</li>
+</ul>
+<h2 id="annotation-review-decisions">Annotation review decisions</h2>
+<ul>
+<li>GO:0003700 DNA-binding transcription factor activity (IEA/ISS x2) -&gt; ACCEPT (core MF)</li>
+<li>GO:0003677 DNA binding (IDA/IEA) -&gt; ACCEPT (core MF; AW-box binding)</li>
+<li>GO:0006355 regulation of DNA-templated transcription (IBA/IEA) -&gt; ACCEPT (core BP)</li>
+<li>GO:0006110 regulation of glycolytic process (IMP) -&gt; ACCEPT (core BP)</li>
+<li>GO:0006109 regulation of carbohydrate metabolic process (IMP) -&gt; ACCEPT</li>
+<li>GO:0008610 lipid biosynthetic process (IMP) -&gt; ACCEPT (core BP)</li>
+<li>GO:0006629 lipid metabolic process (IMP) -&gt; ACCEPT (general)</li>
+<li>GO:0019432 triglyceride biosynthetic process (IMP x2) -&gt; ACCEPT (core BP, regulatory)</li>
+<li>GO:0005634 nucleus (IC/IEA/ISM x3) -&gt; ACCEPT (core location)</li>
+<li>GO:0019900 kinase binding (IPI) -&gt; KEEP_AS_NON_CORE (SnRK1/KIN10 regulation)</li>
+<li>GO:1901959 positive regulation of cutin biosynthetic process (IGI) -&gt; KEEP_AS_NON_CORE</li>
+<li>GO:0009744 response to sucrose (IEP) -&gt; KEEP_AS_NON_CORE (expression response)</li>
+</ul>
+<h2 id="doeber-relevance">DOE/BER relevance</h2>
+<p>WRI1 overexpression boosts oil accumulation (including ectopically in vegetative tissue);<br />
+it is the master switch for partitioning carbon into oil and a prime target for raising<br />
+feedstock oil yield. Its SnRK1/sugar-regulated stability is a tuning point.</p>
+            </div>
+        </details>
+        
+    </div>
+    
+
+    <!-- YAML Preview Section -->
+    <div class="section">
+        <details class="yaml-preview">
+            <summary>
+                <h2 style="display: inline;">📄 View Raw YAML</h2>
+            </summary>
+            <div class="yaml-content">
+                <pre><code>id: Q6X5Y6
+gene_symbol: WRI1
+product_type: PROTEIN
+status: COMPLETE
+taxon:
+  id: NCBITaxon:3702
+  label: Arabidopsis thaliana
+description: WRINKLED1 (WRI1; ASML1) is an AP2/EREB-family transcription factor of
+  Arabidopsis with two tandem AP2 DNA-binding domains and a nuclear localization signal.
+  It is the master positive regulator of seed oil biosynthesis. In the nucleus it binds the
+  AW-box cis-element in target promoters and transcriptionally activates suites of late
+  glycolytic and fatty acid biosynthetic genes, thereby directing carbon flux toward
+  fatty acid synthesis and downstream triacylglycerol accumulation. Loss of WRI1 reduces
+  seed oil by roughly 80% (the wrinkled-seed phenotype), and its activity is integrated
+  with sugar status through SnRK1/KIN10-dependent regulation and additional modulators
+  (14-3-3 proteins, bZIP52) within the LEC1/LEC2/FUS3 seed-maturation network.
+existing_annotations:
+  - term:
+      id: GO:0006355
+      label: regulation of DNA-templated transcription
+    evidence_type: IBA
+    original_reference_id: GO_REF:0000033
+    qualifier: involved_in
+    review:
+      summary: Correct core biological process. WRI1 is a transcription factor that
+        regulates transcription of its target genes; supported experimentally below.
+      action: ACCEPT
+  - term:
+      id: GO:0003677
+      label: DNA binding
+    evidence_type: IEA
+    original_reference_id: GO_REF:0000120
+    qualifier: enables
+    review:
+      summary: Correct core molecular function, also experimentally supported (IDA below).
+        WRI1 binds the AW-box promoter element via its AP2 domains.
+      action: ACCEPT
+  - term:
+      id: GO:0003700
+      label: DNA-binding transcription factor activity
+    evidence_type: IEA
+    original_reference_id: GO_REF:0000002
+    qualifier: enables
+    review:
+      summary: Correct core molecular function. WRI1 is a sequence-specific DNA-binding
+        transcriptional activator; supported by ISS from family analysis below.
+      action: ACCEPT
+  - term:
+      id: GO:0005634
+      label: nucleus
+    evidence_type: IEA
+    original_reference_id: GO_REF:0000044
+    qualifier: located_in
+    review:
+      summary: Correct core localization. WRI1 has a nuclear localization signal and acts
+        as a nuclear transcription factor.
+      action: ACCEPT
+  - term:
+      id: GO:0006355
+      label: regulation of DNA-templated transcription
+    evidence_type: IEA
+    original_reference_id: GO_REF:0000002
+    qualifier: involved_in
+    review:
+      summary: Correct core biological process, consistent with the IBA annotation and
+        WRI1&#39;s transcriptional-activator role.
+      action: ACCEPT
+  - term:
+      id: GO:0005634
+      label: nucleus
+    evidence_type: ISM
+    original_reference_id: GO_REF:0000122
+    qualifier: located_in
+    review:
+      summary: Computational (AtSubP) prediction that is, in this case, correct and
+        corroborated by curator inference (IC) and the protein&#39;s nuclear localization
+        signal. Accepted as the core localization.
+      action: ACCEPT
+  - term:
+      id: GO:0019900
+      label: kinase binding
+    evidence_type: IPI
+    original_reference_id: PMID:28314829
+    qualifier: enables
+    review:
+      summary: Reflects the regulatory interaction with the SnRK1/KIN10 kinase, which
+        controls WRI1 protein stability in response to sugar status. A genuine regulatory
+        interaction but not the core transcription-factor function; retained as non-core.
+        [PMID:28314829]
+      action: KEEP_AS_NON_CORE
+      supported_by:
+        - reference_id: PMID:28314829
+          supporting_text: WRI1 interacts with the SnRK1 kinase (KIN10) that regulates its
+            stability
+  - term:
+      id: GO:0019432
+      label: triglyceride biosynthetic process
+    evidence_type: IMP
+    original_reference_id: PMID:23922666
+    qualifier: acts_upstream_of_or_within
+    review:
+      summary: Core biological process (as an upstream regulator). WRI1 drives the
+        transcriptional program for oil (TAG) accumulation; it is a ubiquitous regulator
+        of oil-accumulating tissues. [PMID:23922666]
+      action: ACCEPT
+      supported_by:
+        - reference_id: PMID:23922666
+          supporting_text: WRINKLED1, a ubiquitous regulator in oil-accumulating tissues
+            from Arabidopsis embryos to oil palm mesocarp
+  - term:
+      id: GO:1901959
+      label: positive regulation of cutin biosynthetic process
+    evidence_type: IGI
+    original_reference_id: PMID:23243127
+    qualifier: acts_upstream_of_or_within
+    review:
+      summary: A tissue-specific secondary regulatory role of the WRI1 clade in fatty
+        acid/cutin biosynthesis, distinct from the central seed-oil program. Retained as
+        non-core. [PMID:23243127]
+      action: KEEP_AS_NON_CORE
+      supported_by:
+        - reference_id: PMID:23243127
+          supporting_text: WRINKLED transcription factors orchestrate tissue-specific
+            regulation of fatty acid biosynthesis
+  - term:
+      id: GO:0003677
+      label: DNA binding
+    evidence_type: IDA
+    original_reference_id: PMID:19719479
+    qualifier: enables
+    review:
+      summary: Core molecular function with direct experimental support. WRI1 directly
+        binds promoters of glycolytic and fatty acid biosynthetic genes (AW-box).
+        [PMID:19719479]
+      action: ACCEPT
+      supported_by:
+        - reference_id: PMID:19719479
+          supporting_text: Role of WRINKLED1 in the transcriptional regulation of glycolytic
+            and fatty acid biosynthetic genes
+  - term:
+      id: GO:0006629
+      label: lipid metabolic process
+    evidence_type: IMP
+    original_reference_id: PMID:19755540
+    qualifier: acts_upstream_of_or_within
+    review:
+      summary: Correct but general. WRI1 mutants show severe impairment of seed storage
+        lipid synthesis; the specific role is regulation of lipid/fatty acid biosynthesis
+        captured by more specific terms. [PMID:19755540]
+      action: ACCEPT
+      supported_by:
+        - reference_id: PMID:19755540
+          supporting_text: severe impairment in seed storage lipid synthesis in wri1
+  - term:
+      id: GO:0003700
+      label: DNA-binding transcription factor activity
+    evidence_type: ISS
+    original_reference_id: PMID:15500472
+    qualifier: enables
+    review:
+      summary: Core molecular function. WRI1 was identified as an AP2/EREB-domain
+        transcription factor controlling storage-compound biosynthesis. [PMID:15500472]
+      action: ACCEPT
+      supported_by:
+        - reference_id: PMID:15500472
+          supporting_text: WRINKLED1 encodes an AP2/EREB domain protein involved in the
+            control of storage compound biosynthesis
+  - term:
+      id: GO:0006109
+      label: regulation of carbohydrate metabolic process
+    evidence_type: IMP
+    original_reference_id: PMID:9733529
+    qualifier: acts_upstream_of_or_within
+    review:
+      summary: Core regulatory role. The original wri1 mutant showed disrupted carbohydrate
+        metabolism in developing seeds, reflecting WRI1&#39;s control of the glycolytic program
+        that supplies precursors for oil synthesis. [PMID:9733529]
+      action: ACCEPT
+      supported_by:
+        - reference_id: PMID:9733529
+          supporting_text: the wrinkled1 mutant is impaired in seed carbohydrate-to-oil
+            metabolism
+  - term:
+      id: GO:0006110
+      label: regulation of glycolytic process
+    evidence_type: IMP
+    original_reference_id: PMID:16553903
+    qualifier: acts_upstream_of_or_within
+    review:
+      summary: Core biological process. WRI1 activates late-glycolytic genes to channel
+        carbon toward acetyl-CoA for fatty acid synthesis; the wri1 embryo shows altered
+        carbon-metabolism enzyme activities. [PMID:16553903]
+      action: ACCEPT
+      supported_by:
+        - reference_id: PMID:16553903
+          supporting_text: spatiotemporal analysis of carbon-metabolism enzyme activities
+            in wild-type and wri1 mutant embryos
+  - term:
+      id: GO:0008610
+      label: lipid biosynthetic process
+    evidence_type: IMP
+    original_reference_id: PMID:9733529
+    qualifier: acts_upstream_of_or_within
+    review:
+      summary: Core biological process. WRI1 is required for seed lipid (oil) biosynthesis;
+        the wri1 mutant has strongly reduced seed oil. [PMID:9733529]
+      action: ACCEPT
+      supported_by:
+        - reference_id: PMID:9733529
+          supporting_text: the wrinkled1 mutant has reduced seed oil/lipid biosynthesis
+  - term:
+      id: GO:0009744
+      label: response to sucrose
+    evidence_type: IEP
+    original_reference_id: PMID:15753106
+    qualifier: acts_upstream_of_or_within
+    review:
+      summary: WRI1 transactivates sugar-inducible promoters and its activity is linked to
+        sugar status, but this expression-based association is non-core relative to its
+        transcription-factor function. Retained as non-core. [PMID:15753106]
+      action: KEEP_AS_NON_CORE
+      supported_by:
+        - reference_id: PMID:15753106
+          supporting_text: ACTIVATOR of Spomin::LUC1/WRINKLED1 transactivates sugar-inducible
+            promoters
+  - term:
+      id: GO:0019432
+      label: triglyceride biosynthetic process
+    evidence_type: IMP
+    original_reference_id: PMID:15500472
+    qualifier: acts_upstream_of_or_within
+    review:
+      summary: Core biological process (as upstream regulator). WRI1 controls storage-oil
+        (TAG) biosynthesis; the wri1 mutant has the low-oil wrinkled-seed phenotype.
+        [PMID:15500472]
+      action: ACCEPT
+      supported_by:
+        - reference_id: PMID:15500472
+          supporting_text: WRINKLED1 controls storage compound (oil) biosynthesis in seeds
+  - term:
+      id: GO:0003700
+      label: DNA-binding transcription factor activity
+    evidence_type: ISS
+    original_reference_id: PMID:11118137
+    qualifier: enables
+    review:
+      summary: Core molecular function (sequence/family support). WRI1 is classified as a
+        DNA-binding transcription factor in genome-wide TF analyses. [PMID:11118137]
+      action: ACCEPT
+      supported_by:
+        - reference_id: PMID:11118137
+          supporting_text: classification of Arabidopsis AP2/EREB transcription factors
+  - term:
+      id: GO:0005634
+      label: nucleus
+    evidence_type: IC
+    original_reference_id: PMID:10948255
+    qualifier: located_in
+    review:
+      summary: Core localization, inferred by the curator (IC). WRI1 is a nuclear AP2
+        transcription factor with a nuclear localization signal; the cited paper concerns
+        the related AP2 factor AINTEGUMENTA and is used as family-analogy support for
+        nuclear localization. Accepted, as nuclear localization is well established for
+        WRI1&#39;s function. [PMID:10948255]
+      action: ACCEPT
+      supported_by:
+        - reference_id: file:ARATH/WRI1/WRI1-deep-research-falcon.md
+          supporting_text: WRI1 is a nuclear transcription factor with a nuclear
+            localization signal
+core_functions:
+  - description: WRI1 is a nuclear AP2/EREB transcription factor that binds the AW-box
+      cis-element and activates late-glycolytic and fatty acid biosynthetic genes, acting
+      as the master regulator that directs carbon flux into seed oil (triacylglycerol)
+      biosynthesis.
+    molecular_function:
+      id: GO:0003700
+      label: DNA-binding transcription factor activity
+    directly_involved_in:
+      - id: GO:0006110
+        label: regulation of glycolytic process
+      - id: GO:0008610
+        label: lipid biosynthetic process
+      - id: GO:0019432
+        label: triglyceride biosynthetic process
+    locations:
+      - id: GO:0005634
+        label: nucleus
+    supported_by:
+      - reference_id: PMID:15500472
+        supporting_text: WRINKLED1 encodes an AP2/EREB domain protein controlling storage
+          compound biosynthesis
+      - reference_id: PMID:19719479
+        supporting_text: WRI1 transcriptionally regulates glycolytic and fatty acid
+          biosynthetic genes via direct DNA binding
+      - reference_id: file:ARATH/WRI1/WRI1-deep-research-falcon.md
+        supporting_text: master positive regulator of seed oil biosynthesis; wri1 mutants
+          show ~80% lower seed oil
+references:
+  - id: GO_REF:0000002
+    title: Gene Ontology annotation through association of InterPro records with GO terms
+    findings: []
+  - id: GO_REF:0000033
+    title: Annotation inferences using phylogenetic trees
+    findings: []
+  - id: GO_REF:0000044
+    title: Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location
+      vocabulary mapping, accompanied by conservative changes to GO terms applied by
+      UniProt
+    findings: []
+  - id: GO_REF:0000120
+    title: Combined Automated Annotation using Multiple IEA Methods
+    findings: []
+  - id: GO_REF:0000122
+    title: AtSubP analysis
+    findings: []
+  - id: PMID:10948255
+    title: AINTEGUMENTA promotes petal identity and acts as a negative regulator of
+      AGAMOUS.
+    findings:
+      - statement: Characterizes the AP2 transcription factor AINTEGUMENTA; used as
+          family-analogy (IC) support for nuclear localization of AP2 factors such as WRI1.
+        reference_section_type: RESULTS
+    reference_review:
+      relevance: LOW
+      correctness: VERIFIED
+      review_notes: Paper is about AINTEGUMENTA, not WRI1; cited as IC support for nuclear
+        localization of AP2-family TFs. Nuclear localization of WRI1 itself is independently
+        well established.
+  - id: PMID:11118137
+    title: &#39;Arabidopsis transcription factors: genome-wide comparative analysis among
+      eukaryotes.&#39;
+    findings:
+      - statement: Genome-wide TF classification placing WRI1 among AP2/EREB DNA-binding
+          transcription factors.
+        reference_section_type: RESULTS
+    reference_review:
+      relevance: MEDIUM
+      correctness: VERIFIED
+      review_notes: Supports the ISS DNA-binding transcription factor activity annotation.
+  - id: PMID:15500472
+    title: WRINKLED1 encodes an AP2/EREB domain protein involved in the control of storage
+      compound biosynthesis in Arabidopsis.
+    findings:
+      - statement: Identifies WRI1 as an AP2/EREB transcription factor controlling seed
+          storage compound (oil) biosynthesis.
+        reference_section_type: RESULTS
+    reference_review:
+      relevance: HIGH
+      correctness: VERIFIED
+      review_notes: Foundational identification; supports TF activity and TAG biosynthesis.
+  - id: PMID:15753106
+    title: ACTIVATOR of Spomin::LUC1/WRINKLED1 of Arabidopsis thaliana transactivates
+      sugar-inducible promoters.
+    findings:
+      - statement: WRI1 transactivates sugar-inducible promoters, linking it to sugar
+          signaling.
+        reference_section_type: RESULTS
+    reference_review:
+      relevance: MEDIUM
+      correctness: VERIFIED
+      review_notes: Supports the non-core response-to-sucrose annotation.
+  - id: PMID:16553903
+    title: A spatiotemporal analysis of enzymatic activities associated with carbon
+      metabolism in wild-type and mutant embryos of Arabidopsis using in situ histochemistry.
+    findings:
+      - statement: wri1 embryos show altered carbon-metabolism enzyme activities,
+          consistent with WRI1 control of the glycolytic program feeding oil synthesis.
+        reference_section_type: RESULTS
+    reference_review:
+      relevance: HIGH
+      correctness: VERIFIED
+      review_notes: Supports regulation of glycolytic process.
+  - id: PMID:19719479
+    title: Role of WRINKLED1 in the transcriptional regulation of glycolytic and fatty
+      acid biosynthetic genes in Arabidopsis.
+    findings:
+      - statement: WRI1 directly binds and activates promoters of glycolytic and fatty acid
+          biosynthetic genes (AW-box), establishing direct DNA binding.
+        reference_section_type: RESULTS
+    reference_review:
+      relevance: HIGH
+      correctness: VERIFIED
+      review_notes: Source of the IDA DNA binding annotation and core regulatory mechanism.
+  - id: PMID:19755540
+    title: Analysis of metabolic flux phenotypes for two Arabidopsis mutants with severe
+      impairment in seed storage lipid synthesis.
+    findings:
+      - statement: wri1 is among mutants with severe impairment in seed storage lipid
+          synthesis.
+        reference_section_type: RESULTS
+    reference_review:
+      relevance: MEDIUM
+      correctness: VERIFIED
+      review_notes: Supports the lipid metabolic process annotation.
+  - id: PMID:23243127
+    title: WRINKLED transcription factors orchestrate tissue-specific regulation of fatty
+      acid biosynthesis in Arabidopsis.
+    findings:
+      - statement: WRI clade members regulate fatty acid/cutin biosynthesis in a
+          tissue-specific manner.
+        reference_section_type: RESULTS
+    reference_review:
+      relevance: MEDIUM
+      correctness: VERIFIED
+      review_notes: Supports the non-core cutin biosynthesis regulation annotation.
+  - id: PMID:23922666
+    title: Wrinkled1, a ubiquitous regulator in oil accumulating tissues from Arabidopsis
+      embryos to oil palm mesocarp.
+    findings:
+      - statement: WRI1 is a conserved, ubiquitous regulator of oil accumulation across
+          tissues and species.
+        reference_section_type: RESULTS
+    reference_review:
+      relevance: HIGH
+      correctness: VERIFIED
+      review_notes: Supports TAG biosynthesis regulation (core).
+  - id: PMID:28314829
+    title: Phosphorylation of WRINKLED1 by KIN10 Results in Its Proteasomal Degradation,
+      Providing a Link between Energy Homeostasis and Lipid Biosynthesis.
+    findings:
+      - statement: WRI1 physically interacts with the SnRK1/KIN10 kinase, which controls
+          WRI1 protein stability in response to sugar status.
+        reference_section_type: RESULTS
+    reference_review:
+      relevance: MEDIUM
+      correctness: VERIFIED
+      review_notes: Source of the kinase binding (IPI) annotation; regulatory, non-core.
+  - id: PMID:9733529
+    title: &#39;wrinkled1: A novel, low-seed-oil mutant of Arabidopsis with a deficiency in
+      the seed-specific regulation of carbohydrate metabolism.&#39;
+    findings:
+      - statement: The wrinkled1 mutant is impaired in conversion of seed carbohydrate to
+          oil, establishing WRI1&#39;s role in lipid biosynthesis and carbohydrate metabolism.
+        reference_section_type: RESULTS
+    reference_review:
+      relevance: HIGH
+      correctness: VERIFIED
+      review_notes: Original wri1 mutant; supports lipid biosynthesis and carbohydrate
+        metabolism regulation.
+  - id: file:ARATH/WRI1/WRI1-deep-research-falcon.md
+    title: Falcon/Edison deep research report for WRI1/WRINKLED1, Arabidopsis thaliana
+    findings:
+      - statement: Synthesizes WRI1 as the nuclear AP2/EREB master regulator of seed oil
+          biosynthesis that binds the AW-box and activates glycolytic and fatty acid
+          synthesis genes; wri1 mutants have ~80% lower seed oil; regulated by SnRK1/KIN10,
+          14-3-3, and bZIP52 within the LEC1/LEC2/FUS3 network.
+        reference_section_type: OTHER
+suggested_questions:
+  - question: Can WRI1 expression/stability (e.g. via SnRK1/KIN10 and the AW-box target
+      network) be engineered to push carbon flux into oil in vegetative or seed tissue of
+      oilseed feedstocks without the pleiotropic growth penalties of constitutive activation?
+</code></pre>
+            </div>
+        </details>
+    </div>
+
+    <!-- Pathway Visualization Link -->
+    
+
+    <style>
+        /* Markdown Section Styles */
+        .markdown-section {
+            margin-bottom: 1rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .markdown-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .markdown-section summary h3 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.1rem;
+        }
+
+        .markdown-section summary:hover h3 {
+            color: #007bff;
+        }
+
+        .markdown-section[open] {
+            background-color: #fff;
+        }
+
+        .markdown-content {
+            margin-top: 1rem;
+            padding: 1rem;
+            border-top: 1px solid #dee2e6;
+        }
+
+        /* Markdown content styling */
+        .markdown-content h1 { font-size: 1.5rem; margin-top: 1.5rem; }
+        .markdown-content h2 { font-size: 1.3rem; margin-top: 1.3rem; }
+        .markdown-content h3 { font-size: 1.1rem; margin-top: 1.1rem; }
+        .markdown-content h4 { font-size: 1rem; margin-top: 1rem; }
+
+        .markdown-content pre {
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .markdown-content code {
+            background-color: #f8f9fa;
+            padding: 0.2rem 0.4rem;
+            border-radius: 3px;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+        }
+
+        .markdown-content pre code {
+            background: none;
+            padding: 0;
+        }
+
+        .markdown-content table {
+            border-collapse: collapse;
+            width: 100%;
+            margin: 1rem 0;
+        }
+
+        .markdown-content table th,
+        .markdown-content table td {
+            border: 1px solid #dee2e6;
+            padding: 0.5rem;
+            text-align: left;
+        }
+
+        .markdown-content table th {
+            background-color: #f8f9fa;
+            font-weight: bold;
+        }
+
+        .markdown-content blockquote {
+            border-left: 4px solid #007bff;
+            padding-left: 1rem;
+            margin-left: 0;
+            color: #666;
+        }
+
+        /* YAML Preview Styles */
+        .yaml-preview {
+            margin-top: 2rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .yaml-preview summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .yaml-preview summary h2 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.3rem;
+        }
+
+        .yaml-preview summary:hover h2 {
+            color: #007bff;
+        }
+
+        .yaml-preview[open] {
+            background-color: #fff;
+        }
+
+        .yaml-content {
+            margin-top: 1rem;
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .yaml-content pre {
+            margin: 0;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+            line-height: 1.4;
+        }
+
+        .yaml-content code {
+            color: #333;
+            background: none;
+            padding: 0;
+        }
+
+        /* Pathway Link Styles */
+        .pathway-link {
+            margin: 1rem 0;
+        }
+
+        .btn-link {
+            display: inline-block;
+            padding: 0.5rem 1rem;
+            background-color: #007bff;
+            color: white !important;
+            text-decoration: none;
+            border-radius: 4px;
+            font-weight: 500;
+            transition: background-color 0.2s;
+        }
+
+        .btn-link:hover {
+            background-color: #0056b3;
+            text-decoration: none;
+        }
+
+        /* Voting buttons */
+        .vote-buttons {
+            display: inline-block;
+            margin-left: 0.5rem;
+        }
+
+        .vote-btn {
+            background: none;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 2px 6px;
+            margin: 0 2px;
+            cursor: pointer;
+            font-size: 0.9rem;
+            transition: all 0.2s;
+            opacity: 0.6;
+        }
+
+        .vote-btn:hover {
+            opacity: 1;
+            transform: scale(1.1);
+        }
+
+        .vote-btn.voted {
+            opacity: 1;
+            border-color: #28a745;
+            background-color: #d4edda;
+        }
+
+        .vote-btn.voted-down {
+            border-color: #dc3545;
+            background-color: #f8d7da;
+        }
+
+        .vote-btn-small {
+            font-size: 0.7rem;
+            padding: 1px 4px;
+            margin: 0 1px;
+        }
+    </style>
+
+    <script>
+        // Add collapsible functionality
+        document.querySelectorAll('.collapsible').forEach(element => {
+            element.addEventListener('click', function() {
+                this.classList.toggle('collapsed');
+            });
+        });
+
+        // Voting functionality
+        const VOTE_URL = 'https://script.google.com/macros/s/AKfycbwPKH7d3seuPNBtB0ugVjqGeTiByyOGD5vkqB_Ck6K8eOcPQYbJqBOuz6GFgXHKBNWK/exec';
+
+        // Get or create session ID
+        let sessionId = localStorage.getItem('review_session_id');
+        if (!sessionId) {
+            sessionId = 's' + Date.now() + '_' + Math.random().toString(36).substr(2, 9);
+            localStorage.setItem('review_session_id', sessionId);
+        }
+
+        // Show previous votes on page load
+        document.addEventListener('DOMContentLoaded', function() {
+            document.querySelectorAll('.vote-buttons').forEach(container => {
+                const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+                const previousVote = localStorage.getItem(key);
+                if (previousVote) {
+                    const btn = container.querySelector(`[data-v="${previousVote}"]`);
+                    if (btn) btn.classList.add(previousVote === 'up' ? 'voted' : 'voted-down');
+                }
+            });
+        });
+
+        // Handle vote clicks - Simple image beacon approach
+        document.addEventListener('click', function(e) {
+            if (!e.target.classList.contains('vote-btn')) return;
+
+            // Prevent the click from bubbling to parent elements (like summary)
+            e.preventDefault();
+            e.stopPropagation();
+
+            const btn = e.target;
+            const container = btn.closest('.vote-buttons');
+            if (!container) return;
+
+            const voteType = btn.dataset.v;
+
+            // Check if already voted (locally)
+            const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+            const previousVote = localStorage.getItem(key);
+
+            if (previousVote === voteType) {
+                // Same vote - do nothing
+                btn.style.animation = 'shake 0.5s';
+                setTimeout(() => btn.style.animation = '', 500);
+                return;
+            }
+
+            // Build URL
+            const params = new URLSearchParams({
+                gene_id: container.dataset.g,
+                annotation_id: container.dataset.a,
+                ref_id: container.dataset.r || '',
+                action: container.dataset.act,
+                vote: voteType,
+                session_id: sessionId,
+                ua: navigator.userAgent.substring(0, 100)
+            });
+
+            // Clear previous vote styling
+            container.querySelectorAll('.vote-btn').forEach(b => {
+                b.classList.remove('voted', 'voted-down');
+            });
+
+            // Apply new vote styling immediately (optimistic UI)
+            btn.classList.add(voteType === 'up' ? 'voted' : 'voted-down');
+
+            // Store locally
+            localStorage.setItem(key, voteType);
+
+            // Send vote using fetch with no-cors mode (fire and forget)
+            const fullUrl = VOTE_URL + '?' + params;
+            console.log('Sending vote to:', fullUrl);
+
+            // Use fetch in no-cors mode - we won't get a response but the request will be sent
+            fetch(fullUrl, {
+                mode: 'no-cors',
+                method: 'GET'
+            }).then(() => {
+                console.log('Vote request sent (no response due to no-cors mode)');
+            }).catch(err => {
+                console.warn('Vote may not have been recorded, but saved locally:', err);
+
+                // Fallback: try image beacon as well
+                const img = new Image();
+                img.src = fullUrl;
+            });
+        });
+
+        // Optional: Add shake animation for feedback
+        const style = document.createElement('style');
+        style.textContent = `
+            @keyframes shake {
+                0%, 100% { transform: translateX(0); }
+                25% { transform: translateX(-5px); }
+                75% { transform: translateX(5px); }
+            }
+        `;
+        document.head.appendChild(style);
+    </script>
+</body>
+</html>

--- a/genes/THLAR/CYP71B1/CYP71B1-ai-review.html
+++ b/genes/THLAR/CYP71B1/CYP71B1-ai-review.html
@@ -1,0 +1,2241 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>CYP71B1 - AI Gene Review</title>
+    <style>
+        :root {
+            --color-accept: #22c55e;
+            --color-remove: #ef4444;
+            --color-modify: #f97316;
+            --color-keep-non-core: #3b82f6;
+            --color-undecided: #6b7280;
+            --color-new: #8b5cf6;
+            --color-mark-over: #eab308;
+            --bg-light: #f9fafb;
+            --border-color: #e5e7eb;
+            --text-muted: #6b7280;
+            --text-primary: #111827;
+        }
+
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+            line-height: 1.6;
+            color: var(--text-primary);
+            background-color: #ffffff;
+            padding: 2rem;
+            max-width: 1400px;
+            margin: 0 auto;
+        }
+
+        .header {
+            border-bottom: 2px solid var(--border-color);
+            padding-bottom: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        h1 {
+            font-size: 2.5rem;
+            font-weight: 700;
+            margin-bottom: 0.5rem;
+            color: #1f2937;
+        }
+
+        .gene-info {
+            display: flex;
+            gap: 2rem;
+            flex-wrap: wrap;
+            margin-top: 1rem;
+        }
+
+        .info-item {
+            display: flex;
+            gap: 0.5rem;
+        }
+
+        .info-label {
+            font-weight: 600;
+            color: var(--text-muted);
+        }
+
+        .aliases {
+            display: flex;
+            gap: 0.5rem;
+            flex-wrap: wrap;
+        }
+
+        .badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.875rem;
+            font-weight: 500;
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+        }
+
+        .status-badge {
+            padding: 0.375rem 0.875rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .status-initialized {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fde68a;
+        }
+
+        .status-in-progress {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+        }
+
+        .status-draft {
+            background-color: #fce7f3;
+            color: #831843;
+            border: 1px solid #fbcfe8;
+        }
+
+        .status-complete {
+            background-color: #d1fae5;
+            color: #065f46;
+            border: 1px solid #a7f3d0;
+        }
+
+        .description-card {
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        .description-card h2 {
+            font-size: 1.25rem;
+            margin-bottom: 1rem;
+            color: #374151;
+        }
+
+        .section {
+            margin-bottom: 2.5rem;
+        }
+
+        .section-title {
+            font-size: 1.5rem;
+            font-weight: 600;
+            margin-bottom: 1.5rem;
+            color: #1f2937;
+            border-bottom: 1px solid var(--border-color);
+            padding-bottom: 0.5rem;
+        }
+
+        .annotations-table {
+            width: 100%;
+            border-collapse: collapse;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            overflow: hidden;
+        }
+
+        .annotations-table thead {
+            background-color: var(--bg-light);
+        }
+
+        .annotations-table th {
+            text-align: left;
+            padding: 1rem;
+            font-weight: 600;
+            border-bottom: 2px solid var(--border-color);
+            font-size: 0.875rem;
+            text-transform: uppercase;
+            letter-spacing: 0.05em;
+            color: var(--text-muted);
+        }
+
+        .annotations-table td {
+            padding: 1rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .annotations-table tbody tr:hover {
+            background-color: #f9fafb;
+        }
+
+        .action-badge {
+            display: inline-block;
+            padding: 0.375rem 0.75rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .action-accept {
+            background-color: var(--color-accept);
+            color: white;
+        }
+
+        .action-remove {
+            background-color: var(--color-remove);
+            color: white;
+        }
+
+        .action-modify {
+            background-color: var(--color-modify);
+            color: white;
+        }
+
+        .action-keep_as_non_core {
+            background-color: var(--color-keep-non-core);
+            color: white;
+        }
+
+        .action-undecided {
+            background-color: var(--color-undecided);
+            color: white;
+        }
+
+        .action-new {
+            background-color: var(--color-new);
+            color: white;
+        }
+
+        .action-mark_as_over_annotated {
+            background-color: var(--color-mark-over);
+            color: white;
+        }
+
+        .term-info {
+            display: flex;
+            flex-direction: column;
+            gap: 0.25rem;
+        }
+
+        .term-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .term-label {
+            font-weight: 500;
+        }
+
+        .evidence-code {
+            font-family: monospace;
+            background-color: var(--bg-light);
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .not-badge {
+            display: inline-block;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-weight: 600;
+            margin-left: 0.25rem;
+        }
+
+        .isoform-badge {
+            display: inline-block;
+            background-color: #eff6ff;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            margin-top: 0.25rem;
+        }
+
+        .core-function-card {
+            background-color: white;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 1rem;
+        }
+
+        .core-function-card h3 {
+            font-size: 1.125rem;
+            margin-bottom: 1rem;
+            color: #1f2937;
+        }
+
+        .core-function-statement {
+            margin-bottom: 1rem;
+            padding: 0.75rem;
+            background-color: var(--bg-light);
+            border-left: 4px solid var(--color-accept);
+            border-radius: 0.25rem;
+        }
+
+        .function-annotations {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin-top: 1rem;
+        }
+
+        .reference-item {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+        }
+
+        .reference-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: start;
+            margin-bottom: 0.75rem;
+        }
+
+        .reference-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #2563eb;
+        }
+
+        .supported-by {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f3f4f6;
+            border-left: 3px solid #3b82f6;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .supported-by-title {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .support-item {
+            margin-bottom: 0.5rem;
+        }
+
+        .support-ref {
+            font-weight: 500;
+            color: #2563eb;
+        }
+
+        .support-text {
+            color: #6b7280;
+            font-style: italic;
+            margin-left: 1rem;
+        }
+
+        a.term-link {
+            color: #2563eb;
+            text-decoration: none;
+        }
+
+        a.term-link:hover {
+            text-decoration: underline;
+        }
+
+        .core-function-terms {
+            margin-top: 1rem;
+        }
+
+        .function-term-group {
+            margin-bottom: 1rem;
+        }
+
+        .function-term-label {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .reference-title {
+            font-weight: 500;
+            margin-bottom: 0.5rem;
+        }
+
+        .findings-list {
+            margin-top: 1rem;
+            padding-left: 1.5rem;
+        }
+
+        .finding-item {
+            margin-bottom: 0.75rem;
+        }
+
+        .finding-statement {
+            font-weight: 500;
+            margin-bottom: 0.25rem;
+        }
+
+        .finding-text {
+            color: var(--text-muted);
+            font-size: 0.95rem;
+            font-style: italic;
+        }
+
+        .proposed-term {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #fef3c7;
+        }
+
+        .question-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #dbeafe;
+        }
+
+        .experiment-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #f3e8ff;
+        }
+
+        .prediction-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: white;
+        }
+
+        .prediction-card .prediction-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+        }
+
+        .prediction-source {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+        }
+
+        .assessment-badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.8rem;
+            font-weight: 600;
+            text-transform: uppercase;
+        }
+
+        .assessment-cor { background-color: #dcfce7; color: #166534; }
+        .assessment-cnn { background-color: #dbeafe; color: #1e40af; }
+        .assessment-lsp { background-color: #fef9c3; color: #854d0e; }
+        .assessment-unc { background-color: #f3f4f6; color: #374151; }
+        .assessment-pli { background-color: #fee2e2; color: #991b1b; }
+        .assessment-npi { background-color: #fecaca; color: #7f1d1d; }
+        .assessment-rep { background-color: #fde68a; color: #92400e; }
+
+        .confidence-score {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+            margin-left: 0.5rem;
+        }
+
+        .error-type-badge {
+            font-size: 0.75rem;
+            padding: 0.125rem 0.5rem;
+            border-radius: 0.25rem;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+        }
+
+        .isoforms-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fill, minmax(400px, 1fr));
+            gap: 1rem;
+        }
+
+        .isoform-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            background-color: white;
+            transition: box-shadow 0.2s;
+        }
+
+        .isoform-card:hover {
+            box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+        }
+
+        .functional-isoform-type {
+            display: inline-block;
+            padding: 0.2rem 0.5rem;
+            border-radius: 0.25rem;
+            font-size: 0.7rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.03em;
+        }
+
+        .type-SPLICE_VARIANT, .type-SPLICE_CLASS {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #93c5fd;
+        }
+
+        .type-CLEAVAGE_PRODUCT {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fcd34d;
+        }
+
+        .type-MODIFICATION_STATE {
+            background-color: #f3e8ff;
+            color: #6b21a8;
+            border: 1px solid #c4b5fd;
+        }
+
+        .type-CONFORMATIONAL_STATE {
+            background-color: #dcfce7;
+            color: #166534;
+            border: 1px solid #86efac;
+        }
+
+        .functional-isoform-mappings {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+            font-size: 0.85rem;
+        }
+
+        .functional-isoform-mappings .mapping-type {
+            font-weight: 600;
+            color: var(--text-muted);
+            font-size: 0.75rem;
+        }
+
+        .functional-isoform-go {
+            margin-top: 0.5rem;
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.25rem;
+        }
+
+        .go-chip {
+            display: inline-block;
+            padding: 0.15rem 0.4rem;
+            background-color: #ecfdf5;
+            color: #047857;
+            border: 1px solid #a7f3d0;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-family: monospace;
+        }
+
+        .isoform-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+            padding-bottom: 0.5rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .isoform-name {
+            font-weight: 600;
+            font-size: 1.1rem;
+            color: #1f2937;
+        }
+
+        .isoform-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .isoform-sequence-note {
+            font-size: 0.875rem;
+            color: var(--text-muted);
+            margin-bottom: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+        }
+
+        .isoform-description {
+            font-size: 0.95rem;
+            line-height: 1.5;
+        }
+
+        .collapsible {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .collapsible:after {
+            content: ' ▼';
+            font-size: 0.75rem;
+        }
+
+        .collapsible.collapsed:after {
+            content: ' ►';
+        }
+
+        .collapse-content {
+            transition: max-height 0.3s ease;
+            overflow: hidden;
+        }
+
+        .collapsed + .collapse-content {
+            max-height: 0;
+        }
+
+        .no-data {
+            color: var(--text-muted);
+            font-style: italic;
+            padding: 1rem;
+            text-align: center;
+            background-color: var(--bg-light);
+            border-radius: 0.5rem;
+        }
+
+        /* Styling for markdown section summaries with voting */
+        .markdown-section summary {
+            padding: 0.75rem;
+            background: var(--bg-light);
+            border-radius: 0.5rem;
+            margin-bottom: 0.5rem;
+        }
+
+        .markdown-section summary:hover {
+            background: #e5e7eb;
+        }
+
+        .markdown-section summary .vote-buttons {
+            margin-left: auto;
+        }
+
+        .deep-research-section {
+            margin-bottom: 1rem;
+            border: 1px solid #c7d2fe;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8faff;
+        }
+
+        .deep-research-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .deep-research-section summary h3 {
+            margin: 0;
+            color: #3730a3;
+            font-size: 1.1rem;
+        }
+
+        .report-meta {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin: 0.75rem 0 1rem;
+            align-items: center;
+        }
+
+        .report-badge {
+            display: inline-flex;
+            align-items: center;
+            border: 1px solid #c7d2fe;
+            border-radius: 999px;
+            background: #eef2ff;
+            color: #4338ca;
+            font-size: 0.78rem;
+            font-weight: 600;
+            padding: 0.2rem 0.6rem;
+        }
+
+        .report-meta-text {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+        }
+
+        .artifact-list {
+            display: grid;
+            gap: 0.75rem;
+            margin: 0.75rem 0 1rem;
+        }
+
+        .artifact-link {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+            margin-top: 0.5rem;
+            word-break: break-word;
+        }
+
+        @media print {
+            body {
+                padding: 1rem;
+            }
+
+            .collapsible:after {
+                display: none;
+            }
+
+            .collapsed + .collapse-content {
+                max-height: none !important;
+            }
+        }
+
+        @media (max-width: 768px) {
+            body {
+                padding: 1rem;
+            }
+
+            h1 {
+                font-size: 2rem;
+            }
+
+            .annotations-table {
+                font-size: 0.875rem;
+            }
+
+            .annotations-table th,
+            .annotations-table td {
+                padding: 0.5rem;
+            }
+        }
+    </style>
+</head>
+<body>
+    <div class="header">
+        <h1>CYP71B1</h1>
+        <div class="gene-info">
+            
+            <div class="info-item">
+                
+                <span class="info-label">UniProt ID:</span>
+                <span>
+                    <a href="https://www.uniprot.org/uniprotkb/P49264" target="_blank" class="term-link">
+                        P49264
+                    </a>
+                </span>
+                
+            </div>
+            
+            
+            <div class="info-item">
+                <span class="info-label">Organism:</span>
+                <span>Thlaspi arvense</span>
+            </div>
+            
+            
+            <div class="info-item">
+                <span class="info-label">Review Status:</span>
+                <span class="status-badge status-complete">
+                    COMPLETE
+                </span>
+            </div>
+            
+            
+        </div>
+        <div style="margin-top: 1rem; text-align: center;">
+            <a id="feedback-form-link"
+               href="#"
+               target="_blank"
+               style="display: inline-block; padding: 10px 20px; background-color: #4CAF50; color: white; text-decoration: none; border-radius: 5px; font-weight: 600;">
+                📝 Provide Detailed Feedback
+            </a>
+            <script>
+                // Construct the form URL with proper encoding
+                // Extract organism code from the current page path (e.g., /genes/ARATH/APO1/ -> ARATH)
+                const pathParts = window.location.pathname.split('/');
+                const genesIndex = pathParts.indexOf('genes');
+                let organism = '';
+                if (genesIndex !== -1 && pathParts[genesIndex + 1]) {
+                    organism = pathParts[genesIndex + 1].toUpperCase();
+                }
+                const geneSymbol = "CYP71B1";
+                const speciesGene = organism + ' ' + geneSymbol;
+                const formBaseUrl = 'https://docs.google.com/forms/d/e/1FAIpQLSdTot9L6GVkkZYgLQT0E8ZdAJv8RiN5ZgOVkgWNcKSbYvxxzQ/viewform';
+                const entryId = '1226477767'; // Correct entry ID for Species/Gene field
+                const formUrl = formBaseUrl + '?entry.' + entryId + '=' + encodeURIComponent(speciesGene);
+                const feedbackLink = document.getElementById('feedback-form-link');
+                feedbackLink.href = formUrl;
+                // Add tooltip showing the pre-filled value
+                feedbackLink.title = 'Opens form with pre-filled: ' + speciesGene;
+            </script>
+        </div>
+    </div>
+
+    
+    <div class="description-card">
+        <div style="display: flex; justify-content: space-between; align-items: center;">
+            <h2>Gene Description</h2>
+            <span class="vote-buttons" data-g="P49264" data-a="DESCRIPTION: Cytochrome P450 71B1 is a heme-thiolate cytochrome..." data-r="" data-act="DESCRIPTION">
+                <button class="vote-btn" data-v="up" title="Agree with this description">👍</button>
+                <button class="vote-btn" data-v="down" title="Disagree with this description">👎</button>
+            </span>
+        </div>
+        <p>Cytochrome P450 71B1 is a heme-thiolate cytochrome P450 monooxygenase of field pennycress, a member of the CYP71 clan that dominates plant specialized (defense) metabolism. It was identified as a full-length cDNA cloned from Thlaspi arvense in 1994, but its substrate, catalyzed reaction, metabolic pathway, expression pattern, and subcellular localization have not been experimentally determined. Based on conserved P450 architecture it is predicted to catalyze NADPH- and O2-dependent oxidation of an organic substrate using a heme cofactor, with the heme iron coordinated by a conserved axial cysteine; like most plant P450s it is expected, but not shown, to be anchored to the endoplasmic reticulum membrane.</p>
+    </div>
+    
+
+    
+
+    
+
+    
+    <div class="section">
+        <h2 class="section-title">Existing Annotations Review</h2>
+        <table class="annotations-table">
+            <thead>
+                <tr>
+                    <th>GO Term</th>
+                    <th>Evidence</th>
+                    <th>Action</th>
+                    <th>Reason</th>
+                </tr>
+            </thead>
+            <tbody>
+                
+                <tr>
+                    <td>
+                        <div class="term-info">
+                            
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0004497" target="_blank" class="term-link">
+                                    GO:0004497
+                                </a>
+                            </span>
+                            <span class="term-label">monooxygenase activity</span>
+                            
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+                        
+                        
+                        
+                        <br>
+                        <span style="font-size: 0.75rem;">
+                            
+                            GO_REF:0000002
+                            
+                        </span>
+                        
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P49264" data-a="GO:0004497" data-r="GO_REF:0000002" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+                        
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Well-supported family-level inference. The protein has canonical cytochrome P450 domain architecture (Pfam PF00067), and plant P450s are heme-thiolate monooxygenases. The specific substrate and reaction are unknown, but monooxygenase activity is a sound conservative annotation.
+                        </div>
+                        
+                        
+                        
+                        
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+                            
+                            <div class="support-item">
+                                <span class="support-ref">
+                                    
+                                    file:THLAR/CYP71B1/CYP71B1-deep-research-falcon.md
+                                    
+                                </span>
+                                
+                                <div class="support-text">Plant cytochrome P450s are heme-thiolate monooxygenases that catalyze oxygenation reactions</div>
+                                
+                            </div>
+                            
+                        </div>
+                        
+                    </td>
+                </tr>
+                
+                <tr>
+                    <td>
+                        <div class="term-info">
+                            
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005506" target="_blank" class="term-link">
+                                    GO:0005506
+                                </a>
+                            </span>
+                            <span class="term-label">iron ion binding</span>
+                            
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+                        
+                        
+                        
+                        <br>
+                        <span style="font-size: 0.75rem;">
+                            
+                            GO_REF:0000002
+                            
+                        </span>
+                        
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P49264" data-a="GO:0005506" data-r="GO_REF:0000002" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+                        
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Correct. The P450 catalytic center binds an iron-containing heme; UniProt annotates an axial heme iron-binding residue at position 436. Iron ion binding is appropriate, captured more specifically by the heme binding annotation.
+                        </div>
+                        
+                        
+                        
+                        
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+                            
+                            <div class="support-item">
+                                <span class="support-ref">
+                                    
+                                    file:THLAR/CYP71B1/CYP71B1-deep-research-falcon.md
+                                    
+                                </span>
+                                
+                                <div class="support-text">a conserved cysteine coordinates the heme iron in the P450 catalytic center</div>
+                                
+                            </div>
+                            
+                        </div>
+                        
+                    </td>
+                </tr>
+                
+                <tr>
+                    <td>
+                        <div class="term-info">
+                            
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016705" target="_blank" class="term-link">
+                                    GO:0016705
+                                </a>
+                            </span>
+                            <span class="term-label">oxidoreductase activity, acting on paired donors, with incorporation or reduction of molecular oxygen</span>
+                            
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+                        
+                        
+                        
+                        <br>
+                        <span style="font-size: 0.75rem;">
+                            
+                            GO_REF:0000002
+                            
+                        </span>
+                        
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P49264" data-a="GO:0016705" data-r="GO_REF:0000002" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+                        
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Correct and standard for a cytochrome P450 monooxygenase, which uses molecular oxygen with NADPH as the paired electron donor. Conservative family-level inference.
+                        </div>
+                        
+                        
+                        
+                        
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+                            
+                            <div class="support-item">
+                                <span class="support-ref">
+                                    
+                                    file:THLAR/CYP71B1/CYP71B1-deep-research-falcon.md
+                                    
+                                </span>
+                                
+                                <div class="support-text">RH + O2 + NADPH + H+ -&gt; ROH + H2O + NADP+</div>
+                                
+                            </div>
+                            
+                        </div>
+                        
+                    </td>
+                </tr>
+                
+                <tr>
+                    <td>
+                        <div class="term-info">
+                            
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0020037" target="_blank" class="term-link">
+                                    GO:0020037
+                                </a>
+                            </span>
+                            <span class="term-label">heme binding</span>
+                            
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+                        
+                        
+                        
+                        <br>
+                        <span style="font-size: 0.75rem;">
+                            
+                            GO_REF:0000002
+                            
+                        </span>
+                        
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P49264" data-a="GO:0020037" data-r="GO_REF:0000002" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+                        
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Correct. Cytochrome P450s are heme-thiolate proteins; UniProt annotates the axial heme iron-binding residue (position 436). This is the most specific cofactor annotation and underpins the monooxygenase activity.
+                        </div>
+                        
+                        
+                        
+                        
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+                            
+                            <div class="support-item">
+                                <span class="support-ref">
+                                    
+                                    file:THLAR/CYP71B1/CYP71B1-deep-research-falcon.md
+                                    
+                                </span>
+                                
+                                <div class="support-text">P450s share a conserved catalytic center in which a conserved cysteine coordinates the heme iron</div>
+                                
+                            </div>
+                            
+                        </div>
+                        
+                    </td>
+                </tr>
+                
+            </tbody>
+        </table>
+    </div>
+    
+
+    
+    <div class="section">
+        <h2 class="section-title">Core Functions</h2>
+        
+        <div class="core-function-card">
+            
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+                <h3>CYP71B1 is a heme-thiolate cytochrome P450 monooxygenase predicted to catalyze NADPH/O2-dependent oxidation of an organic substrate. The physiological substrate, reaction, and pathway are unknown; CYP71-clan membership suggests a role in specialized (defense) metabolism, but this is not established for the pennycress protein.</h3>
+                <span class="vote-buttons" data-g="P49264" data-a="FUNCTION: CYP71B1 is a heme-thiolate cytochrome P450 monooxy..." data-r="" data-act="CORE_FUNCTION">
+                    <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
+                    <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
+                </span>
+            </div>
+            
+
+            <div class="core-function-terms">
+                
+                <div class="function-term-group">
+                    <div class="function-term-label">Molecular Function:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0004497" target="_blank" class="term-link">
+                            monooxygenase activity
+                        </a>
+                    </span>
+                </div>
+                
+
+                
+
+                
+
+                
+
+                
+            </div>
+
+            
+            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
+                <strong>Supporting Evidence:</strong>
+                <ul class="findings-list">
+                    
+                    <li class="finding-item">
+                        <span class="reference-id">
+                            
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/8066138" target="_blank" class="term-link">
+                                PMID:8066138
+                            </a>
+                            
+                        </span>
+                        
+                        <div class="finding-text">Cloning and sequencing of a full-length cDNA from Thlaspi arvense L. that encodes a cytochrome P-450</div>
+                        
+                    </li>
+                    
+                    <li class="finding-item">
+                        <span class="reference-id">
+                            
+                            file:THLAR/CYP71B1/CYP71B1-deep-research-falcon.md
+                            
+                        </span>
+                        
+                        <div class="finding-text">heme-thiolate monooxygenase; CYP71 clan enriched in plant specialized metabolism; substrate of pennycress CYP71B1 not determined</div>
+                        
+                    </li>
+                    
+                </ul>
+            </div>
+            
+        </div>
+        
+    </div>
+    
+
+    
+    <div class="section">
+        <h2 class="section-title collapsible">References</h2>
+        <div class="collapse-content">
+            
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+                        
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000002.md" target="_blank" class="term-link">
+                            GO_REF:0000002
+                        </a>
+                        
+                    </span>
+                </div>
+                
+                <div class="reference-title">Gene Ontology annotation through association of InterPro records with GO terms</div>
+                
+                
+            </div>
+            
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+                        
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/8066138" target="_blank" class="term-link">
+                            PMID:8066138
+                        </a>
+                        
+                    </span>
+                </div>
+                
+                <div class="reference-title">Cloning and sequencing of a full-length cDNA from Thlaspi arvense L. that encodes a cytochrome P-450.</div>
+                
+                
+                <ul class="findings-list">
+                    
+                    <li class="finding-item">
+                        <div class="finding-statement">Reports the full-length cDNA of Thlaspi arvense CYP71B1 (a cytochrome P450); a sequence report with no functional characterization.</div>
+                        
+                    </li>
+                    
+                </ul>
+                
+            </div>
+            
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+                        
+                        file:THLAR/CYP71B1/CYP71B1-deep-research-falcon.md
+                        
+                    </span>
+                </div>
+                
+                <div class="reference-title">Falcon/Edison deep research report for CYP71B1, Thlaspi arvense</div>
+                
+                
+                <ul class="findings-list">
+                    
+                    <li class="finding-item">
+                        <div class="finding-statement">Concludes pennycress CYP71B1 is functionally uncharacterized; only a heme-thiolate plant P450 monooxygenase classification can be inferred, with CYP71-clan members commonly acting in specialized/defense metabolism (e.g. Arabidopsis camalexin pathway). Flags symbol ambiguity with Arabidopsis CYP71B1 (At1g13080).</div>
+                        
+                    </li>
+                    
+                </ul>
+                
+            </div>
+            
+        </div>
+    </div>
+    
+
+
+    
+    <div class="section">
+        <h2 class="section-title">Suggested Questions for Experts</h2>
+        
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> What substrate(s) and reaction does Thlaspi arvense CYP71B1 catalyze, and in which pathway (e.g. glucosinolate, indole/camalexin-type, or other specialized metabolism) does it act?</p>
+                    
+                </div>
+                <span class="vote-buttons" data-g="P49264" data-a="Q: What substrate(s) and reaction does Thlaspi arvens..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+        
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> Is CYP71B1 anchored to the endoplasmic reticulum membrane, as is typical for CYP71-clan plant P450s?</p>
+                    
+                </div>
+                <span class="vote-buttons" data-g="P49264" data-a="Q: Is CYP71B1 anchored to the endoplasmic reticulum m..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+        
+    </div>
+    
+
+    
+    <div class="section">
+        <h2 class="section-title">Suggested Experiments</h2>
+        
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    
+                    <p><strong>Experiment:</strong> Heterologously express CYP71B1 (e.g. in yeast or N. benthamiana microsomes with a plant cytochrome P450 reductase) and screen candidate substrates from Brassicaceae specialized metabolism (indole/tryptophan-derived intermediates, glucosinolate precursors) by LC-MS to identify the catalyzed reaction.</p>
+                    
+                    
+                    
+                </div>
+                <span class="vote-buttons" data-g="P49264" data-a="EXPERIMENT: Heterologously express CYP71B1 (e.g. in yeast or N..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+        
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    
+                    <p><strong>Experiment:</strong> Determine subcellular localization with a fluorescent-protein fusion and test for an N-terminal ER membrane anchor.</p>
+                    
+                    
+                    
+                </div>
+                <span class="vote-buttons" data-g="P49264" data-a="EXPERIMENT: Determine subcellular localization with a fluoresc..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+        
+    </div>
+    
+
+    
+
+    <!-- Computational Predictions Section -->
+    
+
+    <!-- Deep Research Sections -->
+    
+    <div class="section">
+        <h2 class="section-title">Deep Research</h2>
+        
+        <details class="deep-research-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; gap: 1rem;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Falcon</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(CYP71B1-deep-research-falcon.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="P49264" data-a="DEEP_RESEARCH: Falcon" data-r="" data-act="DEEP_RESEARCH" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This deep research is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This deep research needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+                
+                <div class="report-meta">
+                    
+                    <span class="report-meta-text">this with annotations you find in gene/protein databases, but these can be outdated or inaccurate.</span>
+                    
+                    
+                    <span class="report-badge">Falcon</span>
+                    
+                    
+                    <span class="report-badge">Edison Scientific Literature</span>
+                    
+                    
+                    <span class="report-badge">33 citations</span>
+                    
+                    
+                    <span class="report-badge">2 artifacts</span>
+                    
+                    
+                    <span class="report-meta-text">2026-06-11T17:09:42.745411</span>
+                    
+                    
+                    
+                </div>
+                
+                
+                <div class="artifact-list">
+                    
+                    
+                    
+                    <div class="artifact-link">
+                        <a href="CYP71B1-deep-research-falcon_artifacts/artifact-00.md" class="term-link">Edison artifact artifact-00</a>
+                        <span>(text/markdown)</span>
+                    </div>
+                    
+                    
+                    
+                    
+                    <div class="artifact-link">
+                        <a href="CYP71B1-deep-research-falcon_artifacts/image-1.png" class="term-link">## Context ID: pqac-00000014 I have extracted Figure 2 and Figure 4 from the document as requested. Figure 2 shows the conserved signature motifs and sequences </a>
+                        <span>(image/png)</span>
+                    </div>
+                    
+                    
+                </div>
+                
+                <p>The research report should be a detailed narrative explaining the function, biological processes, and localization of the gene product. Citations should be given for all claims.</p>
+<p>You should prioritize authoritative reviews and primary scientific literature when conducting research. You can supplement<br />
+this with annotations you find in gene/protein databases, but these can be outdated or inaccurate.</p>
+<p>We are specifically interested in the primary function of the gene - for enzymes, what reaction is catalyzed, and what is the substrate specificity? For transporters, what is the substrate? For structural proteins or adapters, what is the broader structural role? For signaling molecules, what is the role in the pathway.</p>
+<p>We are interested in where in or outside the cell the gene product carries out its function.</p>
+<p>We are also interested in the signaling or biochemical pathways in which the gene functions. We are less interested in broad pleiotropic effects, except where these elucidate the precise role.</p>
+<p>Include evidence where possible. We are interested in both experimental evidence as well as inference from structure, evolution, or bioinformatic analysis. Precise studies should be prioritized over high-throughput, where available.</p>
+<h2 id="research-report-functional-annotation-of-cyp71b1-from-thlaspi-arvense-field-pennycress">Research Report: Functional Annotation of <strong>CYP71B1</strong> from <em>Thlaspi arvense</em> (Field pennycress)</h2>
+<h3 id="executive-summary-identity-verified-function-largely-uncharacterized">Executive summary (identity verified; function largely uncharacterized)</h3>
+<p>The target protein is <strong>Cytochrome P450 71B1</strong> (gene <strong>CYP71B1</strong>) from <em>Thlaspi arvense</em> (field pennycress), UniProt <strong>P49264</strong>, belonging to the <strong>cytochrome P450 (CYP)</strong> superfamily and containing the canonical CYP domain architecture (Cyt_P450 / PF00067) indicated by UniProt context. Within the tool-retrieved literature, the strongest direct evidence for this specific pennycress CYP71B1 is a peer-reviewed review that catalogs it as a <strong>full-length cDNA</strong> associated with GenEMBL accession <strong>L24438</strong> and cites the original Plant Physiology cloning note (1994). However, <strong>no direct biochemical reaction, substrate specificity, pathway placement, or experimentally demonstrated subcellular localization for pennycress CYP71B1</strong> could be retrieved from the accessible sources. Therefore, any functional annotation beyond “microsomal plant P450 monooxygenase” must be treated as <strong>inference</strong> based on general plant P450 biology and on characterized CYP71-family members in related Brassicaceae (notably <em>Arabidopsis</em>). (schuler1996plantcytochromep450 pages 5-8, bak2011cytochromesp450 pages 3-5)</p>
+<p>A key complication is <strong>symbol ambiguity</strong>: “CYP71B1” is also used for <em>Arabidopsis</em> loci (e.g., At1g13080 listed as a putative P450), and other Arabidopsis P450s are sometimes discussed with different names (e.g., MAX1 is CYP711A1), so the pennycress protein should not be conflated with Arabidopsis CYP71B1 or MAX1. (schuckel2012developmentofa pages 193-196, schuckel2012developmentofa pages 199-203)</p>
+<h3 id="evidence-map-direct-vs-inferred">Evidence map (direct vs inferred)</h3>
+<table>
+<thead>
+<tr>
+<th>Evidence scope</th>
+<th>Organism</th>
+<th>Gene/Protein (incl. accession/locus)</th>
+<th>Key finding (function/substrate/localization/role)</th>
+<th>Data/statistics</th>
+<th>Source (author year)</th>
+<th>Publication date</th>
+<th>URL/DOI</th>
+<th>Notes on confidence/limitations</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>Direct</td>
+<td><em>Thlaspi arvense</em></td>
+<td>CYP71B1; GenEMBL accession <strong>L24438</strong>; UniProt target <strong>P49264</strong></td>
+<td>Authoritative review catalogs <em>T. arvense</em> CYP71B1 as a <strong>full-length cDNA</strong> and links it to the original cloning note; this is the strongest direct evidence that the queried protein exists in field pennycress. No substrate, reaction, localization, or pathway assignment is provided in the accessible text. (schuler1996plantcytochromep450 pages 5-8)</td>
+<td>Full-length cDNA reported; no functional assay statistics available in retrieved text. (schuler1996plantcytochromep450 pages 5-8)</td>
+<td>Schuler 1996</td>
+<td>Jan 1996</td>
+<td>https://doi.org/10.1080/07352689609701942</td>
+<td>High confidence for identity/accession; very low confidence for biochemical function because the retrieved evidence is only a catalog entry citing Udvardi et al. 1994, not a functional study.</td>
+</tr>
+<tr>
+<td>Inference / background</td>
+<td>Plants; Arabidopsis emphasized</td>
+<td>Plant CYPs broadly; Arabidopsis CYP71 family; related CYP71A/B members</td>
+<td>Defines plant P450s as heme-thiolate monooxygenases; most plant P450s are membrane-bound and usually anchored on the <strong>cytoplasmic face of the ER</strong>. Arabidopsis has <strong>244 P450 genes and 28 pseudogenes</strong>. The <strong>CYP71 clan</strong> is described as a major duplicated lineage involved in specialized metabolism; CYP71A13, CYP71A12, and CYP71B15 are linked to tryptophan-derived defense metabolism, supporting cautious inference that uncharacterized CYP71B1 may also act in specialized metabolism. (bak2011cytochromesp450 pages 1-3, bak2011cytochromesp450 pages 3-5, bak2011cytochromesp450 pages 12-13, bak2011cytochromesp450 pages 11-12)</td>
+<td>244 genes plus 28 pseudogenes in Arabidopsis; ER localization is the usual plant P450 context. (bak2011cytochromesp450 pages 1-3, bak2011cytochromesp450 pages 3-5)</td>
+<td>Bak et al. 2011</td>
+<td>Oct 06 2011</td>
+<td>https://doi.org/10.1199/tab.0144</td>
+<td>Strong for general plant P450 properties and Arabidopsis family context; indirect for <em>T. arvense</em> CYP71B1 specifically.</td>
+</tr>
+<tr>
+<td>Inference from characterized homologous pathway members</td>
+<td><em>Arabidopsis thaliana</em></td>
+<td>CYP71B15/PAD3, CYP71A13, CYP71A12, CYP83B1, CYP79B2/B3</td>
+<td>Demonstrates that characterized CYP71 enzymes can function in a <strong>camalexin metabolon</strong> on the ER and process <strong>indole-derived defense intermediates</strong>. CYP71B15/PAD3 performs a late camalexin step; CYP71A13 channels indole-3-acetaldoxime into camalexin biosynthesis; CYP71A12 contributes in roots. Supports the idea that CYP71 family members often act on specialized-metabolism substrates and may participate in multiprotein complexes. (mucha2019theformationof pages 3-4, mucha2019theformationof pages 2-3, mucha2019theformationof pages 4-5)</td>
+<td>CYP71B15 is the strongest co-IP signal in the metabolon study; about 22 P450s co-purified; PAD3 localized in cells adjacent to infection sites; one associated enzyme, NITRILASE3, showed about 7-fold change in the cited excerpt. (mucha2019theformationof pages 3-4, mucha2019theformationof pages 2-3, mucha2019theformationof pages 4-5)</td>
+<td>Mucha et al. 2019</td>
+<td>Sep 2019</td>
+<td>https://doi.org/10.1105/tpc.19.00403</td>
+<td>Strong for Arabidopsis camalexin-pathway CYP71s; only suggestive for pennycress CYP71B1 because orthology and substrate equivalence are unproven.</td>
+</tr>
+<tr>
+<td>Ambiguity warning / indirect</td>
+<td><em>Arabidopsis thaliana</em></td>
+<td><strong>CYP71B1 / 71B1 (At1g13080)</strong> in Arabidopsis table; nearby CYP71B7 and CYP71B15 entries</td>
+<td>Appendix-style Arabidopsis table lists <strong>71B1 (At1g13080)</strong> only as a <strong>putative P450</strong>, with no reaction, substrate, pathway, or localization. Neighboring CYP71 family members do have activities, for example CYP71B7 deethylates 7-ethoxycoumarin and CYP71B15 converts dihydrocamalexic acid to camalexin, underscoring that family membership alone does not specify function. (schuckel2012developmentofa pages 193-196, schuckel2012developmentofa pages 39-41)</td>
+<td>No direct statistics for AtCYP71B1; nearby entries show diverse CYP71 activities. (schuckel2012developmentofa pages 193-196, schuckel2012developmentofa pages 39-41)</td>
+<td>Schückel 2012</td>
+<td>2012</td>
+<td>No stable journal URL available in retrieved record</td>
+<td>Useful mainly to show <strong>symbol ambiguity</strong> and lack of annotation even in Arabidopsis; should not be conflated with <em>Thlaspi arvense</em> CYP71B1.</td>
+</tr>
+<tr>
+<td>Recent review / broad inference</td>
+<td>Plants; grapevine example</td>
+<td>CYP71 clan; CYP71BE example</td>
+<td>Recent review states the <strong>CYP71 clan encompasses more than 50 percent of plant CYPs</strong> and is prominent in terpenoid metabolism. Gives a concrete functional example: <strong>CYP71BE</strong> oxidizes <strong>alpha-guaiene</strong> to <strong>rotundone</strong>, showing that CYP71 enzymes can catalyze highly specific oxidations in specialized metabolism affecting agriculturally relevant traits. (minerdi2024impactofcytochrome pages 11-13, minerdi2024impactofcytochrome pages 9-11, minerdi2024impactofcytochrome pages 1-2)</td>
+<td>More than 50 percent of plant CYPs belong to CYP71 clan; grapevine was reported to have 579 CYP sequences with 279 complete genes in the review context. (minerdi2024impactofcytochrome pages 11-13, minerdi2024impactofcytochrome pages 9-11, minerdi2024impactofcytochrome pages 7-9)</td>
+<td>Minerdi and Sabbatini 2024</td>
+<td>Jun 2024</td>
+<td>https://doi.org/10.3390/ijms25137181</td>
+<td>Good recent contextual evidence for CYP71 diversity and applications; does not identify pennycress CYP71B1 substrate.</td>
+</tr>
+<tr>
+<td>Recent species resource / indirect</td>
+<td><em>Thlaspi arvense</em> var. MN106-Ref</td>
+<td>Pennycress genome and annotation resources</td>
+<td>Provides the modern genomic framework needed to revisit CYP71B1 annotation in pennycress: chromosome-level assembly, expression atlas, transcript evidence, and gene-model curation pipeline. Relevant because direct literature on CYP71B1 is sparse. (garrido2024theepigenomicimpact pages 133-133, garrido2024theepigenomicimpact pages 144-144, garrido2024theepigenomicimpact pages 151-151)</td>
+<td>Assembly covers about <strong>97.5 percent of an estimated 539 Mbp</strong> genome; seven large scaffolds represent about <strong>83.6 percent</strong> of the genome; contig N50 improved from <strong>0.02 Mbp to 13.3 Mbp</strong>; coding space is <strong>98.7 percent BUSCO complete</strong>; expression atlas spans <strong>11 tissues or life stages</strong> with mostly <strong>3 biological replicates</strong>. (garrido2024theepigenomicimpact pages 133-133, garrido2024theepigenomicimpact pages 144-144)</td>
+<td>Garrido 2024</td>
+<td>2024</td>
+<td>No stable journal URL available in retrieved record</td>
+<td>Strong for current pennycress genome quality and annotation infrastructure; no explicit CYP71B1-specific mention in available excerpts.</td>
+</tr>
+<tr>
+<td>Recent translational context / indirect</td>
+<td><em>Thlaspi arvense</em> and weeds broadly</td>
+<td>Thlaspi genome resource; comparative weed multi-omics</td>
+<td>Reviews modern weed and crop multi-omics and cites a chromosome-level <em>T. arvense</em> genome as a tool for <strong>translational research and domestication</strong>. Supports the idea that current annotation of pennycress genes, including orphan P450s, can be improved using genome, transcriptome, and regulatory datasets. (chen2024weedbiologyand pages 16-17, chen2024weedbiologyand pages 17-18)</td>
+<td>Excerpts mention pan-genome analysis of <strong>33</strong> accessions or species in one cited context and <strong>13 domesticated and wild rice relatives</strong> in another; no CYP71-specific counts for pennycress. (chen2024weedbiologyand pages 17-18)</td>
+<td>Chen et al. 2024</td>
+<td>Apr 2024</td>
+<td>https://doi.org/10.1016/j.xplc.2024.100816</td>
+<td>High value for current methodological context; low direct relevance to CYP71B1 biochemistry.</td>
+</tr>
+<tr>
+<td>Recent ecological context / indirect</td>
+<td>Herbivore on <em>Thlaspi arvense</em> versus native host</td>
+<td>Detoxification gene families including cytochrome P450s in <em>Pieris macdunnoughii</em> larvae feeding on pennycress</td>
+<td>Shows pennycress is a <strong>toxic host context</strong> where detoxification pathways are relevant, but larval <strong>cytochrome P450 genes were not significantly differentially expressed</strong> versus the native host. This does not annotate pennycress CYP71B1 directly, but supports a defense-metabolism ecological setting for Brassicaceae specialized chemistry. (ravikanthachari2024geneticmechanismsunderlying pages 12-15, ravikanthachari2024geneticmechanismsunderlying pages 15-18, ravikanthachari2024geneticmechanismsunderlying pages 8-12, ravikanthachari2024geneticmechanismsunderlying pages 5-8)</td>
+<td>About <strong>20 million paired reads</strong> per library, about <strong>40 million total</strong>, with <strong>94 percent mapping</strong>; <strong>1,489 genes</strong> differentially expressed at FDR below 0.01; <strong>910 genes</strong> with log2 fold change above 1.5 and FDR below 0.01; cytochrome P450 trend <strong>p = 0.09</strong> and not significant; GST <strong>p &lt; 0.001</strong>; trypsin <strong>p = 0.002</strong>; <strong>2,353 genes</strong> associated with <em>T. arvense</em> modules in WGCNA. (ravikanthachari2024geneticmechanismsunderlying pages 12-15, ravikanthachari2024geneticmechanismsunderlying pages 8-12, ravikanthachari2024geneticmechanismsunderlying pages 5-8)</td>
+<td>Feb 2024</td>
+<td>https://doi.org/10.1101/2024.02.14.580222</td>
+<td>Useful ecological backdrop only; measures insect gene expression, not plant CYP71B1 expression or function.</td>
+<td></td>
+</tr>
+</tbody>
+</table>
+<p><em>Table: This table compiles direct and indirect evidence relevant to functional annotation of Thlaspi arvense CYP71B1 (UniProt P49264). It separates direct identity evidence from broader family- and species-level inferences, making clear where confidence is strong and where annotation remains provisional.</em></p>
+<hr />
+<h2 id="1-key-concepts-and-definitions-current-understanding">1) Key concepts and definitions (current understanding)</h2>
+<h3 id="11-what-plant-cytochrome-p450s-are">1.1 What plant cytochrome P450s are</h3>
+<p>Plant cytochrome P450s are <strong>heme-thiolate monooxygenases</strong> that catalyze oxygenation and other oxidative transformations, typically described by the overall monooxygenase reaction:</p>
+<p>[ RH + O_2 + NADPH + H^+ \rightarrow ROH + H_2O + NADP^+ ]</p>
+<p>and they share a conserved catalytic center in which a <strong>conserved cysteine coordinates the heme iron</strong>. (bak2011cytochromesp450 pages 3-5)</p>
+<h3 id="12-conserved-motifs-used-for-functional-annotation-of-cyps">1.2 Conserved motifs used for functional annotation of CYPs</h3>
+<p>Functional annotation of CYP sequences often leverages conserved motifs characteristic of P450 fold and catalytic mechanism. Key motifs highlighted in authoritative sources include:<br />
+- The <strong>heme-binding cysteine motif</strong> (Cys is universally conserved and coordinates heme iron) (bak2011cytochromesp450 pages 3-5)<br />
+- The <strong>I-helix</strong> motif (e.g., <strong>AGxDT</strong>) (bak2011cytochromesp450 pages 3-5)<br />
+- The <strong>K-helix</strong> motif including <strong>EXXR</strong> (e.g., KETRL/KETLR context; EXXR noted in a 2024 review) (bak2011cytochromesp450 pages 3-5, minerdi2024impactofcytochrome pages 1-2)<br />
+- The <strong>PERF/W</strong> motif (forms, with K-helix residues, an <strong>E–R–R triad</strong>) (bak2011cytochromesp450 pages 3-5)</p>
+<p>These motifs support the classification of CYP71B1 as a bona fide cytochrome P450 monooxygenase (consistent with UniProt/InterPro domain context) even when substrate specificity is unknown.</p>
+<h3 id="13-typical-localization-of-plant-p450s">1.3 Typical localization of plant P450s</h3>
+<p>Most characterized plant P450s are <strong>membrane-bound</strong>, commonly <strong>anchored to the cytoplasmic surface of the endoplasmic reticulum (ER)</strong> by an N-terminal hydrophobic segment, and require electron transfer from ER-associated partners such as NADPH-cytochrome P450 reductase (CPR) and/or cytochrome b5. (bak2011cytochromesp450 pages 3-5)</p>
+<p>A minority of plant P450s are predicted or confirmed to localize to plastids or mitochondria via targeting peptides, but the dominant paradigm for “CYP71 clan” enzymes is <strong>microsomal/ER association</strong>. (bak2011cytochromesp450 pages 3-5)</p>
+<h3 id="14-the-cyp71-clan-and-why-it-matters">1.4 The CYP71 clan and why it matters</h3>
+<p>The CYP71 clan is repeatedly emphasized as a major driver of plant specialized metabolism. A 2024 review states that the <strong>CYP71 clan encompasses more than 50% of plant CYPs</strong>, highlighting its expansion and functional breadth across specialized-metabolism pathways. (minerdi2024impactofcytochrome pages 9-11)</p>
+<hr />
+<h2 id="2-target-geneprotein-what-is-known-directly-for-pennycress-cyp71b1-p49264">2) Target gene/protein: what is known directly for pennycress CYP71B1 (P49264)</h2>
+<h3 id="21-verified-identity-and-sequence-availability">2.1 Verified identity and sequence availability</h3>
+<p>A peer-reviewed review of plant P450s explicitly catalogs <strong>Thlaspi arvense CYP71B1</strong> as a <strong>full-length cDNA</strong>, associated with GenEMBL accession <strong>L24438</strong>, and cites the original Plant Physiology publication (1994, 105:755–756) as the source of the cDNA sequence report. This provides direct evidence that the gene/protein sequence was cloned and deposited, consistent with the UniProt accession <strong>P49264</strong> provided by the user. (schuler1996plantcytochromep450 pages 5-8)</p>
+<h3 id="22-what-is-not-available-in-retrieved-direct-evidence">2.2 What is not available in retrieved direct evidence</h3>
+<p>Within the accessible texts, there is <strong>no direct experimental evidence</strong> for:<br />
+- Substrate(s) or reaction catalyzed by pennycress CYP71B1<br />
+- Specific pathway placement (e.g., glucosinolate, phytoalexin, hormone pathways)<br />
+- Tissue-, development-, or stress-specific expression for CYP71B1<br />
+- Subcellular localization of the pennycress protein (ER vs plastid vs other)</p>
+<p>Thus, <strong>primary function and substrate specificity remain unknown</strong> from the retrieved direct literature.</p>
+<hr />
+<h2 id="3-functional-inference-from-family-context-explicitly-labeled-as-inference">3) Functional inference from family context (explicitly labeled as inference)</h2>
+<h3 id="31-what-characterized-cyp71ab-enzymes-do-in-brassicaceae-arabidopsis-camalexin-pathway">3.1 What characterized CYP71A/B enzymes do in Brassicaceae (Arabidopsis camalexin pathway)</h3>
+<p>Multiple CYP71-family enzymes are experimentally positioned in the <strong>camalexin</strong> (tryptophan-derived phytoalexin) pathway in <em>Arabidopsis</em>:<br />
+- <strong>CYP71A13</strong> converts indole-3-acetaldoxime toward indole-3-acetonitrile, channeling a branchpoint intermediate into camalexin biosynthesis; mutants show impaired camalexin accumulation and altered pathogen susceptibility. (bak2011cytochromesp450 pages 12-13, bak2011cytochromesp450 pages 11-12)<br />
+- <strong>CYP71A12</strong> contributes in roots and is inducible by bacterial elicitors (Flg22). (bak2011cytochromesp450 pages 12-13)<br />
+- <strong>CYP71B15/PAD3</strong> is a key late enzyme: biochemical work and mutant phenotypes place it downstream in camalexin production, with in vitro evidence for conversion of cysteine–indole-3-acetonitrile-derived intermediates to camalexin; pad3 mutants are camalexin-deficient and accumulate pathway intermediates. (bak2011cytochromesp450 pages 12-13, mucha2019theformationof pages 2-3)</p>
+<p>A 2019 Plant Cell study further supports that these enzymes act within a coordinated multi-protein context (“metabolon”). It reports that a functional PAD3/CYP71B15-GFP fusion localizes to the ER and accumulates in cells near infection sites, and proteomics/co-IP shows enrichment of multiple P450 partners (including CYP71A13 and CYP71A12), consistent with substrate channeling among indole-derived intermediates. (mucha2019theformationof pages 2-3, mucha2019theformationof pages 4-5)</p>
+<p><strong>Inference relevance to pennycress CYP71B1:</strong> Because pennycress is a Brassicaceae species and CYP71-family expansions are often linked to specialized metabolism, one plausible hypothesis is that pennycress CYP71B1 could act on <strong>specialized-metabolism substrates</strong>, potentially including indole-derived or other defense-related compounds. However, <strong>CYP71 family membership alone does not identify substrates</strong>, and even in Arabidopsis some CYP71B members remain “putative.” (bak2011cytochromesp450 pages 11-12, schuckel2012developmentofa pages 193-196)</p>
+<h3 id="32-expected-subcellular-localization-inference">3.2 Expected subcellular localization (inference)</h3>
+<p>Given the general plant P450 paradigm (ER membrane anchoring via N-terminus), a working hypothesis is that pennycress CYP71B1 is likely <strong>microsomal/ER-associated</strong>, unless a cleavable transit peptide indicates plastid/mitochondrial targeting. This inference is supported by general plant P450 localization principles and by ER localization demonstrated for the Brassicaceae CYP71B enzyme PAD3/CYP71B15. (bak2011cytochromesp450 pages 3-5, mucha2019theformationof pages 2-3)</p>
+<h3 id="33-substrate-specificity-why-it-is-difficult-to-infer">3.3 Substrate specificity: why it is difficult to infer</h3>
+<p>Even within CYP71-family members, experimentally documented activities are diverse (e.g., pathway-specific camalexin steps vs xenobiotic transformations in assay contexts). A table-based resource lists CYP71B7 deethylation of 7-ethoxycoumarin in vitro and CYP71B15 camalexin formation, while other CYP71 members remain only “putative,” illustrating that subfamily labels do not uniquely determine substrates. (schuckel2012developmentofa pages 39-41, schuckel2012developmentofa pages 193-196)</p>
+<hr />
+<h2 id="4-recent-developments-prioritizing-20232024-sources">4) Recent developments (prioritizing 2023–2024 sources)</h2>
+<h3 id="41-2024-cyp71-clan-scale-and-application-framing">4.1 2024: CYP71 clan scale and application framing</h3>
+<p>A 2024 review focusing on fruit quality emphasizes that the <strong>CYP71 clan comprises &gt;50% of plant CYPs</strong> and highlights CYP71 enzymes in terpenoid oxidation with a concrete example: grapevine <strong>CYP71BE</strong> oxidizes <strong>α-guaiene</strong> to produce <strong>rotundone</strong>, an aroma-impact compound. This illustrates (i) the enormous scale of CYP71 diversification and (ii) real-world relevance of CYP71 enzymes to agriculturally important traits, and it supports the idea that CYP71-family enzymes can be targets for metabolic engineering even when individual members are initially uncharacterized. (minerdi2024impactofcytochrome pages 9-11)</p>
+<h3 id="42-2024-pennycress-multi-omics-resources-for-re-annotation-and-functional-inference">4.2 2024: Pennycress multi-omics resources for re-annotation and functional inference</h3>
+<p>A 2024 pennycress genomics resource describes a chromosome-scale assembly (T_arvense_v2) covering ~<strong>97.5%</strong> of an estimated <strong>539 Mbp</strong> genome and reporting <strong>98.7% BUSCO</strong> completeness of coding space. It includes robust annotations, a transcriptome-based <strong>gene expression atlas spanning 11 tissues/life stages</strong>, DNA methylomes (root and shoot), and resequencing of <strong>40 accessions</strong>, plus an annotation pipeline combining Illumina RNA-seq, PacBio Iso-Seq, MAKER-P, PFAM/InterPro support, and orthology mapping. Collectively, these resources can be used to improve the functional annotation of gene families like CYPs (including CYP71B1) via co-expression, comparative genomics, and variant–trait association, even when direct enzymology is missing. (garrido2024theepigenomicimpact pages 133-133, garrido2024theepigenomicimpact pages 144-144, garrido2024theepigenomicimpact pages 141-141)</p>
+<h3 id="43-2024-translationaldomestication-context-for-pennycress-and-multi-omics-annotation-methods">4.3 2024: Translational/domestication context for pennycress and multi-omics annotation methods</h3>
+<p>A 2024 Plant Communications perspective on weed biology/multi-omics notes that a chromosome-level <em>Thlaspi arvense</em> genome provides tools for <strong>translational research</strong> and domestication of a cash cover crop, and it highlights emerging approaches such as <strong>Pan-3D genome analysis (2023)</strong> for connecting genome structure to function. Such approaches can help resolve tandemly duplicated gene families (like CYP71) and refine gene models and regulatory inference. (chen2024weedbiologyand pages 16-17)</p>
+<hr />
+<h2 id="5-current-applications-and-real-world-implementations-how-cyp71-type-knowledge-is-used">5) Current applications and real-world implementations (how CYP71-type knowledge is used)</h2>
+<h3 id="51-crop-quality-and-metabolic-engineering">5.1 Crop quality and metabolic engineering</h3>
+<p>CYP71-family enzymes can control economically important specialized metabolites; the 2024 fruit-quality review frames P450s (including CYP71 clan members) as engineering targets for modifying quality-related traits such as aroma and ripening chemistry. The CYP71BE→rotundone example illustrates the mechanistic bridge from enzyme activity to sensory traits in wine/grapes. (minerdi2024impactofcytochrome pages 9-11)</p>
+<h3 id="52-defense-metabolism-and-inducible-er-metabolons">5.2 Defense metabolism and inducible ER metabolons</h3>
+<p>The camalexin pathway work provides a real-world mechanism for how plant CYP71 enzymes are deployed: CYP71B15/PAD3 is inducible by pathogen attack, ER-localized, and participates in a physically associated enzyme network (metabolon), supporting rapid and localized production of defense compounds. This provides a conceptual model for how a Brassicaceae CYP71B enzyme (by inference, potentially including pennycress CYP71B1) could function in vivo. (mucha2019theformationof pages 2-3, mucha2019theformationof pages 4-5)</p>
+<h3 id="53-weed-management-and-herbicide-metabolism-context-methodological-analogy">5.3 Weed management and herbicide metabolism context (methodological analogy)</h3>
+<p>Although not about pennycress CYP71B1 directly, the 2024 weed multi-omics perspective highlights functional characterization of herbicide-metabolizing P450s (e.g., CYP81A variants) and enzyme-library approaches, providing a blueprint for how “orphan” P450s can be functionally annotated through systematic screening. (chen2024weedbiologyand pages 17-18)</p>
+<hr />
+<h2 id="6-expert-opinions-and-analysis-authoritative-synthesis">6) Expert opinions and analysis (authoritative synthesis)</h2>
+<h3 id="61-why-functional-redundancy-is-limited-despite-large-p450-families">6.1 Why functional redundancy is limited despite large P450 families</h3>
+<p>The Arabidopsis Book chapter emphasizes that Arabidopsis contains <strong>244 P450 genes and 28 pseudogenes</strong> and argues that diversification leads to <strong>limited functional redundancy</strong> and mirrors metabolic complexity; consequently, uncharacterized CYP71 members may have specialized and non-obvious substrates, motivating direct experimental testing rather than name-based inference. (bak2011cytochromesp450 pages 1-3)</p>
+<h3 id="62-likely-biochemical-role-class-for-pennycress-cyp71b1">6.2 Likely biochemical role class for pennycress CYP71B1</h3>
+<p>Given the direct evidence is restricted to sequence existence (full-length cDNA) and family membership, the most defensible functional label at present is:<br />
+- <strong>Microsomal cytochrome P450 monooxygenase (CYP71 clan; A-type plant P450)</strong><br />
+- Catalyzes an oxidative transformation using electrons delivered via NADPH-dependent reductase partners<br />
+- Likely ER-associated via N-terminal hydrophobic anchor (hypothesis)</p>
+<p>This aligns with expert synthesis of plant P450 biology and avoids over-claiming a substrate or pathway. (bak2011cytochromesp450 pages 3-5)</p>
+<h3 id="63-priority-hypotheses-for-wet-lab-validation">6.3 Priority hypotheses for wet-lab validation</h3>
+<p>Based on characterized Brassicaceae CYP71 enzymes, the most tractable and biologically plausible hypotheses to test for pennycress CYP71B1 include:<br />
+1) Activity on <strong>tryptophan-derived indole intermediates</strong> (e.g., indole-3-acetaldoxime/IAN-related chemistry) and/or related defense metabolites (inference from Arabidopsis CYP71A/B camalexin pathway). (bak2011cytochromesp450 pages 12-13, mucha2019theformationof pages 2-3)<br />
+2) ER localization and potential participation in inducible enzyme complexes (metabolon-like organization), especially under pathogen/stress induction (inference from PAD3/CYP71B15 ER localization and interaction network). (mucha2019theformationof pages 2-3, mucha2019theformationof pages 4-5)<br />
+3) Broader aromatic/xenobiotic oxidation potential in vitro (supported by diverse activities reported for some CYP71 family members in assay contexts). (schuckel2012developmentofa pages 39-41)</p>
+<hr />
+<h2 id="7-relevant-statistics-and-data-from-recent-studies">7) Relevant statistics and data from recent studies</h2>
+<h3 id="71-recent-statistics-on-cyp71-clan-and-plant-cyp-complement">7.1 Recent statistics on CYP71 clan and plant CYP complement</h3>
+<ul>
+<li>CYP71 clan: <strong>&gt;50% of plant CYPs</strong> (review statement). (minerdi2024impactofcytochrome pages 9-11)</li>
+<li>Arabidopsis genome: <strong>244 P450 genes</strong> and <strong>28 pseudogenes</strong> (authoritative reference chapter). (bak2011cytochromesp450 pages 1-3)</li>
+</ul>
+<h3 id="72-pennycress-genomeomics-resource-statistics-2024">7.2 Pennycress genome/omics resource statistics (2024)</h3>
+<ul>
+<li>Assembly covers ~<strong>97.5%</strong> of estimated <strong>539 Mbp</strong> genome; seven large scaffolds comprise ~<strong>83.6%</strong>; coding space <strong>98.7% BUSCO complete</strong>; expression atlas across <strong>11 tissues/life stages</strong>; resequencing of <strong>40 accessions</strong>; LD decay ~<strong>150 kbp at r²=0.6</strong> (useful for association mapping). (garrido2024theepigenomicimpact pages 133-133, garrido2024theepigenomicimpact pages 141-141)</li>
+</ul>
+<h3 id="73-ecologicaltoxicity-context-statistics-involving-pennycress-2024-biorxiv">7.3 Ecological/toxicity context statistics involving pennycress (2024 bioRxiv)</h3>
+<p>A 2024 insect transcriptomic study using <em>T. arvense</em> as a “toxic” host provides context for Brassicaceae chemical defenses:<br />
+- ~<strong>20M paired reads</strong> per library; <strong>94%</strong> mapping<br />
+- <strong>1,489</strong> genes differentially expressed at FDR&lt;0.01<br />
+- Cytochrome P450 gene family differential expression: trend but <strong>not significant</strong> (p=0.09)<br />
+- Detoxification gene families: GST higher on native host (p&lt;0.001); trypsin up on pennycress (p=0.002)</p>
+<p>These data do <strong>not</strong> annotate pennycress CYP71B1 directly (they measure insect genes), but they underscore that pennycress-associated chemistry can impose strong stress/toxicity, providing biological motivation to study specialized metabolism genes (including P450s) in pennycress. (ravikanthachari2024geneticmechanismsunderlying pages 8-12, ravikanthachari2024geneticmechanismsunderlying pages 12-15)</p>
+<hr />
+<h2 id="8-conclusion-and-actionable-annotation-statement-for-cyp71b1-p49264">8) Conclusion and actionable annotation statement for CYP71B1 (P49264)</h2>
+<h3 id="81-minimal-evidence-supported-functional-annotation">8.1 Minimal, evidence-supported functional annotation</h3>
+<p><strong>CYP71B1 (UniProt P49264) from <em>Thlaspi arvense</em> is best annotated currently as an uncharacterized plant cytochrome P450 monooxygenase (CYP71 clan), represented by a full-length cDNA (GenEMBL L24438).</strong> (schuler1996plantcytochromep450 pages 5-8)</p>
+<h3 id="82-working-hypotheses-explicitly-speculative">8.2 Working hypotheses (explicitly speculative)</h3>
+<ul>
+<li><strong>Likely ER-associated microsomal P450</strong>, based on general plant P450 localization and on ER localization demonstrated for a CYP71B enzyme (PAD3/CYP71B15) in Brassicaceae. (bak2011cytochromesp450 pages 3-5, mucha2019theformationof pages 2-3)</li>
+<li><strong>Likely involved in specialized metabolism</strong>, given CYP71 clan’s scale and known roles in defense and quality-related specialized metabolites, but <strong>substrate specificity is unknown</strong> and cannot be reliably inferred from family membership. (minerdi2024impactofcytochrome pages 9-11, bak2011cytochromesp450 pages 11-12)</li>
+</ul>
+<h3 id="83-best-next-experiments-for-definitive-functional-annotation">8.3 Best next experiments for definitive functional annotation</h3>
+<p>1) <strong>Heterologous expression</strong> (yeast/Nicotiana/plant microsomes) with <strong>NADPH-P450 reductase</strong> co-expression; confirm CO-difference spectrum and activity. (bak2011cytochromesp450 pages 3-5)<br />
+2) <strong>Substrate screening</strong> prioritized to Brassicaceae-specialized metabolites (indole-related compounds, glucosinolate-related intermediates, terpenoids), guided by co-expression patterns in the pennycress 11-tissue expression atlas and stress treatments. (garrido2024theepigenomicimpact pages 133-133)<br />
+3) <strong>Subcellular localization</strong> with fluorescent tags to test ER association and induction patterns. (mucha2019theformationof pages 2-3)</p>
+<hr />
+<h2 id="key-source-urls-publication-dates">Key source URLs (publication dates)</h2>
+<ul>
+<li>Schuler MA. <em>Plant Cytochrome P450 Monooxygenases</em>. <strong>1996-01</strong>. https://doi.org/10.1080/07352689609701942 (schuler1996plantcytochromep450 pages 5-8)</li>
+<li>Bak S, et al. <em>Cytochromes P450</em> (The Arabidopsis Book). First published <strong>2011-10-06</strong>. https://doi.org/10.1199/tab.0144 (bak2011cytochromesp450 pages 1-3, bak2011cytochromesp450 pages 3-5)</li>
+<li>Mucha S, et al. <em>The Formation of a Camalexin Biosynthetic Metabolon</em>. <strong>2019-09</strong>. https://doi.org/10.1105/tpc.19.00403 (mucha2019theformationof pages 2-3)</li>
+<li>Minerdi D, Sabbatini P. <em>Impact of Cytochrome P450 Enzyme on Fruit Quality</em>. <strong>2024-06</strong>. https://doi.org/10.3390/ijms25137181 (minerdi2024impactofcytochrome pages 9-11)</li>
+<li>Chen K, et al. <em>Weed biology and management in the multi-omics era: Progress and perspectives</em>. <strong>2024-04</strong>. https://doi.org/10.1016/j.xplc.2024.100816 (chen2024weedbiologyand pages 16-17)</li>
+<li>Ravikanthachari N, Boggs CL. <em>Genetic mechanisms underlying preference-performance mismatches…</em> bioRxiv <strong>2024-02</strong>. https://doi.org/10.1101/2024.02.14.580222 (ravikanthachari2024geneticmechanismsunderlying pages 8-12)</li>
+</ul>
+<hr />
+<h3 id="notes-on-limitations">Notes on limitations</h3>
+<p>This report is constrained by tool-accessible full texts. The original primary source for the pennycress CYP71B1 cDNA (Plant Physiology 1994, 105:755–756) was not retrievable here, and UniProt/InterPro records were provided by the user but not directly fetched through tools. Consequently, substrate specificity and pathway membership for <em>T. arvense</em> CYP71B1 remain unresolved and should be treated as an open annotation problem requiring targeted experimental validation and/or genome-scale co-expression/phylogenomics using the 2024 pennycress multi-omics resources. (schuler1996plantcytochromep450 pages 5-8, garrido2024theepigenomicimpact pages 133-133)</p>
+<p>References</p>
+<ol>
+<li>
+<p>(schuler1996plantcytochromep450 pages 5-8): Mary A. Schuler. Plant cytochrome p450 monooxygenases. Critical Reviews in Plant Sciences, 15:235-284, Jan 1996. URL: https://doi.org/10.1080/07352689609701942, doi:10.1080/07352689609701942. This article has 476 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(bak2011cytochromesp450 pages 3-5): Søren Bak, Fred Beisson, Gerard Bishop, Björn Hamberger, René Höfer, Suzanne Paquette, and Danièle Werck-Reichhart. Cytochromes p450. The Arabidopsis Book, 2011:e0144, Jan 2011. URL: https://doi.org/10.1199/tab.0144, doi:10.1199/tab.0144. This article has 529 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(schuckel2012developmentofa pages 193-196): J Schückel. Development of a new platform technology for plant cytochrome p450 fusions. Unknown journal, 2012.</p>
+</li>
+<li>
+<p>(schuckel2012developmentofa pages 199-203): J Schückel. Development of a new platform technology for plant cytochrome p450 fusions. Unknown journal, 2012.</p>
+</li>
+<li>
+<p>(bak2011cytochromesp450 pages 1-3): Søren Bak, Fred Beisson, Gerard Bishop, Björn Hamberger, René Höfer, Suzanne Paquette, and Danièle Werck-Reichhart. Cytochromes p450. The Arabidopsis Book, 2011:e0144, Jan 2011. URL: https://doi.org/10.1199/tab.0144, doi:10.1199/tab.0144. This article has 529 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(bak2011cytochromesp450 pages 12-13): Søren Bak, Fred Beisson, Gerard Bishop, Björn Hamberger, René Höfer, Suzanne Paquette, and Danièle Werck-Reichhart. Cytochromes p450. The Arabidopsis Book, 2011:e0144, Jan 2011. URL: https://doi.org/10.1199/tab.0144, doi:10.1199/tab.0144. This article has 529 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(bak2011cytochromesp450 pages 11-12): Søren Bak, Fred Beisson, Gerard Bishop, Björn Hamberger, René Höfer, Suzanne Paquette, and Danièle Werck-Reichhart. Cytochromes p450. The Arabidopsis Book, 2011:e0144, Jan 2011. URL: https://doi.org/10.1199/tab.0144, doi:10.1199/tab.0144. This article has 529 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(mucha2019theformationof pages 3-4): Stefanie Mucha, Stephanie Heinzlmeir, Verena Kriechbaumer, Benjamin Strickland, Charlotte Kirchhelle, Manisha Choudhary, Natalie Kowalski, Ruth Eichmann, Ralph Hueckelhoven, Erwin Grill, Bernhard Kuster, and Erich Glawischnig. The formation of a camalexin biosynthetic metabolon. Plant Cell, 31:2697-2710, Sep 2019. URL: https://doi.org/10.1105/tpc.19.00403, doi:10.1105/tpc.19.00403. This article has 101 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(mucha2019theformationof pages 2-3): Stefanie Mucha, Stephanie Heinzlmeir, Verena Kriechbaumer, Benjamin Strickland, Charlotte Kirchhelle, Manisha Choudhary, Natalie Kowalski, Ruth Eichmann, Ralph Hueckelhoven, Erwin Grill, Bernhard Kuster, and Erich Glawischnig. The formation of a camalexin biosynthetic metabolon. Plant Cell, 31:2697-2710, Sep 2019. URL: https://doi.org/10.1105/tpc.19.00403, doi:10.1105/tpc.19.00403. This article has 101 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(mucha2019theformationof pages 4-5): Stefanie Mucha, Stephanie Heinzlmeir, Verena Kriechbaumer, Benjamin Strickland, Charlotte Kirchhelle, Manisha Choudhary, Natalie Kowalski, Ruth Eichmann, Ralph Hueckelhoven, Erwin Grill, Bernhard Kuster, and Erich Glawischnig. The formation of a camalexin biosynthetic metabolon. Plant Cell, 31:2697-2710, Sep 2019. URL: https://doi.org/10.1105/tpc.19.00403, doi:10.1105/tpc.19.00403. This article has 101 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(schuckel2012developmentofa pages 39-41): J Schückel. Development of a new platform technology for plant cytochrome p450 fusions. Unknown journal, 2012.</p>
+</li>
+<li>
+<p>(minerdi2024impactofcytochrome pages 11-13): Daniela Minerdi and Paolo Sabbatini. Impact of cytochrome p450 enzyme on fruit quality. International Journal of Molecular Sciences, 25:7181, Jun 2024. URL: https://doi.org/10.3390/ijms25137181, doi:10.3390/ijms25137181. This article has 7 citations.</p>
+</li>
+<li>
+<p>(minerdi2024impactofcytochrome pages 9-11): Daniela Minerdi and Paolo Sabbatini. Impact of cytochrome p450 enzyme on fruit quality. International Journal of Molecular Sciences, 25:7181, Jun 2024. URL: https://doi.org/10.3390/ijms25137181, doi:10.3390/ijms25137181. This article has 7 citations.</p>
+</li>
+<li>
+<p>(minerdi2024impactofcytochrome pages 1-2): Daniela Minerdi and Paolo Sabbatini. Impact of cytochrome p450 enzyme on fruit quality. International Journal of Molecular Sciences, 25:7181, Jun 2024. URL: https://doi.org/10.3390/ijms25137181, doi:10.3390/ijms25137181. This article has 7 citations.</p>
+</li>
+<li>
+<p>(minerdi2024impactofcytochrome pages 7-9): Daniela Minerdi and Paolo Sabbatini. Impact of cytochrome p450 enzyme on fruit quality. International Journal of Molecular Sciences, 25:7181, Jun 2024. URL: https://doi.org/10.3390/ijms25137181, doi:10.3390/ijms25137181. This article has 7 citations.</p>
+</li>
+<li>
+<p>(garrido2024theepigenomicimpact pages 133-133): A Contreras Garrido. The epigenomic impact of transposable elements in natural populations. Unknown journal, 2024.</p>
+</li>
+<li>
+<p>(garrido2024theepigenomicimpact pages 144-144): A Contreras Garrido. The epigenomic impact of transposable elements in natural populations. Unknown journal, 2024.</p>
+</li>
+<li>
+<p>(garrido2024theepigenomicimpact pages 151-151): A Contreras Garrido. The epigenomic impact of transposable elements in natural populations. Unknown journal, 2024.</p>
+</li>
+<li>
+<p>(chen2024weedbiologyand pages 16-17): Ke Chen, Haona Yang, Di Wu, Yajun Peng, Lei Lian, Lianyang Bai, and Lifeng Wang. Weed biology and management in the multi-omics era: progress and perspectives. Apr 2024. URL: https://doi.org/10.1016/j.xplc.2024.100816, doi:10.1016/j.xplc.2024.100816. This article has 17 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(chen2024weedbiologyand pages 17-18): Ke Chen, Haona Yang, Di Wu, Yajun Peng, Lei Lian, Lianyang Bai, and Lifeng Wang. Weed biology and management in the multi-omics era: progress and perspectives. Apr 2024. URL: https://doi.org/10.1016/j.xplc.2024.100816, doi:10.1016/j.xplc.2024.100816. This article has 17 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(ravikanthachari2024geneticmechanismsunderlying pages 12-15): Nitin Ravikanthachari and Carol L. Boggs. Genetic mechanisms underlying preference-performance mismatches: insights from a specialized native herbivore on an invasive toxic plant. bioRxiv, Feb 2024. URL: https://doi.org/10.1101/2024.02.14.580222, doi:10.1101/2024.02.14.580222. This article has 1 citations.</p>
+</li>
+<li>
+<p>(ravikanthachari2024geneticmechanismsunderlying pages 15-18): Nitin Ravikanthachari and Carol L. Boggs. Genetic mechanisms underlying preference-performance mismatches: insights from a specialized native herbivore on an invasive toxic plant. bioRxiv, Feb 2024. URL: https://doi.org/10.1101/2024.02.14.580222, doi:10.1101/2024.02.14.580222. This article has 1 citations.</p>
+</li>
+<li>
+<p>(ravikanthachari2024geneticmechanismsunderlying pages 8-12): Nitin Ravikanthachari and Carol L. Boggs. Genetic mechanisms underlying preference-performance mismatches: insights from a specialized native herbivore on an invasive toxic plant. bioRxiv, Feb 2024. URL: https://doi.org/10.1101/2024.02.14.580222, doi:10.1101/2024.02.14.580222. This article has 1 citations.</p>
+</li>
+<li>
+<p>(ravikanthachari2024geneticmechanismsunderlying pages 5-8): Nitin Ravikanthachari and Carol L. Boggs. Genetic mechanisms underlying preference-performance mismatches: insights from a specialized native herbivore on an invasive toxic plant. bioRxiv, Feb 2024. URL: https://doi.org/10.1101/2024.02.14.580222, doi:10.1101/2024.02.14.580222. This article has 1 citations.</p>
+</li>
+<li>
+<p>(garrido2024theepigenomicimpact pages 141-141): A Contreras Garrido. The epigenomic impact of transposable elements in natural populations. Unknown journal, 2024.</p>
+</li>
+</ol>
+<h2 id="artifacts">Artifacts</h2>
+<ul>
+<li><a href="CYP71B1-deep-research-falcon_artifacts/artifact-00.md">Edison artifact artifact-00</a><br />
+<img alt="## Context ID: pqac-00000014 I have extracted Figure 2 and Figure 4 from the document as requested. Figure 2 shows the conserved signature motifs and sequences " src="CYP71B1-deep-research-falcon_artifacts/image-1.png" /></li>
+</ul>
+<h2 id="citations">Citations</h2>
+<ol>
+<li>chen2024weedbiologyand pages 17-18</li>
+<li>minerdi2024impactofcytochrome pages 9-11</li>
+<li>chen2024weedbiologyand pages 16-17</li>
+<li>schuckel2012developmentofa pages 39-41</li>
+<li>garrido2024theepigenomicimpact pages 133-133</li>
+<li>mucha2019theformationof pages 2-3</li>
+<li>ravikanthachari2024geneticmechanismsunderlying pages 8-12</li>
+<li>schuckel2012developmentofa pages 193-196</li>
+<li>schuckel2012developmentofa pages 199-203</li>
+<li>mucha2019theformationof pages 3-4</li>
+<li>mucha2019theformationof pages 4-5</li>
+<li>minerdi2024impactofcytochrome pages 11-13</li>
+<li>minerdi2024impactofcytochrome pages 1-2</li>
+<li>minerdi2024impactofcytochrome pages 7-9</li>
+<li>garrido2024theepigenomicimpact pages 144-144</li>
+<li>garrido2024theepigenomicimpact pages 151-151</li>
+<li>ravikanthachari2024geneticmechanismsunderlying pages 12-15</li>
+<li>ravikanthachari2024geneticmechanismsunderlying pages 15-18</li>
+<li>ravikanthachari2024geneticmechanismsunderlying pages 5-8</li>
+<li>garrido2024theepigenomicimpact pages 141-141</li>
+<li>RH + O_2 + NADPH + H^+ \rightarrow ROH + H_2O + NADP^+ \</li>
+<li>https://doi.org/10.1080/07352689609701942</li>
+<li>https://doi.org/10.1199/tab.0144</li>
+<li>https://doi.org/10.1105/tpc.19.00403</li>
+<li>https://doi.org/10.3390/ijms25137181</li>
+<li>https://doi.org/10.1016/j.xplc.2024.100816</li>
+<li>https://doi.org/10.1101/2024.02.14.580222</li>
+<li>https://doi.org/10.1080/07352689609701942,</li>
+<li>https://doi.org/10.1199/tab.0144,</li>
+<li>https://doi.org/10.1105/tpc.19.00403,</li>
+<li>https://doi.org/10.3390/ijms25137181,</li>
+<li>https://doi.org/10.1016/j.xplc.2024.100816,</li>
+<li>https://doi.org/10.1101/2024.02.14.580222,</li>
+</ol>
+            </div>
+        </details>
+        
+    </div>
+    
+
+    <!-- Additional Documentation Sections -->
+    
+    <div class="section">
+        <h2 class="section-title">📚 Additional Documentation</h2>
+        
+        <details class="markdown-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; cursor: pointer;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Notes</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(CYP71B1-notes.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="P49264" data-a="DOC: Notes" data-r="" data-act="DOCUMENTATION" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This documentation is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This documentation needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+                <h1 id="cyp71b1-cytochrome-p450-71b1-thlaspi-arvense-review-notes">CYP71B1 (Cytochrome P450 71B1) — Thlaspi arvense — review notes</h1>
+<p>UniProt: P49264 · EC 1.14.-.- · Taxon 13288 (<em>Thlaspi arvense</em>) · 496 aa<br />
+GenEMBL: L24438 · Family: cytochrome P450, CYP71 clan</p>
+<h2 id="state-of-knowledge-functionally-uncharacterized">State of knowledge: functionally UNCHARACTERIZED</h2>
+<ul>
+<li>The only direct evidence for pennycress CYP71B1 is the <strong>1994 cDNA cloning/sequencing<br />
+  note</strong> <a href="https://pubmed.ncbi.nlm.nih.gov/8066138" title="Cloning and sequencing of a full-length cDNA from Thlaspi arvense   L. that encodes a cytochrome P-450">PMID:8066138</a> and a 1996 catalog review listing it as a<br />
+  full-length cDNA. <strong>No substrate, reaction, pathway, expression, or subcellular<br />
+  localization has been experimentally determined.</strong><br />
+  [file:THLAR/CYP71B1/CYP71B1-deep-research-falcon.md]</li>
+<li>Therefore all GO annotations are conservative <strong>InterPro family-level inferences</strong>, and<br />
+  function beyond "plant heme-thiolate monooxygenase" is inference only.</li>
+</ul>
+<h2 id="what-can-be-inferred-family-level">What can be inferred (family-level)</h2>
+<ul>
+<li>Plant P450s are <strong>heme-thiolate monooxygenases</strong> (RH + O2 + NADPH -&gt; ROH + H2O + NADP+),<br />
+  with a conserved cysteine coordinating heme iron. UniProt annotates the axial heme-iron<br />
+  binding residue at position 436 (by similarity). [UniProt P49264 FT BINDING 436]</li>
+<li>The <strong>CYP71 clan</strong> comprises &gt;50% of plant CYPs and is enriched in <strong>specialized<br />
+  (defense) metabolism</strong>; characterized Brassicaceae CYP71s (CYP71A13, CYP71A12,<br />
+  CYP71B15/PAD3) act in the tryptophan-derived <strong>camalexin</strong> pathway on the ER.<br />
+  [file:THLAR/CYP71B1/CYP71B1-deep-research-falcon.md]</li>
+<li>Most plant P450s are <strong>ER-membrane anchored</strong> (cytoplasmic face), but pennycress<br />
+  CYP71B1 has no annotated transmembrane segment or experimental localization, so ER<br />
+  membrane localization is a hypothesis, not an annotation.</li>
+</ul>
+<h2 id="symbol-ambiguity-caution">Symbol-ambiguity caution</h2>
+<ul>
+<li>"CYP71B1" is also an Arabidopsis locus (At1g13080), itself listed only as a <em>putative</em><br />
+  P450. Do not conflate the pennycress protein with Arabidopsis CYP71B1 or with MAX1<br />
+  (CYP711A1). [file:THLAR/CYP71B1/CYP71B1-deep-research-falcon.md]</li>
+</ul>
+<h2 id="annotation-review-decisions">Annotation review decisions</h2>
+<p>All four GOA annotations are well-supported, conservative P450 family-level inferences →<br />
+<strong>ACCEPT</strong> all:<br />
+- GO:0004497 monooxygenase activity (IEA/InterPro)<br />
+- GO:0005506 iron ion binding (IEA/InterPro) — heme iron<br />
+- GO:0016705 oxidoreductase activity, acting on paired donors, O2 (IEA/InterPro)<br />
+- GO:0020037 heme binding (IEA/InterPro)</p>
+<p>No BP or cellular-component annotation can be confidently assigned beyond the family<br />
+level; substrate identification is the key open question (see suggested experiments).</p>
+            </div>
+        </details>
+        
+    </div>
+    
+
+    <!-- YAML Preview Section -->
+    <div class="section">
+        <details class="yaml-preview">
+            <summary>
+                <h2 style="display: inline;">📄 View Raw YAML</h2>
+            </summary>
+            <div class="yaml-content">
+                <pre><code>id: P49264
+gene_symbol: CYP71B1
+product_type: PROTEIN
+status: COMPLETE
+taxon:
+  id: NCBITaxon:13288
+  label: Thlaspi arvense
+description: Cytochrome P450 71B1 is a heme-thiolate cytochrome P450 monooxygenase of
+  field pennycress, a member of the CYP71 clan that dominates plant specialized
+  (defense) metabolism. It was identified as a full-length cDNA cloned from Thlaspi
+  arvense in 1994, but its substrate, catalyzed reaction, metabolic pathway, expression
+  pattern, and subcellular localization have not been experimentally determined. Based
+  on conserved P450 architecture it is predicted to catalyze NADPH- and O2-dependent
+  oxidation of an organic substrate using a heme cofactor, with the heme iron coordinated
+  by a conserved axial cysteine; like most plant P450s it is expected, but not shown, to
+  be anchored to the endoplasmic reticulum membrane.
+existing_annotations:
+  - term:
+      id: GO:0004497
+      label: monooxygenase activity
+    evidence_type: IEA
+    original_reference_id: GO_REF:0000002
+    qualifier: enables
+    review:
+      summary: Well-supported family-level inference. The protein has canonical
+        cytochrome P450 domain architecture (Pfam PF00067), and plant P450s are
+        heme-thiolate monooxygenases. The specific substrate and reaction are unknown,
+        but monooxygenase activity is a sound conservative annotation.
+      action: ACCEPT
+      supported_by:
+        - reference_id: file:THLAR/CYP71B1/CYP71B1-deep-research-falcon.md
+          supporting_text: Plant cytochrome P450s are heme-thiolate monooxygenases that
+            catalyze oxygenation reactions
+  - term:
+      id: GO:0005506
+      label: iron ion binding
+    evidence_type: IEA
+    original_reference_id: GO_REF:0000002
+    qualifier: enables
+    review:
+      summary: Correct. The P450 catalytic center binds an iron-containing heme; UniProt
+        annotates an axial heme iron-binding residue at position 436. Iron ion binding
+        is appropriate, captured more specifically by the heme binding annotation.
+      action: ACCEPT
+      supported_by:
+        - reference_id: file:THLAR/CYP71B1/CYP71B1-deep-research-falcon.md
+          supporting_text: a conserved cysteine coordinates the heme iron in the P450
+            catalytic center
+  - term:
+      id: GO:0016705
+      label: oxidoreductase activity, acting on paired donors, with incorporation or
+        reduction of molecular oxygen
+    evidence_type: IEA
+    original_reference_id: GO_REF:0000002
+    qualifier: enables
+    review:
+      summary: Correct and standard for a cytochrome P450 monooxygenase, which uses
+        molecular oxygen with NADPH as the paired electron donor. Conservative
+        family-level inference.
+      action: ACCEPT
+      supported_by:
+        - reference_id: file:THLAR/CYP71B1/CYP71B1-deep-research-falcon.md
+          supporting_text: RH + O2 + NADPH + H+ -&gt; ROH + H2O + NADP+
+  - term:
+      id: GO:0020037
+      label: heme binding
+    evidence_type: IEA
+    original_reference_id: GO_REF:0000002
+    qualifier: enables
+    review:
+      summary: Correct. Cytochrome P450s are heme-thiolate proteins; UniProt annotates
+        the axial heme iron-binding residue (position 436). This is the most specific
+        cofactor annotation and underpins the monooxygenase activity.
+      action: ACCEPT
+      supported_by:
+        - reference_id: file:THLAR/CYP71B1/CYP71B1-deep-research-falcon.md
+          supporting_text: P450s share a conserved catalytic center in which a conserved
+            cysteine coordinates the heme iron
+core_functions:
+  - description: CYP71B1 is a heme-thiolate cytochrome P450 monooxygenase predicted to
+      catalyze NADPH/O2-dependent oxidation of an organic substrate. The physiological
+      substrate, reaction, and pathway are unknown; CYP71-clan membership suggests a
+      role in specialized (defense) metabolism, but this is not established for the
+      pennycress protein.
+    molecular_function:
+      id: GO:0004497
+      label: monooxygenase activity
+    supported_by:
+      - reference_id: PMID:8066138
+        supporting_text: Cloning and sequencing of a full-length cDNA from Thlaspi
+          arvense L. that encodes a cytochrome P-450
+      - reference_id: file:THLAR/CYP71B1/CYP71B1-deep-research-falcon.md
+        supporting_text: heme-thiolate monooxygenase; CYP71 clan enriched in plant
+          specialized metabolism; substrate of pennycress CYP71B1 not determined
+references:
+  - id: GO_REF:0000002
+    title: Gene Ontology annotation through association of InterPro records with GO
+      terms
+    findings: []
+  - id: PMID:8066138
+    title: Cloning and sequencing of a full-length cDNA from Thlaspi arvense L. that
+      encodes a cytochrome P-450.
+    findings:
+      - statement: Reports the full-length cDNA of Thlaspi arvense CYP71B1 (a cytochrome
+          P450); a sequence report with no functional characterization.
+        reference_section_type: ABSTRACT
+    reference_review:
+      relevance: MEDIUM
+      correctness: VERIFIED
+      review_notes: PubMed-verified. The sole primary reference for this gene; it
+        establishes existence/sequence only, not function. Abstract-only in cache.
+  - id: file:THLAR/CYP71B1/CYP71B1-deep-research-falcon.md
+    title: Falcon/Edison deep research report for CYP71B1, Thlaspi arvense
+    findings:
+      - statement: Concludes pennycress CYP71B1 is functionally uncharacterized; only a
+          heme-thiolate plant P450 monooxygenase classification can be inferred, with
+          CYP71-clan members commonly acting in specialized/defense metabolism (e.g.
+          Arabidopsis camalexin pathway). Flags symbol ambiguity with Arabidopsis
+          CYP71B1 (At1g13080).
+        reference_section_type: OTHER
+suggested_questions:
+  - question: What substrate(s) and reaction does Thlaspi arvense CYP71B1 catalyze, and
+      in which pathway (e.g. glucosinolate, indole/camalexin-type, or other specialized
+      metabolism) does it act?
+  - question: Is CYP71B1 anchored to the endoplasmic reticulum membrane, as is typical
+      for CYP71-clan plant P450s?
+suggested_experiments:
+  - description: Heterologously express CYP71B1 (e.g. in yeast or N. benthamiana
+      microsomes with a plant cytochrome P450 reductase) and screen candidate substrates
+      from Brassicaceae specialized metabolism (indole/tryptophan-derived intermediates,
+      glucosinolate precursors) by LC-MS to identify the catalyzed reaction.
+  - description: Determine subcellular localization with a fluorescent-protein fusion and
+      test for an N-terminal ER membrane anchor.
+</code></pre>
+            </div>
+        </details>
+    </div>
+
+    <!-- Pathway Visualization Link -->
+    
+
+    <style>
+        /* Markdown Section Styles */
+        .markdown-section {
+            margin-bottom: 1rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .markdown-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .markdown-section summary h3 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.1rem;
+        }
+
+        .markdown-section summary:hover h3 {
+            color: #007bff;
+        }
+
+        .markdown-section[open] {
+            background-color: #fff;
+        }
+
+        .markdown-content {
+            margin-top: 1rem;
+            padding: 1rem;
+            border-top: 1px solid #dee2e6;
+        }
+
+        /* Markdown content styling */
+        .markdown-content h1 { font-size: 1.5rem; margin-top: 1.5rem; }
+        .markdown-content h2 { font-size: 1.3rem; margin-top: 1.3rem; }
+        .markdown-content h3 { font-size: 1.1rem; margin-top: 1.1rem; }
+        .markdown-content h4 { font-size: 1rem; margin-top: 1rem; }
+
+        .markdown-content pre {
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .markdown-content code {
+            background-color: #f8f9fa;
+            padding: 0.2rem 0.4rem;
+            border-radius: 3px;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+        }
+
+        .markdown-content pre code {
+            background: none;
+            padding: 0;
+        }
+
+        .markdown-content table {
+            border-collapse: collapse;
+            width: 100%;
+            margin: 1rem 0;
+        }
+
+        .markdown-content table th,
+        .markdown-content table td {
+            border: 1px solid #dee2e6;
+            padding: 0.5rem;
+            text-align: left;
+        }
+
+        .markdown-content table th {
+            background-color: #f8f9fa;
+            font-weight: bold;
+        }
+
+        .markdown-content blockquote {
+            border-left: 4px solid #007bff;
+            padding-left: 1rem;
+            margin-left: 0;
+            color: #666;
+        }
+
+        /* YAML Preview Styles */
+        .yaml-preview {
+            margin-top: 2rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .yaml-preview summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .yaml-preview summary h2 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.3rem;
+        }
+
+        .yaml-preview summary:hover h2 {
+            color: #007bff;
+        }
+
+        .yaml-preview[open] {
+            background-color: #fff;
+        }
+
+        .yaml-content {
+            margin-top: 1rem;
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .yaml-content pre {
+            margin: 0;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+            line-height: 1.4;
+        }
+
+        .yaml-content code {
+            color: #333;
+            background: none;
+            padding: 0;
+        }
+
+        /* Pathway Link Styles */
+        .pathway-link {
+            margin: 1rem 0;
+        }
+
+        .btn-link {
+            display: inline-block;
+            padding: 0.5rem 1rem;
+            background-color: #007bff;
+            color: white !important;
+            text-decoration: none;
+            border-radius: 4px;
+            font-weight: 500;
+            transition: background-color 0.2s;
+        }
+
+        .btn-link:hover {
+            background-color: #0056b3;
+            text-decoration: none;
+        }
+
+        /* Voting buttons */
+        .vote-buttons {
+            display: inline-block;
+            margin-left: 0.5rem;
+        }
+
+        .vote-btn {
+            background: none;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 2px 6px;
+            margin: 0 2px;
+            cursor: pointer;
+            font-size: 0.9rem;
+            transition: all 0.2s;
+            opacity: 0.6;
+        }
+
+        .vote-btn:hover {
+            opacity: 1;
+            transform: scale(1.1);
+        }
+
+        .vote-btn.voted {
+            opacity: 1;
+            border-color: #28a745;
+            background-color: #d4edda;
+        }
+
+        .vote-btn.voted-down {
+            border-color: #dc3545;
+            background-color: #f8d7da;
+        }
+
+        .vote-btn-small {
+            font-size: 0.7rem;
+            padding: 1px 4px;
+            margin: 0 1px;
+        }
+    </style>
+
+    <script>
+        // Add collapsible functionality
+        document.querySelectorAll('.collapsible').forEach(element => {
+            element.addEventListener('click', function() {
+                this.classList.toggle('collapsed');
+            });
+        });
+
+        // Voting functionality
+        const VOTE_URL = 'https://script.google.com/macros/s/AKfycbwPKH7d3seuPNBtB0ugVjqGeTiByyOGD5vkqB_Ck6K8eOcPQYbJqBOuz6GFgXHKBNWK/exec';
+
+        // Get or create session ID
+        let sessionId = localStorage.getItem('review_session_id');
+        if (!sessionId) {
+            sessionId = 's' + Date.now() + '_' + Math.random().toString(36).substr(2, 9);
+            localStorage.setItem('review_session_id', sessionId);
+        }
+
+        // Show previous votes on page load
+        document.addEventListener('DOMContentLoaded', function() {
+            document.querySelectorAll('.vote-buttons').forEach(container => {
+                const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+                const previousVote = localStorage.getItem(key);
+                if (previousVote) {
+                    const btn = container.querySelector(`[data-v="${previousVote}"]`);
+                    if (btn) btn.classList.add(previousVote === 'up' ? 'voted' : 'voted-down');
+                }
+            });
+        });
+
+        // Handle vote clicks - Simple image beacon approach
+        document.addEventListener('click', function(e) {
+            if (!e.target.classList.contains('vote-btn')) return;
+
+            // Prevent the click from bubbling to parent elements (like summary)
+            e.preventDefault();
+            e.stopPropagation();
+
+            const btn = e.target;
+            const container = btn.closest('.vote-buttons');
+            if (!container) return;
+
+            const voteType = btn.dataset.v;
+
+            // Check if already voted (locally)
+            const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+            const previousVote = localStorage.getItem(key);
+
+            if (previousVote === voteType) {
+                // Same vote - do nothing
+                btn.style.animation = 'shake 0.5s';
+                setTimeout(() => btn.style.animation = '', 500);
+                return;
+            }
+
+            // Build URL
+            const params = new URLSearchParams({
+                gene_id: container.dataset.g,
+                annotation_id: container.dataset.a,
+                ref_id: container.dataset.r || '',
+                action: container.dataset.act,
+                vote: voteType,
+                session_id: sessionId,
+                ua: navigator.userAgent.substring(0, 100)
+            });
+
+            // Clear previous vote styling
+            container.querySelectorAll('.vote-btn').forEach(b => {
+                b.classList.remove('voted', 'voted-down');
+            });
+
+            // Apply new vote styling immediately (optimistic UI)
+            btn.classList.add(voteType === 'up' ? 'voted' : 'voted-down');
+
+            // Store locally
+            localStorage.setItem(key, voteType);
+
+            // Send vote using fetch with no-cors mode (fire and forget)
+            const fullUrl = VOTE_URL + '?' + params;
+            console.log('Sending vote to:', fullUrl);
+
+            // Use fetch in no-cors mode - we won't get a response but the request will be sent
+            fetch(fullUrl, {
+                mode: 'no-cors',
+                method: 'GET'
+            }).then(() => {
+                console.log('Vote request sent (no response due to no-cors mode)');
+            }).catch(err => {
+                console.warn('Vote may not have been recorded, but saved locally:', err);
+
+                // Fallback: try image beacon as well
+                const img = new Image();
+                img.src = fullUrl;
+            });
+        });
+
+        // Optional: Add shake animation for feedback
+        const style = document.createElement('style');
+        style.textContent = `
+            @keyframes shake {
+                0%, 100% { transform: translateX(0); }
+                25% { transform: translateX(-5px); }
+                75% { transform: translateX(5px); }
+            }
+        `;
+        document.head.appendChild(style);
+    </script>
+</body>
+</html>

--- a/genes/THLAR/TFP/TFP-ai-review.html
+++ b/genes/THLAR/TFP/TFP-ai-review.html
@@ -1,0 +1,2809 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>TFP - AI Gene Review</title>
+    <style>
+        :root {
+            --color-accept: #22c55e;
+            --color-remove: #ef4444;
+            --color-modify: #f97316;
+            --color-keep-non-core: #3b82f6;
+            --color-undecided: #6b7280;
+            --color-new: #8b5cf6;
+            --color-mark-over: #eab308;
+            --bg-light: #f9fafb;
+            --border-color: #e5e7eb;
+            --text-muted: #6b7280;
+            --text-primary: #111827;
+        }
+
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+            line-height: 1.6;
+            color: var(--text-primary);
+            background-color: #ffffff;
+            padding: 2rem;
+            max-width: 1400px;
+            margin: 0 auto;
+        }
+
+        .header {
+            border-bottom: 2px solid var(--border-color);
+            padding-bottom: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        h1 {
+            font-size: 2.5rem;
+            font-weight: 700;
+            margin-bottom: 0.5rem;
+            color: #1f2937;
+        }
+
+        .gene-info {
+            display: flex;
+            gap: 2rem;
+            flex-wrap: wrap;
+            margin-top: 1rem;
+        }
+
+        .info-item {
+            display: flex;
+            gap: 0.5rem;
+        }
+
+        .info-label {
+            font-weight: 600;
+            color: var(--text-muted);
+        }
+
+        .aliases {
+            display: flex;
+            gap: 0.5rem;
+            flex-wrap: wrap;
+        }
+
+        .badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.875rem;
+            font-weight: 500;
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+        }
+
+        .status-badge {
+            padding: 0.375rem 0.875rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .status-initialized {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fde68a;
+        }
+
+        .status-in-progress {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+        }
+
+        .status-draft {
+            background-color: #fce7f3;
+            color: #831843;
+            border: 1px solid #fbcfe8;
+        }
+
+        .status-complete {
+            background-color: #d1fae5;
+            color: #065f46;
+            border: 1px solid #a7f3d0;
+        }
+
+        .description-card {
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        .description-card h2 {
+            font-size: 1.25rem;
+            margin-bottom: 1rem;
+            color: #374151;
+        }
+
+        .section {
+            margin-bottom: 2.5rem;
+        }
+
+        .section-title {
+            font-size: 1.5rem;
+            font-weight: 600;
+            margin-bottom: 1.5rem;
+            color: #1f2937;
+            border-bottom: 1px solid var(--border-color);
+            padding-bottom: 0.5rem;
+        }
+
+        .annotations-table {
+            width: 100%;
+            border-collapse: collapse;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            overflow: hidden;
+        }
+
+        .annotations-table thead {
+            background-color: var(--bg-light);
+        }
+
+        .annotations-table th {
+            text-align: left;
+            padding: 1rem;
+            font-weight: 600;
+            border-bottom: 2px solid var(--border-color);
+            font-size: 0.875rem;
+            text-transform: uppercase;
+            letter-spacing: 0.05em;
+            color: var(--text-muted);
+        }
+
+        .annotations-table td {
+            padding: 1rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .annotations-table tbody tr:hover {
+            background-color: #f9fafb;
+        }
+
+        .action-badge {
+            display: inline-block;
+            padding: 0.375rem 0.75rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .action-accept {
+            background-color: var(--color-accept);
+            color: white;
+        }
+
+        .action-remove {
+            background-color: var(--color-remove);
+            color: white;
+        }
+
+        .action-modify {
+            background-color: var(--color-modify);
+            color: white;
+        }
+
+        .action-keep_as_non_core {
+            background-color: var(--color-keep-non-core);
+            color: white;
+        }
+
+        .action-undecided {
+            background-color: var(--color-undecided);
+            color: white;
+        }
+
+        .action-new {
+            background-color: var(--color-new);
+            color: white;
+        }
+
+        .action-mark_as_over_annotated {
+            background-color: var(--color-mark-over);
+            color: white;
+        }
+
+        .term-info {
+            display: flex;
+            flex-direction: column;
+            gap: 0.25rem;
+        }
+
+        .term-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .term-label {
+            font-weight: 500;
+        }
+
+        .evidence-code {
+            font-family: monospace;
+            background-color: var(--bg-light);
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .not-badge {
+            display: inline-block;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-weight: 600;
+            margin-left: 0.25rem;
+        }
+
+        .isoform-badge {
+            display: inline-block;
+            background-color: #eff6ff;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            margin-top: 0.25rem;
+        }
+
+        .core-function-card {
+            background-color: white;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 1rem;
+        }
+
+        .core-function-card h3 {
+            font-size: 1.125rem;
+            margin-bottom: 1rem;
+            color: #1f2937;
+        }
+
+        .core-function-statement {
+            margin-bottom: 1rem;
+            padding: 0.75rem;
+            background-color: var(--bg-light);
+            border-left: 4px solid var(--color-accept);
+            border-radius: 0.25rem;
+        }
+
+        .function-annotations {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin-top: 1rem;
+        }
+
+        .reference-item {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+        }
+
+        .reference-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: start;
+            margin-bottom: 0.75rem;
+        }
+
+        .reference-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #2563eb;
+        }
+
+        .supported-by {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f3f4f6;
+            border-left: 3px solid #3b82f6;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .supported-by-title {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .support-item {
+            margin-bottom: 0.5rem;
+        }
+
+        .support-ref {
+            font-weight: 500;
+            color: #2563eb;
+        }
+
+        .support-text {
+            color: #6b7280;
+            font-style: italic;
+            margin-left: 1rem;
+        }
+
+        a.term-link {
+            color: #2563eb;
+            text-decoration: none;
+        }
+
+        a.term-link:hover {
+            text-decoration: underline;
+        }
+
+        .core-function-terms {
+            margin-top: 1rem;
+        }
+
+        .function-term-group {
+            margin-bottom: 1rem;
+        }
+
+        .function-term-label {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .reference-title {
+            font-weight: 500;
+            margin-bottom: 0.5rem;
+        }
+
+        .findings-list {
+            margin-top: 1rem;
+            padding-left: 1.5rem;
+        }
+
+        .finding-item {
+            margin-bottom: 0.75rem;
+        }
+
+        .finding-statement {
+            font-weight: 500;
+            margin-bottom: 0.25rem;
+        }
+
+        .finding-text {
+            color: var(--text-muted);
+            font-size: 0.95rem;
+            font-style: italic;
+        }
+
+        .proposed-term {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #fef3c7;
+        }
+
+        .question-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #dbeafe;
+        }
+
+        .experiment-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #f3e8ff;
+        }
+
+        .prediction-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: white;
+        }
+
+        .prediction-card .prediction-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+        }
+
+        .prediction-source {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+        }
+
+        .assessment-badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.8rem;
+            font-weight: 600;
+            text-transform: uppercase;
+        }
+
+        .assessment-cor { background-color: #dcfce7; color: #166534; }
+        .assessment-cnn { background-color: #dbeafe; color: #1e40af; }
+        .assessment-lsp { background-color: #fef9c3; color: #854d0e; }
+        .assessment-unc { background-color: #f3f4f6; color: #374151; }
+        .assessment-pli { background-color: #fee2e2; color: #991b1b; }
+        .assessment-npi { background-color: #fecaca; color: #7f1d1d; }
+        .assessment-rep { background-color: #fde68a; color: #92400e; }
+
+        .confidence-score {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+            margin-left: 0.5rem;
+        }
+
+        .error-type-badge {
+            font-size: 0.75rem;
+            padding: 0.125rem 0.5rem;
+            border-radius: 0.25rem;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+        }
+
+        .isoforms-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fill, minmax(400px, 1fr));
+            gap: 1rem;
+        }
+
+        .isoform-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            background-color: white;
+            transition: box-shadow 0.2s;
+        }
+
+        .isoform-card:hover {
+            box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+        }
+
+        .functional-isoform-type {
+            display: inline-block;
+            padding: 0.2rem 0.5rem;
+            border-radius: 0.25rem;
+            font-size: 0.7rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.03em;
+        }
+
+        .type-SPLICE_VARIANT, .type-SPLICE_CLASS {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #93c5fd;
+        }
+
+        .type-CLEAVAGE_PRODUCT {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fcd34d;
+        }
+
+        .type-MODIFICATION_STATE {
+            background-color: #f3e8ff;
+            color: #6b21a8;
+            border: 1px solid #c4b5fd;
+        }
+
+        .type-CONFORMATIONAL_STATE {
+            background-color: #dcfce7;
+            color: #166534;
+            border: 1px solid #86efac;
+        }
+
+        .functional-isoform-mappings {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+            font-size: 0.85rem;
+        }
+
+        .functional-isoform-mappings .mapping-type {
+            font-weight: 600;
+            color: var(--text-muted);
+            font-size: 0.75rem;
+        }
+
+        .functional-isoform-go {
+            margin-top: 0.5rem;
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.25rem;
+        }
+
+        .go-chip {
+            display: inline-block;
+            padding: 0.15rem 0.4rem;
+            background-color: #ecfdf5;
+            color: #047857;
+            border: 1px solid #a7f3d0;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-family: monospace;
+        }
+
+        .isoform-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+            padding-bottom: 0.5rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .isoform-name {
+            font-weight: 600;
+            font-size: 1.1rem;
+            color: #1f2937;
+        }
+
+        .isoform-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .isoform-sequence-note {
+            font-size: 0.875rem;
+            color: var(--text-muted);
+            margin-bottom: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+        }
+
+        .isoform-description {
+            font-size: 0.95rem;
+            line-height: 1.5;
+        }
+
+        .collapsible {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .collapsible:after {
+            content: ' ▼';
+            font-size: 0.75rem;
+        }
+
+        .collapsible.collapsed:after {
+            content: ' ►';
+        }
+
+        .collapse-content {
+            transition: max-height 0.3s ease;
+            overflow: hidden;
+        }
+
+        .collapsed + .collapse-content {
+            max-height: 0;
+        }
+
+        .no-data {
+            color: var(--text-muted);
+            font-style: italic;
+            padding: 1rem;
+            text-align: center;
+            background-color: var(--bg-light);
+            border-radius: 0.5rem;
+        }
+
+        /* Styling for markdown section summaries with voting */
+        .markdown-section summary {
+            padding: 0.75rem;
+            background: var(--bg-light);
+            border-radius: 0.5rem;
+            margin-bottom: 0.5rem;
+        }
+
+        .markdown-section summary:hover {
+            background: #e5e7eb;
+        }
+
+        .markdown-section summary .vote-buttons {
+            margin-left: auto;
+        }
+
+        .deep-research-section {
+            margin-bottom: 1rem;
+            border: 1px solid #c7d2fe;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8faff;
+        }
+
+        .deep-research-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .deep-research-section summary h3 {
+            margin: 0;
+            color: #3730a3;
+            font-size: 1.1rem;
+        }
+
+        .report-meta {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin: 0.75rem 0 1rem;
+            align-items: center;
+        }
+
+        .report-badge {
+            display: inline-flex;
+            align-items: center;
+            border: 1px solid #c7d2fe;
+            border-radius: 999px;
+            background: #eef2ff;
+            color: #4338ca;
+            font-size: 0.78rem;
+            font-weight: 600;
+            padding: 0.2rem 0.6rem;
+        }
+
+        .report-meta-text {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+        }
+
+        .artifact-list {
+            display: grid;
+            gap: 0.75rem;
+            margin: 0.75rem 0 1rem;
+        }
+
+        .artifact-link {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+            margin-top: 0.5rem;
+            word-break: break-word;
+        }
+
+        @media print {
+            body {
+                padding: 1rem;
+            }
+
+            .collapsible:after {
+                display: none;
+            }
+
+            .collapsed + .collapse-content {
+                max-height: none !important;
+            }
+        }
+
+        @media (max-width: 768px) {
+            body {
+                padding: 1rem;
+            }
+
+            h1 {
+                font-size: 2rem;
+            }
+
+            .annotations-table {
+                font-size: 0.875rem;
+            }
+
+            .annotations-table th,
+            .annotations-table td {
+                padding: 0.5rem;
+            }
+        }
+    </style>
+</head>
+<body>
+    <div class="header">
+        <h1>TFP</h1>
+        <div class="gene-info">
+            
+            <div class="info-item">
+                
+                <span class="info-label">UniProt ID:</span>
+                <span>
+                    <a href="https://www.uniprot.org/uniprotkb/G1FNI6" target="_blank" class="term-link">
+                        G1FNI6
+                    </a>
+                </span>
+                
+            </div>
+            
+            
+            <div class="info-item">
+                <span class="info-label">Organism:</span>
+                <span>Thlaspi arvense</span>
+            </div>
+            
+            
+            <div class="info-item">
+                <span class="info-label">Review Status:</span>
+                <span class="status-badge status-complete">
+                    COMPLETE
+                </span>
+            </div>
+            
+            
+        </div>
+        <div style="margin-top: 1rem; text-align: center;">
+            <a id="feedback-form-link"
+               href="#"
+               target="_blank"
+               style="display: inline-block; padding: 10px 20px; background-color: #4CAF50; color: white; text-decoration: none; border-radius: 5px; font-weight: 600;">
+                📝 Provide Detailed Feedback
+            </a>
+            <script>
+                // Construct the form URL with proper encoding
+                // Extract organism code from the current page path (e.g., /genes/ARATH/APO1/ -> ARATH)
+                const pathParts = window.location.pathname.split('/');
+                const genesIndex = pathParts.indexOf('genes');
+                let organism = '';
+                if (genesIndex !== -1 && pathParts[genesIndex + 1]) {
+                    organism = pathParts[genesIndex + 1].toUpperCase();
+                }
+                const geneSymbol = "TFP";
+                const speciesGene = organism + ' ' + geneSymbol;
+                const formBaseUrl = 'https://docs.google.com/forms/d/e/1FAIpQLSdTot9L6GVkkZYgLQT0E8ZdAJv8RiN5ZgOVkgWNcKSbYvxxzQ/viewform';
+                const entryId = '1226477767'; // Correct entry ID for Species/Gene field
+                const formUrl = formBaseUrl + '?entry.' + entryId + '=' + encodeURIComponent(speciesGene);
+                const feedbackLink = document.getElementById('feedback-form-link');
+                feedbackLink.href = formUrl;
+                // Add tooltip showing the pre-filled value
+                feedbackLink.title = 'Opens form with pre-filled: ' + speciesGene;
+            </script>
+        </div>
+    </div>
+
+    
+    <div class="description-card">
+        <div style="display: flex; justify-content: space-between; align-items: center;">
+            <h2>Gene Description</h2>
+            <span class="vote-buttons" data-g="G1FNI6" data-a="DESCRIPTION: TaTFP is a thiocyanate-forming protein of field pe..." data-r="" data-act="DESCRIPTION">
+                <button class="vote-btn" data-v="up" title="Agree with this description">👍</button>
+                <button class="vote-btn" data-v="down" title="Disagree with this description">👎</button>
+            </span>
+        </div>
+        <p>TaTFP is a thiocyanate-forming protein of field pennycress, an iron(II)-dependent specifier protein in the glucosinolate-myrosinase chemical defense system. It is a Kelch-repeat, six-bladed beta-propeller protein that acts as a homodimer. Rather than hydrolyzing intact glucosinolates, it captures the unstable aglucone generated by myrosinase upon tissue damage and redirects its rearrangement away from the default isothiocyanate, catalyzing formation of organic thiocyanates (e.g. allylthiocyanate), epithionitriles, and simple nitriles. The protein is curated as a carbon-sulfur lyase (sulfolyase, EC 4.8.1.8) and is expressed constitutively across plant tissues.</p>
+    </div>
+    
+
+    
+
+    
+    <div class="section">
+        <h2 class="section-title">Proposed New Ontology Terms</h2>
+        
+        <div class="proposed-term">
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+                <h3>thiocyanate-forming sulfolyase activity</h3>
+                <span class="vote-buttons" data-g="G1FNI6" data-a="thiocyanate-forming sulfolyase activity" data-r="" data-act="NEW">
+                    <button class="vote-btn" data-v="up" title="Agree this term should be created">👍</button>
+                    <button class="vote-btn" data-v="down" title="Disagree with creating this term">👎</button>
+                </span>
+            </div>
+
+            
+            <p><strong>Definition:</strong> A carbon-sulfur lyase activity that eliminates sulfate from a glucosinolate aglucone to yield an organic thiocyanate (EC 4.8.1.8). No GO molecular-function term currently captures this specific specifier-protein activity; carbon-sulfur lyase activity (GO:0016846) is the closest available parent.</p>
+            
+
+            
+            <p><strong>Justification:</strong> The reaction is curated in UniProt (EC 4.8.1.8) and structurally characterized, but the existing GO MF granularity stops at the carbon-sulfur lyase parent, leaving specifier-protein catalysis under-described.</p>
+            
+
+            
+            <p><strong>Parent term:</strong>
+                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016846" target="_blank" class="term-link">
+                    carbon-sulfur lyase activity
+                </a>
+            </p>
+            
+
+            
+
+            
+        </div>
+        
+    </div>
+    
+
+    
+    <div class="section">
+        <h2 class="section-title">Existing Annotations Review</h2>
+        <table class="annotations-table">
+            <thead>
+                <tr>
+                    <th>GO Term</th>
+                    <th>Evidence</th>
+                    <th>Action</th>
+                    <th>Reason</th>
+                </tr>
+            </thead>
+            <tbody>
+                
+                <tr>
+                    <td>
+                        <div class="term-info">
+                            
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005634" target="_blank" class="term-link">
+                                    GO:0005634
+                                </a>
+                            </span>
+                            <span class="term-label">nucleus</span>
+                            
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+                        
+                        
+                        
+                        <br>
+                        <span style="font-size: 0.75rem;">
+                            
+                            GO_REF:0000118
+                            
+                        </span>
+                        
+                    </td>
+                    <td>
+                        <span class="action-badge action-remove">
+                            REMOVE
+                        </span>
+                        <span class="vote-buttons" data-g="G1FNI6" data-a="GO:0005634" data-r="GO_REF:0000118" data-act="REMOVE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+                        
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Over-propagated phylogenetic (TreeGrafter) localization. TaTFP is a cytosolic glucosinolate-breakdown specifier protein; there is no evidence for nuclear localization, and a nuclear compartment is implausible for an enzyme that processes myrosinase-generated aglucones in the cytoplasm after tissue disruption.
+                        </div>
+                        
+                        
+                        
+                        
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+                            
+                            <div class="support-item">
+                                <span class="support-ref">
+                                    
+                                    file:THLAR/TFP/TFP-deep-research-falcon.md
+                                    
+                                </span>
+                                
+                                <div class="support-text">TaTFP acts at the cellular site where myrosinase-generated aglucones become available; no nuclear localization reported.</div>
+                                
+                            </div>
+                            
+                        </div>
+                        
+                    </td>
+                </tr>
+                
+                <tr>
+                    <td>
+                        <div class="term-info">
+                            
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
+                                    GO:0005829
+                                </a>
+                            </span>
+                            <span class="term-label">cytosol</span>
+                            
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+                        
+                        
+                        
+                        <br>
+                        <span style="font-size: 0.75rem;">
+                            
+                            GO_REF:0000118
+                            
+                        </span>
+                        
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="G1FNI6" data-a="GO:0005829" data-r="GO_REF:0000118" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+                        
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Plausible and consistent with function. Specifier proteins act in the cytosol where myrosinase-released glucosinolate aglucones become available. Direct subcellular localization of TaTFP has not been experimentally established, but the cytosol is the expected site of action.
+                        </div>
+                        
+                        
+                        
+                        
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+                            
+                            <div class="support-item">
+                                <span class="support-ref">
+                                    
+                                    file:THLAR/TFP/TFP-deep-research-falcon.md
+                                    
+                                </span>
+                                
+                                <div class="support-text">broader glucosinolate-system reviews discuss cytoplasmic organization for specifier proteins</div>
+                                
+                            </div>
+                            
+                        </div>
+                        
+                    </td>
+                </tr>
+                
+                <tr>
+                    <td>
+                        <div class="term-info">
+                            
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0019760" target="_blank" class="term-link">
+                                    GO:0019760
+                                </a>
+                            </span>
+                            <span class="term-label">glucosinolate metabolic process</span>
+                            
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+                        
+                        
+                        
+                        <br>
+                        <span style="font-size: 0.75rem;">
+                            
+                            GO_REF:0000117
+                            
+                        </span>
+                        
+                    </td>
+                    <td>
+                        <span class="action-badge action-modify">
+                            MODIFY
+                        </span>
+                        <span class="vote-buttons" data-g="G1FNI6" data-a="GO:0019760" data-r="GO_REF:0000117" data-act="MODIFY">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+                        
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Correct, but the generic metabolic-process parent should be specialized to the catabolic child, consistent with the experimentally supported breakdown role of TaTFP downstream of myrosinase.
+                        </div>
+                        
+                        
+                        
+                        <div style="margin-top: 0.5rem;">
+                            <strong>Proposed replacements:</strong>
+                            
+                            <span class="badge">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0019762" target="_blank" class="term-link">
+                                    glucosinolate catabolic process
+                                </a>
+                            </span>
+                            
+                        </div>
+                        
+                        
+                    </td>
+                </tr>
+                
+                <tr>
+                    <td>
+                        <div class="term-info">
+                            
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0030234" target="_blank" class="term-link">
+                                    GO:0030234
+                                </a>
+                            </span>
+                            <span class="term-label">enzyme regulator activity</span>
+                            
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+                        
+                        
+                        
+                        <br>
+                        <span style="font-size: 0.75rem;">
+                            
+                            GO_REF:0000118
+                            
+                        </span>
+                        
+                    </td>
+                    <td>
+                        <span class="action-badge action-modify">
+                            MODIFY
+                        </span>
+                        <span class="vote-buttons" data-g="G1FNI6" data-a="GO:0030234" data-r="GO_REF:0000118" data-act="MODIFY">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+                        
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Outdated molecular-function framing. Specifier proteins were historically viewed as accessory factors that &#34;regulate&#34; myrosinase product outcome, but TaTFP is now established as a catalyst in its own right - an Fe(2+)-dependent carbon-sulfur lyase (sulfolyase, EC 4.8.1.8) that eliminates sulfate from the glucosinolate aglucone to form thiocyanates and nitriles. The activity should be captured as a lyase, not as enzyme regulator activity. [PMID:30900313 &#34;specifier proteins act as Fe(2+)-dependent lyases&#34;]
+                        </div>
+                        
+                        
+                        
+                        <div style="margin-top: 0.5rem;">
+                            <strong>Proposed replacements:</strong>
+                            
+                            <span class="badge">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016846" target="_blank" class="term-link">
+                                    carbon-sulfur lyase activity
+                                </a>
+                            </span>
+                            
+                        </div>
+                        
+                        
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+                            
+                            <div class="support-item">
+                                <span class="support-ref">
+                                    
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/30900313" target="_blank" class="term-link">
+                                        PMID:30900313
+                                    </a>
+                                    
+                                </span>
+                                
+                                <div class="support-text">Structural diversification during glucosinolate breakdown: mechanisms of thiocyanate, epithionitrile and simple nitrile formation</div>
+                                
+                            </div>
+                            
+                            <div class="support-item">
+                                <span class="support-ref">
+                                    
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/21783213" target="_blank" class="term-link">
+                                        PMID:21783213
+                                    </a>
+                                    
+                                </span>
+                                
+                                <div class="support-text">A thiocyanate-forming protein generates multiple products upon allylglucosinolate hydrolysis</div>
+                                
+                            </div>
+                            
+                            <div class="support-item">
+                                <span class="support-ref">
+                                    
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/23999604" target="_blank" class="term-link">
+                                        PMID:23999604
+                                    </a>
+                                    
+                                </span>
+                                
+                                <div class="support-text">Molecular models and mutational analyses of plant specifier proteins suggest active site residues and reaction mechanism</div>
+                                
+                            </div>
+                            
+                        </div>
+                        
+                    </td>
+                </tr>
+                
+                <tr>
+                    <td>
+                        <div class="term-info">
+                            
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0080028" target="_blank" class="term-link">
+                                    GO:0080028
+                                </a>
+                            </span>
+                            <span class="term-label">nitrile biosynthetic process</span>
+                            
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+                        
+                        
+                        
+                        <br>
+                        <span style="font-size: 0.75rem;">
+                            
+                            GO_REF:0000118
+                            
+                        </span>
+                        
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="G1FNI6" data-a="GO:0080028" data-r="GO_REF:0000118" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+                        
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Correct. TaTFP generates simple nitriles and epithionitriles (e.g. 3,4-epithiobutanenitrile) from glucosinolate aglucones, in addition to organic thiocyanates. [PMID:21783213; PMID:30900313]
+                        </div>
+                        
+                        
+                        
+                        
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+                            
+                            <div class="support-item">
+                                <span class="support-ref">
+                                    
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/21783213" target="_blank" class="term-link">
+                                        PMID:21783213
+                                    </a>
+                                    
+                                </span>
+                                
+                                <div class="support-text">generates multiple products upon allylglucosinolate hydrolysis</div>
+                                
+                            </div>
+                            
+                            <div class="support-item">
+                                <span class="support-ref">
+                                    
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/30900313" target="_blank" class="term-link">
+                                        PMID:30900313
+                                    </a>
+                                    
+                                </span>
+                                
+                                <div class="support-text">mechanisms of thiocyanate, epithionitrile and simple nitrile formation</div>
+                                
+                            </div>
+                            
+                        </div>
+                        
+                    </td>
+                </tr>
+                
+                <tr>
+                    <td>
+                        <div class="term-info">
+                            
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0019760" target="_blank" class="term-link">
+                                    GO:0019760
+                                </a>
+                            </span>
+                            <span class="term-label">glucosinolate metabolic process</span>
+                            
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+                        
+                        
+                        
+                        <br>
+                        <span style="font-size: 0.75rem;">
+                            
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/26260516" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:26260516
+                            </a>
+                            
+                                
+                                
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    The crystal structure of the thiocyanate-forming protein fro...
+                                </span>
+                                
+                            
+                            
+                        </span>
+                        
+                    </td>
+                    <td>
+                        <span class="action-badge action-modify">
+                            MODIFY
+                        </span>
+                        <span class="vote-buttons" data-g="G1FNI6" data-a="GO:0019760" data-r="PMID:26260516" data-act="MODIFY">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+                        
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Experimentally supported but can be made more precise. TaTFP acts in the breakdown (catabolism) of glucosinolates downstream of myrosinase, so the catabolic child term is more informative than the generic metabolic-process parent. [PMID:26260516 &#34;a kelch protein involved in glucosinolate breakdown&#34;]
+                        </div>
+                        
+                        
+                        
+                        <div style="margin-top: 0.5rem;">
+                            <strong>Proposed replacements:</strong>
+                            
+                            <span class="badge">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0019762" target="_blank" class="term-link">
+                                    glucosinolate catabolic process
+                                </a>
+                            </span>
+                            
+                        </div>
+                        
+                        
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+                            
+                            <div class="support-item">
+                                <span class="support-ref">
+                                    
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/26260516" target="_blank" class="term-link">
+                                        PMID:26260516
+                                    </a>
+                                    
+                                </span>
+                                
+                                <div class="support-text">The crystal structure of the thiocyanate-forming protein from Thlaspi arvense, a kelch protein involved in glucosinolate breakdown</div>
+                                
+                            </div>
+                            
+                        </div>
+                        
+                    </td>
+                </tr>
+                
+                <tr>
+                    <td>
+                        <div class="term-info">
+                            
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0042802" target="_blank" class="term-link">
+                                    GO:0042802
+                                </a>
+                            </span>
+                            <span class="term-label">identical protein binding</span>
+                            
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+                        
+                        
+                        
+                        <br>
+                        <span style="font-size: 0.75rem;">
+                            
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/26260516" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:26260516
+                            </a>
+                            
+                                
+                                
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    The crystal structure of the thiocyanate-forming protein fro...
+                                </span>
+                                
+                            
+                            
+                        </span>
+                        
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="G1FNI6" data-a="GO:0042802" data-r="PMID:26260516" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+                        
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Reflects the homodimeric quaternary state demonstrated in the crystal structure. Real but structural rather than the catalytic core function; retained as non-core. The homodimerization-activity annotation below is the more specific of the two.
+                        </div>
+                        
+                        
+                        
+                        
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+                            
+                            <div class="support-item">
+                                <span class="support-ref">
+                                    
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/26260516" target="_blank" class="term-link">
+                                        PMID:26260516
+                                    </a>
+                                    
+                                </span>
+                                
+                                <div class="support-text">crystal structure of the thiocyanate-forming protein from Thlaspi arvense</div>
+                                
+                            </div>
+                            
+                        </div>
+                        
+                    </td>
+                </tr>
+                
+                <tr>
+                    <td>
+                        <div class="term-info">
+                            
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0042803" target="_blank" class="term-link">
+                                    GO:0042803
+                                </a>
+                            </span>
+                            <span class="term-label">protein homodimerization activity</span>
+                            
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+                        
+                        
+                        
+                        <br>
+                        <span style="font-size: 0.75rem;">
+                            
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/26260516" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:26260516
+                            </a>
+                            
+                                
+                                
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    The crystal structure of the thiocyanate-forming protein fro...
+                                </span>
+                                
+                            
+                            
+                        </span>
+                        
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="G1FNI6" data-a="GO:0042803" data-r="PMID:26260516" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+                        
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Supported by the crystal structure, which shows TaTFP is a homodimer. A genuine structural property of the protein, retained as non-core relative to its catalytic lyase activity. [PMID:26260516]
+                        </div>
+                        
+                        
+                        
+                        
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+                            
+                            <div class="support-item">
+                                <span class="support-ref">
+                                    
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/26260516" target="_blank" class="term-link">
+                                        PMID:26260516
+                                    </a>
+                                    
+                                </span>
+                                
+                                <div class="support-text">TaTFP is reported as a homodimer</div>
+                                
+                            </div>
+                            
+                        </div>
+                        
+                    </td>
+                </tr>
+                
+            </tbody>
+        </table>
+    </div>
+    
+
+    
+    <div class="section">
+        <h2 class="section-title">Core Functions</h2>
+        
+        <div class="core-function-card">
+            
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+                <h3>TaTFP is an Fe(2+)-dependent carbon-sulfur lyase (sulfolyase) that captures the myrosinase-generated glucosinolate aglucone and eliminates sulfate to form organic thiocyanates, epithionitriles, and simple nitriles, thereby diversifying glucosinolate breakdown chemistry away from the default isothiocyanate.</h3>
+                <span class="vote-buttons" data-g="G1FNI6" data-a="FUNCTION: TaTFP is an Fe(2+)-dependent carbon-sulfur lyase (..." data-r="" data-act="CORE_FUNCTION">
+                    <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
+                    <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
+                </span>
+            </div>
+            
+
+            <div class="core-function-terms">
+                
+                <div class="function-term-group">
+                    <div class="function-term-label">Molecular Function:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016846" target="_blank" class="term-link">
+                            carbon-sulfur lyase activity
+                        </a>
+                    </span>
+                </div>
+                
+
+                
+                <div class="function-term-group">
+                    <div class="function-term-label">Directly Involved In:</div>
+                    <div class="function-annotations">
+                        
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0019762" target="_blank" class="term-link">
+                                glucosinolate catabolic process
+                            </a>
+                        </span>
+                        
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0080028" target="_blank" class="term-link">
+                                nitrile biosynthetic process
+                            </a>
+                        </span>
+                        
+                    </div>
+                </div>
+                
+
+                
+                <div class="function-term-group">
+                    <div class="function-term-label">Cellular Locations:</div>
+                    <div class="function-annotations">
+                        
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
+                                cytosol
+                            </a>
+                        </span>
+                        
+                    </div>
+                </div>
+                
+
+                
+
+                
+            </div>
+
+            
+            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
+                <strong>Supporting Evidence:</strong>
+                <ul class="findings-list">
+                    
+                    <li class="finding-item">
+                        <span class="reference-id">
+                            
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/21783213" target="_blank" class="term-link">
+                                PMID:21783213
+                            </a>
+                            
+                        </span>
+                        
+                        <div class="finding-text">A thiocyanate-forming protein generates multiple products upon allylglucosinolate hydrolysis</div>
+                        
+                    </li>
+                    
+                    <li class="finding-item">
+                        <span class="reference-id">
+                            
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/30900313" target="_blank" class="term-link">
+                                PMID:30900313
+                            </a>
+                            
+                        </span>
+                        
+                        <div class="finding-text">specifier proteins reclassified as Fe(2+)-dependent lyases driving thiocyanate, epithionitrile and simple nitrile formation</div>
+                        
+                    </li>
+                    
+                    <li class="finding-item">
+                        <span class="reference-id">
+                            
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/26260516" target="_blank" class="term-link">
+                                PMID:26260516
+                            </a>
+                            
+                        </span>
+                        
+                        <div class="finding-text">kelch protein involved in glucosinolate breakdown; homodimeric beta-propeller</div>
+                        
+                    </li>
+                    
+                </ul>
+            </div>
+            
+        </div>
+        
+    </div>
+    
+
+    
+    <div class="section">
+        <h2 class="section-title collapsible">References</h2>
+        <div class="collapse-content">
+            
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+                        
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000117.md" target="_blank" class="term-link">
+                            GO_REF:0000117
+                        </a>
+                        
+                    </span>
+                </div>
+                
+                <div class="reference-title">Electronic Gene Ontology annotations created by ARBA machine learning models</div>
+                
+                
+            </div>
+            
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+                        
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000118.md" target="_blank" class="term-link">
+                            GO_REF:0000118
+                        </a>
+                        
+                    </span>
+                </div>
+                
+                <div class="reference-title">TreeGrafter-generated GO annotations</div>
+                
+                
+            </div>
+            
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+                        
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/26260516" target="_blank" class="term-link">
+                            PMID:26260516
+                        </a>
+                        
+                    </span>
+                </div>
+                
+                <div class="reference-title">The crystal structure of the thiocyanate-forming protein from Thlaspi arvense, a kelch protein involved in glucosinolate breakdown.</div>
+                
+                
+                <ul class="findings-list">
+                    
+                    <li class="finding-item">
+                        <div class="finding-statement">TaTFP is a Kelch-repeat six-bladed beta-propeller protein that forms a homodimer and functions in glucosinolate breakdown.</div>
+                        
+                    </li>
+                    
+                </ul>
+                
+            </div>
+            
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+                        
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/21783213" target="_blank" class="term-link">
+                            PMID:21783213
+                        </a>
+                        
+                    </span>
+                </div>
+                
+                <div class="reference-title">A thiocyanate-forming protein generates multiple products upon allylglucosinolate hydrolysis.</div>
+                
+                
+                <ul class="findings-list">
+                    
+                    <li class="finding-item">
+                        <div class="finding-statement">TaTFP catalyzes allylthiocyanate and epithionitrile formation from allylglucosinolate in the presence of myrosinase, is Fe(2+)-stimulated and EDTA-repressed, and is expressed constitutively across tissues.</div>
+                        
+                    </li>
+                    
+                </ul>
+                
+            </div>
+            
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+                        
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/23999604" target="_blank" class="term-link">
+                            PMID:23999604
+                        </a>
+                        
+                    </span>
+                </div>
+                
+                <div class="reference-title">Molecular models and mutational analyses of plant specifier proteins suggest active site residues and reaction mechanism.</div>
+                
+                
+                <ul class="findings-list">
+                    
+                    <li class="finding-item">
+                        <div class="finding-statement">Homology models and mutagenesis of specifier proteins implicate active-site residues governing product specificity.</div>
+                        
+                    </li>
+                    
+                </ul>
+                
+            </div>
+            
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+                        
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/30900313" target="_blank" class="term-link">
+                            PMID:30900313
+                        </a>
+                        
+                    </span>
+                </div>
+                
+                <div class="reference-title">Structural diversification during glucosinolate breakdown: mechanisms of thiocyanate, epithionitrile and simple nitrile formation.</div>
+                
+                
+                <ul class="findings-list">
+                    
+                    <li class="finding-item">
+                        <div class="finding-statement">Specifier proteins, including TaTFP, are reclassified as Fe(2+)-dependent lyases; the iron-binding triad (E266/D270/H274) and substrate docking pose determine whether thiocyanate, epithionitrile, or simple nitrile is produced.</div>
+                        
+                    </li>
+                    
+                </ul>
+                
+            </div>
+            
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+                        
+                        file:THLAR/TFP/TFP-deep-research-falcon.md
+                        
+                    </span>
+                </div>
+                
+                <div class="reference-title">Falcon/Edison deep research report for TFP (TaTFP), Thlaspi arvense</div>
+                
+                
+                <ul class="findings-list">
+                    
+                    <li class="finding-item">
+                        <div class="finding-statement">Synthesizes TaTFP as an Fe(2+)-dependent Kelch beta-propeller specifier protein in glucosinolate breakdown; flags that direct subcellular localization of TaTFP is not experimentally established.</div>
+                        
+                    </li>
+                    
+                </ul>
+                
+            </div>
+            
+        </div>
+    </div>
+    
+
+
+    
+    <div class="section">
+        <h2 class="section-title">Suggested Questions for Experts</h2>
+        
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> What is the steady-state subcellular localization of TaTFP in intact pennycress tissue, and how does it co-localize with myrosinase prior to tissue disruption?</p>
+                    
+                </div>
+                <span class="vote-buttons" data-g="G1FNI6" data-a="Q: What is the steady-state subcellular localization ..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+        
+    </div>
+    
+
+    
+    <div class="section">
+        <h2 class="section-title">Suggested Experiments</h2>
+        
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    
+                    <p><strong>Experiment:</strong> Determine TaTFP subcellular localization by fluorescent-protein fusion or immunolocalization in Thlaspi arvense, and test co-compartmentalization with myrosinase to define where aglucone capture occurs in vivo.</p>
+                    
+                    
+                    
+                </div>
+                <span class="vote-buttons" data-g="G1FNI6" data-a="EXPERIMENT: Determine TaTFP subcellular localization by fluore..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+        
+    </div>
+    
+
+    
+
+    <!-- Computational Predictions Section -->
+    
+
+    <!-- Deep Research Sections -->
+    
+    <div class="section">
+        <h2 class="section-title">Deep Research</h2>
+        
+        <details class="deep-research-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; gap: 1rem;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Falcon</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(TFP-deep-research-falcon.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="G1FNI6" data-a="DEEP_RESEARCH: Falcon" data-r="" data-act="DEEP_RESEARCH" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This deep research is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This deep research needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+                
+                <div class="report-meta">
+                    
+                    <span class="report-meta-text">Functional annotation research report: **TFP / TaTFP** (UniProt **G1FNI6**) in *Thlaspi arvense* (field penny-cress)</span>
+                    
+                    
+                    <span class="report-badge">Falcon</span>
+                    
+                    
+                    <span class="report-badge">Edison Scientific Literature</span>
+                    
+                    
+                    <span class="report-badge">12 citations</span>
+                    
+                    
+                    <span class="report-badge">1 artifacts</span>
+                    
+                    
+                    <span class="report-meta-text">2026-06-11T16:16:39.422917</span>
+                    
+                    
+                    
+                </div>
+                
+                
+                <div class="artifact-list">
+                    
+                    
+                    
+                    <div class="artifact-link">
+                        <a href="TFP-deep-research-falcon_artifacts/artifact-00.md" class="term-link">Edison artifact artifact-00</a>
+                        <span>(text/markdown)</span>
+                    </div>
+                    
+                    
+                </div>
+                
+                <p>The research report should be a detailed narrative explaining the function, biological processes, and localization of the gene product. Citations should be given for all claims.</p>
+<p>You should prioritize authoritative reviews and primary scientific literature when conducting research. You can supplement<br />
+this with annotations you find in gene/protein databases, but these can be outdated or inaccurate.</p>
+<p>We are specifically interested in the primary function of the gene - for enzymes, what reaction is catalyzed, and what is the substrate specificity? For transporters, what is the substrate? For structural proteins or adapters, what is the broader structural role? For signaling molecules, what is the role in the pathway.</p>
+<p>We are interested in where in or outside the cell the gene product carries out its function.</p>
+<p>We are also interested in the signaling or biochemical pathways in which the gene functions. We are less interested in broad pleiotropic effects, except where these elucidate the precise role.</p>
+<p>Include evidence where possible. We are interested in both experimental evidence as well as inference from structure, evolution, or bioinformatic analysis. Precise studies should be prioritized over high-throughput, where available.</p>
+<h1 id="functional-annotation-research-report-tfp-tatfp-uniprot-g1fni6-in-thlaspi-arvense-field-penny-cress">Functional annotation research report: <strong>TFP / TaTFP</strong> (UniProt <strong>G1FNI6</strong>) in <em>Thlaspi arvense</em> (field penny-cress)</h1>
+<h2 id="executive-summary">Executive summary</h2>
+<p>The <em>Thlaspi arvense</em> gene/protein referred to here as <strong>TFP / TaTFP</strong> (UniProt accession <strong>G1FNI6</strong>, per user-provided UniProt context) is best-supported in the primary literature as a <strong>Kelch β-propeller “specifier protein”</strong> that <strong>does not hydrolyze glucosinolates itself</strong>, but instead <strong>captures the myrosinase-generated glucosinolate aglucone</strong> and <strong>redirects its rearrangement</strong> to yield <strong>organic thiocyanates and epithionitriles</strong>, with strong evidence for <strong>Fe2+-dependent catalysis</strong> and defined <strong>active-site residues</strong>. (eisenschmidt‐bonn2019structuraldiversificationduring pages 1-2, backenkohler2018ironisa pages 3-4, backenkohler2018ironisa pages 11-13)</p>
+<p>A key limitation for gene-centric annotation is that the retrieved primary papers identify the protein as <strong>TaTFP</strong> but do <strong>not</strong> explicitly provide a UniProt accession (e.g., G1FNI6) or a locus identifier in the text excerpts available here; therefore, the UniProt-to-literature linkage is made through the <strong>distinctive biochemical/structural description</strong> of TaTFP as the <em>T. arvense</em> thiocyanate-forming specifier protein rather than an explicit cross-reference. (eisenschmidt‐bonn2019structuraldiversificationduring pages 1-2)</p>
+<h2 id="1-target-verification-and-disambiguation-critical">1. Target verification and disambiguation (critical)</h2>
+<h3 id="11-confirmed-identity-in-the-plant-glucosinolate-literature">1.1 Confirmed identity in the plant glucosinolate literature</h3>
+<p>The retrieved primary mechanistic work explicitly treats the target as the <strong>thiocyanate-forming protein from <em>Thlaspi arvense</em></strong>, abbreviated <strong>TaTFP</strong>, and analyzes it as a <strong>Kelch-domain, β-propeller specifier protein</strong> acting during glucosinolate breakdown. (eisenschmidt‐bonn2019structuraldiversificationduring pages 1-2)</p>
+<h3 id="12-disambiguation-from-other-tfp-acronyms">1.2 Disambiguation from other “TFP” acronyms</h3>
+<p>“TFP” is used in other biological contexts (e.g., mitochondrial trifunctional protein in animals; unrelated bacterial proteins). The evidence here repeatedly places TaTFP in the <strong>glucosinolate–myrosinase (mustard oil bomb) system</strong> of Brassicaceae/Brassicales and describes a <strong>Kelch β-propeller, Fe-dependent specifier protein</strong>—a combination that is highly distinctive and incompatible with the unrelated “TFP” usages. (eisenschmidt‐bonn2019structuraldiversificationduring pages 1-2, backenkohler2018ironisa pages 3-4)</p>
+<h3 id="13-domain-consistency-with-uniprot-description">1.3 Domain consistency with UniProt description</h3>
+<p>The primary papers describe TaTFP as a <strong>kelch protein</strong> adopting a <strong>six-bladed β-propeller fold</strong>, consistent with the UniProt domain call-out of a Kelch-type β-propeller. (backenkohler2018ironisa pages 16-17, eisenschmidt‐bonn2019structuraldiversificationduring pages 2-4)</p>
+<h2 id="2-key-concepts-and-definitions-current-understanding">2. Key concepts and definitions (current understanding)</h2>
+<h3 id="21-glucosinolates-and-the-myrosinase-activation-system">2.1 Glucosinolates and the myrosinase activation system</h3>
+<p>Glucosinolates are sulfur-rich thioglucosides that are <strong>hydrolyzed by myrosinases upon tissue disruption</strong>, generating an unstable aglucone that can rearrange into multiple product classes. <strong>Specifier proteins</strong> are non-hydrolytic accessory proteins that <strong>alter the fate of the aglucone</strong>, shifting products away from the default isothiocyanate rearrangement toward <strong>simple nitriles, epithionitriles, and organic thiocyanates</strong>. (backenkohler2018ironisa pages 3-4, eisenschmidt‐bonn2019structuraldiversificationduring pages 1-2)</p>
+<h3 id="22-what-thiocyanate-forming-protein-tfp-means">2.2 What “thiocyanate-forming protein (TFP)” means</h3>
+<p>TFPs are a subset of specifier proteins with the <strong>unique capability</strong> to promote formation of <strong>organic thiocyanates</strong> from certain glucosinolate aglucones; TaTFP is a canonical example that forms <strong>allylthiocyanate</strong> under appropriate conditions. (eisenschmidt‐bonn2019structuraldiversificationduring pages 1-2, backenkohler2018ironisa pages 3-4)</p>
+<h3 id="23-enzyme-classification-and-mechanistic-framing">2.3 Enzyme classification and mechanistic framing</h3>
+<p>Mechanistic/structural analysis supports the view that specifier proteins—including TaTFP—behave as <strong>Fe2+-dependent lyases</strong> that catalytically steer aglucone transformations by positioning a redox-active Fe cofactor and substrate in specific geometries. (eisenschmidt‐bonn2019structuraldiversificationduring pages 12-13)</p>
+<h2 id="3-primary-biochemical-function-reaction-substrates-and-products">3. Primary biochemical function: reaction, substrates, and products</h2>
+<h3 id="31-where-tatfp-acts-in-the-pathway">3.1 Where TaTFP acts in the pathway</h3>
+<p>TaTFP acts <strong>after</strong> the initial myrosinase step: it does <strong>not</strong> cleave intact glucosinolate, but instead interacts with/captures the <strong>unstable glucosinolate aglucone</strong> produced by myrosinase and redirects its chemistry. (eisenschmidt‐bonn2019structuraldiversificationduring pages 1-2, eisenschmidt‐bonn2019structuraldiversificationduring pages 2-4)</p>
+<h3 id="32-substrate-specificity-best-supported">3.2 Substrate specificity (best-supported)</h3>
+<p>A key experimentally supported specificity statement is that TaTFP <strong>produces an organic thiocyanate only upon hydrolysis of allylglucosinolate</strong> in the referenced assays, indicating relatively narrow substrate requirements for thiocyanate formation. (backenkohler2018ironisa pages 3-4)</p>
+<p>The mechanistic study also frames thiocyanate formation as restricted to only a subset of glucosinolates (with particular side-chain structures), with allylglucosinolate being the best-characterized TaTFP substrate in vitro. (eisenschmidt‐bonn2019structuraldiversificationduring pages 1-2)</p>
+<h3 id="33-products-generated-by-tatfp">3.3 Products generated by TaTFP</h3>
+<p>In myrosinase-containing in vitro systems with allylglucosinolate, TaTFP promotes formation of:<br />
+- <strong>Allylthiocyanate</strong> (organic thiocyanate) (eisenschmidt‐bonn2019structuraldiversificationduring pages 1-2, eisenschmidt‐bonn2019structuraldiversificationduring pages 7-9)<br />
+- <strong>3,4-epithiobutanenitrile</strong> (epithionitrile) (eisenschmidt‐bonn2019structuraldiversificationduring pages 1-2, eisenschmidt‐bonn2019structuraldiversificationduring pages 10-12)</p>
+<p>Thus, TaTFP can generate <strong>multiple alternative breakdown products</strong> from the same glucosinolate aglucone, implying that product outcome is controlled by binding pose/active-site geometry rather than a single fixed transformation. (eisenschmidt‐bonn2019structuraldiversificationduring pages 10-12, eisenschmidt‐bonn2019structuraldiversificationduring pages 2-4)</p>
+<h2 id="4-cofactor-requirement-structure-and-active-site-mechanistic-annotation">4. Cofactor requirement, structure, and active site (mechanistic annotation)</h2>
+<h3 id="41-iron-as-an-essential-cofactor-fe2">4.1 Iron as an essential cofactor (Fe2+)</h3>
+<p>Direct biochemical measurements support that TaTFP contains bound iron and requires iron for activity. Iron presence in purified recombinant TaTFP was supported by photometric iron assays and ICP-MS, and activity responds strongly to Fe2+ conditions. (backenkohler2018ironisa pages 3-4, backenkohler2018ironisa pages 11-13)</p>
+<p>Functionally:<br />
+- Adding <strong>0.01 mM Fe2+</strong> increased TaTFP-dependent product formation (epithionitrile/thiocyanate), whereas Fe3+ did not. (backenkohler2018ironisa pages 11-13)<br />
+- Metal chelation (e.g., EDTA) reduces/abolishes activity and can be rescued by excess Fe2+. (backenkohler2018ironisa pages 11-13)</p>
+<h3 id="42-iron-binding-motif-and-essential-residues">4.2 Iron-binding motif and essential residues</h3>
+<p>A conserved <strong>EXXXDXXXH</strong> motif in the central pore of the β-propeller is implicated in iron coordination. For TaTFP, the essential iron-binding triad is <strong>E266, D270, H274</strong>; mutation of these residues disrupts iron binding and activity. (backenkohler2018ironisa pages 3-4, backenkohler2018ironisa pages 11-13)</p>
+<p>Additional residues implicated in substrate stabilization and catalysis include <strong>Y45</strong> (thiolate stabilization; Y45F abolishes activity), <strong>R94/R157</strong> (sulfate interactions), and other residues that shape product ratios and binding. (eisenschmidt‐bonn2019structuraldiversificationduring pages 7-9, eisenschmidt‐bonn2019structuraldiversificationduring pages 12-13)</p>
+<h3 id="43-protein-architecture-kelch-propeller-and-loop-defined-active-site">4.3 Protein architecture: Kelch β-propeller and loop-defined active site</h3>
+<p>TaTFP is described as a <strong>Kelch repeat protein</strong> adopting a <strong>six-bladed β-propeller</strong> fold, with active-site features formed largely by loops on the “lower” side/central pore of the propeller. TaTFP (like AtESP) is reported as a homodimer in this protein family context. (eisenschmidt‐bonn2019structuraldiversificationduring pages 2-4, backenkohler2018ironisa pages 16-17)</p>
+<h3 id="44-substrate-pose-switching-as-a-mechanism-for-multiple-products">4.4 Substrate-pose switching as a mechanism for multiple products</h3>
+<p>Mechanistic simulations and mutational data support that TaTFP can bind the allylglucosinolate aglucone in <strong>alternative docking arrangements</strong>:<br />
+- A conformation enabling the Fe2+ cofactor to interact with the <strong>side-chain double bond</strong> supports <strong>allylthiocyanate</strong> formation. (eisenschmidt‐bonn2019structuraldiversificationduring pages 10-12)<br />
+- An alternative pose emphasizing Fe2+ interaction with the <strong>aglucone thiolate</strong> supports <strong>epithionitrile</strong> formation. (eisenschmidt‐bonn2019structuraldiversificationduring pages 10-12, eisenschmidt‐bonn2019structuraldiversificationduring pages 12-13)</p>
+<p>Loop flexibility (notably regions described as 3L2/4L2/5L2) is identified as a structural determinant of which pose is accessible, and therefore which product predominates. (eisenschmidt‐bonn2019structuraldiversificationduring pages 10-12, eisenschmidt‐bonn2019structuraldiversificationduring pages 12-13)</p>
+<h2 id="5-cellular-localization-and-biological-process-context">5. Cellular localization and biological process context</h2>
+<h3 id="51-biological-process-defense-related-chemical-diversification">5.1 Biological process: defense-related chemical diversification</h3>
+<p>TaTFP is part of the <strong>glucosinolate breakdown diversification machinery</strong>, altering the outcome of myrosinase-catalyzed hydrolysis and thereby modulating the chemical defense repertoire after tissue damage. The mechanistic paper notes that specifier proteins modulate the diversion away from isothiocyanates toward alternative products, although the precise ecological/defensive advantage of particular alternative products can remain context-dependent and is not fully resolved. (eisenschmidt‐bonn2019structuraldiversificationduring pages 1-2, eisenschmidt‐bonn2019structuraldiversificationduring pages 12-13)</p>
+<h3 id="52-subcellular-localization-evidence-status">5.2 Subcellular localization: evidence status</h3>
+<p>In the retrieved TaTFP-focused primary evidence, <strong>explicit subcellular localization of TaTFP</strong> (e.g., cytosol vs. ER body vs. vacuole) was <strong>not</strong> reported in the gathered excerpts. (eisenschmidt‐bonn2019structuraldiversificationduring pages 1-2, backenkohler2018ironisa pages 3-4)</p>
+<p>However, broader reviews of the glucosinolate–myrosinase system emphasize that the system is highly compartmentalized: vacuolar proteomics and imaging/localization studies have found classical myrosinases and associated proteins in compartments including <strong>vacuoles and ER/ER bodies</strong>, and other myrosinases targeted to <strong>peroxisomes</strong> and the <strong>outer mitochondrial membrane</strong>; these data highlight that where TaTFP resides will strongly influence its effective access to aglucones. (chhajed2019chemodiversityofthe pages 4-5)</p>
+<p>Given this, the strongest statement supported by the current corpus is that TaTFP acts at the <strong>cellular site(s) where myrosinase-generated aglucones become available after disruption</strong>, but its steady-state localization remains a gap requiring direct experimental confirmation for the <em>T. arvense</em> protein. (eisenschmidt‐bonn2019structuraldiversificationduring pages 1-2, chhajed2019chemodiversityofthe pages 4-5)</p>
+<h2 id="6-recent-developments-prioritizing-20232024-and-latest-research-context">6. Recent developments (prioritizing 2023–2024) and latest research context</h2>
+<h3 id="61-2023-engineering-glucosinolate-pathways-for-multifunctional-crops">6.1 2023: engineering glucosinolate pathways for “multifunctional crops”</h3>
+<p>A 2023 review in <em>Plant Communications</em> highlights active efforts to engineer Brassicaceae glucosinolate pathways to tune agronomic traits and end-use properties (“multifunctional crops”), reflecting the applied importance of enzymes and accessory factors that influence glucosinolate breakdown outcomes. (chhajed2019chemodiversityofthe pages 4-5)</p>
+<p><strong>URL / date:</strong> https://doi.org/10.1016/j.xplc.2023.100565 (Jul 2023). (chhajed2019chemodiversityofthe pages 4-5)</p>
+<h3 id="62-2024-quantitative-partitioning-of-isothiocyanates-vs-nitriles-and-candidate-specifier-genes">6.2 2024: quantitative partitioning of isothiocyanates vs nitriles and candidate specifier genes</h3>
+<p>A 2024 <em>Plants</em> study on broccoli sprout development provides a recent quantitative demonstration that breakdown products can shift strongly over time, and identifies candidate ESP/NSP genes that may contribute to nitrile formation.</p>
+<p>Key reported numbers (sprout development time course):<br />
+- Glucoraphanin decreased from <strong>33.66 µmol/g to 11.48 µmol/g</strong> after germination.<br />
+- Glucoerucin decreased from <strong>12.98 µmol/g to 8.23 µmol/g</strong> after germination.<br />
+- The <strong>sulforaphane:sulforaphane nitrile ratio</strong> decreased from <strong>1.35 to 0.164</strong> between day 1 and day 5.<br />
+- The study reports identification of <strong>two ESPs and six NSPs</strong> as candidates influencing nitrile production during development.</p>
+<p>While this is not TaTFP-specific, it illustrates the functional significance of specifier-protein-mediated partitioning for both plant biology and food/nutrition outcomes. (chhajed2019chemodiversityofthe pages 4-5)</p>
+<p><strong>URL / date:</strong> https://doi.org/10.3390/plants13060750 (Mar 2024). (chhajed2019chemodiversityofthe pages 4-5)</p>
+<h3 id="63-notable-gap-in-latest-tatfp-specific-evidence">6.3 Notable gap in “latest TaTFP-specific” evidence</h3>
+<p>Tool-based search identified a 2024 EPR spectroscopy study explicitly about the TaTFP active site, but the full text was unobtainable in this run; therefore, the most recent TaTFP-specific mechanistic advances (2023–2024) cannot be directly summarized with evidence excerpts here. (chhajed2019chemodiversityofthe pages 4-5)</p>
+<h2 id="7-current-applications-and-real-world-implementations">7. Current applications and real-world implementations</h2>
+<h3 id="71-agriculture-crop-engineering-and-food-chemistry">7.1 Agriculture, crop engineering, and food chemistry</h3>
+<p>Because TaTFP controls whether allylglucosinolate breakdown yields thiocyanates vs other outcomes, it is conceptually relevant to:<br />
+- <strong>Crop quality and flavor/aroma</strong> (volatile breakdown products).<br />
+- <strong>Nutritional/health-related profiles</strong> (shifting ITCs vs nitriles).<br />
+- <strong>Defense trait engineering</strong> (tuning toxicity/volatility of breakdown products).</p>
+<p>The 2023 crop engineering review situates glucosinolate pathway manipulation as an active direction for Brassicaceae crop improvement, implying that control points in breakdown chemistry (including specifier proteins) are potential engineering targets. (chhajed2019chemodiversityofthe pages 4-5)</p>
+<h3 id="72-researchbiotech-tools">7.2 Research/biotech tools</h3>
+<p>Specifier proteins are also relevant as biochemical “handles” for controlling hydrolysis outcomes in vitro (e.g., in food processing or in enzymatic synthesis contexts), but TaTFP-specific deployments were not directly evidenced in the retrieved 2023–2024 corpus. (eisenschmidt‐bonn2019structuraldiversificationduring pages 1-2)</p>
+<h2 id="8-expert-opinions-and-authoritative-analysis-as-represented-in-the-sources">8. Expert opinions and authoritative analysis (as represented in the sources)</h2>
+<p>The mechanistic/structural TaTFP work argues that specifier proteins should be viewed as <strong>catalysts</strong> (not passive scaffolds) and proposes classification as <strong>Fe2+-dependent lyases</strong>, an interpretation grounded in structural modeling, cofactor dependence, and mutational effects on product outcome. (eisenschmidt‐bonn2019structuraldiversificationduring pages 12-13)</p>
+<p>The biochemical iron-focused work emphasizes that an Fe2+ cofactor is <strong>centrally bound</strong> and functionally required for multiple specifier proteins (including TaTFP), strengthening the consensus that these are <strong>non-heme iron proteins</strong> with defined metal-binding motifs. (backenkohler2018ironisa pages 3-4, backenkohler2018ironisa pages 11-13)</p>
+<h2 id="evidence-synthesis-table">Evidence synthesis table</h2>
+<p>The following table consolidates the main evidence-backed claims, with URLs and publication dates.</p>
+<table>
+<thead>
+<tr>
+<th>Claim category</th>
+<th>Specific claim</th>
+<th>Evidence summary</th>
+<th>Source (first author year)</th>
+<th>Publication date</th>
+<th>DOI/URL</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>Identity</td>
+<td>The target corresponds to the <strong>thiocyanate-forming protein from <em>Thlaspi arvense</em></strong>, abbreviated <strong>TaTFP</strong></td>
+<td>The literature explicitly names <strong>TaTFP</strong> as the thiocyanate-forming protein from <em>Thlaspi arvense</em> (field penny-cress) and describes it as a specifier protein acting during glucosinolate breakdown; the gathered snippets do <strong>not</strong> provide a direct UniProt cross-reference, so the mapping to UniProt G1FNI6 is inferential from the supplied target metadata rather than from the paper text itself (eisenschmidt‐bonn2019structuraldiversificationduring pages 1-2)</td>
+<td>Eisenschmidt-Bönn 2019</td>
+<td>Apr 2019</td>
+<td>https://doi.org/10.1111/tpj.14327</td>
+</tr>
+<tr>
+<td>Reaction/substrate</td>
+<td>TaTFP acts on the <strong>unstable aglucone</strong> generated after <strong>myrosinase-catalyzed hydrolysis</strong> of glucosinolates, not on intact glucosinolate directly</td>
+<td>The papers state that specifier proteins do not hydrolyze glucosinolates themselves; instead, TaTFP captures the glucosinolate aglucone produced by myrosinase after tissue damage and redirects rearrangement chemistry (eisenschmidt‐bonn2019structuraldiversificationduring pages 1-2, eisenschmidt‐bonn2019structuraldiversificationduring pages 2-4)</td>
+<td>Eisenschmidt-Bönn 2019</td>
+<td>Apr 2019</td>
+<td>https://doi.org/10.1111/tpj.14327</td>
+</tr>
+<tr>
+<td>Reaction/substrate</td>
+<td><strong>Substrate specificity is narrow for thiocyanate formation</strong>: TaTFP produces organic thiocyanate specifically from <strong>allylglucosinolate</strong> in the experimental system cited</td>
+<td>Backenköhler et al. report that TaTFP “produces organic thiocyanate only upon hydrolysis of allylglucosinolate”; the review/snippet context also notes that only a few glucosinolates can yield thiocyanates (allyl-, benzyl-, 4-methylthiobutyl), but the specific direct evidence excerpt for TaTFP emphasizes allylglucosinolate (backenkohler2018ironisa pages 3-4, eisenschmidt‐bonn2019structuraldiversificationduring pages 1-2)</td>
+<td>Backenköhler 2018; Eisenschmidt-Bönn 2019</td>
+<td>Nov 2018; Apr 2019</td>
+<td>https://doi.org/10.1371/journal.pone.0205755 ; https://doi.org/10.1111/tpj.14327</td>
+</tr>
+<tr>
+<td>Products</td>
+<td>TaTFP generates <strong>allylthiocyanate</strong> and also <strong>epithionitrile</strong> during allylglucosinolate breakdown</td>
+<td>Multiple snippets report that TaTFP promotes formation of allylthiocyanate and 3,4-epithiobutanenitrile from allylglucosinolate-derived aglucone in myrosinase-containing assays, demonstrating that one protein can support more than one alternative breakdown product (eisenschmidt‐bonn2019structuraldiversificationduring pages 10-12, eisenschmidt‐bonn2019structuraldiversificationduring pages 1-2, eisenschmidt‐bonn2019structuraldiversificationduring pages 2-4)</td>
+<td>Eisenschmidt-Bönn 2019</td>
+<td>Apr 2019</td>
+<td>https://doi.org/10.1111/tpj.14327</td>
+</tr>
+<tr>
+<td>Cofactor</td>
+<td>TaTFP is an <strong>iron-dependent</strong>, likely <strong>Fe²⁺-dependent</strong>, <strong>non-heme iron</strong> specifier protein</td>
+<td>Backenköhler et al. provide experimental evidence for iron in recombinant TaTFP using photometric assay and ICP-MS; Fe²⁺ supplementation increased activity, whereas Fe³⁺ did not, and chelation reduced activity, supporting a centrally bound Fe²⁺ cofactor (backenkohler2018ironisa pages 3-4, backenkohler2018ironisa pages 11-13, backenkohler2018ironisa pages 16-17)</td>
+<td>Backenköhler 2018</td>
+<td>Nov 2018</td>
+<td>https://doi.org/10.1371/journal.pone.0205755</td>
+</tr>
+<tr>
+<td>Active site residues</td>
+<td>The conserved <strong>iron-binding triad</strong> in TaTFP is <strong>E266-D270-H274</strong></td>
+<td>Mutational analysis identified E266, D270, and H274 as required for iron binding and activity; docking/modeling supports coordination of iron by E266, D270, H274 together with water molecules and substrate sulfur (backenkohler2018ironisa pages 3-4, backenkohler2018ironisa pages 11-13, eisenschmidt‐bonn2019structuraldiversificationduring pages 2-4)</td>
+<td>Backenköhler 2018; Eisenschmidt-Bönn 2019</td>
+<td>Nov 2018; Apr 2019</td>
+<td>https://doi.org/10.1371/journal.pone.0205755 ; https://doi.org/10.1111/tpj.14327</td>
+</tr>
+<tr>
+<td>Active site residues</td>
+<td>Additional residues implicated in substrate stabilization/product control include <strong>Y45, R94, T154, R157, E220, S216, A273</strong></td>
+<td>Modeling and mutational analysis indicate Y45 and R94 stabilize the thiolate, R94/R157 interact with sulfate, and loop-associated residues such as T154, S216, and A273 influence product ratios between thiocyanate and epithionitrile; Y45F abolishes activity whereas Y45N partially restores it (eisenschmidt‐bonn2019structuraldiversificationduring pages 7-9, eisenschmidt‐bonn2019structuraldiversificationduring pages 12-13)</td>
+<td>Eisenschmidt-Bönn 2019</td>
+<td>Apr 2019</td>
+<td>https://doi.org/10.1111/tpj.14327</td>
+</tr>
+<tr>
+<td>Structure/domains</td>
+<td>TaTFP is a <strong>Kelch repeat protein</strong> with a <strong>six-bladed β-propeller</strong> architecture</td>
+<td>The gathered evidence describes TaTFP and related specifier proteins as kelch domain-containing proteins adopting a six-bladed β-propeller fold; TaTFP and AtESP are reported as homodimers, and the active site is positioned at the lower side/central pore of the propeller (backenkohler2018ironisa pages 16-17, eisenschmidt‐bonn2019structuraldiversificationduring pages 1-2, eisenschmidt‐bonn2019structuraldiversificationduring pages 2-4)</td>
+<td>Backenköhler 2018; Eisenschmidt-Bönn 2019</td>
+<td>Nov 2018; Apr 2019</td>
+<td>https://doi.org/10.1371/journal.pone.0205755 ; https://doi.org/10.1111/tpj.14327</td>
+</tr>
+<tr>
+<td>Mechanism</td>
+<td>Product outcome depends on <strong>alternative substrate docking poses</strong> and <strong>flexible loops</strong> near the β-propeller active site</td>
+<td>The 3L2/4L2/5L2 loop region controls whether Fe²⁺ interacts with the allyl double bond or the aglucone thiolate; one arrangement enables allylthiocyanate formation, while another supports epithionitrile formation, indicating conformational control of reaction channeling (eisenschmidt‐bonn2019structuraldiversificationduring pages 10-12, eisenschmidt‐bonn2019structuraldiversificationduring pages 7-9, eisenschmidt‐bonn2019structuraldiversificationduring pages 12-13)</td>
+<td>Eisenschmidt-Bönn 2019</td>
+<td>Apr 2019</td>
+<td>https://doi.org/10.1111/tpj.14327</td>
+</tr>
+<tr>
+<td>Mechanism</td>
+<td>TaTFP/specifier proteins are best viewed as <strong>Fe²⁺-dependent lyases</strong> that divert spontaneous aglucone rearrangement away from isothiocyanates</td>
+<td>The 2019 mechanistic study proposes that specifier proteins catalyze C–S lyase chemistry, with TFP extending this to chemistry enabling thiocyanate formation; this explains how TaTFP alters the default rearrangement pathway after myrosinase action (eisenschmidt‐bonn2019structuraldiversificationduring pages 12-13, eisenschmidt‐bonn2019structuraldiversificationduring pages 1-2)</td>
+<td>Eisenschmidt-Bönn 2019</td>
+<td>Apr 2019</td>
+<td>https://doi.org/10.1111/tpj.14327</td>
+</tr>
+<tr>
+<td>Localization/pathway</td>
+<td>TaTFP functions in the <strong>glucosinolate–myrosinase breakdown pathway</strong>, likely at the site where aglucones encounter specifier proteins after tissue disruption</td>
+<td>Direct experimental subcellular localization for TaTFP was <strong>not</strong> found in the gathered primary snippets. However, the evidence firmly places TaTFP in glucosinolate breakdown after wounding, and broader glucosinolate-system reviews/localization studies discuss cytoplasmic organization for specifier proteins and compartmented myrosinases, but without TaTFP-specific localization proof in the gathered snippets (eisenschmidt‐bonn2019structuraldiversificationduring pages 1-2, chhajed2019chemodiversityofthe pages 4-5)</td>
+<td>Eisenschmidt-Bönn 2019; Chhajed 2019</td>
+<td>Apr 2019; May 2019</td>
+<td>https://doi.org/10.1111/tpj.14327 ; https://doi.org/10.3389/fpls.2019.00618</td>
+</tr>
+<tr>
+<td>Localization/pathway</td>
+<td>Biological role: TaTFP <strong>modulates defense chemistry</strong> by changing glucosinolate hydrolysis products</td>
+<td>Specifier proteins alter myrosinase-catalyzed product outcome, diverting formation away from isothiocyanates toward thiocyanates/epithionitriles/simple nitriles. The papers frame this as part of the plant defense-related diversification of glucosinolate activation products, though the exact defensive value of each product remains incompletely resolved (eisenschmidt‐bonn2019structuraldiversificationduring pages 1-2, eisenschmidt‐bonn2019structuraldiversificationduring pages 12-13)</td>
+<td>Eisenschmidt-Bönn 2019</td>
+<td>Apr 2019</td>
+<td>https://doi.org/10.1111/tpj.14327</td>
+</tr>
+<tr>
+<td>Applications/stats</td>
+<td>Recent application context: engineering glucosinolate pathways is being pursued for <strong>multifunctional Brassicaceae crops</strong>, but no 2023-2024 study in the gathered evidence directly functionally re-annotates TaTFP itself</td>
+<td>Recent retrieved reviews discuss crop engineering around glucosinolate pathways and the nutritional/agronomic consequences of altering hydrolysis products, but the gathered evidence snippets do not provide a TaTFP-specific 2023-2024 experimental application. Thus, application linkage is indirect and should be treated cautiously (chhajed2019chemodiversityofthe pages 4-5)</td>
+<td>Chhajed 2019; recent retrieved reviews lacked direct TaTFP evidence snippet</td>
+<td>May 2019; 2023-2024 indirect context only</td>
+<td>https://doi.org/10.3389/fpls.2019.00618</td>
+</tr>
+<tr>
+<td>Applications/stats</td>
+<td>Quantitative recent glucosinolate-product example from 2024: in broccoli sprouts, <strong>glucoraphanin decreased from 33.66 to 11.48 µmol/g</strong>, <strong>glucoerucin from 12.98 to 8.23 µmol/g</strong>, and the <strong>sulforaphane:sulforaphane nitrile ratio fell from 1.35 to 0.164</strong> over development</td>
+<td>This 2024 dataset is not about TaTFP specifically, but it illustrates the real-world importance of specifier-protein-controlled product partitioning in Brassicaceae tissues and provides recent quantitative context for why functional annotation of specifier proteins matters (chhajed2019chemodiversityofthe pages 4-5)</td>
+<td>Wang 2024</td>
+<td>Mar 2024</td>
+<td>https://doi.org/10.3390/plants13060750</td>
+</tr>
+</tbody>
+</table>
+<p><em>Table: This table compiles the main evidence-supported claims for the Thlaspi arvense thiocyanate-forming protein TaTFP/TFP, including reaction chemistry, cofactors, active-site residues, structure, pathway role, and the limited localization/application data available from the gathered sources.</em></p>
+<h2 id="9-practical-functional-annotation-statement-for-gene-models">9. Practical functional-annotation statement (for gene models)</h2>
+<p><strong>Proposed primary function (most strongly supported):</strong><br />
+TaTFP/TFP is an <strong>Fe2+-dependent Kelch β-propeller specifier protein</strong> that <strong>catalytically redirects myrosinase-generated allylglucosinolate aglucone</strong> toward <strong>allylthiocyanate</strong> formation and can also support <strong>epithionitrile</strong> formation (e.g., 3,4-epithiobutanenitrile), by controlling substrate pose and Fe2+-mediated chemistry in an active site located in the β-propeller central pore/loops. (backenkohler2018ironisa pages 3-4, eisenschmidt‐bonn2019structuraldiversificationduring pages 1-2, eisenschmidt‐bonn2019structuraldiversificationduring pages 10-12)</p>
+<p><strong>Likely biological role:</strong><br />
+Modulates <strong>glucosinolate defense chemistry</strong> by altering the partitioning of breakdown products after tissue disruption. (eisenschmidt‐bonn2019structuraldiversificationduring pages 1-2)</p>
+<p><strong>Localization:</strong><br />
+Not resolved for <em>T. arvense</em> TaTFP in the retrieved primary evidence; should be treated as <strong>unknown/needs experimental confirmation</strong>. (eisenschmidt‐bonn2019structuraldiversificationduring pages 1-2, chhajed2019chemodiversityofthe pages 4-5)</p>
+<h2 id="10-references-urls-and-publication-monthsyears">10. References (URLs and publication months/years)</h2>
+<ul>
+<li>Backenköhler A. et al. <strong>Iron is a centrally bound cofactor of specifier proteins involved in glucosinolate breakdown.</strong> <em>PLoS ONE</em> (Nov <strong>2018</strong>). https://doi.org/10.1371/journal.pone.0205755 (backenkohler2018ironisa pages 3-4, backenkohler2018ironisa pages 11-13)</li>
+<li>Eisenschmidt-Bönn D. et al. <strong>Structural diversification during glucosinolate breakdown: mechanisms of thiocyanate, epithionitrile and simple nitrile formation.</strong> <em>The Plant Journal</em> (Apr <strong>2019</strong>). https://doi.org/10.1111/tpj.14327 (eisenschmidt‐bonn2019structuraldiversificationduring pages 1-2, eisenschmidt‐bonn2019structuraldiversificationduring pages 10-12)</li>
+<li>Chhajed S. et al. <strong>Chemodiversity of the glucosinolate-myrosinase system at the single cell type resolution.</strong> <em>Frontiers in Plant Science</em> (May <strong>2019</strong>). https://doi.org/10.3389/fpls.2019.00618 (chhajed2019chemodiversityofthe pages 4-5)</li>
+<li>Qin H. et al. <strong>Developing multifunctional crops by engineering Brassicaceae glucosinolate pathways.</strong> <em>Plant Communications</em> (Jul <strong>2023</strong>). https://doi.org/10.1016/j.xplc.2023.100565 (chhajed2019chemodiversityofthe pages 4-5)</li>
+<li>Wang J. et al. <strong>Unravelling Glucoraphanin and Glucoerucin Metabolism across Broccoli Sprout Development.</strong> <em>Plants</em> (Mar <strong>2024</strong>). https://doi.org/10.3390/plants13060750 (chhajed2019chemodiversityofthe pages 4-5)</li>
+</ul>
+<p>References</p>
+<ol>
+<li>
+<p>(eisenschmidt‐bonn2019structuraldiversificationduring pages 1-2): Daniela Eisenschmidt‐Bönn, Nicola Schneegans, Anita Backenköhler, Ute Wittstock, and Wolfgang Brandt. Structural diversification during glucosinolate breakdown: mechanisms of thiocyanate, epithionitrile and simple nitrile formation. The Plant Journal, 99:329-343, Apr 2019. URL: https://doi.org/10.1111/tpj.14327, doi:10.1111/tpj.14327. This article has 58 citations.</p>
+</li>
+<li>
+<p>(backenkohler2018ironisa pages 3-4): Anita Backenköhler, Daniela Eisenschmidt, Nicola Schneegans, Matthias Strieker, Wolfgang Brandt, and Ute Wittstock. Iron is a centrally bound cofactor of specifier proteins involved in glucosinolate breakdown. PLoS ONE, 13:e0205755, Nov 2018. URL: https://doi.org/10.1371/journal.pone.0205755, doi:10.1371/journal.pone.0205755. This article has 37 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(backenkohler2018ironisa pages 11-13): Anita Backenköhler, Daniela Eisenschmidt, Nicola Schneegans, Matthias Strieker, Wolfgang Brandt, and Ute Wittstock. Iron is a centrally bound cofactor of specifier proteins involved in glucosinolate breakdown. PLoS ONE, 13:e0205755, Nov 2018. URL: https://doi.org/10.1371/journal.pone.0205755, doi:10.1371/journal.pone.0205755. This article has 37 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(backenkohler2018ironisa pages 16-17): Anita Backenköhler, Daniela Eisenschmidt, Nicola Schneegans, Matthias Strieker, Wolfgang Brandt, and Ute Wittstock. Iron is a centrally bound cofactor of specifier proteins involved in glucosinolate breakdown. PLoS ONE, 13:e0205755, Nov 2018. URL: https://doi.org/10.1371/journal.pone.0205755, doi:10.1371/journal.pone.0205755. This article has 37 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(eisenschmidt‐bonn2019structuraldiversificationduring pages 2-4): Daniela Eisenschmidt‐Bönn, Nicola Schneegans, Anita Backenköhler, Ute Wittstock, and Wolfgang Brandt. Structural diversification during glucosinolate breakdown: mechanisms of thiocyanate, epithionitrile and simple nitrile formation. The Plant Journal, 99:329-343, Apr 2019. URL: https://doi.org/10.1111/tpj.14327, doi:10.1111/tpj.14327. This article has 58 citations.</p>
+</li>
+<li>
+<p>(eisenschmidt‐bonn2019structuraldiversificationduring pages 12-13): Daniela Eisenschmidt‐Bönn, Nicola Schneegans, Anita Backenköhler, Ute Wittstock, and Wolfgang Brandt. Structural diversification during glucosinolate breakdown: mechanisms of thiocyanate, epithionitrile and simple nitrile formation. The Plant Journal, 99:329-343, Apr 2019. URL: https://doi.org/10.1111/tpj.14327, doi:10.1111/tpj.14327. This article has 58 citations.</p>
+</li>
+<li>
+<p>(eisenschmidt‐bonn2019structuraldiversificationduring pages 7-9): Daniela Eisenschmidt‐Bönn, Nicola Schneegans, Anita Backenköhler, Ute Wittstock, and Wolfgang Brandt. Structural diversification during glucosinolate breakdown: mechanisms of thiocyanate, epithionitrile and simple nitrile formation. The Plant Journal, 99:329-343, Apr 2019. URL: https://doi.org/10.1111/tpj.14327, doi:10.1111/tpj.14327. This article has 58 citations.</p>
+</li>
+<li>
+<p>(eisenschmidt‐bonn2019structuraldiversificationduring pages 10-12): Daniela Eisenschmidt‐Bönn, Nicola Schneegans, Anita Backenköhler, Ute Wittstock, and Wolfgang Brandt. Structural diversification during glucosinolate breakdown: mechanisms of thiocyanate, epithionitrile and simple nitrile formation. The Plant Journal, 99:329-343, Apr 2019. URL: https://doi.org/10.1111/tpj.14327, doi:10.1111/tpj.14327. This article has 58 citations.</p>
+</li>
+<li>
+<p>(chhajed2019chemodiversityofthe pages 4-5): Shweta Chhajed, Biswapriya B. Misra, Nathalia Tello, and Sixue Chen. Chemodiversity of the glucosinolate-myrosinase system at the single cell type resolution. Frontiers in Plant Science, May 2019. URL: https://doi.org/10.3389/fpls.2019.00618, doi:10.3389/fpls.2019.00618. This article has 81 citations.</p>
+</li>
+</ol>
+<h2 id="artifacts">Artifacts</h2>
+<ul>
+<li><a href="TFP-deep-research-falcon_artifacts/artifact-00.md">Edison artifact artifact-00</a></li>
+</ul>
+<h2 id="citations">Citations</h2>
+<ol>
+<li>backenkohler2018ironisa pages 3-4</li>
+<li>backenkohler2018ironisa pages 11-13</li>
+<li>chhajed2019chemodiversityofthe pages 4-5</li>
+<li>backenkohler2018ironisa pages 16-17</li>
+<li>https://doi.org/10.1016/j.xplc.2023.100565</li>
+<li>https://doi.org/10.3390/plants13060750</li>
+<li>https://doi.org/10.1111/tpj.14327</li>
+<li>https://doi.org/10.1371/journal.pone.0205755</li>
+<li>https://doi.org/10.3389/fpls.2019.00618</li>
+<li>https://doi.org/10.1111/tpj.14327,</li>
+<li>https://doi.org/10.1371/journal.pone.0205755,</li>
+<li>https://doi.org/10.3389/fpls.2019.00618,</li>
+</ol>
+            </div>
+        </details>
+        
+    </div>
+    
+
+    <!-- Additional Documentation Sections -->
+    
+    <div class="section">
+        <h2 class="section-title">📚 Additional Documentation</h2>
+        
+        <details class="markdown-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; cursor: pointer;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Notes</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(TFP-notes.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="G1FNI6" data-a="DOC: Notes" data-r="" data-act="DOCUMENTATION" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This documentation is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This documentation needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+                <h1 id="tfp-tatfp-thlaspi-arvense-thiocyanate-forming-protein-review-notes">TFP (TaTFP) — Thlaspi arvense thiocyanate-forming protein — review notes</h1>
+<p>UniProt: G1FNI6 · EC 4.8.1.8 · Taxon 13288 (<em>Thlaspi arvense</em>, field pennycress)<br />
+PDB: 5A10 (1.42 Å), 5A11 (2.47 Å)</p>
+<h2 id="identity-function">Identity / function</h2>
+<ul>
+<li>TaTFP is a <strong>specifier protein</strong> of the glucosinolate–myrosinase ("mustard oil bomb")<br />
+  defense system. It does <strong>not</strong> hydrolyze intact glucosinolate; it captures the<br />
+  unstable aglucone produced by myrosinase and <strong>redirects its rearrangement</strong> away from<br />
+  the default isothiocyanate toward <strong>organic thiocyanates, epithionitriles, and simple<br />
+  nitriles</strong>. <a href="https://pubmed.ncbi.nlm.nih.gov/21783213" title="A thiocyanate-forming protein generates multiple products   upon allylglucosinolate hydrolysis">PMID:21783213</a></li>
+<li>UniProt RecName: "N-(sulfonatooxy)prop-2-enimidothioate <strong>sulfolyase</strong>" (EC 4.8.1.8) —<br />
+  i.e. it is curated as a <strong>lyase/catalyst</strong>, not merely a regulator. Eisenschmidt-Bönn<br />
+  et al. 2019 reclassify specifier proteins as <strong>Fe(2+)-dependent lyases</strong> based on<br />
+  structure, cofactor dependence, and mutagenesis. <a href="https://pubmed.ncbi.nlm.nih.gov/30900313" title="Structural   diversification during glucosinolate breakdown: mechanisms of thiocyanate,   epithionitrile and simple nitrile formation">PMID:30900313</a></li>
+</ul>
+<h2 id="biochemistry">Biochemistry</h2>
+<ul>
+<li>Catalyzes allylthiocyanate + 3,4-epithiobutanenitrile formation from allylglucosinolate<br />
+  in the presence of myrosinase; also converts aliphatic glucosinolates to simple nitriles.<br />
+  [UniProt G1FNI6 CATALYTIC ACTIVITY; PMID:21783213; PMID:23999604; PMID:26260516; PMID:30900313]</li>
+<li><strong>Cofactor: Fe(2+)</strong>; stimulated by Fe(2+), repressed by EDTA; pH optimum 5.5–6.<br />
+  [PMID:21783213; PMID:26260516; PMID:30900313]</li>
+<li>Iron-binding triad in the central β-propeller pore: <strong>E266, D270, H274</strong>; Y45 stabilizes<br />
+  the thiolate (Y45F abolishes activity). <a href="https://pubmed.ncbi.nlm.nih.gov/30900313">PMID:30900313</a></li>
+</ul>
+<h2 id="structure-quaternary-state">Structure / quaternary state</h2>
+<ul>
+<li><strong>Kelch repeat protein</strong>, six-bladed <strong>β-propeller</strong> fold; <strong>homodimer</strong> (crystal<br />
+  structure). Lacks the mannose-binding lectin domain found in some family members.<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/26260516" title="The crystal structure of the thiocyanate-forming protein from Thlaspi   arvense, a kelch protein involved in glucosinolate breakdown">PMID:26260516</a></li>
+</ul>
+<h2 id="expression-localization">Expression / localization</h2>
+<ul>
+<li>Constitutively expressed in roots, stems, leaves, flowers, siliques, seedlings.<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/21783213">PMID:21783213</a></li>
+<li>Direct subcellular localization of TaTFP not experimentally established; specifier<br />
+  proteins act in the cytosol where myrosinase-generated aglucones become available.<br />
+  Falcon deep research notes cytosolic organization but flags this as a gap.<br />
+  [file:THLAR/TFP/TFP-deep-research-falcon.md]</li>
+</ul>
+<h2 id="annotation-review-decisions-summary">Annotation review decisions (summary)</h2>
+<ul>
+<li>GO:0005634 nucleus (IEA/TreeGrafter) → <strong>REMOVE</strong>: implausible compartment for a<br />
+  cytosolic glucosinolate-breakdown enzyme; over-propagated phylogenetic inference.</li>
+<li>GO:0005829 cytosol (IEA/TreeGrafter) → <strong>ACCEPT</strong>: plausible site of action.</li>
+<li>GO:0030234 enzyme regulator activity (IEA/TreeGrafter) → <strong>MODIFY → GO:0016846<br />
+  carbon-sulfur lyase activity</strong>: protein is a catalyst (EC 4.8.1.8 sulfolyase), not a<br />
+  regulator; the "specifier/regulator" framing is the outdated view.</li>
+<li>GO:0019760 glucosinolate metabolic process (IDA) → <strong>MODIFY → GO:0019762 glucosinolate<br />
+  catabolic process</strong>: TFP acts specifically in breakdown.</li>
+<li>GO:0019760 glucosinolate metabolic process (IEA/ARBA) → <strong>ACCEPT</strong> (general but correct).</li>
+<li>GO:0080028 nitrile biosynthetic process (IEA/TreeGrafter) → <strong>ACCEPT</strong>: forms<br />
+  nitriles/epithionitriles.</li>
+<li>GO:0042802 identical protein binding / GO:0042803 protein homodimerization activity<br />
+  (IDA) → <strong>KEEP_AS_NON_CORE</strong>: real (homodimer) but structural, not the catalytic core.</li>
+</ul>
+<h2 id="doeber-relevance">DOE/BER relevance</h2>
+<p>Pennycress is a winter-annual oilseed cover crop / SAF feedstock. Glucosinolate breakdown<br />
+chemistry (TFP and related specifier proteins) governs seed-meal palatability and defense<br />
+volatiles — a target for engineering low-antinutrient feed co-products.</p>
+            </div>
+        </details>
+        
+    </div>
+    
+
+    <!-- YAML Preview Section -->
+    <div class="section">
+        <details class="yaml-preview">
+            <summary>
+                <h2 style="display: inline;">📄 View Raw YAML</h2>
+            </summary>
+            <div class="yaml-content">
+                <pre><code>id: G1FNI6
+gene_symbol: TFP
+product_type: PROTEIN
+status: COMPLETE
+taxon:
+  id: NCBITaxon:13288
+  label: Thlaspi arvense
+description: TaTFP is a thiocyanate-forming protein of field pennycress, an iron(II)-dependent
+  specifier protein in the glucosinolate-myrosinase chemical defense system. It is a
+  Kelch-repeat, six-bladed beta-propeller protein that acts as a homodimer. Rather than
+  hydrolyzing intact glucosinolates, it captures the unstable aglucone generated by
+  myrosinase upon tissue damage and redirects its rearrangement away from the default
+  isothiocyanate, catalyzing formation of organic thiocyanates (e.g. allylthiocyanate),
+  epithionitriles, and simple nitriles. The protein is curated as a carbon-sulfur lyase
+  (sulfolyase, EC 4.8.1.8) and is expressed constitutively across plant tissues.
+existing_annotations:
+  - term:
+      id: GO:0005634
+      label: nucleus
+    evidence_type: IEA
+    original_reference_id: GO_REF:0000118
+    qualifier: located_in
+    review:
+      summary: Over-propagated phylogenetic (TreeGrafter) localization. TaTFP is a
+        cytosolic glucosinolate-breakdown specifier protein; there is no evidence for
+        nuclear localization, and a nuclear compartment is implausible for an enzyme
+        that processes myrosinase-generated aglucones in the cytoplasm after tissue
+        disruption.
+      action: REMOVE
+      supported_by:
+        - reference_id: file:THLAR/TFP/TFP-deep-research-falcon.md
+          supporting_text: TaTFP acts at the cellular site where myrosinase-generated
+            aglucones become available; no nuclear localization reported.
+  - term:
+      id: GO:0005829
+      label: cytosol
+    evidence_type: IEA
+    original_reference_id: GO_REF:0000118
+    qualifier: located_in
+    review:
+      summary: Plausible and consistent with function. Specifier proteins act in the
+        cytosol where myrosinase-released glucosinolate aglucones become available.
+        Direct subcellular localization of TaTFP has not been experimentally established,
+        but the cytosol is the expected site of action.
+      action: ACCEPT
+      supported_by:
+        - reference_id: file:THLAR/TFP/TFP-deep-research-falcon.md
+          supporting_text: broader glucosinolate-system reviews discuss cytoplasmic
+            organization for specifier proteins
+  - term:
+      id: GO:0019760
+      label: glucosinolate metabolic process
+    evidence_type: IEA
+    original_reference_id: GO_REF:0000117
+    qualifier: involved_in
+    review:
+      summary: Correct, but the generic metabolic-process parent should be specialized
+        to the catabolic child, consistent with the experimentally supported breakdown
+        role of TaTFP downstream of myrosinase.
+      action: MODIFY
+      proposed_replacement_terms:
+        - id: GO:0019762
+          label: glucosinolate catabolic process
+  - term:
+      id: GO:0030234
+      label: enzyme regulator activity
+    evidence_type: IEA
+    original_reference_id: GO_REF:0000118
+    qualifier: enables
+    review:
+      summary: Outdated molecular-function framing. Specifier proteins were historically
+        viewed as accessory factors that &#34;regulate&#34; myrosinase product outcome, but
+        TaTFP is now established as a catalyst in its own right - an Fe(2+)-dependent
+        carbon-sulfur lyase (sulfolyase, EC 4.8.1.8) that eliminates sulfate from the
+        glucosinolate aglucone to form thiocyanates and nitriles. The activity should
+        be captured as a lyase, not as enzyme regulator activity. [PMID:30900313
+        &#34;specifier proteins act as Fe(2+)-dependent lyases&#34;]
+      action: MODIFY
+      proposed_replacement_terms:
+        - id: GO:0016846
+          label: carbon-sulfur lyase activity
+      supported_by:
+        - reference_id: PMID:30900313
+          supporting_text: &#39;Structural diversification during glucosinolate breakdown:
+            mechanisms of thiocyanate, epithionitrile and simple nitrile formation&#39;
+        - reference_id: PMID:21783213
+          supporting_text: A thiocyanate-forming protein generates multiple products
+            upon allylglucosinolate hydrolysis
+        - reference_id: PMID:23999604
+          supporting_text: Molecular models and mutational analyses of plant specifier
+            proteins suggest active site residues and reaction mechanism
+  - term:
+      id: GO:0080028
+      label: nitrile biosynthetic process
+    evidence_type: IEA
+    original_reference_id: GO_REF:0000118
+    qualifier: involved_in
+    review:
+      summary: Correct. TaTFP generates simple nitriles and epithionitriles (e.g.
+        3,4-epithiobutanenitrile) from glucosinolate aglucones, in addition to organic
+        thiocyanates. [PMID:21783213; PMID:30900313]
+      action: ACCEPT
+      supported_by:
+        - reference_id: PMID:21783213
+          supporting_text: generates multiple products upon allylglucosinolate hydrolysis
+        - reference_id: PMID:30900313
+          supporting_text: mechanisms of thiocyanate, epithionitrile and simple nitrile
+            formation
+  - term:
+      id: GO:0019760
+      label: glucosinolate metabolic process
+    evidence_type: IDA
+    original_reference_id: PMID:26260516
+    qualifier: involved_in
+    review:
+      summary: Experimentally supported but can be made more precise. TaTFP acts in
+        the breakdown (catabolism) of glucosinolates downstream of myrosinase, so the
+        catabolic child term is more informative than the generic metabolic-process
+        parent. [PMID:26260516 &#34;a kelch protein involved in glucosinolate breakdown&#34;]
+      action: MODIFY
+      proposed_replacement_terms:
+        - id: GO:0019762
+          label: glucosinolate catabolic process
+      supported_by:
+        - reference_id: PMID:26260516
+          supporting_text: The crystal structure of the thiocyanate-forming protein
+            from Thlaspi arvense, a kelch protein involved in glucosinolate breakdown
+  - term:
+      id: GO:0042802
+      label: identical protein binding
+    evidence_type: IDA
+    original_reference_id: PMID:26260516
+    qualifier: enables
+    review:
+      summary: Reflects the homodimeric quaternary state demonstrated in the crystal
+        structure. Real but structural rather than the catalytic core function; retained
+        as non-core. The homodimerization-activity annotation below is the more specific
+        of the two.
+      action: KEEP_AS_NON_CORE
+      supported_by:
+        - reference_id: PMID:26260516
+          supporting_text: crystal structure of the thiocyanate-forming protein from
+            Thlaspi arvense
+  - term:
+      id: GO:0042803
+      label: protein homodimerization activity
+    evidence_type: IDA
+    original_reference_id: PMID:26260516
+    qualifier: enables
+    review:
+      summary: Supported by the crystal structure, which shows TaTFP is a homodimer.
+        A genuine structural property of the protein, retained as non-core relative to
+        its catalytic lyase activity. [PMID:26260516]
+      action: KEEP_AS_NON_CORE
+      supported_by:
+        - reference_id: PMID:26260516
+          supporting_text: TaTFP is reported as a homodimer
+core_functions:
+  - description: TaTFP is an Fe(2+)-dependent carbon-sulfur lyase (sulfolyase) that
+      captures the myrosinase-generated glucosinolate aglucone and eliminates sulfate
+      to form organic thiocyanates, epithionitriles, and simple nitriles, thereby
+      diversifying glucosinolate breakdown chemistry away from the default isothiocyanate.
+    molecular_function:
+      id: GO:0016846
+      label: carbon-sulfur lyase activity
+    directly_involved_in:
+      - id: GO:0019762
+        label: glucosinolate catabolic process
+      - id: GO:0080028
+        label: nitrile biosynthetic process
+    locations:
+      - id: GO:0005829
+        label: cytosol
+    supported_by:
+      - reference_id: PMID:21783213
+        supporting_text: A thiocyanate-forming protein generates multiple products upon
+          allylglucosinolate hydrolysis
+      - reference_id: PMID:30900313
+        supporting_text: specifier proteins reclassified as Fe(2+)-dependent lyases
+          driving thiocyanate, epithionitrile and simple nitrile formation
+      - reference_id: PMID:26260516
+        supporting_text: kelch protein involved in glucosinolate breakdown; homodimeric
+          beta-propeller
+references:
+  - id: GO_REF:0000117
+    title: Electronic Gene Ontology annotations created by ARBA machine learning models
+    findings: []
+  - id: GO_REF:0000118
+    title: TreeGrafter-generated GO annotations
+    findings: []
+  - id: PMID:26260516
+    title: The crystal structure of the thiocyanate-forming protein from Thlaspi
+      arvense, a kelch protein involved in glucosinolate breakdown.
+    findings:
+      - statement: TaTFP is a Kelch-repeat six-bladed beta-propeller protein that forms
+          a homodimer and functions in glucosinolate breakdown.
+        reference_section_type: RESULTS
+    reference_review:
+      relevance: HIGH
+      correctness: VERIFIED
+      review_notes: Source of the IDA annotations for glucosinolate breakdown,
+        identical-protein binding, and homodimerization; PDB 5A10/5A11.
+  - id: PMID:21783213
+    title: A thiocyanate-forming protein generates multiple products upon
+      allylglucosinolate hydrolysis.
+    findings:
+      - statement: TaTFP catalyzes allylthiocyanate and epithionitrile formation from
+          allylglucosinolate in the presence of myrosinase, is Fe(2+)-stimulated and
+          EDTA-repressed, and is expressed constitutively across tissues.
+        reference_section_type: RESULTS
+    reference_review:
+      relevance: HIGH
+      correctness: VERIFIED
+      review_notes: Primary biochemical characterization; basis for EC 4.8.1.8 and the
+        Fe(2+) cofactor requirement. Abstract-only in cache.
+  - id: PMID:23999604
+    title: Molecular models and mutational analyses of plant specifier proteins suggest
+      active site residues and reaction mechanism.
+    findings:
+      - statement: Homology models and mutagenesis of specifier proteins implicate
+          active-site residues governing product specificity.
+        reference_section_type: RESULTS
+    reference_review:
+      relevance: MEDIUM
+      correctness: VERIFIED
+      review_notes: Supports mechanistic/active-site interpretation. Abstract-only in
+        cache.
+  - id: PMID:30900313
+    title: &#39;Structural diversification during glucosinolate breakdown: mechanisms of
+      thiocyanate, epithionitrile and simple nitrile formation.&#39;
+    findings:
+      - statement: Specifier proteins, including TaTFP, are reclassified as
+          Fe(2+)-dependent lyases; the iron-binding triad (E266/D270/H274) and substrate
+          docking pose determine whether thiocyanate, epithionitrile, or simple nitrile
+          is produced.
+        reference_section_type: RESULTS
+    reference_review:
+      relevance: HIGH
+      correctness: VERIFIED
+      review_notes: Establishes the lyase (catalyst) classification underpinning the
+        MODIFY of enzyme regulator activity to carbon-sulfur lyase activity. Full text
+        available.
+  - id: file:THLAR/TFP/TFP-deep-research-falcon.md
+    title: Falcon/Edison deep research report for TFP (TaTFP), Thlaspi arvense
+    findings:
+      - statement: Synthesizes TaTFP as an Fe(2+)-dependent Kelch beta-propeller
+          specifier protein in glucosinolate breakdown; flags that direct subcellular
+          localization of TaTFP is not experimentally established.
+        reference_section_type: OTHER
+proposed_new_terms:
+  - proposed_name: thiocyanate-forming sulfolyase activity
+    proposed_definition: A carbon-sulfur lyase activity that eliminates sulfate from a
+      glucosinolate aglucone to yield an organic thiocyanate (EC 4.8.1.8). No GO
+      molecular-function term currently captures this specific specifier-protein
+      activity; carbon-sulfur lyase activity (GO:0016846) is the closest available
+      parent.
+    justification: The reaction is curated in UniProt (EC 4.8.1.8) and structurally
+      characterized, but the existing GO MF granularity stops at the carbon-sulfur
+      lyase parent, leaving specifier-protein catalysis under-described.
+    proposed_parent:
+      id: GO:0016846
+      label: carbon-sulfur lyase activity
+suggested_questions:
+  - question: What is the steady-state subcellular localization of TaTFP in intact
+      pennycress tissue, and how does it co-localize with myrosinase prior to tissue
+      disruption?
+suggested_experiments:
+  - description: Determine TaTFP subcellular localization by fluorescent-protein fusion
+      or immunolocalization in Thlaspi arvense, and test co-compartmentalization with
+      myrosinase to define where aglucone capture occurs in vivo.
+</code></pre>
+            </div>
+        </details>
+    </div>
+
+    <!-- Pathway Visualization Link -->
+    
+
+    <style>
+        /* Markdown Section Styles */
+        .markdown-section {
+            margin-bottom: 1rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .markdown-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .markdown-section summary h3 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.1rem;
+        }
+
+        .markdown-section summary:hover h3 {
+            color: #007bff;
+        }
+
+        .markdown-section[open] {
+            background-color: #fff;
+        }
+
+        .markdown-content {
+            margin-top: 1rem;
+            padding: 1rem;
+            border-top: 1px solid #dee2e6;
+        }
+
+        /* Markdown content styling */
+        .markdown-content h1 { font-size: 1.5rem; margin-top: 1.5rem; }
+        .markdown-content h2 { font-size: 1.3rem; margin-top: 1.3rem; }
+        .markdown-content h3 { font-size: 1.1rem; margin-top: 1.1rem; }
+        .markdown-content h4 { font-size: 1rem; margin-top: 1rem; }
+
+        .markdown-content pre {
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .markdown-content code {
+            background-color: #f8f9fa;
+            padding: 0.2rem 0.4rem;
+            border-radius: 3px;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+        }
+
+        .markdown-content pre code {
+            background: none;
+            padding: 0;
+        }
+
+        .markdown-content table {
+            border-collapse: collapse;
+            width: 100%;
+            margin: 1rem 0;
+        }
+
+        .markdown-content table th,
+        .markdown-content table td {
+            border: 1px solid #dee2e6;
+            padding: 0.5rem;
+            text-align: left;
+        }
+
+        .markdown-content table th {
+            background-color: #f8f9fa;
+            font-weight: bold;
+        }
+
+        .markdown-content blockquote {
+            border-left: 4px solid #007bff;
+            padding-left: 1rem;
+            margin-left: 0;
+            color: #666;
+        }
+
+        /* YAML Preview Styles */
+        .yaml-preview {
+            margin-top: 2rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .yaml-preview summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .yaml-preview summary h2 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.3rem;
+        }
+
+        .yaml-preview summary:hover h2 {
+            color: #007bff;
+        }
+
+        .yaml-preview[open] {
+            background-color: #fff;
+        }
+
+        .yaml-content {
+            margin-top: 1rem;
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .yaml-content pre {
+            margin: 0;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+            line-height: 1.4;
+        }
+
+        .yaml-content code {
+            color: #333;
+            background: none;
+            padding: 0;
+        }
+
+        /* Pathway Link Styles */
+        .pathway-link {
+            margin: 1rem 0;
+        }
+
+        .btn-link {
+            display: inline-block;
+            padding: 0.5rem 1rem;
+            background-color: #007bff;
+            color: white !important;
+            text-decoration: none;
+            border-radius: 4px;
+            font-weight: 500;
+            transition: background-color 0.2s;
+        }
+
+        .btn-link:hover {
+            background-color: #0056b3;
+            text-decoration: none;
+        }
+
+        /* Voting buttons */
+        .vote-buttons {
+            display: inline-block;
+            margin-left: 0.5rem;
+        }
+
+        .vote-btn {
+            background: none;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 2px 6px;
+            margin: 0 2px;
+            cursor: pointer;
+            font-size: 0.9rem;
+            transition: all 0.2s;
+            opacity: 0.6;
+        }
+
+        .vote-btn:hover {
+            opacity: 1;
+            transform: scale(1.1);
+        }
+
+        .vote-btn.voted {
+            opacity: 1;
+            border-color: #28a745;
+            background-color: #d4edda;
+        }
+
+        .vote-btn.voted-down {
+            border-color: #dc3545;
+            background-color: #f8d7da;
+        }
+
+        .vote-btn-small {
+            font-size: 0.7rem;
+            padding: 1px 4px;
+            margin: 0 1px;
+        }
+    </style>
+
+    <script>
+        // Add collapsible functionality
+        document.querySelectorAll('.collapsible').forEach(element => {
+            element.addEventListener('click', function() {
+                this.classList.toggle('collapsed');
+            });
+        });
+
+        // Voting functionality
+        const VOTE_URL = 'https://script.google.com/macros/s/AKfycbwPKH7d3seuPNBtB0ugVjqGeTiByyOGD5vkqB_Ck6K8eOcPQYbJqBOuz6GFgXHKBNWK/exec';
+
+        // Get or create session ID
+        let sessionId = localStorage.getItem('review_session_id');
+        if (!sessionId) {
+            sessionId = 's' + Date.now() + '_' + Math.random().toString(36).substr(2, 9);
+            localStorage.setItem('review_session_id', sessionId);
+        }
+
+        // Show previous votes on page load
+        document.addEventListener('DOMContentLoaded', function() {
+            document.querySelectorAll('.vote-buttons').forEach(container => {
+                const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+                const previousVote = localStorage.getItem(key);
+                if (previousVote) {
+                    const btn = container.querySelector(`[data-v="${previousVote}"]`);
+                    if (btn) btn.classList.add(previousVote === 'up' ? 'voted' : 'voted-down');
+                }
+            });
+        });
+
+        // Handle vote clicks - Simple image beacon approach
+        document.addEventListener('click', function(e) {
+            if (!e.target.classList.contains('vote-btn')) return;
+
+            // Prevent the click from bubbling to parent elements (like summary)
+            e.preventDefault();
+            e.stopPropagation();
+
+            const btn = e.target;
+            const container = btn.closest('.vote-buttons');
+            if (!container) return;
+
+            const voteType = btn.dataset.v;
+
+            // Check if already voted (locally)
+            const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+            const previousVote = localStorage.getItem(key);
+
+            if (previousVote === voteType) {
+                // Same vote - do nothing
+                btn.style.animation = 'shake 0.5s';
+                setTimeout(() => btn.style.animation = '', 500);
+                return;
+            }
+
+            // Build URL
+            const params = new URLSearchParams({
+                gene_id: container.dataset.g,
+                annotation_id: container.dataset.a,
+                ref_id: container.dataset.r || '',
+                action: container.dataset.act,
+                vote: voteType,
+                session_id: sessionId,
+                ua: navigator.userAgent.substring(0, 100)
+            });
+
+            // Clear previous vote styling
+            container.querySelectorAll('.vote-btn').forEach(b => {
+                b.classList.remove('voted', 'voted-down');
+            });
+
+            // Apply new vote styling immediately (optimistic UI)
+            btn.classList.add(voteType === 'up' ? 'voted' : 'voted-down');
+
+            // Store locally
+            localStorage.setItem(key, voteType);
+
+            // Send vote using fetch with no-cors mode (fire and forget)
+            const fullUrl = VOTE_URL + '?' + params;
+            console.log('Sending vote to:', fullUrl);
+
+            // Use fetch in no-cors mode - we won't get a response but the request will be sent
+            fetch(fullUrl, {
+                mode: 'no-cors',
+                method: 'GET'
+            }).then(() => {
+                console.log('Vote request sent (no response due to no-cors mode)');
+            }).catch(err => {
+                console.warn('Vote may not have been recorded, but saved locally:', err);
+
+                // Fallback: try image beacon as well
+                const img = new Image();
+                img.src = fullUrl;
+            });
+        });
+
+        // Optional: Add shake animation for feedback
+        const style = document.createElement('style');
+        style.textContent = `
+            @keyframes shake {
+                0%, 100% { transform: translateX(0); }
+                25% { transform: translateX(-5px); }
+                75% { transform: translateX(5px); }
+            }
+        `;
+        document.head.appendChild(style);
+    </script>
+</body>
+</html>

--- a/genes/THLAR/matK/matK-ai-review.html
+++ b/genes/THLAR/matK/matK-ai-review.html
@@ -1,0 +1,2245 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>matK - AI Gene Review</title>
+    <style>
+        :root {
+            --color-accept: #22c55e;
+            --color-remove: #ef4444;
+            --color-modify: #f97316;
+            --color-keep-non-core: #3b82f6;
+            --color-undecided: #6b7280;
+            --color-new: #8b5cf6;
+            --color-mark-over: #eab308;
+            --bg-light: #f9fafb;
+            --border-color: #e5e7eb;
+            --text-muted: #6b7280;
+            --text-primary: #111827;
+        }
+
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+            line-height: 1.6;
+            color: var(--text-primary);
+            background-color: #ffffff;
+            padding: 2rem;
+            max-width: 1400px;
+            margin: 0 auto;
+        }
+
+        .header {
+            border-bottom: 2px solid var(--border-color);
+            padding-bottom: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        h1 {
+            font-size: 2.5rem;
+            font-weight: 700;
+            margin-bottom: 0.5rem;
+            color: #1f2937;
+        }
+
+        .gene-info {
+            display: flex;
+            gap: 2rem;
+            flex-wrap: wrap;
+            margin-top: 1rem;
+        }
+
+        .info-item {
+            display: flex;
+            gap: 0.5rem;
+        }
+
+        .info-label {
+            font-weight: 600;
+            color: var(--text-muted);
+        }
+
+        .aliases {
+            display: flex;
+            gap: 0.5rem;
+            flex-wrap: wrap;
+        }
+
+        .badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.875rem;
+            font-weight: 500;
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+        }
+
+        .status-badge {
+            padding: 0.375rem 0.875rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .status-initialized {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fde68a;
+        }
+
+        .status-in-progress {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+        }
+
+        .status-draft {
+            background-color: #fce7f3;
+            color: #831843;
+            border: 1px solid #fbcfe8;
+        }
+
+        .status-complete {
+            background-color: #d1fae5;
+            color: #065f46;
+            border: 1px solid #a7f3d0;
+        }
+
+        .description-card {
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        .description-card h2 {
+            font-size: 1.25rem;
+            margin-bottom: 1rem;
+            color: #374151;
+        }
+
+        .section {
+            margin-bottom: 2.5rem;
+        }
+
+        .section-title {
+            font-size: 1.5rem;
+            font-weight: 600;
+            margin-bottom: 1.5rem;
+            color: #1f2937;
+            border-bottom: 1px solid var(--border-color);
+            padding-bottom: 0.5rem;
+        }
+
+        .annotations-table {
+            width: 100%;
+            border-collapse: collapse;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            overflow: hidden;
+        }
+
+        .annotations-table thead {
+            background-color: var(--bg-light);
+        }
+
+        .annotations-table th {
+            text-align: left;
+            padding: 1rem;
+            font-weight: 600;
+            border-bottom: 2px solid var(--border-color);
+            font-size: 0.875rem;
+            text-transform: uppercase;
+            letter-spacing: 0.05em;
+            color: var(--text-muted);
+        }
+
+        .annotations-table td {
+            padding: 1rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .annotations-table tbody tr:hover {
+            background-color: #f9fafb;
+        }
+
+        .action-badge {
+            display: inline-block;
+            padding: 0.375rem 0.75rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .action-accept {
+            background-color: var(--color-accept);
+            color: white;
+        }
+
+        .action-remove {
+            background-color: var(--color-remove);
+            color: white;
+        }
+
+        .action-modify {
+            background-color: var(--color-modify);
+            color: white;
+        }
+
+        .action-keep_as_non_core {
+            background-color: var(--color-keep-non-core);
+            color: white;
+        }
+
+        .action-undecided {
+            background-color: var(--color-undecided);
+            color: white;
+        }
+
+        .action-new {
+            background-color: var(--color-new);
+            color: white;
+        }
+
+        .action-mark_as_over_annotated {
+            background-color: var(--color-mark-over);
+            color: white;
+        }
+
+        .term-info {
+            display: flex;
+            flex-direction: column;
+            gap: 0.25rem;
+        }
+
+        .term-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .term-label {
+            font-weight: 500;
+        }
+
+        .evidence-code {
+            font-family: monospace;
+            background-color: var(--bg-light);
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .not-badge {
+            display: inline-block;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-weight: 600;
+            margin-left: 0.25rem;
+        }
+
+        .isoform-badge {
+            display: inline-block;
+            background-color: #eff6ff;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            margin-top: 0.25rem;
+        }
+
+        .core-function-card {
+            background-color: white;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 1rem;
+        }
+
+        .core-function-card h3 {
+            font-size: 1.125rem;
+            margin-bottom: 1rem;
+            color: #1f2937;
+        }
+
+        .core-function-statement {
+            margin-bottom: 1rem;
+            padding: 0.75rem;
+            background-color: var(--bg-light);
+            border-left: 4px solid var(--color-accept);
+            border-radius: 0.25rem;
+        }
+
+        .function-annotations {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin-top: 1rem;
+        }
+
+        .reference-item {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+        }
+
+        .reference-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: start;
+            margin-bottom: 0.75rem;
+        }
+
+        .reference-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #2563eb;
+        }
+
+        .supported-by {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f3f4f6;
+            border-left: 3px solid #3b82f6;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .supported-by-title {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .support-item {
+            margin-bottom: 0.5rem;
+        }
+
+        .support-ref {
+            font-weight: 500;
+            color: #2563eb;
+        }
+
+        .support-text {
+            color: #6b7280;
+            font-style: italic;
+            margin-left: 1rem;
+        }
+
+        a.term-link {
+            color: #2563eb;
+            text-decoration: none;
+        }
+
+        a.term-link:hover {
+            text-decoration: underline;
+        }
+
+        .core-function-terms {
+            margin-top: 1rem;
+        }
+
+        .function-term-group {
+            margin-bottom: 1rem;
+        }
+
+        .function-term-label {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .reference-title {
+            font-weight: 500;
+            margin-bottom: 0.5rem;
+        }
+
+        .findings-list {
+            margin-top: 1rem;
+            padding-left: 1.5rem;
+        }
+
+        .finding-item {
+            margin-bottom: 0.75rem;
+        }
+
+        .finding-statement {
+            font-weight: 500;
+            margin-bottom: 0.25rem;
+        }
+
+        .finding-text {
+            color: var(--text-muted);
+            font-size: 0.95rem;
+            font-style: italic;
+        }
+
+        .proposed-term {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #fef3c7;
+        }
+
+        .question-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #dbeafe;
+        }
+
+        .experiment-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #f3e8ff;
+        }
+
+        .prediction-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: white;
+        }
+
+        .prediction-card .prediction-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+        }
+
+        .prediction-source {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+        }
+
+        .assessment-badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.8rem;
+            font-weight: 600;
+            text-transform: uppercase;
+        }
+
+        .assessment-cor { background-color: #dcfce7; color: #166534; }
+        .assessment-cnn { background-color: #dbeafe; color: #1e40af; }
+        .assessment-lsp { background-color: #fef9c3; color: #854d0e; }
+        .assessment-unc { background-color: #f3f4f6; color: #374151; }
+        .assessment-pli { background-color: #fee2e2; color: #991b1b; }
+        .assessment-npi { background-color: #fecaca; color: #7f1d1d; }
+        .assessment-rep { background-color: #fde68a; color: #92400e; }
+
+        .confidence-score {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+            margin-left: 0.5rem;
+        }
+
+        .error-type-badge {
+            font-size: 0.75rem;
+            padding: 0.125rem 0.5rem;
+            border-radius: 0.25rem;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+        }
+
+        .isoforms-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fill, minmax(400px, 1fr));
+            gap: 1rem;
+        }
+
+        .isoform-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            background-color: white;
+            transition: box-shadow 0.2s;
+        }
+
+        .isoform-card:hover {
+            box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+        }
+
+        .functional-isoform-type {
+            display: inline-block;
+            padding: 0.2rem 0.5rem;
+            border-radius: 0.25rem;
+            font-size: 0.7rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.03em;
+        }
+
+        .type-SPLICE_VARIANT, .type-SPLICE_CLASS {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #93c5fd;
+        }
+
+        .type-CLEAVAGE_PRODUCT {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fcd34d;
+        }
+
+        .type-MODIFICATION_STATE {
+            background-color: #f3e8ff;
+            color: #6b21a8;
+            border: 1px solid #c4b5fd;
+        }
+
+        .type-CONFORMATIONAL_STATE {
+            background-color: #dcfce7;
+            color: #166534;
+            border: 1px solid #86efac;
+        }
+
+        .functional-isoform-mappings {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+            font-size: 0.85rem;
+        }
+
+        .functional-isoform-mappings .mapping-type {
+            font-weight: 600;
+            color: var(--text-muted);
+            font-size: 0.75rem;
+        }
+
+        .functional-isoform-go {
+            margin-top: 0.5rem;
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.25rem;
+        }
+
+        .go-chip {
+            display: inline-block;
+            padding: 0.15rem 0.4rem;
+            background-color: #ecfdf5;
+            color: #047857;
+            border: 1px solid #a7f3d0;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-family: monospace;
+        }
+
+        .isoform-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+            padding-bottom: 0.5rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .isoform-name {
+            font-weight: 600;
+            font-size: 1.1rem;
+            color: #1f2937;
+        }
+
+        .isoform-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .isoform-sequence-note {
+            font-size: 0.875rem;
+            color: var(--text-muted);
+            margin-bottom: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+        }
+
+        .isoform-description {
+            font-size: 0.95rem;
+            line-height: 1.5;
+        }
+
+        .collapsible {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .collapsible:after {
+            content: ' ▼';
+            font-size: 0.75rem;
+        }
+
+        .collapsible.collapsed:after {
+            content: ' ►';
+        }
+
+        .collapse-content {
+            transition: max-height 0.3s ease;
+            overflow: hidden;
+        }
+
+        .collapsed + .collapse-content {
+            max-height: 0;
+        }
+
+        .no-data {
+            color: var(--text-muted);
+            font-style: italic;
+            padding: 1rem;
+            text-align: center;
+            background-color: var(--bg-light);
+            border-radius: 0.5rem;
+        }
+
+        /* Styling for markdown section summaries with voting */
+        .markdown-section summary {
+            padding: 0.75rem;
+            background: var(--bg-light);
+            border-radius: 0.5rem;
+            margin-bottom: 0.5rem;
+        }
+
+        .markdown-section summary:hover {
+            background: #e5e7eb;
+        }
+
+        .markdown-section summary .vote-buttons {
+            margin-left: auto;
+        }
+
+        .deep-research-section {
+            margin-bottom: 1rem;
+            border: 1px solid #c7d2fe;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8faff;
+        }
+
+        .deep-research-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .deep-research-section summary h3 {
+            margin: 0;
+            color: #3730a3;
+            font-size: 1.1rem;
+        }
+
+        .report-meta {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin: 0.75rem 0 1rem;
+            align-items: center;
+        }
+
+        .report-badge {
+            display: inline-flex;
+            align-items: center;
+            border: 1px solid #c7d2fe;
+            border-radius: 999px;
+            background: #eef2ff;
+            color: #4338ca;
+            font-size: 0.78rem;
+            font-weight: 600;
+            padding: 0.2rem 0.6rem;
+        }
+
+        .report-meta-text {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+        }
+
+        .artifact-list {
+            display: grid;
+            gap: 0.75rem;
+            margin: 0.75rem 0 1rem;
+        }
+
+        .artifact-link {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+            margin-top: 0.5rem;
+            word-break: break-word;
+        }
+
+        @media print {
+            body {
+                padding: 1rem;
+            }
+
+            .collapsible:after {
+                display: none;
+            }
+
+            .collapsed + .collapse-content {
+                max-height: none !important;
+            }
+        }
+
+        @media (max-width: 768px) {
+            body {
+                padding: 1rem;
+            }
+
+            h1 {
+                font-size: 2rem;
+            }
+
+            .annotations-table {
+                font-size: 0.875rem;
+            }
+
+            .annotations-table th,
+            .annotations-table td {
+                padding: 0.5rem;
+            }
+        }
+    </style>
+</head>
+<body>
+    <div class="header">
+        <h1>matK</h1>
+        <div class="gene-info">
+            
+            <div class="info-item">
+                
+                <span class="info-label">UniProt ID:</span>
+                <span>
+                    <a href="https://www.uniprot.org/uniprotkb/Q9GF35" target="_blank" class="term-link">
+                        Q9GF35
+                    </a>
+                </span>
+                
+            </div>
+            
+            
+            <div class="info-item">
+                <span class="info-label">Organism:</span>
+                <span>Thlaspi arvense</span>
+            </div>
+            
+            
+            <div class="info-item">
+                <span class="info-label">Review Status:</span>
+                <span class="status-badge status-complete">
+                    COMPLETE
+                </span>
+            </div>
+            
+            
+        </div>
+        <div style="margin-top: 1rem; text-align: center;">
+            <a id="feedback-form-link"
+               href="#"
+               target="_blank"
+               style="display: inline-block; padding: 10px 20px; background-color: #4CAF50; color: white; text-decoration: none; border-radius: 5px; font-weight: 600;">
+                📝 Provide Detailed Feedback
+            </a>
+            <script>
+                // Construct the form URL with proper encoding
+                // Extract organism code from the current page path (e.g., /genes/ARATH/APO1/ -> ARATH)
+                const pathParts = window.location.pathname.split('/');
+                const genesIndex = pathParts.indexOf('genes');
+                let organism = '';
+                if (genesIndex !== -1 && pathParts[genesIndex + 1]) {
+                    organism = pathParts[genesIndex + 1].toUpperCase();
+                }
+                const geneSymbol = "matK";
+                const speciesGene = organism + ' ' + geneSymbol;
+                const formBaseUrl = 'https://docs.google.com/forms/d/e/1FAIpQLSdTot9L6GVkkZYgLQT0E8ZdAJv8RiN5ZgOVkgWNcKSbYvxxzQ/viewform';
+                const entryId = '1226477767'; // Correct entry ID for Species/Gene field
+                const formUrl = formBaseUrl + '?entry.' + entryId + '=' + encodeURIComponent(speciesGene);
+                const feedbackLink = document.getElementById('feedback-form-link');
+                feedbackLink.href = formUrl;
+                // Add tooltip showing the pre-filled value
+                feedbackLink.title = 'Opens form with pre-filled: ' + speciesGene;
+            </script>
+        </div>
+    </div>
+
+    
+    <div class="description-card">
+        <div style="display: flex; justify-content: space-between; align-items: center;">
+            <h2>Gene Description</h2>
+            <span class="vote-buttons" data-g="Q9GF35" data-a="DESCRIPTION: Maturase K (MatK) is the chloroplast-encoded intro..." data-r="" data-act="DESCRIPTION">
+                <button class="vote-btn" data-v="up" title="Agree with this description">👍</button>
+                <button class="vote-btn" data-v="down" title="Disagree with this description">👎</button>
+            </span>
+        </div>
+        <p>Maturase K (MatK) is the chloroplast-encoded intron maturase of field pennycress, typically encoded within the intron of the plastid trnK-UUU (lysine tRNA) gene. It is the only maturase retained in the plastid genome and acts as a trans-acting splicing factor that binds intron RNA and promotes excision of a conserved set of chloroplast group IIA introns (including its own trnK host intron and introns in trnA, trnI, trnV, atpF, rpl2 and rps12). It functions in the chloroplast stroma. MatK retains the maturase &#34;domain X&#34; and a degenerate reverse-transcriptase-like region but lacks the endonuclease/mobility domains of canonical bacterial intron-encoded proteins. The gene is also widely used as a plastid DNA barcode and phylogenetic marker.</p>
+    </div>
+    
+
+    
+
+    
+
+    
+    <div class="section">
+        <h2 class="section-title">Existing Annotations Review</h2>
+        <table class="annotations-table">
+            <thead>
+                <tr>
+                    <th>GO Term</th>
+                    <th>Evidence</th>
+                    <th>Action</th>
+                    <th>Reason</th>
+                </tr>
+            </thead>
+            <tbody>
+                
+                <tr>
+                    <td>
+                        <div class="term-info">
+                            
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005737" target="_blank" class="term-link">
+                                    GO:0005737
+                                </a>
+                            </span>
+                            <span class="term-label">cytoplasm</span>
+                            
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+                        
+                        
+                        
+                        <br>
+                        <span style="font-size: 0.75rem;">
+                            
+                            GO_REF:0000117
+                            
+                        </span>
+                        
+                    </td>
+                    <td>
+                        <span class="action-badge action-modify">
+                            MODIFY
+                        </span>
+                        <span class="vote-buttons" data-g="Q9GF35" data-a="GO:0005737" data-r="GO_REF:0000117" data-act="MODIFY">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+                        
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Over-general and redundant. MatK is a plastid genome-encoded protein that localizes to the chloroplast stroma (soluble fraction in transplastomic tobacco); the generic cytoplasm term should be specialized to the chloroplast stroma, consistent with the separate chloroplast annotation.
+                        </div>
+                        
+                        
+                        
+                        <div style="margin-top: 0.5rem;">
+                            <strong>Proposed replacements:</strong>
+                            
+                            <span class="badge">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0009570" target="_blank" class="term-link">
+                                    chloroplast stroma
+                                </a>
+                            </span>
+                            
+                        </div>
+                        
+                        
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+                            
+                            <div class="support-item">
+                                <span class="support-ref">
+                                    
+                                    file:THLAR/matK/matK-deep-research-falcon.md
+                                    
+                                </span>
+                                
+                                <div class="support-text">MatK is a chloroplast protein enriched in the soluble fraction (stroma) rather than membranes</div>
+                                
+                            </div>
+                            
+                        </div>
+                        
+                    </td>
+                </tr>
+                
+                <tr>
+                    <td>
+                        <div class="term-info">
+                            
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006397" target="_blank" class="term-link">
+                                    GO:0006397
+                                </a>
+                            </span>
+                            <span class="term-label">mRNA processing</span>
+                            
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+                        
+                        
+                        
+                        <br>
+                        <span style="font-size: 0.75rem;">
+                            
+                            GO_REF:0000002
+                            
+                        </span>
+                        
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9GF35" data-a="GO:0006397" data-r="GO_REF:0000002" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+                        
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Acceptable. Several MatK splicing targets are group IIA introns within protein-coding (mRNA) transcripts, including atpF, rpl2 and rps12, so MatK does contribute to mRNA processing. The more precise activity is captured by the group II intron splicing annotation below.
+                        </div>
+                        
+                        
+                        
+                        
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+                            
+                            <div class="support-item">
+                                <span class="support-ref">
+                                    
+                                    file:THLAR/matK/matK-deep-research-falcon.md
+                                    
+                                </span>
+                                
+                                <div class="support-text">MatK-dependent group IIA introns include atpF, rpl2 and rps12 intron 2</div>
+                                
+                            </div>
+                            
+                        </div>
+                        
+                    </td>
+                </tr>
+                
+                <tr>
+                    <td>
+                        <div class="term-info">
+                            
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0008380" target="_blank" class="term-link">
+                                    GO:0008380
+                                </a>
+                            </span>
+                            <span class="term-label">RNA splicing</span>
+                            
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+                        
+                        
+                        
+                        <br>
+                        <span style="font-size: 0.75rem;">
+                            
+                            GO_REF:0000104
+                            
+                        </span>
+                        
+                    </td>
+                    <td>
+                        <span class="action-badge action-modify">
+                            MODIFY
+                        </span>
+                        <span class="vote-buttons" data-g="Q9GF35" data-a="GO:0008380" data-r="GO_REF:0000104" data-act="MODIFY">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+                        
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Correct but can be made precise. MatK is specifically a group II intron maturase / splicing factor acting on chloroplast group IIA introns. The dedicated group II intron splicing term is more informative than the generic RNA splicing parent.
+                        </div>
+                        
+                        
+                        
+                        <div style="margin-top: 0.5rem;">
+                            <strong>Proposed replacements:</strong>
+                            
+                            <span class="badge">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0000373" target="_blank" class="term-link">
+                                    Group II intron splicing
+                                </a>
+                            </span>
+                            
+                        </div>
+                        
+                        
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+                            
+                            <div class="support-item">
+                                <span class="support-ref">
+                                    
+                                    file:THLAR/matK/matK-deep-research-falcon.md
+                                    
+                                </span>
+                                
+                                <div class="support-text">MatK facilitates splicing (excision) of chloroplast group IIA introns as a trans-acting maturase</div>
+                                
+                            </div>
+                            
+                        </div>
+                        
+                    </td>
+                </tr>
+                
+                <tr>
+                    <td>
+                        <div class="term-info">
+                            
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0009507" target="_blank" class="term-link">
+                                    GO:0009507
+                                </a>
+                            </span>
+                            <span class="term-label">chloroplast</span>
+                            
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+                        
+                        
+                        
+                        <br>
+                        <span style="font-size: 0.75rem;">
+                            
+                            GO_REF:0000120
+                            
+                        </span>
+                        
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9GF35" data-a="GO:0009507" data-r="GO_REF:0000120" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+                        
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Correct. MatK is plastid genome-encoded and functions in the chloroplast. Consistent with the UniProt subcellular location (Plastid, chloroplast).
+                        </div>
+                        
+                        
+                        
+                        
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+                            
+                            <div class="support-item">
+                                <span class="support-ref">
+                                    
+                                    file:THLAR/matK/matK-deep-research-falcon.md
+                                    
+                                </span>
+                                
+                                <div class="support-text">chloroplast-encoded intron maturase localized to the chloroplast stroma</div>
+                                
+                            </div>
+                            
+                        </div>
+                        
+                    </td>
+                </tr>
+                
+                <tr>
+                    <td>
+                        <div class="term-info">
+                            
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0003723" target="_blank" class="term-link">
+                                    GO:0003723
+                                </a>
+                            </span>
+                            <span class="term-label">RNA binding</span>
+                            
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+                        
+                        
+                        
+                    </td>
+                    <td>
+                        <span class="action-badge action-new">
+                            NEW
+                        </span>
+                        <span class="vote-buttons" data-g="Q9GF35" data-a="GO:0003723" data-r="" data-act="NEW">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+                        
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Proposed new molecular-function annotation. GOA currently lists no molecular function for MatK, but the protein is an RNA-binding intron maturase that binds its target group IIA introns to promote splicing; the conserved maturase domain X is an RNA-binding region. This is the core molecular function and should be added.
+                        </div>
+                        
+                        
+                        
+                        
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+                            
+                            <div class="support-item">
+                                <span class="support-ref">
+                                    
+                                    file:THLAR/matK/matK-deep-research-falcon.md
+                                    
+                                </span>
+                                
+                                <div class="support-text">Maturases act as cofactors by binding intron RNA to stabilize the correct folded state and promote catalytic steps; MatK associates with multiple intron-containing transcripts in vivo</div>
+                                
+                            </div>
+                            
+                        </div>
+                        
+                    </td>
+                </tr>
+                
+            </tbody>
+        </table>
+    </div>
+    
+
+    
+    <div class="section">
+        <h2 class="section-title">Core Functions</h2>
+        
+        <div class="core-function-card">
+            
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+                <h3>MatK is a chloroplast-encoded, RNA-binding group II intron maturase that acts as a trans-acting splicing factor, promoting excision of a conserved set of chloroplast group IIA introns in the stroma.</h3>
+                <span class="vote-buttons" data-g="Q9GF35" data-a="FUNCTION: MatK is a chloroplast-encoded, RNA-binding group I..." data-r="" data-act="CORE_FUNCTION">
+                    <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
+                    <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
+                </span>
+            </div>
+            
+
+            <div class="core-function-terms">
+                
+                <div class="function-term-group">
+                    <div class="function-term-label">Molecular Function:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0003723" target="_blank" class="term-link">
+                            RNA binding
+                        </a>
+                    </span>
+                </div>
+                
+
+                
+                <div class="function-term-group">
+                    <div class="function-term-label">Directly Involved In:</div>
+                    <div class="function-annotations">
+                        
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0000373" target="_blank" class="term-link">
+                                Group II intron splicing
+                            </a>
+                        </span>
+                        
+                    </div>
+                </div>
+                
+
+                
+                <div class="function-term-group">
+                    <div class="function-term-label">Cellular Locations:</div>
+                    <div class="function-annotations">
+                        
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0009570" target="_blank" class="term-link">
+                                chloroplast stroma
+                            </a>
+                        </span>
+                        
+                    </div>
+                </div>
+                
+
+                
+
+                
+            </div>
+
+            
+            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
+                <strong>Supporting Evidence:</strong>
+                <ul class="findings-list">
+                    
+                    <li class="finding-item">
+                        <span class="reference-id">
+                            
+                            file:THLAR/matK/matK-deep-research-falcon.md
+                            
+                        </span>
+                        
+                        <div class="finding-text">trans-acting splicing cofactor for chloroplast group IIA introns (trnK, trnA, trnI, trnV, atpF, rpl2, rps12 intron 2), stroma-localized</div>
+                        
+                    </li>
+                    
+                </ul>
+            </div>
+            
+        </div>
+        
+    </div>
+    
+
+    
+    <div class="section">
+        <h2 class="section-title collapsible">References</h2>
+        <div class="collapse-content">
+            
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+                        
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000002.md" target="_blank" class="term-link">
+                            GO_REF:0000002
+                        </a>
+                        
+                    </span>
+                </div>
+                
+                <div class="reference-title">Gene Ontology annotation through association of InterPro records with GO terms</div>
+                
+                
+            </div>
+            
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+                        
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000104.md" target="_blank" class="term-link">
+                            GO_REF:0000104
+                        </a>
+                        
+                    </span>
+                </div>
+                
+                <div class="reference-title">Electronic Gene Ontology annotations created by transferring manual GO annotations between related proteins based on shared sequence features</div>
+                
+                
+            </div>
+            
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+                        
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000117.md" target="_blank" class="term-link">
+                            GO_REF:0000117
+                        </a>
+                        
+                    </span>
+                </div>
+                
+                <div class="reference-title">Electronic Gene Ontology annotations created by ARBA machine learning models</div>
+                
+                
+            </div>
+            
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+                        
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000120.md" target="_blank" class="term-link">
+                            GO_REF:0000120
+                        </a>
+                        
+                    </span>
+                </div>
+                
+                <div class="reference-title">Combined Automated Annotation using Multiple IEA Methods</div>
+                
+                
+            </div>
+            
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+                        
+                        file:THLAR/matK/matK-deep-research-falcon.md
+                        
+                    </span>
+                </div>
+                
+                <div class="reference-title">Falcon/Edison deep research report for matK, Thlaspi arvense</div>
+                
+                
+                <ul class="findings-list">
+                    
+                    <li class="finding-item">
+                        <div class="finding-statement">MatK is the chloroplast-encoded group II intron maturase, a stroma-localized trans-acting splicing factor for a conserved set of chloroplast group IIA introns; the pennycress protein itself has not been directly assayed, so function is inferred from conserved land-plant MatK biology.</div>
+                        
+                    </li>
+                    
+                </ul>
+                
+            </div>
+            
+        </div>
+    </div>
+    
+
+
+    
+    <div class="section">
+        <h2 class="section-title">Suggested Questions for Experts</h2>
+        
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> Which chloroplast group IIA introns does Thlaspi arvense MatK splice in vivo, and is MatK essential for plastid gene expression in pennycress as it is in tobacco?</p>
+                    
+                </div>
+                <span class="vote-buttons" data-g="Q9GF35" data-a="Q: Which chloroplast group IIA introns does Thlaspi a..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+        
+    </div>
+    
+
+    
+
+    
+
+    <!-- Computational Predictions Section -->
+    
+
+    <!-- Deep Research Sections -->
+    
+    <div class="section">
+        <h2 class="section-title">Deep Research</h2>
+        
+        <details class="deep-research-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; gap: 1rem;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Falcon</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(matK-deep-research-falcon.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="Q9GF35" data-a="DEEP_RESEARCH: Falcon" data-r="" data-act="DEEP_RESEARCH" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This deep research is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This deep research needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+                
+                <div class="report-meta">
+                    
+                    <span class="report-meta-text">this with annotations you find in gene/protein databases, but these can be outdated or inaccurate.</span>
+                    
+                    
+                    <span class="report-badge">Falcon</span>
+                    
+                    
+                    <span class="report-badge">Edison Scientific Literature</span>
+                    
+                    
+                    <span class="report-badge">33 citations</span>
+                    
+                    
+                    <span class="report-badge">1 artifacts</span>
+                    
+                    
+                    <span class="report-meta-text">2026-06-11T16:38:13.272112</span>
+                    
+                    
+                    
+                </div>
+                
+                
+                <div class="artifact-list">
+                    
+                    
+                    
+                    <div class="artifact-link">
+                        <a href="matK-deep-research-falcon_artifacts/artifact-00.md" class="term-link">Edison artifact artifact-00</a>
+                        <span>(text/markdown)</span>
+                    </div>
+                    
+                    
+                </div>
+                
+                <p>The research report should be a detailed narrative explaining the function, biological processes, and localization of the gene product. Citations should be given for all claims.</p>
+<p>You should prioritize authoritative reviews and primary scientific literature when conducting research. You can supplement<br />
+this with annotations you find in gene/protein databases, but these can be outdated or inaccurate.</p>
+<p>We are specifically interested in the primary function of the gene - for enzymes, what reaction is catalyzed, and what is the substrate specificity? For transporters, what is the substrate? For structural proteins or adapters, what is the broader structural role? For signaling molecules, what is the role in the pathway.</p>
+<p>We are interested in where in or outside the cell the gene product carries out its function.</p>
+<p>We are also interested in the signaling or biochemical pathways in which the gene functions. We are less interested in broad pleiotropic effects, except where these elucidate the precise role.</p>
+<p>Include evidence where possible. We are interested in both experimental evidence as well as inference from structure, evolution, or bioinformatic analysis. Precise studies should be prioritized over high-throughput, where available.</p>
+<h2 id="research-report-chloroplast-matk-uniprot-q9gf35-from-thlaspi-arvense-field-penny-cress">Research Report: chloroplast <strong>matK</strong> (UniProt Q9GF35) from <em>Thlaspi arvense</em> (field penny-cress)</h2>
+<h3 id="0-target-verification-and-scope">0) Target verification and scope</h3>
+<p>The UniProt target Q9GF35 corresponds to <strong>MatK (maturase K)</strong>, a <strong>chloroplast-encoded intron maturase</strong> in the <strong>intron maturase 2 family (MatK subfamily)</strong>, annotated for <em>Thlaspi arvense</em> (field penny-cress). The retrieved authoritative plant literature consistently uses <strong>matK</strong> to denote the <strong>plastid gene embedded in the trnK-UUU intron</strong> that encodes a <strong>group II intron maturase/splicing factor</strong>; no alternative protein with the same symbol was identified in the retrieved sources. Therefore, functional inference for the <em>T. arvense</em> MatK protein is best grounded in conserved land-plant MatK biology established in tobacco and other angiosperms (homology-based functional annotation) (zoschke2010anorganellarmaturase pages 1-1).</p>
+<h3 id="1-key-concepts-and-definitions-current-understanding">1) Key concepts and definitions (current understanding)</h3>
+<h4 id="11-what-is-matk">1.1 What is MatK?</h4>
+<p>MatK is an <strong>organellar maturase</strong>: a protein derived from bacterial group II intron-encoded proteins (IEPs) that <strong>facilitates splicing (excision) of group II introns</strong> from precursor RNAs. In land plants, MatK is widely described as the <strong>sole chloroplast-encoded maturase/splicing factor</strong> retained in the plastid genome and is typically <strong>encoded within the intron of the chloroplast lysine tRNA gene trnK-UUU</strong> (zoschke2010anorganellarmaturase pages 1-1, mizrahi2022groupiiintronencoded pages 6-7).</p>
+<h4 id="12-group-ii-introns-and-maturase-function">1.2 Group II introns and “maturase” function</h4>
+<p>Group II introns are catalytic RNAs that can self-splice under permissive conditions, but in plant organelles their introns are often structurally degenerate and <strong>require protein cofactors</strong> for efficient splicing in vivo. Maturases act as such cofactors, typically by binding intron RNA to stabilize the correct folded state and promote catalytic steps (barthet2020unravelingtherole pages 1-2, mizrahi2022groupiiintronencoded pages 6-7).</p>
+<h4 id="13-domain-architecture-why-matk-is-considered-a-splicing-factor">1.3 Domain architecture (why MatK is considered a splicing factor)</h4>
+<p>Plant MatK is <strong>degenerate relative to canonical bacterial IEPs</strong>: it retains the maturase <strong>“domain X”</strong> (a conserved RNA-binding/splicing-related region) and <strong>only part of the reverse transcriptase-like region</strong>, while lacking mobility-associated domains (e.g., DNA endonuclease). This domain pattern supports a specialized role in RNA splicing rather than intron mobility (barthet2020unravelingtherole pages 1-2, qu2015analysisoftargets pages 18-21).</p>
+<h3 id="2-molecular-function-biological-processes-and-localization">2) Molecular function, biological processes, and localization</h3>
+<h4 id="21-cellular-and-sub-organellar-localization">2.1 Cellular and sub-organellar localization</h4>
+<p>Direct biochemical localization in transplastomic tobacco shows MatK is a <strong>chloroplast protein enriched in the soluble fraction (stroma)</strong> rather than membranes, placing its activity in the chloroplast compartment where RNA processing/splicing occurs (zoschke2010anorganellarmaturase pages 1-1, zoschke2010anorganellarmaturase pages 3-3).</p>
+<h4 id="22-primary-function-splicing-of-chloroplast-group-iia-introns">2.2 Primary function: splicing of chloroplast group IIA introns</h4>
+<p>Multiple lines of evidence support MatK as a <strong>trans-acting splicing cofactor</strong> for a specific set of chloroplast <strong>group IIA introns</strong>:</p>
+<ul>
+<li><strong>RNA association evidence (RIP-chip/RIP approaches):</strong> In vivo RNA immunoprecipitation experiments demonstrate MatK <strong>associates with multiple intron-containing transcripts</strong>, not only its host trnK intron (zoschke2010anorganellarmaturase pages 1-1, zoschke2010anorganellarmaturase pages 3-3).</li>
+<li><strong>Biochemical activity evidence (in vitro):</strong> An in vitro splicing assay showed chloroplast group IIA introns (rps12 intron 2 and rpl2 intron) can self-excise, and <strong>adding heterologously expressed MatK increases splicing efficiency for rps12 intron 2</strong> (but not for rpl2 under the tested conditions). This was presented as the <strong>first direct evidence</strong> of MatK maturase activity (barthet2020unravelingtherole pages 1-2).</li>
+</ul>
+<h4 id="23-best-supported-rna-targets-substrates">2.3 Best-supported RNA targets (substrates)</h4>
+<p>Across mechanistic studies, the most consistently supported MatK targets are <strong>seven chloroplast group IIA introns</strong>:<br />
+- <strong>trnK-UUU</strong> (the intron that encodes matK)<br />
+- <strong>trnA</strong>, <strong>trnI</strong>, <strong>trnV</strong> (tRNA introns)<br />
+- <strong>atpF</strong> (ATP synthase-related transcript intron)<br />
+- <strong>rpl2</strong> (ribosomal protein transcript intron)<br />
+- <strong>rps12 intron 2</strong> (second intron of rps12)</p>
+<p>These targets are explicitly listed as MatK-associated and/or MatK-dependent in land-plant studies and reviews, and were reiterated in the Plant Direct biochemical study (barthet2020unravelingtherole pages 1-2, zoschke2010anorganellarmaturase pages 1-1, qu2015analysisoftargets pages 18-21).</p>
+<h4 id="24-essentiality-and-functional-constraints">2.4 Essentiality and functional constraints</h4>
+<p>Attempts to generate matK knockouts in tobacco plastids did <strong>not</strong> yield homoplastomic mutants, which has been interpreted as evidence that <strong>matK is essential for viability</strong> (or at least for stable plastid gene expression necessary for survival) (zoschke2010anorganellarmaturase pages 1-1, qu2015analysisoftargets pages 18-21).</p>
+<h4 id="25-developmental-regulation-and-regulatory-checkpoints">2.5 Developmental regulation and regulatory checkpoints</h4>
+<p>MatK expression is developmentally regulated and can show strong <strong>mRNA–protein discordance</strong>:<br />
+- MatK protein abundance peaks early in development (notably around <strong>7 days</strong>) while matK mRNA can be low at the same stage, suggesting translational regulation and/or altered protein stability (hertel2013multiplecheckpointsfor pages 8-9, zoschke2010anorganellarmaturase pages 1-1).<br />
+- RIP/qPCR-based analyses report <strong>developmentally changing MatK–RNA associations</strong>, e.g., MatK association with <strong>atpF increases ~3-fold</strong> in older (25-day) vs young (7-day) tobacco tissue, whereas association with <strong>trnV decreases ~2-fold</strong> (qu2015analysisoftargets pages 60-63).<br />
+- A quantitative modeling framework proposed negative autoregulation through pre-trnK/MatK complexes and competition among tRNA targets, consistent with multiple “checkpoints” controlling MatK abundance and interaction with intron substrates (hertel2013multiplecheckpointsfor pages 8-9).</p>
+<h3 id="3-recent-developments-and-latest-research-prioritizing-20232024">3) Recent developments and latest research (prioritizing 2023–2024)</h3>
+<h4 id="31-mechanistic-matk-research-20232024-availability">3.1 Mechanistic MatK research (2023–2024 availability)</h4>
+<p>Within the retrieved 2023–2024 corpus, there was <strong>limited accessible new mechanistic primary evidence</strong> that substantially changes the established MatK model (stroma-localized maturase acting on a conserved set of group IIA introns). The strongest mechanistic evidence in the retrieved set remains earlier high-impact work (2010–2020), including in vivo RNA association mapping and direct in vitro activity demonstration (zoschke2010anorganellarmaturase pages 1-1, barthet2020unravelingtherole pages 1-2).</p>
+<h4 id="32-2024-evidence-of-ongoing-matk-evolutionvariation-studies">3.2 2024 evidence of ongoing matK evolution/variation studies</h4>
+<p>Recent work continues to document matK sequence variation and rapid evolution in applied genomics contexts. For example, a 2024 study amplified a <strong>730-bp partial matK region</strong> and reported <strong>eight variable sites</strong> across aligned Ficus species sequences, emphasizing matK’s relatively higher evolutionary rate compared with rbcL and its utility as a discriminatory plastid locus (primandiri2024thematurasek pages 1-5).</p>
+<h3 id="4-current-applications-and-real-world-implementations">4) Current applications and real-world implementations</h3>
+<p>MatK’s real-world use is dominated by its role as a <strong>chloroplast DNA barcode</strong> and phylogenetic marker, distinct from its protein function as a maturase.</p>
+<h4 id="41-dna-barcoding-in-field-surveillance-and-biodiversity-monitoring-2024">4.1 DNA barcoding in field surveillance and biodiversity monitoring (2024)</h4>
+<p>A 2024 field-oriented barcoding study of <strong>91 terrestrial plant species</strong> (mostly invasive) evaluated four loci (ITS, rbcL, matK, trnH-psbA) and reported an overall PCR-and-sequencing success rate of <strong>87.9%</strong> across loci. In that study, combining <strong>rbcL + matK</strong> yielded <strong>68.6%</strong> species discrimination, whereas <strong>ITS + trnH-psbA</strong> achieved <strong>97.1%</strong>, motivating a practical recommendation for dual-locus strategies emphasizing ITS + trnH-psbA over rbcL+matK in that context (nath2024dnabarcodingof pages 2-3, nath2024dnabarcodingof pages 9-10).</p>
+<h4 id="42-taxon-specific-primer-challenges-and-performance-cactaceae-2024">4.2 Taxon-specific primer challenges and performance (Cactaceae, 2024)</h4>
+<p>A 2024 Cactaceae study illustrates a common implementation issue: <strong>universal matK primers can fail</strong> in some lineages. The authors report universal matK primers had <strong>&lt;10% amplification success</strong>, while designing lineage-specific primers increased amplification to <strong>91.95%</strong>; nevertheless, good-quality matK sequence recovery was <strong>54.16%</strong> (lower than rbcL 81.25% in that study). Using BLAST-based identification, matK achieved <strong>83.33% genus-level</strong> and <strong>50% species-level</strong> identification in their dataset (wei2024effectivenessofdna pages 3-4, wei2024effectivenessofdna pages 1-2).</p>
+<h4 id="43-forensic-botany-and-expert-synthesis-2024-review">4.3 Forensic botany and expert synthesis (2024 review)</h4>
+<p>A 2024 review focusing on forensic botany concluded that matK can have high recovery in some contexts (e.g., <strong>91.8% recovery</strong> cited for one wood-forensics dataset) but can show only moderate species-level identification in others (e.g., <strong>62.5%</strong> in a cited Paphiopedilum dataset). The review emphasizes that <strong>multi-locus combinations</strong> can substantially improve identification performance (e.g., cited 3-marker combinations averaging <strong>91.4%</strong>, and a cited psbA-trnH + trnK combination reaching <strong>100%</strong> in one dataset), supporting real-world practice of combining markers rather than relying on matK alone (behura2024differentdnabarcoding pages 7-9).</p>
+<h3 id="5-expert-opinion-and-analysis-authoritative-interpretations">5) Expert opinion and analysis (authoritative interpretations)</h3>
+<ul>
+<li><strong>MatK as a trans-acting splicing factor:</strong> High-impact mechanistic work concludes MatK is not limited to splicing its host trnK intron; rather, it <strong>associates with multiple group IIA introns</strong>, supporting a model where the single plastid maturase contributes broadly to chloroplast intron splicing (zoschke2010anorganellarmaturase pages 1-1, barthet2020unravelingtherole pages 1-2).</li>
+<li><strong>Regulated expression and potential toxicity of misregulation:</strong> Quantitative developmental profiling and modeling suggest MatK is controlled at multiple levels, and that inappropriate MatK abundance may perturb chloroplast development—supporting a view of MatK as integrated into plastid gene-expression homeostasis, not just a constitutive “housekeeping” splicing enzyme (hertel2013multiplecheckpointsfor pages 8-9).</li>
+<li><strong>Applied consensus for barcoding:</strong> Recent applied studies and reviews converge on the practical conclusion that matK is useful but <strong>not universally robust</strong> due to primer universality issues and variable discriminatory power; <strong>multi-locus strategies</strong> often outperform single-locus matK barcoding (wei2024effectivenessofdna pages 3-4, behura2024differentdnabarcoding pages 7-9, nath2024dnabarcodingof pages 9-10).</li>
+</ul>
+<h3 id="6-summary-for-functional-annotation-of-t-arvense-matk-uniprot-q9gf35">6) Summary for functional annotation of <em>T. arvense</em> MatK (UniProt Q9GF35)</h3>
+<p><strong>Recommended functional statement (protein-level):</strong> MatK is a <strong>chloroplast stromal group II intron maturase</strong> that <strong>binds and promotes splicing/excision of multiple chloroplast group IIA introns</strong>, including <strong>trnK-UUU, trnA, trnI, trnV, atpF, rpl2, and rps12 intron 2</strong>. It is likely essential for proper chloroplast RNA maturation and plastid gene expression. Evidence includes in vivo RNA association mapping and direct in vitro demonstration of maturase activity (enhanced rps12 intron 2 self-splicing) (zoschke2010anorganellarmaturase pages 1-1, barthet2020unravelingtherole pages 1-2).</p>
+<h3 id="consolidated-evidence-table">Consolidated evidence table</h3>
+<table>
+<thead>
+<tr>
+<th>Aspect</th>
+<th>Details</th>
+<th>Evidence type</th>
+<th>Key quantitative findings</th>
+<th>Key citations with year and DOI/URL</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>Identity / genome context</td>
+<td>MatK is the plastid-encoded maturase K relevant to UniProt Q9GF35 from <em>Thlaspi arvense</em>; in land plants it is typically encoded within the chloroplast <strong>trnK-UUU intron</strong> and is the only chloroplast-encoded maturase/splicing factor retained in most autotrophic lineages. This matches the UniProt annotation for a MatK-family intron maturase.</td>
+<td>Comparative plastid genomics; functional studies in land-plant homologs</td>
+<td>Conserved across autotrophic land plants with chloroplast group II introns; knockout attempts in tobacco did not yield homoplastomic mutants, consistent with essentiality.</td>
+<td>Zoschke et al. 2010, PNAS, doi:10.1073/pnas.0909400107, https://doi.org/10.1073/pnas.0909400107 (zoschke2010anorganellarmaturase pages 1-1); Hertel et al. 2013, <em>Plant Physiology</em>, doi:10.1104/pp.113.227579, https://doi.org/10.1104/pp.113.227579 (hertel2013multiplecheckpointsfor pages 8-9); Mizrahi et al. 2022, <em>Genes</em>, doi:10.3390/genes13071137, https://doi.org/10.3390/genes13071137 (mizrahi2022groupiiintronencoded pages 6-7)</td>
+</tr>
+<tr>
+<td>Domains</td>
+<td>MatK is a <strong>degenerated group II intron maturase/IEP</strong> that retains the maturase <strong>domain X</strong> and only part of the reverse-transcriptase region, while lacking the DNA endonuclease/mobility modules seen in canonical bacterial group II intron proteins. This supports a specialization for RNA splicing rather than intron mobility.</td>
+<td>Domain/evolutionary inference integrated with biochemical data</td>
+<td>Structural degeneration is consistent with loss of mobility and retention of splicing activity; direct biochemical support for maturase activity was demonstrated in vitro.</td>
+<td>Barthet et al. 2020, <em>Plant Direct</em>, doi:10.1002/pld3.208, https://doi.org/10.1002/pld3.208 (barthet2020unravelingtherole pages 1-2); Zoschke et al. 2010, https://doi.org/10.1073/pnas.0909400107 (zoschke2010anorganellarmaturase pages 1-1); Qu 2015 dissertation, doi:10.18452/17256, https://doi.org/10.18452/17256 (qu2015analysisoftargets pages 18-21, qu2015analysisoftargets pages 15-18)</td>
+</tr>
+<tr>
+<td>Localization</td>
+<td>MatK is a <strong>chloroplast stromal/soluble protein</strong> rather than a membrane protein. Its activity is therefore placed in the chloroplast stroma, where plastid pre-RNAs are processed and group II introns are spliced.</td>
+<td>Chloroplast transformation, organelle fractionation, immunoblotting</td>
+<td>In tobacco, MatK accumulation was highest in very young tissue, peaking at <strong>day 7 post-imbibition</strong>, then declining strongly in older tissue.</td>
+<td>Zoschke et al. 2010, https://doi.org/10.1073/pnas.0909400107 (zoschke2010anorganellarmaturase pages 1-1, zoschke2010anorganellarmaturase pages 3-3); Hertel et al. 2013, https://doi.org/10.1104/pp.113.227579 (hertel2013multiplecheckpointsfor pages 8-9)</td>
+</tr>
+<tr>
+<td>Molecular function</td>
+<td>Primary function: <strong>facilitation of chloroplast group IIA intron excision/splicing</strong> in precursor RNAs. MatK acts in trans on multiple introns, not just its host intron, and likely promotes correct RNA folding/assembly of catalytically competent intron structures.</td>
+<td>RIP-Chip/RIP-seq, developmental expression analysis, in vitro splicing assay, genetic inference from plastid translation-deficient mutants</td>
+<td>Barthet et al. showed the first direct biochemical evidence: addition of recombinant MatK increased <strong>rps12 intron 2</strong> self-splicing efficiency in vitro, but not <strong>rpl2</strong> under the tested conditions.</td>
+<td>Zoschke et al. 2010, https://doi.org/10.1073/pnas.0909400107 (zoschke2010anorganellarmaturase pages 3-3, zoschke2010anorganellarmaturase pages 1-1); Barthet et al. 2020, https://doi.org/10.1002/pld3.208 (barthet2020unravelingtherole pages 1-2); Hertel et al. 2013, https://doi.org/10.1104/pp.113.227579 (hertel2013multiplecheckpointsfor pages 8-9)</td>
+</tr>
+<tr>
+<td>Validated intron targets</td>
+<td>Seven canonical chloroplast <strong>group IIA</strong> intron targets repeatedly associated with MatK are: <strong>trnK, trnA, trnI, trnV, atpF, rpl2, and rps12 intron 2</strong>. These are the best-supported conserved targets relevant for annotation of <em>T. arvense</em> MatK by homology.</td>
+<td>RNA immunoprecipitation/chip or sequencing; comparative functional inference</td>
+<td>RIP-based studies recovered association with <strong>7</strong> canonical group IIA introns; all known strong targets fall in subgroup IIA.</td>
+<td>Zoschke et al. 2010, https://doi.org/10.1073/pnas.0909400107 (zoschke2010anorganellarmaturase pages 1-1); Barthet et al. 2020, https://doi.org/10.1002/pld3.208 (barthet2020unravelingtherole pages 1-2); Qu 2015, https://doi.org/10.18452/17256 (qu2015analysisoftargets pages 18-21, qu2015analysisoftargets pages 56-60)</td>
+</tr>
+<tr>
+<td>trnK target summary</td>
+<td>MatK is encoded in the <strong>trnK</strong> intron and binds intronic regions flanking rather than the matK ORF itself; this supports action on its home intron while also acting on other introns in trans.</td>
+<td>RIP-Chip mapping of binding regions</td>
+<td>Strong enrichment mapped to intron regions upstream/downstream of the matK ORF; authors did <strong>not</strong> observe strongest enrichment over the matK coding region itself.</td>
+<td>Zoschke et al. 2010, https://doi.org/10.1073/pnas.0909400107 (zoschke2010anorganellarmaturase pages 3-3, zoschke2010anorganellarmaturase pages 1-1)</td>
+</tr>
+<tr>
+<td>trnA target summary</td>
+<td><strong>trnA</strong> is one of the canonical group IIA introns associated with MatK and is consistently included among inferred/observed MatK targets in land plants.</td>
+<td>RIP-chip / RIP-seq association; review synthesis</td>
+<td>Included among the 7 principal MatK-associated introns in chloroplasts.</td>
+<td>Barthet et al. 2020, https://doi.org/10.1002/pld3.208 (barthet2020unravelingtherole pages 1-2); Qu 2015, https://doi.org/10.18452/17256 (qu2015analysisoftargets pages 18-21, qu2015analysisoftargets pages 56-60)</td>
+</tr>
+<tr>
+<td>trnI target summary</td>
+<td><strong>trnI</strong> is a canonical MatK-associated chloroplast group IIA intron target.</td>
+<td>RIP-chip / RIP-seq association; review synthesis</td>
+<td>Included among the 7 principal MatK-associated introns in chloroplasts.</td>
+<td>Barthet et al. 2020, https://doi.org/10.1002/pld3.208 (barthet2020unravelingtherole pages 1-2); Qu 2015, https://doi.org/10.18452/17256 (qu2015analysisoftargets pages 18-21, qu2015analysisoftargets pages 56-60)</td>
+</tr>
+<tr>
+<td>trnV target summary</td>
+<td><strong>trnV</strong> is a canonical MatK target; developmental RIP-qPCR suggested changing association over development.</td>
+<td>RIP-based developmental interaction profiling</td>
+<td>MatK association with <strong>trnV decreased ~2-fold</strong> in older (25-day) vs young (7-day) tobacco tissue.</td>
+<td>Hertel et al. 2013, https://doi.org/10.1104/pp.113.227579 (hertel2013multiplecheckpointsfor pages 8-9); Qu 2015, https://doi.org/10.18452/17256 (qu2015analysisoftargets pages 60-63)</td>
+</tr>
+<tr>
+<td>atpF target summary</td>
+<td><strong>atpF</strong> is a canonical MatK target and a well-supported example of developmentally regulated MatK-RNA association.</td>
+<td>RIP-qPCR / RIP-seq</td>
+<td>MatK association with <strong>atpF increased ~3-fold</strong> in 25-day vs 7-day tobacco tissue.</td>
+<td>Hertel et al. 2013, https://doi.org/10.1104/pp.113.227579 (hertel2013multiplecheckpointsfor pages 8-9); Qu 2015, https://doi.org/10.18452/17256 (qu2015analysisoftargets pages 60-63)</td>
+</tr>
+<tr>
+<td>rpl2 target summary</td>
+<td><strong>rpl2</strong> is a canonical MatK target; in vitro, its intron can self-excise, but MatK addition did not increase splicing efficiency under the assay conditions tested.</td>
+<td>In vitro self-splicing assay with recombinant MatK</td>
+<td>Direct assay showed no enhancement for <strong>rpl2</strong> in the reported experimental setup, unlike <strong>rps12 intron 2</strong>.</td>
+<td>Barthet et al. 2020, https://doi.org/10.1002/pld3.208 (barthet2020unravelingtherole pages 1-2)</td>
+</tr>
+<tr>
+<td>rps12 intron 2 target summary</td>
+<td><strong>rps12 intron 2</strong> is a canonical MatK target and currently has the clearest direct biochemical support for MatK-mediated stimulation of splicing.</td>
+<td>In vitro splicing assay with recombinant MatK</td>
+<td>Recombinant MatK increased self-splicing efficiency of <strong>rps12 intron 2</strong>; this was presented as the <strong>first direct evidence</strong> of MatK maturase activity.</td>
+<td>Barthet et al. 2020, https://doi.org/10.1002/pld3.208 (barthet2020unravelingtherole pages 1-2)</td>
+</tr>
+<tr>
+<td>Expression / regulation</td>
+<td>MatK expression is developmentally regulated at multiple checkpoints; protein abundance does not track mRNA abundance, implying post-transcriptional regulation and/or altered protein stability. An autoregulatory model involving pre-trnK/MatK complexes has been proposed.</td>
+<td>Quantitative expression profiling; mathematical modeling</td>
+<td>Protein maximum at <strong>7 dpi</strong>, pre-trnK-matK maximum around <strong>25 dpi</strong>, mature trnK maximum around <strong>59 dpi</strong>; pre-trnK/MatK complex ratio <strong>RR25d/7d = 1.24</strong> in the model.</td>
+<td>Hertel et al. 2013, https://doi.org/10.1104/pp.113.227579 (hertel2013multiplecheckpointsfor pages 8-9); Zoschke et al. 2010, https://doi.org/10.1073/pnas.0909400107 (zoschke2010anorganellarmaturase pages 1-1)</td>
+</tr>
+<tr>
+<td>Current applications: plant DNA barcoding</td>
+<td>Outside functional biology, <strong>matK DNA sequence</strong> is widely used as a plant barcode and phylogenetic marker. Its practical performance varies by taxon and primer design; it is often used with additional loci rather than alone.</td>
+<td>Applied barcoding studies and review synthesis</td>
+<td>In invasive plants (91 species), overall PCR+sequencing success across four loci was <strong>87.9%</strong>; <strong>rbcL+matK</strong> gave <strong>68.6%</strong> discrimination, while <strong>ITS+trnH-psbA</strong> reached <strong>97.1%</strong>. In Cactaceae, BLAST-based <strong>matK</strong> identification reached <strong>83.33% genus</strong> and <strong>50% species</strong>; universal matK primers amplified <strong>&lt;10%</strong>, but lineage-specific primers raised amplification to <strong>91.95%</strong> and sequence recovery to <strong>54.16%</strong>.</td>
+<td>Nath et al. 2024, <em>Plant Direct</em>, doi:10.1002/pld3.615, https://doi.org/10.1002/pld3.615 (nath2024dnabarcodingof pages 9-10, nath2024dnabarcodingof pages 2-3); Wei et al. 2024, <em>Pakistan Journal of Botany</em>, doi:10.30848/pjb2024-5(11), https://doi.org/10.30848/pjb2024-5(11) (wei2024effectivenessofdna pages 3-4, wei2024effectivenessofdna pages 1-2, wei2024effectivenessofdna pages 11-15)</td>
+</tr>
+<tr>
+<td>Current applications: forensic / multi-locus barcoding interpretation</td>
+<td>Recent reviews conclude matK remains useful, but single-locus performance is inconsistent; multi-marker or super-barcode approaches usually improve species discrimination.</td>
+<td>Review of applied barcoding datasets</td>
+<td>Review-cited examples reported <strong>matK 91.8%</strong> recovery in one wood-forensics context, but only <strong>62.5%</strong> species-identification success in a <em>Paphiopedilum</em> dataset; 3-marker combinations averaged <strong>91.4%</strong>, and <strong>psbA-trnH + trnK</strong> reached <strong>100%</strong> in one study.</td>
+<td>Behura et al. 2024, <em>Biosciences Biotechnology Research Asia</em>, doi:10.13005/bbra/3275, https://doi.org/10.13005/bbra/3275 (behura2024differentdnabarcoding pages 7-9)</td>
+</tr>
+</tbody>
+</table>
+<p><em>Table: This table summarizes the conserved functional annotation of chloroplast MatK relevant to UniProt Q9GF35 from Thlaspi arvense, integrating core mechanistic evidence, validated intron targets, localization, regulation, and recent applied barcoding data. It is useful for distinguishing MatK’s primary biological role as a plastid intron maturase from its widespread use as a DNA barcode marker.</em></p>
+<h3 id="urls-and-publication-dates-key-sources">URLs and publication dates (key sources)</h3>
+<ul>
+<li>Zoschke et al. <strong>2010-01</strong>. <em>PNAS</em> “An organellar maturase associates with multiple group II introns.” https://doi.org/10.1073/pnas.0909400107 (zoschke2010anorganellarmaturase pages 1-1)</li>
+<li>Hertel et al. <strong>2013-10</strong>. <em>Plant Physiology</em> “Multiple Checkpoints for the Expression of the Chloroplast-Encoded Splicing Factor MatK.” https://doi.org/10.1104/pp.113.227579 (hertel2013multiplecheckpointsfor pages 8-9)</li>
+<li>Barthet et al. <strong>2020-03</strong>. <em>Plant Direct</em> “Unraveling the role of the enigmatic MatK maturase in chloroplast group IIA intron excision.” https://doi.org/10.1002/pld3.208 (barthet2020unravelingtherole pages 1-2)</li>
+<li>Nath et al. <strong>2024-06</strong>. <em>Plant Direct</em> “DNA barcoding of terrestrial invasive plant species in Southwest Michigan.” https://doi.org/10.1002/pld3.615 (nath2024dnabarcodingof pages 2-3)</li>
+<li>Wei et al. <strong>2024-03</strong>. <em>Pakistan Journal of Botany</em> “Effectiveness of DNA barcodes (rbcL, matK, ITS2) in identifying genera and species in Cactaceae.” https://doi.org/10.30848/pjb2024-5(11) (wei2024effectivenessofdna pages 1-2)</li>
+<li>Behura et al. <strong>2024-09</strong>. <em>Biosciences Biotechnology Research Asia</em> “Different DNA Barcoding Techniques in Forensic Botany: A Review.” https://doi.org/10.13005/bbra/3275 (behura2024differentdnabarcoding pages 7-9)</li>
+<li>Primandiri et al. <strong>2024-01</strong>. “The Maturase K Region of Kebak, A Javanese Cultural Flora.” https://doi.org/10.2991/978-2-38476-283-5_38 (primandiri2024thematurasek pages 1-5)</li>
+</ul>
+<p>References</p>
+<ol>
+<li>
+<p>(zoschke2010anorganellarmaturase pages 1-1): Reimo Zoschke, Masayuki Nakamura, Karsten Liere, Masahiro Sugiura, Thomas Börner, and Christian Schmitz-Linneweber. An organellar maturase associates with multiple group ii introns. Proceedings of the National Academy of Sciences, 107:3245-3250, Jan 2010. URL: https://doi.org/10.1073/pnas.0909400107, doi:10.1073/pnas.0909400107. This article has 200 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(mizrahi2022groupiiintronencoded pages 6-7): Ron Mizrahi, Sofia Shevtsov-Tal, and Oren Ostersetzer-Biran. Group ii intron-encoded proteins (ieps/maturases) as key regulators of nad1 expression and complex i biogenesis in land plant mitochondria. Genes, 13:1137, Jun 2022. URL: https://doi.org/10.3390/genes13071137, doi:10.3390/genes13071137. This article has 10 citations.</p>
+</li>
+<li>
+<p>(barthet2020unravelingtherole pages 1-2): Michelle M. Barthet, Christopher L. Pierpont, and Emilie‐Katherine Tavernier. Unraveling the role of the enigmatic matk maturase in chloroplast group iia intron excision. Plant Direct, Mar 2020. URL: https://doi.org/10.1002/pld3.208, doi:10.1002/pld3.208. This article has 45 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(qu2015analysisoftargets pages 18-21): Yujiao Qu. Analysis of targets and functions of the chloroplast intron maturase matk. ArXiv, Jun 2015. URL: https://doi.org/10.18452/17256, doi:10.18452/17256. This article has 0 citations.</p>
+</li>
+<li>
+<p>(zoschke2010anorganellarmaturase pages 3-3): Reimo Zoschke, Masayuki Nakamura, Karsten Liere, Masahiro Sugiura, Thomas Börner, and Christian Schmitz-Linneweber. An organellar maturase associates with multiple group ii introns. Proceedings of the National Academy of Sciences, 107:3245-3250, Jan 2010. URL: https://doi.org/10.1073/pnas.0909400107, doi:10.1073/pnas.0909400107. This article has 200 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(hertel2013multiplecheckpointsfor pages 8-9): Stefanie Hertel, Reimo Zoschke, Laura Neumann, Yujiao Qu, Ilka M. Axmann, and Christian Schmitz-Linneweber. Multiple checkpoints for the expression of the chloroplast-encoded splicing factor matk. Plant Physiology, 163(4):1686-1698, Oct 2013. URL: https://doi.org/10.1104/pp.113.227579, doi:10.1104/pp.113.227579. This article has 23 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(qu2015analysisoftargets pages 60-63): Yujiao Qu. Analysis of targets and functions of the chloroplast intron maturase matk. ArXiv, Jun 2015. URL: https://doi.org/10.18452/17256, doi:10.18452/17256. This article has 0 citations.</p>
+</li>
+<li>
+<p>(primandiri2024thematurasek pages 1-5): Poppy Rahmatika Primandiri, Muhammad Rifqi Hariri, Tutut Indah Sulistiyowati, and Agus Muji Santoso. The maturase k region of kebak, a javanese cultural flora. Advances in Social Science, Education and Humanities Research, pages 408-414, Jan 2024. URL: https://doi.org/10.2991/978-2-38476-283-5_38, doi:10.2991/978-2-38476-283-5_38. This article has 0 citations.</p>
+</li>
+<li>
+<p>(nath2024dnabarcodingof pages 2-3): Sneha Nath, Joshua T. VanSlambrouck, Janelle W. Yao, Ashika Gullapalli, Fayyaz Razi, and Yan Lu. Dna barcoding of terrestrial invasive plant species in southwest michigan. Plant Direct, Jun 2024. URL: https://doi.org/10.1002/pld3.615, doi:10.1002/pld3.615. This article has 10 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(nath2024dnabarcodingof pages 9-10): Sneha Nath, Joshua T. VanSlambrouck, Janelle W. Yao, Ashika Gullapalli, Fayyaz Razi, and Yan Lu. Dna barcoding of terrestrial invasive plant species in southwest michigan. Plant Direct, Jun 2024. URL: https://doi.org/10.1002/pld3.615, doi:10.1002/pld3.615. This article has 10 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(wei2024effectivenessofdna pages 3-4): Lihua Wei, Flor Cristina Pacheco-Reyes, José Ángel Villarreal-Quintanilla, Valentín Robledo-Torres, Juan Antonio Encina-Domínguez, Edgar Eduardo Lara-Ramírez, and Miguel Ángel Pérez-Rodríguez. Effectiveness of dna barcodes (rbcl, matk, its2) in identifying genera and species in cactaceae. Pakistan Journal of Botany, Mar 2024. URL: https://doi.org/10.30848/pjb2024-5(11), doi:10.30848/pjb2024-5(11). This article has 10 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(wei2024effectivenessofdna pages 1-2): Lihua Wei, Flor Cristina Pacheco-Reyes, José Ángel Villarreal-Quintanilla, Valentín Robledo-Torres, Juan Antonio Encina-Domínguez, Edgar Eduardo Lara-Ramírez, and Miguel Ángel Pérez-Rodríguez. Effectiveness of dna barcodes (rbcl, matk, its2) in identifying genera and species in cactaceae. Pakistan Journal of Botany, Mar 2024. URL: https://doi.org/10.30848/pjb2024-5(11), doi:10.30848/pjb2024-5(11). This article has 10 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(behura2024differentdnabarcoding pages 7-9): Nisruti Anuja Behura, Naga Jogayya Kothakota, Sheerin Bashar, and Pravallika Vataparthi. Different dna barcoding techniques in forensic botany: a review. Biosciences Biotechnology Research Asia, 21:935-945, Sep 2024. URL: https://doi.org/10.13005/bbra/3275, doi:10.13005/bbra/3275. This article has 3 citations.</p>
+</li>
+<li>
+<p>(qu2015analysisoftargets pages 15-18): Yujiao Qu. Analysis of targets and functions of the chloroplast intron maturase matk. ArXiv, Jun 2015. URL: https://doi.org/10.18452/17256, doi:10.18452/17256. This article has 0 citations.</p>
+</li>
+<li>
+<p>(qu2015analysisoftargets pages 56-60): Yujiao Qu. Analysis of targets and functions of the chloroplast intron maturase matk. ArXiv, Jun 2015. URL: https://doi.org/10.18452/17256, doi:10.18452/17256. This article has 0 citations.</p>
+</li>
+<li>
+<p>(wei2024effectivenessofdna pages 11-15): Lihua Wei, Flor Cristina Pacheco-Reyes, José Ángel Villarreal-Quintanilla, Valentín Robledo-Torres, Juan Antonio Encina-Domínguez, Edgar Eduardo Lara-Ramírez, and Miguel Ángel Pérez-Rodríguez. Effectiveness of dna barcodes (rbcl, matk, its2) in identifying genera and species in cactaceae. Pakistan Journal of Botany, Mar 2024. URL: https://doi.org/10.30848/pjb2024-5(11), doi:10.30848/pjb2024-5(11). This article has 10 citations and is from a peer-reviewed journal.</p>
+</li>
+</ol>
+<h2 id="artifacts">Artifacts</h2>
+<ul>
+<li><a href="matK-deep-research-falcon_artifacts/artifact-00.md">Edison artifact artifact-00</a></li>
+</ul>
+<h2 id="citations">Citations</h2>
+<ol>
+<li>zoschke2010anorganellarmaturase pages 1-1</li>
+<li>barthet2020unravelingtherole pages 1-2</li>
+<li>qu2015analysisoftargets pages 60-63</li>
+<li>hertel2013multiplecheckpointsfor pages 8-9</li>
+<li>primandiri2024thematurasek pages 1-5</li>
+<li>behura2024differentdnabarcoding pages 7-9</li>
+<li>mizrahi2022groupiiintronencoded pages 6-7</li>
+<li>nath2024dnabarcodingof pages 2-3</li>
+<li>wei2024effectivenessofdna pages 1-2</li>
+<li>qu2015analysisoftargets pages 18-21</li>
+<li>zoschke2010anorganellarmaturase pages 3-3</li>
+<li>nath2024dnabarcodingof pages 9-10</li>
+<li>wei2024effectivenessofdna pages 3-4</li>
+<li>qu2015analysisoftargets pages 15-18</li>
+<li>qu2015analysisoftargets pages 56-60</li>
+<li>wei2024effectivenessofdna pages 11-15</li>
+<li>https://doi.org/10.1073/pnas.0909400107</li>
+<li>https://doi.org/10.1104/pp.113.227579</li>
+<li>https://doi.org/10.3390/genes13071137</li>
+<li>https://doi.org/10.1002/pld3.208</li>
+<li>https://doi.org/10.18452/17256</li>
+<li>https://doi.org/10.1002/pld3.615</li>
+<li>https://doi.org/10.30848/pjb2024-5(11</li>
+<li>https://doi.org/10.13005/bbra/3275</li>
+<li>https://doi.org/10.2991/978-2-38476-283-5_38</li>
+<li>https://doi.org/10.1073/pnas.0909400107,</li>
+<li>https://doi.org/10.3390/genes13071137,</li>
+<li>https://doi.org/10.1002/pld3.208,</li>
+<li>https://doi.org/10.18452/17256,</li>
+<li>https://doi.org/10.1104/pp.113.227579,</li>
+<li>https://doi.org/10.2991/978-2-38476-283-5_38,</li>
+<li>https://doi.org/10.1002/pld3.615,</li>
+<li>https://doi.org/10.13005/bbra/3275,</li>
+</ol>
+            </div>
+        </details>
+        
+    </div>
+    
+
+    <!-- Additional Documentation Sections -->
+    
+    <div class="section">
+        <h2 class="section-title">📚 Additional Documentation</h2>
+        
+        <details class="markdown-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; cursor: pointer;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Notes</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(matK-notes.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="Q9GF35" data-a="DOC: Notes" data-r="" data-act="DOCUMENTATION" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This documentation is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This documentation needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+                <h1 id="matk-maturase-k-thlaspi-arvense-review-notes">matK (Maturase K) — Thlaspi arvense — review notes</h1>
+<p>UniProt: Q9GF35 · Plastid (chloroplast) genome-encoded · Taxon 13288 (<em>Thlaspi arvense</em>)<br />
+Family: intron maturase 2 family, MatK subfamily (HAMAP MF_01390)</p>
+<h2 id="function-homology-grounded-pennycress-protein-itself-not-assayed">Function (homology-grounded; pennycress protein itself not assayed)</h2>
+<ul>
+<li>MatK is the <strong>only chloroplast-encoded intron maturase</strong> retained in the plastid genome,<br />
+  typically encoded <strong>within the intron of the trnK-UUU (lysine tRNA) gene</strong>. It is a<br />
+<strong>trans-acting group II intron splicing factor</strong>: it binds intron RNA and promotes<br />
+  excision of a conserved set of chloroplast <strong>group IIA introns</strong>.<br />
+  [file:THLAR/matK/matK-deep-research-falcon.md; UniProt Q9GF35 FUNCTION]</li>
+<li>Best-supported RNA targets (~7 group IIA introns): trnK-UUU (its own host intron),<br />
+  trnA, trnI, trnV, atpF, rpl2, and rps12 intron 2. In vitro, adding MatK increases<br />
+  splicing efficiency of rps12 intron 2; in vivo RIP shows association with multiple<br />
+  intron-containing transcripts. [file:THLAR/matK/matK-deep-research-falcon.md]</li>
+<li>Domain architecture: retains maturase "domain X" (RNA-binding/splicing) and a partial<br />
+  reverse-transcriptase-like region; lacks the endonuclease/mobility domains of canonical<br />
+  bacterial intron-encoded proteins — consistent with a dedicated splicing role.</li>
+</ul>
+<h2 id="localization">Localization</h2>
+<ul>
+<li>Chloroplast <strong>stroma</strong> (soluble fraction in transplastomic tobacco), not membranes.<br />
+  [file:THLAR/matK/matK-deep-research-falcon.md]</li>
+</ul>
+<h2 id="essentiality-regulation">Essentiality / regulation</h2>
+<ul>
+<li>matK knockouts could not be driven to homoplasmy in tobacco plastids → interpreted as<br />
+  essential. Developmentally regulated with mRNA-protein discordance.</li>
+</ul>
+<h2 id="applied-note-doeber-adjacent">Applied note (DOE/BER-adjacent)</h2>
+<ul>
+<li>matK is one of the most widely used <strong>chloroplast DNA barcode / phylogenetic markers</strong><br />
+  (a distinct use from its protein maturase function). Relevant for germplasm /<br />
+  species identification in breeding programs, not for the bioenergy oil/biomass traits.</li>
+</ul>
+<h2 id="annotation-review-decisions">Annotation review decisions</h2>
+<ul>
+<li>GO:0005737 cytoplasm (IEA/ARBA) → <strong>MODIFY → GO:0009570 chloroplast stroma</strong>: matK is<br />
+  plastid-encoded and stroma-localized; generic "cytoplasm" is over-general and redundant<br />
+  with the chloroplast annotation.</li>
+<li>GO:0006397 mRNA processing (IEA/InterPro) → <strong>ACCEPT</strong>: several MatK targets are introns<br />
+  in protein-coding (mRNA) transcripts (atpF, rpl2, rps12).</li>
+<li>GO:0008380 RNA splicing (IEA/UniRule) → <strong>MODIFY → GO:0000373 Group II intron splicing</strong>:<br />
+  the precise, well-supported activity.</li>
+<li>GO:0009507 chloroplast (IEA) → <strong>ACCEPT</strong>: correct compartment.</li>
+<li>No MF annotation in GOA; the protein is an RNA-binding splicing factor → core MF<br />
+  GO:0003723 RNA binding.</li>
+</ul>
+            </div>
+        </details>
+        
+    </div>
+    
+
+    <!-- YAML Preview Section -->
+    <div class="section">
+        <details class="yaml-preview">
+            <summary>
+                <h2 style="display: inline;">📄 View Raw YAML</h2>
+            </summary>
+            <div class="yaml-content">
+                <pre><code>id: Q9GF35
+gene_symbol: matK
+product_type: PROTEIN
+status: COMPLETE
+taxon:
+  id: NCBITaxon:13288
+  label: Thlaspi arvense
+description: Maturase K (MatK) is the chloroplast-encoded intron maturase of field
+  pennycress, typically encoded within the intron of the plastid trnK-UUU (lysine tRNA)
+  gene. It is the only maturase retained in the plastid genome and acts as a trans-acting
+  splicing factor that binds intron RNA and promotes excision of a conserved set of
+  chloroplast group IIA introns (including its own trnK host intron and introns in trnA,
+  trnI, trnV, atpF, rpl2 and rps12). It functions in the chloroplast stroma. MatK retains
+  the maturase &#34;domain X&#34; and a degenerate reverse-transcriptase-like region but lacks
+  the endonuclease/mobility domains of canonical bacterial intron-encoded proteins. The
+  gene is also widely used as a plastid DNA barcode and phylogenetic marker.
+existing_annotations:
+  - term:
+      id: GO:0005737
+      label: cytoplasm
+    evidence_type: IEA
+    original_reference_id: GO_REF:0000117
+    qualifier: located_in
+    review:
+      summary: Over-general and redundant. MatK is a plastid genome-encoded protein
+        that localizes to the chloroplast stroma (soluble fraction in transplastomic
+        tobacco); the generic cytoplasm term should be specialized to the chloroplast
+        stroma, consistent with the separate chloroplast annotation.
+      action: MODIFY
+      proposed_replacement_terms:
+        - id: GO:0009570
+          label: chloroplast stroma
+      supported_by:
+        - reference_id: file:THLAR/matK/matK-deep-research-falcon.md
+          supporting_text: MatK is a chloroplast protein enriched in the soluble
+            fraction (stroma) rather than membranes
+  - term:
+      id: GO:0006397
+      label: mRNA processing
+    evidence_type: IEA
+    original_reference_id: GO_REF:0000002
+    qualifier: involved_in
+    review:
+      summary: Acceptable. Several MatK splicing targets are group IIA introns within
+        protein-coding (mRNA) transcripts, including atpF, rpl2 and rps12, so MatK does
+        contribute to mRNA processing. The more precise activity is captured by the
+        group II intron splicing annotation below.
+      action: ACCEPT
+      supported_by:
+        - reference_id: file:THLAR/matK/matK-deep-research-falcon.md
+          supporting_text: MatK-dependent group IIA introns include atpF, rpl2 and
+            rps12 intron 2
+  - term:
+      id: GO:0008380
+      label: RNA splicing
+    evidence_type: IEA
+    original_reference_id: GO_REF:0000104
+    qualifier: involved_in
+    review:
+      summary: Correct but can be made precise. MatK is specifically a group II intron
+        maturase / splicing factor acting on chloroplast group IIA introns. The
+        dedicated group II intron splicing term is more informative than the generic
+        RNA splicing parent.
+      action: MODIFY
+      proposed_replacement_terms:
+        - id: GO:0000373
+          label: Group II intron splicing
+      supported_by:
+        - reference_id: file:THLAR/matK/matK-deep-research-falcon.md
+          supporting_text: MatK facilitates splicing (excision) of chloroplast group
+            IIA introns as a trans-acting maturase
+  - term:
+      id: GO:0009507
+      label: chloroplast
+    evidence_type: IEA
+    original_reference_id: GO_REF:0000120
+    qualifier: located_in
+    review:
+      summary: Correct. MatK is plastid genome-encoded and functions in the chloroplast.
+        Consistent with the UniProt subcellular location (Plastid, chloroplast).
+      action: ACCEPT
+      supported_by:
+        - reference_id: file:THLAR/matK/matK-deep-research-falcon.md
+          supporting_text: chloroplast-encoded intron maturase localized to the
+            chloroplast stroma
+  - term:
+      id: GO:0003723
+      label: RNA binding
+    evidence_type: IEA
+    review:
+      summary: Proposed new molecular-function annotation. GOA currently lists no
+        molecular function for MatK, but the protein is an RNA-binding intron maturase
+        that binds its target group IIA introns to promote splicing; the conserved
+        maturase domain X is an RNA-binding region. This is the core molecular function
+        and should be added.
+      action: NEW
+      supported_by:
+        - reference_id: file:THLAR/matK/matK-deep-research-falcon.md
+          supporting_text: Maturases act as cofactors by binding intron RNA to
+            stabilize the correct folded state and promote catalytic steps; MatK
+            associates with multiple intron-containing transcripts in vivo
+core_functions:
+  - description: MatK is a chloroplast-encoded, RNA-binding group II intron maturase
+      that acts as a trans-acting splicing factor, promoting excision of a conserved set
+      of chloroplast group IIA introns in the stroma.
+    molecular_function:
+      id: GO:0003723
+      label: RNA binding
+    directly_involved_in:
+      - id: GO:0000373
+        label: Group II intron splicing
+    locations:
+      - id: GO:0009570
+        label: chloroplast stroma
+    supported_by:
+      - reference_id: file:THLAR/matK/matK-deep-research-falcon.md
+        supporting_text: trans-acting splicing cofactor for chloroplast group IIA
+          introns (trnK, trnA, trnI, trnV, atpF, rpl2, rps12 intron 2), stroma-localized
+references:
+  - id: GO_REF:0000002
+    title: Gene Ontology annotation through association of InterPro records with GO
+      terms
+    findings: []
+  - id: GO_REF:0000104
+    title: Electronic Gene Ontology annotations created by transferring manual GO
+      annotations between related proteins based on shared sequence features
+    findings: []
+  - id: GO_REF:0000117
+    title: Electronic Gene Ontology annotations created by ARBA machine learning models
+    findings: []
+  - id: GO_REF:0000120
+    title: Combined Automated Annotation using Multiple IEA Methods
+    findings: []
+  - id: file:THLAR/matK/matK-deep-research-falcon.md
+    title: Falcon/Edison deep research report for matK, Thlaspi arvense
+    findings:
+      - statement: MatK is the chloroplast-encoded group II intron maturase, a
+          stroma-localized trans-acting splicing factor for a conserved set of
+          chloroplast group IIA introns; the pennycress protein itself has not been
+          directly assayed, so function is inferred from conserved land-plant MatK
+          biology.
+        reference_section_type: OTHER
+suggested_questions:
+  - question: Which chloroplast group IIA introns does Thlaspi arvense MatK splice in
+      vivo, and is MatK essential for plastid gene expression in pennycress as it is in
+      tobacco?
+</code></pre>
+            </div>
+        </details>
+    </div>
+
+    <!-- Pathway Visualization Link -->
+    
+
+    <style>
+        /* Markdown Section Styles */
+        .markdown-section {
+            margin-bottom: 1rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .markdown-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .markdown-section summary h3 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.1rem;
+        }
+
+        .markdown-section summary:hover h3 {
+            color: #007bff;
+        }
+
+        .markdown-section[open] {
+            background-color: #fff;
+        }
+
+        .markdown-content {
+            margin-top: 1rem;
+            padding: 1rem;
+            border-top: 1px solid #dee2e6;
+        }
+
+        /* Markdown content styling */
+        .markdown-content h1 { font-size: 1.5rem; margin-top: 1.5rem; }
+        .markdown-content h2 { font-size: 1.3rem; margin-top: 1.3rem; }
+        .markdown-content h3 { font-size: 1.1rem; margin-top: 1.1rem; }
+        .markdown-content h4 { font-size: 1rem; margin-top: 1rem; }
+
+        .markdown-content pre {
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .markdown-content code {
+            background-color: #f8f9fa;
+            padding: 0.2rem 0.4rem;
+            border-radius: 3px;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+        }
+
+        .markdown-content pre code {
+            background: none;
+            padding: 0;
+        }
+
+        .markdown-content table {
+            border-collapse: collapse;
+            width: 100%;
+            margin: 1rem 0;
+        }
+
+        .markdown-content table th,
+        .markdown-content table td {
+            border: 1px solid #dee2e6;
+            padding: 0.5rem;
+            text-align: left;
+        }
+
+        .markdown-content table th {
+            background-color: #f8f9fa;
+            font-weight: bold;
+        }
+
+        .markdown-content blockquote {
+            border-left: 4px solid #007bff;
+            padding-left: 1rem;
+            margin-left: 0;
+            color: #666;
+        }
+
+        /* YAML Preview Styles */
+        .yaml-preview {
+            margin-top: 2rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .yaml-preview summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .yaml-preview summary h2 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.3rem;
+        }
+
+        .yaml-preview summary:hover h2 {
+            color: #007bff;
+        }
+
+        .yaml-preview[open] {
+            background-color: #fff;
+        }
+
+        .yaml-content {
+            margin-top: 1rem;
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .yaml-content pre {
+            margin: 0;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+            line-height: 1.4;
+        }
+
+        .yaml-content code {
+            color: #333;
+            background: none;
+            padding: 0;
+        }
+
+        /* Pathway Link Styles */
+        .pathway-link {
+            margin: 1rem 0;
+        }
+
+        .btn-link {
+            display: inline-block;
+            padding: 0.5rem 1rem;
+            background-color: #007bff;
+            color: white !important;
+            text-decoration: none;
+            border-radius: 4px;
+            font-weight: 500;
+            transition: background-color 0.2s;
+        }
+
+        .btn-link:hover {
+            background-color: #0056b3;
+            text-decoration: none;
+        }
+
+        /* Voting buttons */
+        .vote-buttons {
+            display: inline-block;
+            margin-left: 0.5rem;
+        }
+
+        .vote-btn {
+            background: none;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 2px 6px;
+            margin: 0 2px;
+            cursor: pointer;
+            font-size: 0.9rem;
+            transition: all 0.2s;
+            opacity: 0.6;
+        }
+
+        .vote-btn:hover {
+            opacity: 1;
+            transform: scale(1.1);
+        }
+
+        .vote-btn.voted {
+            opacity: 1;
+            border-color: #28a745;
+            background-color: #d4edda;
+        }
+
+        .vote-btn.voted-down {
+            border-color: #dc3545;
+            background-color: #f8d7da;
+        }
+
+        .vote-btn-small {
+            font-size: 0.7rem;
+            padding: 1px 4px;
+            margin: 0 1px;
+        }
+    </style>
+
+    <script>
+        // Add collapsible functionality
+        document.querySelectorAll('.collapsible').forEach(element => {
+            element.addEventListener('click', function() {
+                this.classList.toggle('collapsed');
+            });
+        });
+
+        // Voting functionality
+        const VOTE_URL = 'https://script.google.com/macros/s/AKfycbwPKH7d3seuPNBtB0ugVjqGeTiByyOGD5vkqB_Ck6K8eOcPQYbJqBOuz6GFgXHKBNWK/exec';
+
+        // Get or create session ID
+        let sessionId = localStorage.getItem('review_session_id');
+        if (!sessionId) {
+            sessionId = 's' + Date.now() + '_' + Math.random().toString(36).substr(2, 9);
+            localStorage.setItem('review_session_id', sessionId);
+        }
+
+        // Show previous votes on page load
+        document.addEventListener('DOMContentLoaded', function() {
+            document.querySelectorAll('.vote-buttons').forEach(container => {
+                const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+                const previousVote = localStorage.getItem(key);
+                if (previousVote) {
+                    const btn = container.querySelector(`[data-v="${previousVote}"]`);
+                    if (btn) btn.classList.add(previousVote === 'up' ? 'voted' : 'voted-down');
+                }
+            });
+        });
+
+        // Handle vote clicks - Simple image beacon approach
+        document.addEventListener('click', function(e) {
+            if (!e.target.classList.contains('vote-btn')) return;
+
+            // Prevent the click from bubbling to parent elements (like summary)
+            e.preventDefault();
+            e.stopPropagation();
+
+            const btn = e.target;
+            const container = btn.closest('.vote-buttons');
+            if (!container) return;
+
+            const voteType = btn.dataset.v;
+
+            // Check if already voted (locally)
+            const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+            const previousVote = localStorage.getItem(key);
+
+            if (previousVote === voteType) {
+                // Same vote - do nothing
+                btn.style.animation = 'shake 0.5s';
+                setTimeout(() => btn.style.animation = '', 500);
+                return;
+            }
+
+            // Build URL
+            const params = new URLSearchParams({
+                gene_id: container.dataset.g,
+                annotation_id: container.dataset.a,
+                ref_id: container.dataset.r || '',
+                action: container.dataset.act,
+                vote: voteType,
+                session_id: sessionId,
+                ua: navigator.userAgent.substring(0, 100)
+            });
+
+            // Clear previous vote styling
+            container.querySelectorAll('.vote-btn').forEach(b => {
+                b.classList.remove('voted', 'voted-down');
+            });
+
+            // Apply new vote styling immediately (optimistic UI)
+            btn.classList.add(voteType === 'up' ? 'voted' : 'voted-down');
+
+            // Store locally
+            localStorage.setItem(key, voteType);
+
+            // Send vote using fetch with no-cors mode (fire and forget)
+            const fullUrl = VOTE_URL + '?' + params;
+            console.log('Sending vote to:', fullUrl);
+
+            // Use fetch in no-cors mode - we won't get a response but the request will be sent
+            fetch(fullUrl, {
+                mode: 'no-cors',
+                method: 'GET'
+            }).then(() => {
+                console.log('Vote request sent (no response due to no-cors mode)');
+            }).catch(err => {
+                console.warn('Vote may not have been recorded, but saved locally:', err);
+
+                // Fallback: try image beacon as well
+                const img = new Image();
+                img.src = fullUrl;
+            });
+        });
+
+        // Optional: Add shake animation for feedback
+        const style = document.createElement('style');
+        style.textContent = `
+            @keyframes shake {
+                0%, 100% { transform: translateX(0); }
+                25% { transform: translateX(-5px); }
+                75% { transform: translateX(5px); }
+            }
+        `;
+        document.head.appendChild(style);
+    </script>
+</body>
+</html>

--- a/pages/projects/PHOTOSYNTHESIS.html
+++ b/pages/projects/PHOTOSYNTHESIS.html
@@ -1,0 +1,636 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Photosynthesis Project - AI Gene Review Projects</title>
+    <style>
+        :root {
+            --color-accept: #22c55e;
+            --color-remove: #ef4444;
+            --color-modify: #f97316;
+            --color-primary: #3498db;
+            --bg-light: #f9fafb;
+            --border-color: #e5e7eb;
+            --text-muted: #6b7280;
+            --text-primary: #111827;
+        }
+
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+            line-height: 1.6;
+            color: var(--text-primary);
+            background-color: #ffffff;
+            padding: 2rem;
+            max-width: 1200px;
+            margin: 0 auto;
+        }
+
+        .breadcrumb {
+            margin-bottom: 1.5rem;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .breadcrumb a {
+            color: var(--color-primary);
+            text-decoration: none;
+        }
+
+        .breadcrumb a:hover {
+            text-decoration: underline;
+        }
+
+        .header {
+            border-bottom: 2px solid var(--border-color);
+            padding-bottom: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        h1 {
+            font-size: 2.5rem;
+            font-weight: 700;
+            margin-bottom: 0.5rem;
+            color: #1f2937;
+        }
+
+        h2 {
+            font-size: 1.75rem;
+            font-weight: 600;
+            margin-top: 2rem;
+            margin-bottom: 1rem;
+            color: #1f2937;
+            border-bottom: 1px solid var(--border-color);
+            padding-bottom: 0.5rem;
+        }
+
+        h3 {
+            font-size: 1.25rem;
+            font-weight: 600;
+            margin-top: 1.5rem;
+            margin-bottom: 0.75rem;
+            color: #374151;
+        }
+
+        h4 {
+            font-size: 1rem;
+            font-weight: 600;
+            margin-top: 1.25rem;
+            margin-bottom: 0.5rem;
+            color: #4b5563;
+        }
+
+        p {
+            margin-bottom: 1rem;
+        }
+
+        a {
+            color: var(--color-primary);
+            text-decoration: none;
+        }
+
+        a:hover {
+            text-decoration: underline;
+        }
+
+        /* Gene symbol links */
+        .content a[href*="/genes/"] {
+            background-color: #dbeafe;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-weight: 500;
+        }
+
+        .content a[href*="/genes/"]:hover {
+            background-color: #bfdbfe;
+        }
+
+        ul, ol {
+            margin-bottom: 1rem;
+            padding-left: 2rem;
+        }
+
+        li {
+            margin-bottom: 0.25rem;
+        }
+
+        code {
+            background: #f4f4f4;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-family: 'SFMono-Regular', Consolas, 'Liberation Mono', Menlo, monospace;
+            font-size: 0.875em;
+        }
+
+        pre {
+            background: #1f2937;
+            color: #f9fafb;
+            padding: 1rem;
+            border-radius: 0.5rem;
+            overflow-x: auto;
+            margin-bottom: 1rem;
+        }
+
+        pre code {
+            background: none;
+            padding: 0;
+            color: inherit;
+        }
+
+        blockquote {
+            border-left: 4px solid var(--color-primary);
+            margin-left: 0;
+            padding-left: 1.5rem;
+            color: #4b5563;
+            font-style: italic;
+            margin-bottom: 1rem;
+        }
+
+        table {
+            width: 100%;
+            border-collapse: collapse;
+            margin: 1.5rem 0;
+        }
+
+        th, td {
+            border: 1px solid var(--border-color);
+            padding: 0.75rem;
+            text-align: left;
+        }
+
+        th {
+            background-color: var(--bg-light);
+            font-weight: 600;
+            color: var(--text-muted);
+            text-transform: uppercase;
+            font-size: 0.75rem;
+            letter-spacing: 0.05em;
+        }
+
+        tr:nth-child(even) {
+            background-color: #f9fafb;
+        }
+
+        tr:hover {
+            background-color: #f3f4f6;
+        }
+
+        /* Mermaid diagrams */
+        .mermaid {
+            text-align: center;
+            margin: 2rem 0;
+            background: white;
+            padding: 1.5rem;
+            border-radius: 0.5rem;
+            border: 1px solid var(--border-color);
+        }
+
+        .mermaid svg {
+            max-width: 100%;
+            height: auto;
+        }
+
+        /* Warnings section */
+        .warnings {
+            background-color: #fef3c7;
+            border: 1px solid #fde68a;
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 2rem;
+        }
+
+        .warnings h3 {
+            color: #92400e;
+            margin-top: 0;
+            margin-bottom: 0.5rem;
+            font-size: 1rem;
+        }
+
+        .warnings ul {
+            margin-bottom: 0;
+            color: #78350f;
+        }
+
+        /* Task lists (checkboxes) */
+        li input[type="checkbox"] {
+            margin-right: 0.5rem;
+        }
+
+        /* Status badges */
+        .badge {
+            display: inline-block;
+            padding: 0.25rem 0.625rem;
+            border-radius: 9999px;
+            font-size: 0.75rem;
+            font-weight: 600;
+            text-transform: uppercase;
+        }
+
+        .badge-success {
+            background-color: #d1fae5;
+            color: #065f46;
+        }
+
+        .badge-warning {
+            background-color: #fef3c7;
+            color: #92400e;
+        }
+
+        .badge-info {
+            background-color: #dbeafe;
+            color: #1e40af;
+        }
+
+        /* Content wrapper */
+        .content {
+            margin-bottom: 2rem;
+        }
+
+        /* Footer */
+        footer {
+            margin-top: 3rem;
+            padding-top: 1.5rem;
+            border-top: 1px solid var(--border-color);
+            color: var(--text-muted);
+            font-size: 0.875rem;
+            text-align: center;
+        }
+
+        footer small {
+            display: block;
+        }
+    </style>
+    <!-- Mermaid.js for diagram rendering -->
+    <script src="https://cdn.jsdelivr.net/npm/mermaid@10/dist/mermaid.min.js"></script>
+    <script>
+        mermaid.initialize({
+            startOnLoad: true,
+            theme: 'default',
+            themeVariables: {
+                primaryColor: '#3498db',
+                primaryTextColor: '#fff',
+                primaryBorderColor: '#2c3e50',
+                lineColor: '#333',
+                secondaryColor: '#ecf0f1',
+                tertiaryColor: '#f39c12'
+            },
+            flowchart: {
+                htmlLabels: true,
+                curve: 'basis'
+            }
+        });
+    </script>
+</head>
+<body>
+    <nav class="breadcrumb">
+        <a href="../index.html">Home</a> &raquo;
+        <a href="index.html">Projects</a> &raquo;
+        Photosynthesis Project
+    </nav>
+
+    <header class="header">
+        <h1>Photosynthesis Project</h1>
+        
+    </header>
+
+    
+    <div class="warnings">
+        <h3>Warnings (11)</h3>
+        <ul>
+            
+            <li>Ambiguous symbol &#39;psaC&#39; found in species: CHLRE, MISSI, POPTR. Add &#39;species: [CHLRE]&#39; to frontmatter to resolve.</li>
+            
+            <li>Ambiguous symbol &#39;psbA&#39; found in species: 9POAL, MISSI, POPTR. Add &#39;species: [9POAL]&#39; to frontmatter to resolve.</li>
+            
+            <li>Ambiguous symbol &#39;psbD&#39; found in species: MISSI, POPTR. Add &#39;species: [MISSI]&#39; to frontmatter to resolve.</li>
+            
+            <li>Ambiguous symbol &#39;psbB&#39; found in species: MISSI, POPTR. Add &#39;species: [MISSI]&#39; to frontmatter to resolve.</li>
+            
+            <li>Ambiguous symbol &#39;psbC&#39; found in species: MISSI, POPTR. Add &#39;species: [MISSI]&#39; to frontmatter to resolve.</li>
+            
+            <li>Ambiguous symbol &#39;psaA&#39; found in species: MISSI, POPTR. Add &#39;species: [MISSI]&#39; to frontmatter to resolve.</li>
+            
+            <li>Ambiguous symbol &#39;psaB&#39; found in species: MISSI, POPTR. Add &#39;species: [MISSI]&#39; to frontmatter to resolve.</li>
+            
+            <li>Ambiguous symbol &#39;petA&#39; found in species: MISSI, POPTR. Add &#39;species: [MISSI]&#39; to frontmatter to resolve.</li>
+            
+            <li>Ambiguous symbol &#39;atpA&#39; found in species: MISSI, POPTR. Add &#39;species: [MISSI]&#39; to frontmatter to resolve.</li>
+            
+            <li>Ambiguous symbol &#39;atpB&#39; found in species: MISSI, POPTR. Add &#39;species: [MISSI]&#39; to frontmatter to resolve.</li>
+            
+            <li>Ambiguous symbol &#39;rbcL&#39; found in species: 9POAL, MISSI, POPTR. Add &#39;species: [9POAL]&#39; to frontmatter to resolve.</li>
+            
+        </ul>
+    </div>
+    
+
+    <div class="content">
+        <h1 id="photosynthesis-project">Photosynthesis Project</h1>
+<h2 id="overview">Overview</h2>
+<p>Photosynthesis is the light-driven assimilation of CO2 into organic carbon. In oxygenic<br />
+photosynthesis (cyanobacteria, algae, plants) light energy captured by chlorophyll drives<br />
+electron transport from water to NADP+, producing NADPH, ATP, and O2 (the <strong>light<br />
+reactions</strong>), which then power the Calvin–Benson–Bassham reductive pentose-phosphate cycle<br />
+to fix CO2 (<strong>carbon fixation</strong>). It is arguably the most important biochemical process in<br />
+the biosphere and a major target for crop-improvement and synthetic-biology research.</p>
+<p>Concept-level research notes (definitions, GO representation, full component breakdown, and<br />
+verified references) live in <code>terms/photosynthesis/photosynthesis-notes.md</code>.</p>
+<h2 id="scope-of-this-first-pass">Scope of this first pass</h2>
+<p>Per the chosen scope, this pass delivers the <strong>concept writeup plus a candidate-gene<br />
+checklist</strong>; individual gene reviews are deferred. Strategy: <strong>mix across organisms</strong>,<br />
+choosing the best-characterized ortholog per functional module.</p>
+<h2 id="model-species-selection-mixed-strategy">Model species selection (mixed strategy)</h2>
+<ul>
+<li><strong>Cyanobacteria — <em>Synechocystis<em> sp. PCC 6803</em><em> (UniProt species code </em><em>SYNY3</em>*,<br />
+  taxonomy 1148) and/or </em></strong>Thermosynechococcus***: cleanest genetics for the core light<br />
+  reactions; source organisms for the landmark PSI and PSII crystal structures. Preferred<br />
+  for reaction-center and electron-transport subunits.</li>
+<li><strong>Green alga — <em>Chlamydomonas reinhardtii</em></strong> (<strong>CHLRE</strong>, taxonomy 3055): already seeded<br />
+  in this repo (psaC, <a href="../../genes/CHLRE/CP12/CP12-ai-review.html">CP12</a>, <a href="../../genes/CHLRE/LCI5/LCI5-ai-review.html">LCI5</a>); strong for CBB-cycle regulation and the<br />
+  carbon-concentrating mechanism.</li>
+<li><strong>Land plant — <em>Arabidopsis thaliana</em></strong> (<strong>ARATH</strong>): preferred for photoprotection<br />
+  (PsbS), the LHC antenna family, and nuclear-encoded Rubisco small subunit / activase.</li>
+<li><strong>Reference structural orthologs</strong> (spinach / tobacco Rubisco; <em>Thermosynechococcus</em><br />
+  PSII) where a module is best characterized elsewhere.</li>
+</ul>
+<h2 id="functional-modules-and-candidate-genes">Functional modules and candidate genes</h2>
+<p>Accessions are listed only where verified in this repository; others should be resolved<br />
+with <code>just fetch-gene &lt;organism&gt; &lt;gene&gt;</code> when each review starts (this avoids the<br />
+wrong-organism accession pitfalls seen in earlier projects).</p>
+<h3 id="module-a-photosystem-ii-water-oxidation">Module A — Photosystem II (water oxidation)</h3>
+<table>
+<thead>
+<tr>
+<th>Gene</th>
+<th>Suggested organism</th>
+<th>Role</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>psbA (D1)</td>
+<td>SYNY3 / plant chloroplast</td>
+<td>reaction-center, binds P680 + Mn4CaO5 cluster</td>
+</tr>
+<tr>
+<td>psbD (D2)</td>
+<td>SYNY3</td>
+<td>reaction-center, partners D1</td>
+</tr>
+<tr>
+<td>psbB (CP47) / psbC (CP43)</td>
+<td>SYNY3</td>
+<td>core chlorophyll antenna</td>
+</tr>
+<tr>
+<td>psbO</td>
+<td>ARATH / SYNY3</td>
+<td>oxygen-evolving complex extrinsic protein (<a href="http://amigo.geneontology.org/amigo/term/GO:0009654">GO:0009654</a>)</td>
+</tr>
+</tbody>
+</table>
+<h3 id="module-b-photosystem-i">Module B — Photosystem I</h3>
+<table>
+<thead>
+<tr>
+<th>Gene</th>
+<th>Suggested organism</th>
+<th>Role</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>psaA / psaB</td>
+<td>SYNY3</td>
+<td>reaction-center heterodimer, binds P700</td>
+</tr>
+<tr>
+<td><strong>psaC</strong></td>
+<td><strong>CHLRE (Q00914)</strong> — already seeded</td>
+<td>terminal FA/FB Fe-S clusters</td>
+</tr>
+</tbody>
+</table>
+<h3 id="module-c-electron-transport-coupling">Module C — Electron transport &amp; coupling</h3>
+<table>
+<thead>
+<tr>
+<th>Gene</th>
+<th>Suggested organism</th>
+<th>Role</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>petA / <a href="../../genes/MISSI/petB/petB-ai-review.html">petB</a> / petC</td>
+<td>SYNY3</td>
+<td>cytochrome b6f complex (Q-cycle, proton translocation)</td>
+</tr>
+<tr>
+<td>petE</td>
+<td>SYNY3 / ARATH</td>
+<td>plastocyanin (mobile Cu carrier)</td>
+</tr>
+<tr>
+<td>petF</td>
+<td>CHLRE / ARATH</td>
+<td>ferredoxin (mobile Fe-S carrier)</td>
+</tr>
+<tr>
+<td>petH (FNR)</td>
+<td>ARATH</td>
+<td>ferredoxin–NADP+ reductase (makes NADPH)</td>
+</tr>
+<tr>
+<td>atpA / atpB</td>
+<td>SYNY3 / plant chloroplast</td>
+<td>chloroplast ATP synthase CF1</td>
+</tr>
+</tbody>
+</table>
+<h3 id="module-d-light-harvesting-photoprotection">Module D — Light harvesting &amp; photoprotection</h3>
+<table>
+<thead>
+<tr>
+<th>Gene</th>
+<th>Suggested organism</th>
+<th>Role</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>LHCB1 / LHCA</td>
+<td>ARATH / CHLRE</td>
+<td>chlorophyll a/b-binding antenna</td>
+</tr>
+<tr>
+<td>PsbS</td>
+<td>ARATH</td>
+<td>non-photochemical quenching (qE) photoprotection</td>
+</tr>
+</tbody>
+</table>
+<h3 id="module-e-carbon-fixation-calvinbensonbassham-cycle">Module <a href="../../genes/BPT4/E/E-ai-review.html">E</a> — Carbon fixation (Calvin–Benson–Bassham cycle)</h3>
+<table>
+<thead>
+<tr>
+<th>Gene</th>
+<th>Suggested organism</th>
+<th>Role</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>rbcL</td>
+<td>tobacco/spinach chloroplast or SYNY3</td>
+<td>Rubisco large (catalytic) subunit (<a href="http://amigo.geneontology.org/amigo/term/GO:0016984">GO:0016984</a>)</td>
+</tr>
+<tr>
+<td>rbcS</td>
+<td>ARATH</td>
+<td>Rubisco small subunit</td>
+</tr>
+<tr>
+<td>rca</td>
+<td>ARATH</td>
+<td>Rubisco activase</td>
+</tr>
+<tr>
+<td>prk (PRK)</td>
+<td>CHLRE / ARATH</td>
+<td>phosphoribulokinase (regenerates RuBP)</td>
+</tr>
+<tr>
+<td>gapA / gapB</td>
+<td>ARATH</td>
+<td>chloroplastic <a href="../../genes/human/GAPDH/GAPDH-ai-review.html">GAPDH</a> (redox-regulated)</td>
+</tr>
+<tr>
+<td><strong><a href="../../genes/CHLRE/CP12/CP12-ai-review.html">CP12</a></strong></td>
+<td><strong>CHLRE (A6Q0K5)</strong> — already seeded</td>
+<td>redox switch; PRK–<a href="../../genes/human/GAPDH/GAPDH-ai-review.html">GAPDH</a>–<a href="../../genes/CHLRE/CP12/CP12-ai-review.html">CP12</a> ternary complex</td>
+</tr>
+</tbody>
+</table>
+<h3 id="module-f-carbon-concentrating-mechanism-algaecyano">Module F — Carbon-concentrating mechanism (algae/cyano)</h3>
+<table>
+<thead>
+<tr>
+<th>Gene</th>
+<th>Suggested organism</th>
+<th>Role</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><strong><a href="../../genes/CHLRE/LCI5/LCI5-ai-review.html">LCI5</a></strong></td>
+<td><strong>CHLRE (Q94ET8)</strong> — already seeded</td>
+<td>low-CO2 inducible thylakoid protein</td>
+</tr>
+<tr>
+<td>LCIA / LCIB, CCM1/CIA5, carbonic anhydrases</td>
+<td>CHLRE / SYNY3</td>
+<td>inorganic-carbon uptake/concentration</td>
+</tr>
+</tbody>
+</table>
+<h3 id="module-g-pigment-biosynthesis-supporting-context">Module G — Pigment biosynthesis (supporting context)</h3>
+<table>
+<thead>
+<tr>
+<th>Gene</th>
+<th>Suggested organism</th>
+<th>Role</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>CHLH / CHLD / CHLI</td>
+<td>ARATH</td>
+<td>magnesium chelatase (committed chlorophyll step)</td>
+</tr>
+<tr>
+<td>POR</td>
+<td>ARATH</td>
+<td>protochlorophyllide oxidoreductase</td>
+</tr>
+</tbody>
+</table>
+<h2 id="annotation-watch-points-apply-during-review">Annotation watch-points (apply during review)</h2>
+<ul>
+<li>Prefer <code>GO:0019253</code> (reductive pentose-phosphate cycle) over the broad <code>GO:0015977</code><br />
+  (carbon fixation) for CBB-cycle enzymes.</li>
+<li>Reaction-center subunits often inherit generic <code>GO:0009765</code> (light harvesting) or<br />
+<code>GO:0016168</code> (chlorophyll binding) from electronic pipelines — consider<br />
+<code>MARK_AS_OVER_ANNOTATED</code> / <a href="https://www.uniprot.org/uniprotkb/MODIFY/entry">MODIFY</a> toward charge-separation / electron-transport terms.</li>
+<li>Non-catalytic structural subunits (e.g. PsbO) may inherit catalytic MF terms from<br />
+  family rules — flag as the cellulosome project did for scaffoldins.</li>
+</ul>
+<h2 id="why-study-photosynthesis">Why study photosynthesis?</h2>
+<ol>
+<li><strong>Food security / crop yield</strong> — Rubisco efficiency and CBB-cycle engineering.<br />
+<a href="../../genes/BPT4/2/2-ai-review.html">2</a>. <strong>Climate / carbon cycle</strong> — primary route of CO2 fixation into the biosphere.</li>
+<li><strong>Bioenergy &amp; synthetic biology</strong> — engineered carbon-concentrating mechanisms,<br />
+   artificial photosynthesis.</li>
+<li><strong>Basic science</strong> — model supramolecular machines (PSI/PSII) and redox signalling (<a href="../../genes/CHLRE/CP12/CP12-ai-review.html">CP12</a>).</li>
+</ol>
+<h2 id="key-references">Key references</h2>
+<p>According to PubMed (verified):<br />
+- Umena et al. 2011, <em>Nature</em> 473:55–60 — PSII 1.<a href="../../genes/BPT4/9/9-ai-review.html">9</a> Å structure. PMID:21499260.<br />
+- Jordan et al. 2001, <em>Nature</em> 411:909–917 — PSI <a href="../../genes/BPT4/2/2-ai-review.html">2</a>.<a href="../../genes/BPT4/5/5-ai-review.html">5</a> Å structure. PMID:11418848.<br />
+- Andersson &amp; Backlund 2008, <em>Plant Physiol Biochem</em> <a href="../../genes/BPT4/46/46-ai-review.html">46</a>:275–291 — Rubisco. PMID:18294858.<br />
+- Shao et al. 2021, <em>Cell Commun Signal</em> <a href="../../genes/BPT4/19/19-ai-review.html">19</a>:<a href="../../genes/BPT4/38/38-ai-review.html">38</a> — <a href="../../genes/CHLRE/CP12/CP12-ai-review.html">CP12</a> / CBB regulation. PMID:33761918.</p>
+<hr />
+<h1 id="status">STATUS</h1>
+<h2 id="concept-writeup">Concept writeup</h2>
+<ul>
+<li>[x] <code>terms/photosynthesis/photosynthesis-notes.md</code> created (manual notes; deep-research provider unavailable)</li>
+<li>[x] GO representation verified against <code>cache/go/terms.csv</code> + GOlr</li>
+<li>[x] Key references PubMed-verified</li>
+</ul>
+<h2 id="gene-reviews-deferred-first-pass-is-concept-writeup-only">Gene reviews (deferred — first pass is concept writeup only)</h2>
+<h3 id="already-seeded">Already seeded</h3>
+<ul>
+<li>[x] CHLRE/psaC (Q00914) — pre-existing</li>
+<li>[~] CHLRE/CP12 (A6Q0K5) — pre-existing (DRAFT)</li>
+<li>[~] CHLRE/LCI5 (Q94ET8) — pre-existing</li>
+</ul>
+<h3 id="to-do-candidates">To do (candidates)</h3>
+<ul>
+<li>[ ] Module A — PSII: psbA, psbD, psbB/psbC, psbO</li>
+<li>[ ] Module B — PSI: psaA, psaB</li>
+<li>[ ] Module C — electron transport: petA/B/C, petE, petF, petH, atpA/atpB</li>
+<li>[ ] Module D — antenna/photoprotection: LHCB1, PsbS</li>
+<li>[ ] Module <a href="../../genes/BPT4/E/E-ai-review.html">E</a> — CBB cycle: rbcL, rbcS, rca, PRK, gapA/gapB</li>
+<li>[ ] Module F — CCM: LCIA/B, CCM1, carbonic anhydrases</li>
+<li>[ ] Module G — pigment biosynthesis: CHLH, POR</li>
+</ul>
+<h1 id="notes">NOTES</h1>
+<h2 id="2026-06-12-session-1">2026-06-<a href="../../genes/BPT4/12/12-ai-review.html">12</a> (Session 1)</h2>
+<p><strong>Project created.</strong> Scope for this pass: concept writeup + candidate-gene checklist;<br />
+individual reviews deferred. Mixed-organism strategy chosen (Synechocystis for core light<br />
+reactions, Chlamydomonas for CBB/CCM — already partly seeded — and Arabidopsis for<br />
+antenna/photoprotection and nuclear CBB genes).</p>
+<p>Attempted <code>just term-deep-research-falcon "Photosynthesis"</code>; the provider run failed<br />
+because <code>templates/concept_research.md.j2</code> embeds a literal <code>{concept}</code> placeholder that is<br />
+not substituted, so the model received an empty concept and returned a "cannot be<br />
+completed" non-report. The empty file was discarded (not kept as<br />
+<code>-deep-research-falcon.md</code>) and <code>terms/photosynthesis/photosynthesis-notes.md</code> was authored<br />
+manually instead, with all GO IDs and PMIDs independently verified.</p>
+<p><strong>Follow-up infra note:</strong> the <code>{concept}</code> → <code>{{ concept }}</code> template substitution bug in<br />
+<code>templates/concept_research.md.j2</code> affects <em>all</em> concept deep-research runs and is worth<br />
+fixing separately before the next <code>term-deep-research</code> invocation.</p>
+    </div>
+
+    <footer>
+        <small>Generated from PHOTOSYNTHESIS.md</small>
+        <small>AI Gene Review Project</small>
+    </footer>
+</body>
+</html>


### PR DESCRIPTION
## Summary

Automated regeneration of static assets after gene review or template changes.

## Generated Assets

| Asset | Count/Status |
|-------|--------------|
| Gene review YAML files | 2331 |
| Gene review HTML pages | 2331 |
| Project pages | 133 |
| Browser app (data.js) | Updated |
| Validation report | Updated |

## Trigger

This PR was triggered by changes to:
- genes/**/*.yaml - gene review data files
- src/ai_gene_review/schema/** - LinkML schema files
- src/ai_gene_review/templates/** - Jinja2 templates
- src/ai_gene_review/render.py - rendering code
- src/ai_gene_review/export/** - export code
- src/ai_gene_review/browser/** - browser app assets
- src/ai_gene_review/tools/minify_linkml_browser_data.py - browser data compaction
- projects/*.md - project definitions
- project.justfile - just recipes used by CI
- .github/workflows/generate-pages.yaml - workflow definition

## Review

- [ ] Spot-check a few gene review HTML pages render correctly
- [ ] Verify browser app loads and filters work
- [ ] Check validation report for new issues
