### PR TITLE
Regenerate pages and browser app

### DIFF
--- a/genes/ECO8N/A0A0H3EUF3_ECO8N/A0A0H3EUF3_ECO8N-ai-review.html
+++ b/genes/ECO8N/A0A0H3EUF3_ECO8N/A0A0H3EUF3_ECO8N-ai-review.html
@@ -1,0 +1,2854 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>mphB - AI Gene Review</title>
+    <style>
+        :root {
+            --color-accept: #22c55e;
+            --color-remove: #ef4444;
+            --color-modify: #f97316;
+            --color-keep-non-core: #3b82f6;
+            --color-undecided: #6b7280;
+            --color-new: #8b5cf6;
+            --color-mark-over: #eab308;
+            --bg-light: #f9fafb;
+            --border-color: #e5e7eb;
+            --text-muted: #6b7280;
+            --text-primary: #111827;
+        }
+
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+            line-height: 1.6;
+            color: var(--text-primary);
+            background-color: #ffffff;
+            padding: 2rem;
+            max-width: 1400px;
+            margin: 0 auto;
+        }
+
+        .header {
+            border-bottom: 2px solid var(--border-color);
+            padding-bottom: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        h1 {
+            font-size: 2.5rem;
+            font-weight: 700;
+            margin-bottom: 0.5rem;
+            color: #1f2937;
+        }
+
+        .gene-info {
+            display: flex;
+            gap: 2rem;
+            flex-wrap: wrap;
+            margin-top: 1rem;
+        }
+
+        .info-item {
+            display: flex;
+            gap: 0.5rem;
+        }
+
+        .info-label {
+            font-weight: 600;
+            color: var(--text-muted);
+        }
+
+        .aliases {
+            display: flex;
+            gap: 0.5rem;
+            flex-wrap: wrap;
+        }
+
+        .badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.875rem;
+            font-weight: 500;
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+        }
+
+        .status-badge {
+            padding: 0.375rem 0.875rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .status-initialized {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fde68a;
+        }
+
+        .status-in-progress {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+        }
+
+        .status-draft {
+            background-color: #fce7f3;
+            color: #831843;
+            border: 1px solid #fbcfe8;
+        }
+
+        .status-complete {
+            background-color: #d1fae5;
+            color: #065f46;
+            border: 1px solid #a7f3d0;
+        }
+
+        .description-card {
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        .description-card h2 {
+            font-size: 1.25rem;
+            margin-bottom: 1rem;
+            color: #374151;
+        }
+
+        .section {
+            margin-bottom: 2.5rem;
+        }
+
+        .section-title {
+            font-size: 1.5rem;
+            font-weight: 600;
+            margin-bottom: 1.5rem;
+            color: #1f2937;
+            border-bottom: 1px solid var(--border-color);
+            padding-bottom: 0.5rem;
+        }
+
+        .annotations-table {
+            width: 100%;
+            border-collapse: collapse;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            overflow: hidden;
+        }
+
+        .annotations-table thead {
+            background-color: var(--bg-light);
+        }
+
+        .annotations-table th {
+            text-align: left;
+            padding: 1rem;
+            font-weight: 600;
+            border-bottom: 2px solid var(--border-color);
+            font-size: 0.875rem;
+            text-transform: uppercase;
+            letter-spacing: 0.05em;
+            color: var(--text-muted);
+        }
+
+        .annotations-table td {
+            padding: 1rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .annotations-table tbody tr:hover {
+            background-color: #f9fafb;
+        }
+
+        .action-badge {
+            display: inline-block;
+            padding: 0.375rem 0.75rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .action-accept {
+            background-color: var(--color-accept);
+            color: white;
+        }
+
+        .action-remove {
+            background-color: var(--color-remove);
+            color: white;
+        }
+
+        .action-modify {
+            background-color: var(--color-modify);
+            color: white;
+        }
+
+        .action-keep_as_non_core {
+            background-color: var(--color-keep-non-core);
+            color: white;
+        }
+
+        .action-undecided {
+            background-color: var(--color-undecided);
+            color: white;
+        }
+
+        .action-new {
+            background-color: var(--color-new);
+            color: white;
+        }
+
+        .action-mark_as_over_annotated {
+            background-color: var(--color-mark-over);
+            color: white;
+        }
+
+        .term-info {
+            display: flex;
+            flex-direction: column;
+            gap: 0.25rem;
+        }
+
+        .term-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .term-label {
+            font-weight: 500;
+        }
+
+        .evidence-code {
+            font-family: monospace;
+            background-color: var(--bg-light);
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .not-badge {
+            display: inline-block;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-weight: 600;
+            margin-left: 0.25rem;
+        }
+
+        .isoform-badge {
+            display: inline-block;
+            background-color: #eff6ff;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            margin-top: 0.25rem;
+        }
+
+        .core-function-card {
+            background-color: white;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 1rem;
+        }
+
+        .core-function-card h3 {
+            font-size: 1.125rem;
+            margin-bottom: 1rem;
+            color: #1f2937;
+        }
+
+        .core-function-statement {
+            margin-bottom: 1rem;
+            padding: 0.75rem;
+            background-color: var(--bg-light);
+            border-left: 4px solid var(--color-accept);
+            border-radius: 0.25rem;
+        }
+
+        .function-annotations {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin-top: 1rem;
+        }
+
+        .reference-item {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+        }
+
+        .reference-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: start;
+            margin-bottom: 0.75rem;
+        }
+
+        .reference-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #2563eb;
+        }
+
+        .supported-by {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f3f4f6;
+            border-left: 3px solid #3b82f6;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .supported-by-title {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .support-item {
+            margin-bottom: 0.5rem;
+        }
+
+        .support-ref {
+            font-weight: 500;
+            color: #2563eb;
+        }
+
+        .support-text {
+            color: #6b7280;
+            font-style: italic;
+            margin-left: 1rem;
+        }
+
+        a.term-link {
+            color: #2563eb;
+            text-decoration: none;
+        }
+
+        a.term-link:hover {
+            text-decoration: underline;
+        }
+
+        .core-function-terms {
+            margin-top: 1rem;
+        }
+
+        .function-term-group {
+            margin-bottom: 1rem;
+        }
+
+        .function-term-label {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .reference-title {
+            font-weight: 500;
+            margin-bottom: 0.5rem;
+        }
+
+        .findings-list {
+            margin-top: 1rem;
+            padding-left: 1.5rem;
+        }
+
+        .finding-item {
+            margin-bottom: 0.75rem;
+        }
+
+        .finding-statement {
+            font-weight: 500;
+            margin-bottom: 0.25rem;
+        }
+
+        .finding-text {
+            color: var(--text-muted);
+            font-size: 0.95rem;
+            font-style: italic;
+        }
+
+        .proposed-term {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #fef3c7;
+        }
+
+        .question-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #dbeafe;
+        }
+
+        .experiment-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #f3e8ff;
+        }
+
+        .prediction-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: white;
+        }
+
+        .prediction-card .prediction-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+        }
+
+        .prediction-source {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+        }
+
+        .assessment-badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.8rem;
+            font-weight: 600;
+            text-transform: uppercase;
+        }
+
+        .assessment-cor { background-color: #dcfce7; color: #166534; }
+        .assessment-cnn { background-color: #dbeafe; color: #1e40af; }
+        .assessment-lsp { background-color: #fef9c3; color: #854d0e; }
+        .assessment-unc { background-color: #f3f4f6; color: #374151; }
+        .assessment-pli { background-color: #fee2e2; color: #991b1b; }
+        .assessment-npi { background-color: #fecaca; color: #7f1d1d; }
+        .assessment-rep { background-color: #fde68a; color: #92400e; }
+
+        .confidence-score {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+            margin-left: 0.5rem;
+        }
+
+        .error-type-badge {
+            font-size: 0.75rem;
+            padding: 0.125rem 0.5rem;
+            border-radius: 0.25rem;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+        }
+
+        .isoforms-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fill, minmax(400px, 1fr));
+            gap: 1rem;
+        }
+
+        .isoform-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            background-color: white;
+            transition: box-shadow 0.2s;
+        }
+
+        .isoform-card:hover {
+            box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+        }
+
+        .functional-isoform-type {
+            display: inline-block;
+            padding: 0.2rem 0.5rem;
+            border-radius: 0.25rem;
+            font-size: 0.7rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.03em;
+        }
+
+        .type-SPLICE_VARIANT, .type-SPLICE_CLASS {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #93c5fd;
+        }
+
+        .type-CLEAVAGE_PRODUCT {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fcd34d;
+        }
+
+        .type-MODIFICATION_STATE {
+            background-color: #f3e8ff;
+            color: #6b21a8;
+            border: 1px solid #c4b5fd;
+        }
+
+        .type-CONFORMATIONAL_STATE {
+            background-color: #dcfce7;
+            color: #166534;
+            border: 1px solid #86efac;
+        }
+
+        .functional-isoform-mappings {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+            font-size: 0.85rem;
+        }
+
+        .functional-isoform-mappings .mapping-type {
+            font-weight: 600;
+            color: var(--text-muted);
+            font-size: 0.75rem;
+        }
+
+        .functional-isoform-go {
+            margin-top: 0.5rem;
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.25rem;
+        }
+
+        .go-chip {
+            display: inline-block;
+            padding: 0.15rem 0.4rem;
+            background-color: #ecfdf5;
+            color: #047857;
+            border: 1px solid #a7f3d0;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-family: monospace;
+        }
+
+        .isoform-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+            padding-bottom: 0.5rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .isoform-name {
+            font-weight: 600;
+            font-size: 1.1rem;
+            color: #1f2937;
+        }
+
+        .isoform-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .isoform-sequence-note {
+            font-size: 0.875rem;
+            color: var(--text-muted);
+            margin-bottom: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+        }
+
+        .isoform-description {
+            font-size: 0.95rem;
+            line-height: 1.5;
+        }
+
+        .collapsible {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .collapsible:after {
+            content: ' ▼';
+            font-size: 0.75rem;
+        }
+
+        .collapsible.collapsed:after {
+            content: ' ►';
+        }
+
+        .collapse-content {
+            transition: max-height 0.3s ease;
+            overflow: hidden;
+        }
+
+        .collapsed + .collapse-content {
+            max-height: 0;
+        }
+
+        .no-data {
+            color: var(--text-muted);
+            font-style: italic;
+            padding: 1rem;
+            text-align: center;
+            background-color: var(--bg-light);
+            border-radius: 0.5rem;
+        }
+
+        /* Styling for markdown section summaries with voting */
+        .markdown-section summary {
+            padding: 0.75rem;
+            background: var(--bg-light);
+            border-radius: 0.5rem;
+            margin-bottom: 0.5rem;
+        }
+
+        .markdown-section summary:hover {
+            background: #e5e7eb;
+        }
+
+        .markdown-section summary .vote-buttons {
+            margin-left: auto;
+        }
+
+        .deep-research-section {
+            margin-bottom: 1rem;
+            border: 1px solid #c7d2fe;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8faff;
+        }
+
+        .deep-research-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .deep-research-section summary h3 {
+            margin: 0;
+            color: #3730a3;
+            font-size: 1.1rem;
+        }
+
+        .report-meta {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin: 0.75rem 0 1rem;
+            align-items: center;
+        }
+
+        .report-badge {
+            display: inline-flex;
+            align-items: center;
+            border: 1px solid #c7d2fe;
+            border-radius: 999px;
+            background: #eef2ff;
+            color: #4338ca;
+            font-size: 0.78rem;
+            font-weight: 600;
+            padding: 0.2rem 0.6rem;
+        }
+
+        .report-meta-text {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+        }
+
+        .artifact-list {
+            display: grid;
+            gap: 0.75rem;
+            margin: 0.75rem 0 1rem;
+        }
+
+        .artifact-link {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+            margin-top: 0.5rem;
+            word-break: break-word;
+        }
+
+        @media print {
+            body {
+                padding: 1rem;
+            }
+
+            .collapsible:after {
+                display: none;
+            }
+
+            .collapsed + .collapse-content {
+                max-height: none !important;
+            }
+        }
+
+        @media (max-width: 768px) {
+            body {
+                padding: 1rem;
+            }
+
+            h1 {
+                font-size: 2rem;
+            }
+
+            .annotations-table {
+                font-size: 0.875rem;
+            }
+
+            .annotations-table th,
+            .annotations-table td {
+                padding: 0.5rem;
+            }
+        }
+    </style>
+</head>
+<body>
+    <div class="header">
+        <h1>mphB</h1>
+        <div class="gene-info">
+            
+            <div class="info-item">
+                
+                <span class="info-label">UniProt ID:</span>
+                <span>
+                    <a href="https://www.uniprot.org/uniprotkb/A0A0H3EUF3" target="_blank" class="term-link">
+                        A0A0H3EUF3
+                    </a>
+                </span>
+                
+            </div>
+            
+            
+            <div class="info-item">
+                <span class="info-label">Organism:</span>
+                <span>Escherichia coli O83:H1 (strain NRG 857C / AIEC)</span>
+            </div>
+            
+            
+            <div class="info-item">
+                <span class="info-label">Review Status:</span>
+                <span class="status-badge status-draft">
+                    DRAFT
+                </span>
+            </div>
+            
+            
+            <div class="info-item">
+                <span class="info-label">Aliases:</span>
+                <div class="aliases">
+                    
+                    <span class="badge">MphB</span>
+                    
+                    <span class="badge">macrolide 2&#39;-phosphotransferase II</span>
+                    
+                    <span class="badge">MPH(2&#39;)II</span>
+                    
+                </div>
+            </div>
+            
+        </div>
+        <div style="margin-top: 1rem; text-align: center;">
+            <a id="feedback-form-link"
+               href="#"
+               target="_blank"
+               style="display: inline-block; padding: 10px 20px; background-color: #4CAF50; color: white; text-decoration: none; border-radius: 5px; font-weight: 600;">
+                📝 Provide Detailed Feedback
+            </a>
+            <script>
+                // Construct the form URL with proper encoding
+                // Extract organism code from the current page path (e.g., /genes/ARATH/APO1/ -> ARATH)
+                const pathParts = window.location.pathname.split('/');
+                const genesIndex = pathParts.indexOf('genes');
+                let organism = '';
+                if (genesIndex !== -1 && pathParts[genesIndex + 1]) {
+                    organism = pathParts[genesIndex + 1].toUpperCase();
+                }
+                const geneSymbol = "mphB";
+                const speciesGene = organism + ' ' + geneSymbol;
+                const formBaseUrl = 'https://docs.google.com/forms/d/e/1FAIpQLSdTot9L6GVkkZYgLQT0E8ZdAJv8RiN5ZgOVkgWNcKSbYvxxzQ/viewform';
+                const entryId = '1226477767'; // Correct entry ID for Species/Gene field
+                const formUrl = formBaseUrl + '?entry.' + entryId + '=' + encodeURIComponent(speciesGene);
+                const feedbackLink = document.getElementById('feedback-form-link');
+                feedbackLink.href = formUrl;
+                // Add tooltip showing the pre-filled value
+                feedbackLink.title = 'Opens form with pre-filled: ' + speciesGene;
+            </script>
+        </div>
+    </div>
+
+    
+    <div class="description-card">
+        <div style="display: flex; justify-content: space-between; align-items: center;">
+            <h2>Gene Description</h2>
+            <span class="vote-buttons" data-g="A0A0H3EUF3" data-a="DESCRIPTION: MphB (macrolide 2&#39;-phosphotransferase II, MPH(2&#39;)I..." data-r="" data-act="DESCRIPTION">
+                <button class="vote-btn" data-v="up" title="Agree with this description">👍</button>
+                <button class="vote-btn" data-v="down" title="Disagree with this description">👎</button>
+            </span>
+        </div>
+        <p>MphB (macrolide 2&#39;-phosphotransferase II, MPH(2&#39;)II) is a plasmid-encoded macrolide kinase that inactivates macrolide antibiotics. It transfers the gamma-phosphate of a purine nucleoside triphosphate (ATP, GTP or ITP) to the 2&#39;-hydroxyl group of the desosamine sugar of macrolides, producing an inactive macrolide 2&#39;-O-phosphate that can no longer bind the bacterial ribosome; this enzymatic detoxification confers macrolide resistance. MphB acts on a broad range of substrates spanning 14-membered (e.g. oleandomycin, erythromycin, clarithromycin, roxithromycin, dirithromycin), 15-membered (azithromycin), and 16-membered (e.g. spiramycin, tylosin, josamycin) macrolides as well as the ketolide telithromycin (CARD ARO:3000318). Early phenotyping placed MphB as relatively narrow (with azithromycin resistance attributed specifically to MphA), but later enzymatic and mass-spectrometric work showed MphB inactivates essentially all macrolides tested, including azithromycin and telithromycin. The cloned mphB encodes a 302-residue, ~34.5 kDa protein matching this UniProt entry exactly. Crystal structures of the MphB class (MPH(2&#39;)-II) reveal the bi-lobed protein-kinase-like fold of the aminoglycoside phosphotransferase (APH) superfamily, distinguished by a large interdomain linker that forms an expanded, largely hydrophobic macrolide-binding pocket; nucleotide is bound in the kinase pocket (structures captured with GTP analogs, and GTP is a preferred donor in vitro, though ATP, GTP and ITP can all serve). Catalysis depends on conserved active-site residues — aspartates D200/D209/D219/ D231 and the conserved His205 — and on a divalent metal (activity is EDTA-inhibited), consistent with the Mg2+-dependent phosphotransfer chemistry of this fold; D227 contributes to recognition of 16-membered macrolides. In this organism the gene is carried on plasmid pO83_CORR of the adherent-invasive Escherichia coli strain NRG 857C, making it part of the mobile macrolide-resistance gene pool of enteric bacteria.</p>
+    </div>
+    
+
+    
+
+    
+
+    
+    <div class="section">
+        <h2 class="section-title">Existing Annotations Review</h2>
+        <table class="annotations-table">
+            <thead>
+                <tr>
+                    <th>GO Term</th>
+                    <th>Evidence</th>
+                    <th>Action</th>
+                    <th>Reason</th>
+                </tr>
+            </thead>
+            <tbody>
+                
+                <tr>
+                    <td>
+                        <div class="term-info">
+                            
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0050073" target="_blank" class="term-link">
+                                    GO:0050073
+                                </a>
+                            </span>
+                            <span class="term-label">macrolide 2&#39;-kinase activity</span>
+                            
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+                        
+                        
+                        
+                        <br>
+                        <span style="font-size: 0.75rem;">
+                            
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/1330822" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:1330822
+                            </a>
+                            
+                                
+                                
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Purification and characterization of macrolide 2&#39;-phosphotra...
+                                </span>
+                                
+                            
+                            
+                        </span>
+                        
+                    </td>
+                    <td>
+                        <span class="action-badge action-new">
+                            NEW
+                        </span>
+                        <span class="vote-buttons" data-g="A0A0H3EUF3" data-a="GO:0050073" data-r="PMID:1330822" data-act="NEW">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+                        
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> MphB phosphorylates the 2&#39;-OH of macrolides using a purine NTP, producing inactive macrolide 2&#39;-O-phosphate. This is the core, experimentally demonstrated molecular function and exactly matches the GO:0050073 definition (ATP + oleandomycin = ADP + 2 H+ + oleandomycin 2&#39;-O-phosphate).
+                        </div>
+                        
+                        
+                        <div>
+                            <strong>Reason:</strong> The purified enzyme was shown biochemically to phosphorylate macrolides at the 2&#39;-position, and the product was identified as oleandomycin 2&#39;-phosphate by TLC; the mechanism (gamma-phosphate transfer from ATP to the macrolide 2&#39;-OH) and catalytic aspartates were confirmed by mutagenesis. No curated GOA annotation exists for this TrEMBL entry, so this specific MF should be added.
+                        </div>
+                        
+                        
+                        
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+                            
+                            <div class="support-item">
+                                <span class="support-ref">
+                                    
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/1330822" target="_blank" class="term-link">
+                                        PMID:1330822
+                                    </a>
+                                    
+                                </span>
+                                
+                                <div class="support-text">Inactivated oleandomycin was identified as oleandomycin 2&#39;-phosphate by thin-layer chromatography.</div>
+                                
+                            </div>
+                            
+                            <div class="support-item">
+                                <span class="support-ref">
+                                    
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/10428938" target="_blank" class="term-link">
+                                        PMID:10428938
+                                    </a>
+                                    
+                                </span>
+                                
+                                <div class="support-text">transfers the gamma phosphate of ATP to the 2&#39;-OH group of macrolide antibiotics.</div>
+                                
+                            </div>
+                            
+                            <div class="support-item">
+                                <span class="support-ref">
+                                    
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/29317655" target="_blank" class="term-link">
+                                        PMID:29317655
+                                    </a>
+                                    
+                                </span>
+                                
+                                <div class="support-text">Using tandem mass spectrometry, we also confirmed that MphB phosphorylates the desosamine 2′-OH of erythromycin</div>
+                                
+                            </div>
+                            
+                        </div>
+                        
+                    </td>
+                </tr>
+                
+                <tr>
+                    <td>
+                        <div class="term-info">
+                            
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0046677" target="_blank" class="term-link">
+                                    GO:0046677
+                                </a>
+                            </span>
+                            <span class="term-label">response to antibiotic</span>
+                            
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IMP</span>
+                        
+                        
+                        
+                        <br>
+                        <span style="font-size: 0.75rem;">
+                            
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/9503630" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:9503630
+                            </a>
+                            
+                                
+                                
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Expression of the mphB gene for macrolide 2&#39;-phosphotransfer...
+                                </span>
+                                
+                            
+                            
+                        </span>
+                        
+                    </td>
+                    <td>
+                        <span class="action-badge action-new">
+                            NEW
+                        </span>
+                        <span class="vote-buttons" data-g="A0A0H3EUF3" data-a="GO:0046677" data-r="PMID:9503630" data-act="NEW">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+                        
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> By enzymatically inactivating macrolides, MphB confers macrolide antibiotic resistance; expression of mphB renders host bacteria resistant to 14-, 15- and 16-membered macrolides (e.g. high-level spiramycin resistance when expressed in S. aureus).
+                        </div>
+                        
+                        
+                        <div>
+                            <strong>Reason:</strong> Resistance is the biological process in which this enzyme participates: mphB expression confers macrolide resistance in both E. coli and a heterologous host. &#34;response to antibiotic&#34; is the standard, well-supported BP for an antibiotic-modifying resistance enzyme. (Note: phosphorylation inactivates/modifies rather than degrades the drug, so an &#34;antibiotic catabolic process&#34; term would be less accurate.)
+                        </div>
+                        
+                        
+                        
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+                            
+                            <div class="support-item">
+                                <span class="support-ref">
+                                    
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/9503630" target="_blank" class="term-link">
+                                        PMID:9503630
+                                    </a>
+                                    
+                                </span>
+                                
+                                <div class="support-text">The gene endowed S. aureus with high-level resistance to spiramycin, a macrolide antibiotic with a 16-membered ring.</div>
+                                
+                            </div>
+                            
+                            <div class="support-item">
+                                <span class="support-ref">
+                                    
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/9503630" target="_blank" class="term-link">
+                                        PMID:9503630
+                                    </a>
+                                    
+                                </span>
+                                
+                                <div class="support-text">The genes mphA and mphB encode macrolide 2&#39;-phosphotransferases I and II, respectively, and they confer resistance to macrolide antibiotics in Escherichia coli.</div>
+                                
+                            </div>
+                            
+                            <div class="support-item">
+                                <span class="support-ref">
+                                    
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/29317655" target="_blank" class="term-link">
+                                        PMID:29317655
+                                    </a>
+                                    
+                                </span>
+                                
+                                <div class="support-text">we found that MphB confers resistance to all macrolides tested...and inactivates both telithromycin and azithromycin</div>
+                                
+                            </div>
+                            
+                            <div class="support-item">
+                                <span class="support-ref">
+                                    
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/17302923" target="_blank" class="term-link">
+                                        PMID:17302923
+                                    </a>
+                                    
+                                </span>
+                                
+                                <div class="support-text">The mph(C) gene, as reported for mph(B), also conferred resistance to spiramycin...The four investigated genes conferred resistance to telithromycin.</div>
+                                
+                            </div>
+                            
+                        </div>
+                        
+                    </td>
+                </tr>
+                
+                <tr>
+                    <td>
+                        <div class="term-info">
+                            
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005737" target="_blank" class="term-link">
+                                    GO:0005737
+                                </a>
+                            </span>
+                            <span class="term-label">cytoplasm</span>
+                            
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+                        
+                        
+                        
+                        <br>
+                        <span style="font-size: 0.75rem;">
+                            
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/1330822" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:1330822
+                            </a>
+                            
+                                
+                                
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Purification and characterization of macrolide 2&#39;-phosphotra...
+                                </span>
+                                
+                            
+                            
+                        </span>
+                        
+                    </td>
+                    <td>
+                        <span class="action-badge action-new">
+                            NEW
+                        </span>
+                        <span class="vote-buttons" data-g="A0A0H3EUF3" data-a="GO:0005737" data-r="PMID:1330822" data-act="NEW">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+                        
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> MphB was characterized as a soluble, intracellular (cytoplasmic) enzyme upon purification from E. coli, consistent with cytoplasmic detoxification of macrolides before they reach the ribosome.
+                        </div>
+                        
+                        
+                        <div>
+                            <strong>Reason:</strong> The purified enzyme was reported as a constitutive intracellular enzyme, indicating cytoplasmic localization — the expected compartment for a soluble macrolide-inactivating kinase.
+                        </div>
+                        
+                        
+                        
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+                            
+                            <div class="support-item">
+                                <span class="support-ref">
+                                    
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/1330822" target="_blank" class="term-link">
+                                        PMID:1330822
+                                    </a>
+                                    
+                                </span>
+                                
+                                <div class="support-text">MPH(2&#39;)II was a constitutive intracellular enzyme</div>
+                                
+                            </div>
+                            
+                        </div>
+                        
+                    </td>
+                </tr>
+                
+            </tbody>
+        </table>
+    </div>
+    
+
+    
+    <div class="section">
+        <h2 class="section-title">Core Functions</h2>
+        
+        <div class="core-function-card">
+            
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+                <h3>MphB is a macrolide 2&#39;-phosphotransferase (macrolide kinase): it transfers the gamma-phosphate of a purine nucleoside triphosphate to the 2&#39;-hydroxyl of the desosamine sugar of macrolide antibiotics, generating an inactive macrolide 2&#39;-O-phosphate. This enzymatic modification detoxifies the drug and is the molecular basis of macrolide resistance conferred by the gene. The enzyme has broad macrolide substrate specificity (14-, 15- and 16-membered rings) and uses the conserved active-site aspartates of the protein-kinase-like/APH fold for metal-dependent phosphoryl transfer.</h3>
+                <span class="vote-buttons" data-g="A0A0H3EUF3" data-a="FUNCTION: MphB is a macrolide 2&#39;-phosphotransferase (macroli..." data-r="" data-act="CORE_FUNCTION">
+                    <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
+                    <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
+                </span>
+            </div>
+            
+
+            <div class="core-function-terms">
+                
+                <div class="function-term-group">
+                    <div class="function-term-label">Molecular Function:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0050073" target="_blank" class="term-link">
+                            macrolide 2&#39;-kinase activity
+                        </a>
+                    </span>
+                </div>
+                
+
+                
+                <div class="function-term-group">
+                    <div class="function-term-label">Directly Involved In:</div>
+                    <div class="function-annotations">
+                        
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0046677" target="_blank" class="term-link">
+                                response to antibiotic
+                            </a>
+                        </span>
+                        
+                    </div>
+                </div>
+                
+
+                
+                <div class="function-term-group">
+                    <div class="function-term-label">Cellular Locations:</div>
+                    <div class="function-annotations">
+                        
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005737" target="_blank" class="term-link">
+                                cytoplasm
+                            </a>
+                        </span>
+                        
+                    </div>
+                </div>
+                
+
+                
+
+                
+                <div class="function-term-group">
+                    <div class="function-term-label">Substrates:</div>
+                    <div class="function-annotations">
+                        
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/chebi/searchId.do?chebiId=CHEBI:48923" target="_blank" class="term-link">
+                                erythromycin
+                            </a>
+                        </span>
+                        
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/chebi/searchId.do?chebiId=CHEBI:16869" target="_blank" class="term-link">
+                                oleandomycin
+                            </a>
+                        </span>
+                        
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/chebi/searchId.do?chebiId=CHEBI:2955" target="_blank" class="term-link">
+                                azithromycin
+                            </a>
+                        </span>
+                        
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/chebi/searchId.do?chebiId=CHEBI:31739" target="_blank" class="term-link">
+                                josamycin
+                            </a>
+                        </span>
+                        
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/chebi/searchId.do?chebiId=CHEBI:17658" target="_blank" class="term-link">
+                                tylosin
+                            </a>
+                        </span>
+                        
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/chebi/searchId.do?chebiId=CHEBI:29688" target="_blank" class="term-link">
+                                telithromycin
+                            </a>
+                        </span>
+                        
+                    </div>
+                </div>
+                
+            </div>
+
+            
+            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
+                <strong>Supporting Evidence:</strong>
+                <ul class="findings-list">
+                    
+                    <li class="finding-item">
+                        <span class="reference-id">
+                            
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/1330822" target="_blank" class="term-link">
+                                PMID:1330822
+                            </a>
+                            
+                        </span>
+                        
+                        <div class="finding-text">Inactivated oleandomycin was identified as oleandomycin 2&#39;-phosphate by thin-layer chromatography.</div>
+                        
+                    </li>
+                    
+                    <li class="finding-item">
+                        <span class="reference-id">
+                            
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/10428938" target="_blank" class="term-link">
+                                PMID:10428938
+                            </a>
+                            
+                        </span>
+                        
+                        <div class="finding-text">transfers the gamma phosphate of ATP to the 2&#39;-OH group of macrolide antibiotics.</div>
+                        
+                    </li>
+                    
+                    <li class="finding-item">
+                        <span class="reference-id">
+                            
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/29317655" target="_blank" class="term-link">
+                                PMID:29317655
+                            </a>
+                            
+                        </span>
+                        
+                        <div class="finding-text">Using tandem mass spectrometry, we also confirmed that MphB phosphorylates the desosamine 2′-OH of erythromycin</div>
+                        
+                    </li>
+                    
+                    <li class="finding-item">
+                        <span class="reference-id">
+                            
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/30177927" target="_blank" class="term-link">
+                                PMID:30177927
+                            </a>
+                            
+                        </span>
+                        
+                        <div class="finding-text">MPH(2′)-I can only efficiently inactivate 14- and 15-membered lactone macrolides, whereas MPH(2′)-II can additionally inactivate 16-membered lactone macrolides and the ketolide, telithromycin</div>
+                        
+                    </li>
+                    
+                </ul>
+            </div>
+            
+        </div>
+        
+    </div>
+    
+
+    
+    <div class="section">
+        <h2 class="section-title collapsible">References</h2>
+        <div class="collapse-content">
+            
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+                        
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/8900063" target="_blank" class="term-link">
+                            PMID:8900063
+                        </a>
+                        
+                    </span>
+                </div>
+                
+                <div class="reference-title">Cloning and nucleotide sequence of the mphB gene for macrolide 2&#39;-phosphotransferase II in Escherichia coli</div>
+                
+                
+                <ul class="findings-list">
+                    
+                    <li class="finding-item">
+                        <div class="finding-statement">The mphB gene encoding MPH(2&#39;)II was cloned and sequenced from E. coli; it encodes a 302-aa protein of 34483 Da, matching this UniProt entry (302 aa, ~34485 Da).</div>
+                        
+                        <div class="finding-text">"mphB encoded a protein of 302 amino acids with a molecular mass of 34483 Da."</div>
+                        
+                    </li>
+                    
+                    <li class="finding-item">
+                        <div class="finding-statement">The C-terminal region resembles the conserved functional domain of aminoglycoside phosphotransferases (the APH/protein-kinase-like fold).</div>
+                        
+                        <div class="finding-text">"The carboxy terminal region of the deduced protein contained a sequence that resembled a conserved functional domain in aminoglycoside phosphotransferases."</div>
+                        
+                    </li>
+                    
+                </ul>
+                
+            </div>
+            
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+                        
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/17302923" target="_blank" class="term-link">
+                            PMID:17302923
+                        </a>
+                        
+                    </span>
+                </div>
+                
+                <div class="reference-title">Resistance phenotypes conferred by macrolide phosphotransferases</div>
+                
+                
+                <ul class="findings-list">
+                    
+                    <li class="finding-item">
+                        <div class="finding-statement">mph genes were assayed in a macrolide/ketolide-susceptible E. coli AG100A background (AcrAB efflux pump disrupted), enabling clean comparison of phosphotransferase-conferred resistance.</div>
+                        
+                        <div class="finding-text">"The mph genes were cloned into Escherichia coli AG100A susceptible to macrolides and ketolides following disruption of the AcrAB pump."</div>
+                        
+                    </li>
+                    
+                    <li class="finding-item">
+                        <div class="finding-statement">mph(B) confers resistance to spiramycin (16-membered) and, like the other mph genes, to telithromycin.</div>
+                        
+                        <div class="finding-text">"The mph(C) gene, as reported for mph(B), also conferred resistance to spiramycin...The four investigated genes conferred resistance to telithromycin."</div>
+                        
+                    </li>
+                    
+                    <li class="finding-item">
+                        <div class="finding-statement">In this 2007 comparison mph(A) was reported as uniquely conferring azithromycin resistance — the older narrow-spectrum view of mph(B) later revised by Pawlowski et al. 2018 (PMID:29317655).</div>
+                        
+                        <div class="finding-text">"The mph(A) gene was unique in conferring resistance to azithromycin."</div>
+                        
+                    </li>
+                    
+                </ul>
+                
+            </div>
+            
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+                        
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/1330822" target="_blank" class="term-link">
+                            PMID:1330822
+                        </a>
+                        
+                    </span>
+                </div>
+                
+                <div class="reference-title">Purification and characterization of macrolide 2&#39;-phosphotransferase type II from a strain of Escherichia coli highly resistant to macrolide antibiotics</div>
+                
+                
+                <ul class="findings-list">
+                    
+                    <li class="finding-item">
+                        <div class="finding-statement">MPH(2&#39;)II inactivates macrolides by phosphorylation of the 2&#39;-hydroxyl; the inactivated oleandomycin product was identified as oleandomycin 2&#39;-phosphate.</div>
+                        
+                        <div class="finding-text">"Inactivated oleandomycin was identified as oleandomycin 2&#39;-phosphate by thin-layer chromatography."</div>
+                        
+                    </li>
+                    
+                    <li class="finding-item">
+                        <div class="finding-statement">MPH(2&#39;)II is a constitutive intracellular enzyme active on both 14- and 16-membered macrolides.</div>
+                        
+                        <div class="finding-text">"MPH(2&#39;)II was a constitutive intracellular enzyme which showed high levels of activity with both 14-member-ring and 16-member-ring macrolides."</div>
+                        
+                    </li>
+                    
+                    <li class="finding-item">
+                        <div class="finding-statement">Purine nucleotides (ITP, GTP, ATP) serve as phosphate donors; activity is metal-dependent (EDTA-inhibited).</div>
+                        
+                        <div class="finding-text">"Purine nucleotides, such as ITP, GTP and ATP, were effective as cofactors in the inactivation of macrolides. An inhibitory effect of iodine, EDTA, or divalent cations on MPH(2&#39;)II activity was observed."</div>
+                        
+                    </li>
+                    
+                </ul>
+                
+            </div>
+            
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+                        
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/9503630" target="_blank" class="term-link">
+                            PMID:9503630
+                        </a>
+                        
+                    </span>
+                </div>
+                
+                <div class="reference-title">Expression of the mphB gene for macrolide 2&#39;-phosphotransferase II from Escherichia coli in Staphylococcus aureus</div>
+                
+                
+                <ul class="findings-list">
+                    
+                    <li class="finding-item">
+                        <div class="finding-statement">mphA and mphB encode macrolide 2&#39;-phosphotransferases I and II and confer macrolide resistance in E. coli.</div>
+                        
+                        <div class="finding-text">"The genes mphA and mphB encode macrolide 2&#39;-phosphotransferases I and II, respectively, and they confer resistance to macrolide antibiotics in Escherichia coli."</div>
+                        
+                    </li>
+                    
+                    <li class="finding-item">
+                        <div class="finding-statement">mphB conferred high-level resistance to the 16-membered-ring macrolide spiramycin when expressed in S. aureus.</div>
+                        
+                        <div class="finding-text">"The gene endowed S. aureus with high-level resistance to spiramycin, a macrolide antibiotic with a 16-membered ring."</div>
+                        
+                    </li>
+                    
+                </ul>
+                
+            </div>
+            
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+                        
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/10428938" target="_blank" class="term-link">
+                            PMID:10428938
+                        </a>
+                        
+                    </span>
+                </div>
+                
+                <div class="reference-title">Identification of functional amino acids in the macrolide 2&#39;-phosphotransferase II</div>
+                
+                
+                <ul class="findings-list">
+                    
+                    <li class="finding-item">
+                        <div class="finding-statement">MPH(2&#39;) transfers the gamma-phosphate of ATP to the 2&#39;-OH group of macrolide antibiotics.</div>
+                        
+                        <div class="finding-text">"Macrolide 2&#39;-phosphotransferase [MPH(2&#39;)] transfers the gamma phosphate of ATP to the 2&#39;-OH group of macrolide antibiotics."</div>
+                        
+                    </li>
+                    
+                    <li class="finding-item">
+                        <div class="finding-statement">Active-site aspartates D200, D209, D219 and D231 are essential for catalysis; D227 is non-essential and contributes to 16-membered-ring macrolide recognition.</div>
+                        
+                        <div class="finding-text">"D200A, D209A, D219A, and D231A mutant strains were unable to inactivate the substrate oleandomycin, while a D227A mutant retained 7% of the activity of the original enzyme."</div>
+                        
+                    </li>
+                    
+                </ul>
+                
+            </div>
+            
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+                        
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/15033229" target="_blank" class="term-link">
+                            PMID:15033229
+                        </a>
+                        
+                    </span>
+                </div>
+                
+                <div class="reference-title">The role of histidine residues conserved in the putative ATP-binding region of macrolide 2&#39;-phosphotransferase II</div>
+                
+                
+                <ul class="findings-list">
+                    
+                    <li class="finding-item">
+                        <div class="finding-statement">MPH(2&#39;)II catalyzes transfer of the gamma-phosphate of ATP to the 2&#39;-hydroxyl group of macrolides.</div>
+                        
+                        <div class="finding-text">"Macrolide 2&#39;-phosphotransferase (MPH(2&#39;)) catalyzes the transfer of the gamma-phosphate of ATP to the 2&#39;-hydroxyl group of macrolide antibiotics."</div>
+                        
+                    </li>
+                    
+                    <li class="finding-item">
+                        <div class="finding-statement">His205 in the ATP-binding motif is critical for catalysis (H205A retains &lt;1% activity).</div>
+                        
+                        <div class="finding-text">"the specific activity of the H205A mutant enzyme was reduced to less than 1% of that of the wild enzyme."</div>
+                        
+                    </li>
+                    
+                </ul>
+                
+            </div>
+            
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+                        
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/28416110" target="_blank" class="term-link">
+                            PMID:28416110
+                        </a>
+                        
+                    </span>
+                </div>
+                
+                <div class="reference-title">Structural Basis for Kinase-Mediated Macrolide Antibiotic Resistance</div>
+                
+                
+                <ul class="findings-list">
+                    
+                    <li class="finding-item">
+                        <div class="finding-statement">Crystal structures of MPH(2&#39;)-II (the MphB class) were solved in the apo state and in complex with GTP analogs and six macrolides.</div>
+                        
+                        <div class="finding-text">"We present structures for MPH(2&#39;)-I and MPH(2&#39;)-II in the apo state, and in complex with GTP analogs and six different macrolides."</div>
+                        
+                    </li>
+                    
+                    <li class="finding-item">
+                        <div class="finding-statement">Mph enzymes share the aminoglycoside-phosphotransferase (protein-kinase-like) fold but have a large interdomain linker forming an expanded antibiotic-binding pocket.</div>
+                        
+                        <div class="finding-text">"the enzymes are related to the aminoglycoside phosphotransferases, but are distinguished from them by the presence of a large interdomain linker that contributes to an expanded antibiotic binding pocket."</div>
+                        
+                    </li>
+                    
+                    <li class="finding-item">
+                        <div class="finding-statement">A hydrophobic, partly negatively charged binding pocket (with a conserved aspartate) rationalizes the broad-spectrum macrolide resistance.</div>
+                        
+                        <div class="finding-text">"This pocket is largely hydrophobic, with a negatively charged patch located at a conserved aspartate residue, rationalizing the broad-spectrum resistance conferred by the enzymes."</div>
+                        
+                    </li>
+                    
+                </ul>
+                
+            </div>
+            
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+                        
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/29317655" target="_blank" class="term-link">
+                            PMID:29317655
+                        </a>
+                        
+                    </span>
+                </div>
+                
+                <div class="reference-title">The evolution of substrate discrimination in macrolide antibiotic resistance enzymes</div>
+                
+                
+                <ul class="findings-list">
+                    
+                    <li class="finding-item">
+                        <div class="finding-statement">Contrary to earlier reports of a narrow range, MphB confers resistance to all macrolides tested and inactivates both telithromycin and azithromycin.</div>
+                        
+                        <div class="finding-text">"we found that MphB confers resistance to all macrolides tested...and inactivates both telithromycin and azithromycin"</div>
+                        
+                    </li>
+                    
+                    <li class="finding-item">
+                        <div class="finding-statement">Tandem mass spectrometry confirmed that MphB phosphorylates the desosamine 2&#39;-OH of erythromycin.</div>
+                        
+                        <div class="finding-text">"Using tandem mass spectrometry, we also confirmed that MphB phosphorylates the desosamine 2′-OH of erythromycin"</div>
+                        
+                    </li>
+                    
+                    <li class="finding-item">
+                        <div class="finding-statement">MphB is one of the mobilized Mph homologs widespread in Gram-negative bacteria.</div>
+                        
+                        <div class="finding-text">"MphA, MphB, and MphE are widespread in Gram-negative bacteria"</div>
+                        
+                    </li>
+                    
+                </ul>
+                
+            </div>
+            
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+                        
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/21108814" target="_blank" class="term-link">
+                            PMID:21108814
+                        </a>
+                        
+                    </span>
+                </div>
+                
+                <div class="reference-title">Genome sequence of adherent-invasive Escherichia coli and comparative genomic analysis with other E. coli pathotypes</div>
+                
+                
+                <ul class="findings-list">
+                    
+                    <li class="finding-item">
+                        <div class="finding-statement">Source genome of strain NRG 857C (AIEC); the mphB gene reviewed here (locus NRG857_30123) is carried on plasmid pO83_CORR.</div>
+                        
+                        <div class="finding-text">"Genome sequence of adherent-invasive Escherichia coli"</div>
+                        
+                    </li>
+                    
+                </ul>
+                
+            </div>
+            
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+                        
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/30177927" target="_blank" class="term-link">
+                            PMID:30177927
+                        </a>
+                        
+                    </span>
+                </div>
+                
+                <div class="reference-title">Look and Outlook on Enzyme-Mediated Macrolide Resistance</div>
+                
+                
+                <ul class="findings-list">
+                    
+                    <li class="finding-item">
+                        <div class="finding-statement">MPH(2&#39;)-II (MphB) inactivates 16-membered macrolides and the ketolide telithromycin in addition to 14-/15-membered macrolides, distinguishing it from the narrower MPH(2&#39;)-I (MphA).</div>
+                        
+                        <div class="finding-text">"MPH(2′)-I can only efficiently inactivate 14- and 15-membered lactone macrolides, whereas MPH(2′)-II can additionally inactivate 16-membered lactone macrolides and the ketolide, telithromycin"</div>
+                        
+                    </li>
+                    
+                </ul>
+                
+            </div>
+            
+        </div>
+    </div>
+    
+
+
+    
+    <div class="section">
+        <h2 class="section-title">Suggested Questions for Experts</h2>
+        
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> Does the plasmid-borne mphB in this AIEC strain (NRG 857C) contribute meaningfully to clinical macrolide resistance in vivo, and is its expression constitutive or induced under macrolide exposure?</p>
+                    
+                </div>
+                <span class="vote-buttons" data-g="A0A0H3EUF3" data-a="Q: Does the plasmid-borne mphB in this AIEC strain (N..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+        
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> Is the in vitro preference for GTP over ATP as phosphate donor (seen structurally) physiologically relevant in the cell, where ATP is far more abundant than GTP?</p>
+                    
+                </div>
+                <span class="vote-buttons" data-g="A0A0H3EUF3" data-a="Q: Is the in vitro preference for GTP over ATP as pho..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+        
+    </div>
+    
+
+    
+    <div class="section">
+        <h2 class="section-title">Suggested Experiments</h2>
+        
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    
+                    <p><strong>Experiment:</strong> Measure steady-state kinetics (kcat/Km) of purified MphB against a panel of 14-, 15- and 16-membered macrolides and ketolides, comparing ATP vs GTP/ITP donors, to quantify substrate and cofactor preferences.</p>
+                    
+                    
+                    
+                </div>
+                <span class="vote-buttons" data-g="A0A0H3EUF3" data-a="EXPERIMENT: Measure steady-state kinetics (kcat/Km) of purifie..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+        
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    
+                    <p><strong>Experiment:</strong> Construct an mphB deletion in E. coli O83:H1 NRG 857C and measure MICs across macrolides/ketolides to quantify the gene&#39;s contribution to resistance in its native genetic background.</p>
+                    
+                    
+                    
+                </div>
+                <span class="vote-buttons" data-g="A0A0H3EUF3" data-a="EXPERIMENT: Construct an mphB deletion in E. coli O83:H1 NRG 8..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+        
+    </div>
+    
+
+    
+
+    <!-- Computational Predictions Section -->
+    
+
+    <!-- Deep Research Sections -->
+    
+    <div class="section">
+        <h2 class="section-title">Deep Research</h2>
+        
+        <details class="deep-research-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; gap: 1rem;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Falcon</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(A0A0H3EUF3_ECO8N-deep-research-falcon.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="A0A0H3EUF3" data-a="DEEP_RESEARCH: Falcon" data-r="" data-act="DEEP_RESEARCH" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This deep research is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This deep research needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+                
+                <div class="report-meta">
+                    
+                    <span class="report-meta-text">Research Report: Functional Annotation of **A0A0H3EUF3_ECO8N** (UniProt A0A0H3EUF3) — Macrolide 2′-Phosphotransferase II (MphB)</span>
+                    
+                    
+                    <span class="report-badge">Falcon</span>
+                    
+                    
+                    <span class="report-badge">Edison Scientific Literature</span>
+                    
+                    
+                    <span class="report-badge">24 citations</span>
+                    
+                    
+                    <span class="report-badge">2 artifacts</span>
+                    
+                    
+                    <span class="report-meta-text">2026-06-12T05:59:57.983339</span>
+                    
+                    
+                    
+                </div>
+                
+                
+                <div class="artifact-list">
+                    
+                    
+                    
+                    <div class="artifact-link">
+                        <a href="A0A0H3EUF3_ECO8N-deep-research-falcon_artifacts/artifact-00.md" class="term-link">Edison artifact artifact-00</a>
+                        <span>(text/markdown)</span>
+                    </div>
+                    
+                    
+                    
+                    
+                    <div class="artifact-link">
+                        <a href="A0A0H3EUF3_ECO8N-deep-research-falcon_artifacts/image-1.png" class="term-link">## Context ID: pqac-00000008 The structural architecture and active site details for macrolide 2&#39;-phosphotransferase (specifically MPH(2&#39;)-II, also known as Mph</a>
+                        <span>(image/png)</span>
+                    </div>
+                    
+                    
+                </div>
+                
+                <p>The research report should be a detailed narrative explaining the function, biological processes, and localization of the gene product. Citations should be given for all claims.</p>
+<p>You should prioritize authoritative reviews and primary scientific literature when conducting research. You can supplement<br />
+this with annotations you find in gene/protein databases, but these can be outdated or inaccurate.</p>
+<p>We are specifically interested in the primary function of the gene - for enzymes, what reaction is catalyzed, and what is the substrate specificity? For transporters, what is the substrate? For structural proteins or adapters, what is the broader structural role? For signaling molecules, what is the role in the pathway.</p>
+<p>We are interested in where in or outside the cell the gene product carries out its function.</p>
+<p>We are also interested in the signaling or biochemical pathways in which the gene functions. We are less interested in broad pleiotropic effects, except where these elucidate the precise role.</p>
+<p>Include evidence where possible. We are interested in both experimental evidence as well as inference from structure, evolution, or bioinformatic analysis. Precise studies should be prioritized over high-throughput, where available.</p>
+<h1 id="research-report-functional-annotation-of-a0a0h3euf3_eco8n-uniprot-a0a0h3euf3-macrolide-2-phosphotransferase-ii-mphb">Research Report: Functional Annotation of <strong>A0A0H3EUF3_ECO8N</strong> (UniProt A0A0H3EUF3) — Macrolide 2′-Phosphotransferase II (MphB)</h1>
+<h2 id="0-target-verification-identity-and-scope">0. Target verification (identity and scope)</h2>
+<p>The user-specified UniProt description identifies A0A0H3EUF3 as <strong>macrolide 2′-phosphotransferase type II (MphB)</strong> from <em>Escherichia coli</em> O83:H1 (strain NRG 857C / AIEC). Direct UniProt retrieval was not available through the current toolchain; therefore, this report verifies identity indirectly by matching the provided description and InterPro/Pfam domain expectations (APH/kinase-like phosphotransferase superfamily) to authoritative biochemical and structural literature on <strong>MphB/MPH(2′)-II</strong>. These studies characterize <strong>MPH(2′)-II (MphB)</strong> as a kinase-like enzyme that phosphorylates macrolides at the <strong>desosamine 2′-OH</strong>, conferring macrolide resistance, consistent with the UniProt-provided functional label and APH-like domain annotation. (taniguchi2004theroleof pages 1-2, taniguchi2004theroleof pages 2-4, fong2017structuralbasisfor pages 1-3, pawlowski2018theevolutionof pages 4-6)</p>
+<h2 id="1-key-concepts-and-definitions-current-understanding">1. Key concepts and definitions (current understanding)</h2>
+<h3 id="11-what-is-mphb">1.1 What is MphB?</h3>
+<p><strong>MphB (macrolide 2′-phosphotransferase II; MPH(2′)-II)</strong> is an antibiotic resistance enzyme that <strong>chemically inactivates macrolide antibiotics</strong> by <strong>phosphorylation</strong>. It belongs to a broader class of <strong>macrolide phosphotransferases (Mph)</strong>, which are <strong>kinase-like</strong> enzymes evolutionarily/structurally related to aminoglycoside phosphotransferases. (fong2017structuralbasisfor pages 1-3, pawlowski2018theevolutionof pages 6-7)</p>
+<h3 id="12-reaction-chemistry-what-bond-is-made-what-position-is-modified">1.2 Reaction chemistry (what bond is made, what position is modified?)</h3>
+<p>Multiple lines of evidence support that Mph enzymes, including MphB, inactivate macrolides by <strong>O-phosphorylation of the desosamine sugar</strong>, specifically at the <strong>2′-hydroxyl (2′-OH)</strong> position. A tandem-MS-supported analysis cited in a Nature Communications study identifies <strong>MphB</strong> as a <strong>macrolide 2′-phosphotransferase that phosphorylates the desosamine 2′-OH of erythromycin</strong>. (pawlowski2018theevolutionof pages 4-6)</p>
+<h3 id="13-cofactors-and-donor-nucleotide-usage">1.3 Cofactors and donor nucleotide usage</h3>
+<p>MphB is a <strong>nucleotidyl-phosphate–dependent kinase-like enzyme</strong> requiring a <strong>divalent metal ion</strong> (typically Mg2+ in kinase chemistry) for nucleotide handling/catalysis. Structural work observed divalent metal in the nucleotide-binding pocket (Mg2+ or Ca2+ in structures) and highlighted metal-coordinating residues. (fong2017structuralbasisfor pages 5-6)</p>
+<p>The literature indicates <strong>purine nucleotides</strong> can be used as phosphate donors, with some differences between experimental systems/studies: mutational enzymology work describes transfer of the <strong>γ-phosphate of ATP</strong> to macrolides, whereas a high-resolution structural/enzymology study reported that <strong>MPH(2′)-II shows a preference for GTP over ATP</strong>. These findings can be reconciled by the view that MphB is a kinase-like enzyme that can act with ATP but may be optimized for guanine nucleotides in vitro for some homologs/assay formats. (taniguchi2004theroleof pages 1-2, fong2017structuralbasisfor pages 1-3, fong2017structuralbasisfor pages 16-17)</p>
+<h2 id="2-molecular-function-substrate-specificity-and-catalytic-determinants">2. Molecular function: substrate specificity and catalytic determinants</h2>
+<h3 id="21-substrate-spectrum-which-macrolides-are-modified">2.1 Substrate spectrum (which macrolides are modified?)</h3>
+<p>Evidence supports a <strong>broad macrolide spectrum</strong> for MphB/MPH(2′)-II, spanning <strong>14-, 15-, and 16-membered lactone macrolides</strong> and including the ketolide <strong>telithromycin</strong>. A biochemical panel reported substrates including <strong>oleandomycin, troleandomycin, erythromycin, clarithromycin, roxithromycin, azithromycin, kitasamycin, spiramycin, josamycin, rokitamycin, and tylosin</strong>. (taniguchi2004theroleof pages 2-4)</p>
+<p>Importantly, a Nature Communications study notes that although earlier reports had described MphB as narrow-spectrum (e.g., erythromycin but not azithromycin), their results show <strong>MphB conferred resistance to all macrolides tested</strong>, and <strong>inactivated both azithromycin and telithromycin</strong>. (pawlowski2018theevolutionof pages 3-4, pawlowski2018theevolutionof pages 4-6)</p>
+<h3 id="22-catalytic-residues-and-mechanistic-interpretation">2.2 Catalytic residues and mechanistic interpretation</h3>
+<p>Mutagenesis and structural work converge on conserved active-site residues. In one functional study, substitution of a conserved histidine showed <strong>His205 is critical</strong>: the H205A mutant reduced activity to <strong>&lt;1%</strong> (relative to wild type) with oleandomycin, while other substitutions retained substantially more activity, implying a key catalytic/nucleotide-binding role. (taniguchi2004theroleof pages 2-4)</p>
+<p>Structural analysis similarly emphasizes a catalytic core involving residues such as <strong>Asp200</strong> (proposed catalytic role) and <strong>His205/Asp219</strong> (metal coordination) in the nucleotide pocket. (fong2017structuralbasisfor pages 5-6)</p>
+<h3 id="23-quantitative-activity-and-resistance-metrics-available-data">2.3 Quantitative activity and resistance metrics (available data)</h3>
+<p>The 2004 mutagenesis/biochemical study reports relative activities (nmol·h−1·mg−1) across macrolides and shows that mutations in conserved nucleotide-binding residues reduce both <strong>enzymatic activity</strong> and <strong>macrolide MICs</strong> (e.g., MIC reductions to approximately one-half for H198A and one-eighth for H205A compared with wild type, per excerpt). (taniguchi2004theroleof pages 2-4)</p>
+<p>A 2023 WGS-focused study (primarily addressing mphA) cites a prior <em>E. coli</em> mphB example associated with an erythromycin <strong>MIC of 128 μg/mL</strong>, indicating that high-level resistance can be associated with mphB carriage in Enterobacterales contexts. (wang2023characterizationofresistance pages 7-9)</p>
+<h2 id="3-structural-biology-and-domain-architecture-linking-uniprot-domains-to-function">3. Structural biology and domain architecture (linking UniProt domains to function)</h2>
+<h3 id="31-fold-and-domain-organization">3.1 Fold and domain organization</h3>
+<p>Mph enzymes adopt a <strong>bi-lobed kinase fold</strong> reminiscent of aminoglycoside phosphotransferases, with an N-terminal lobe and C-terminal lobe, and (in the 2017 structural study) a prominent <strong>interdomain linker</strong> that contributes to an expanded macrolide-binding pocket. This architecture is consistent with the UniProt-provided APH/kinase-like domain annotations for A0A0H3EUF3. (fong2017structuralbasisfor pages 1-3, pawlowski2018theevolutionof pages 6-7)</p>
+<h3 id="32-binding-pocket-features-that-explain-broad-spectrum-macrolide-activity">3.2 Binding pocket features that explain broad-spectrum macrolide activity</h3>
+<p>The 2017 study describes the macrolide-binding pocket as largely hydrophobic with a negatively charged patch, rationalizing binding of diverse macrolide scaffolds. It also reports structures of MPH(2′)-II (MphB-type) in complex with multiple macrolides and guanine nucleotides (e.g., GDP observed in a ternary structure), supporting how nucleotide and antibiotic binding are coordinated in the active site. (fong2017structuralbasisfor pages 1-3, fong2017structuralbasisfor pages 5-6, fong2017structuralbasisfor pages 16-17)</p>
+<h3 id="33-visual-evidence-from-structural-figures">3.3 Visual evidence from structural figures</h3>
+<p>The following figure crops from Fong et al. (2017) depict (i) overall domain architecture and (ii) active-site organization and macrolide binding in MPH(2′)-II (MphB-type). (fong2017structuralbasisfor media bf5dafa2, fong2017structuralbasisfor media 8aeb75cf, fong2017structuralbasisfor media 7b5acc3d, fong2017structuralbasisfor media 53437096)</p>
+<h2 id="4-cellular-localization-and-biological-process-context">4. Cellular localization and biological process context</h2>
+<h3 id="41-cellular-localization-what-is-known-and-what-is-not">4.1 Cellular localization (what is known and what is not)</h3>
+<p>The retrieved sources characterize MphB as a cytosolic enzyme expressed in bacteria (e.g., recombinant expression in <em>E. coli</em> for biochemical and structural work), consistent with its role in <strong>intracellular antibiotic inactivation</strong>; however, none of the retrieved excerpts provide a definitive experimentally validated subcellular localization statement (e.g., cytosol vs periplasm) for the native protein in the target AIEC strain. Therefore, localization should be annotated conservatively as <strong>intracellular/cytosolic</strong>, inferred from enzyme class and expression/assay context, rather than as a directly demonstrated localization in <em>E. coli</em> O83:H1 NRG 857C. (fong2017structuralbasisfor pages 16-17, taniguchi2004theroleof pages 2-4)</p>
+<h3 id="42-pathwayprocess-role">4.2 Pathway/process role</h3>
+<p>MphB participates in the <strong>antibiotic resistance process</strong> (macrolide resistance) by <strong>drug modification (phosphorylation)</strong>. This is a direct resistance mechanism distinct from target modification (erm methylases) or efflux. (taniguchi2004theroleof pages 1-2, fong2017structuralbasisfor pages 1-3)</p>
+<h2 id="5-genetic-context-mobility-and-real-world-implementation">5. Genetic context, mobility, and real-world implementation</h2>
+<h3 id="51-plasmid-association-and-horizontal-transfer-potential">5.1 Plasmid association and horizontal transfer potential</h3>
+<p>A key feature of mph-family resistance determinants is association with mobile elements. A 2010 study reports <strong>mphB on a transferable multidrug resistance plasmid</strong> (pAPEC-O103-ColBM) in extraintestinal <em>E. coli</em>, where it contributed to decreased erythromycin susceptibility in a broader MDR plasmid background. (johnson2010sequenceanalysisand pages 7-8)</p>
+<p>Environmental mobilization is supported by characterization of a mosaic plasmid from fish farm sediment containing an mphB-like ORF (high similarity to MphB) that, when expressed in <em>E. coli</em>, produced a <strong>32-fold increase in erythromycin resistance</strong>, illustrating cross-host functionality and HGT risk. (yang2014characterizationofa pages 9-13)</p>
+<h3 id="52-recent-developments-20232024-emphasizing-genomicssurveillance">5.2 Recent developments (2023–2024) emphasizing genomics/surveillance</h3>
+<p>While recent (2023–2024) primary biochemical studies specific to MphB were not prominent in the retrieved corpus, <strong>genome sequencing and AMR surveillance</strong> studies continue to mention mphB as a macrolide-inactivating phosphotransferase in clinically relevant Gram-negative pathogens. For example, a 2024 hospital isolate WGS study of multidrug-resistant <em>Klebsiella pneumoniae</em> explicitly lists <strong>mphB as a phosphotransferase that phosphorylates macrolide antibiotics</strong> among detected resistance determinants. (wang2023characterizationofresistance pages 7-9)</p>
+<p>A 2023 study on azithromycin-resistant <em>Salmonella enterica</em> (primarily focusing on mphA plasmids) cites prior mphB-associated high MICs in <em>E. coli</em> and illustrates how WGS/hybrid assembly and plasmid comparisons are used to understand dissemination of macrolide resistance in Enterobacterales. (wang2023characterizationofresistance pages 7-9)</p>
+<h2 id="6-applications-and-implementations">6. Applications and implementations</h2>
+<h3 id="61-clinical-microbiology-and-genomic-amr-prediction">6.1 Clinical microbiology and genomic AMR prediction</h3>
+<p>In real-world settings, mph genes (including mphB) are used as <strong>genomic markers</strong> in WGS-based AMR prediction pipelines, informing antibiotic stewardship when macrolide therapy (e.g., azithromycin) is considered. WGS studies highlight that these determinants are often plasmid-associated and can spread across Enterobacterales, increasing the importance of genomic surveillance. (wang2023characterizationofresistance pages 7-9, johnson2010sequenceanalysisand pages 7-8)</p>
+<h3 id="62-structural-insights-enabling-inhibitor-design-research-application">6.2 Structural insights enabling inhibitor design (research application)</h3>
+<p>High-resolution structural characterization of MPH(2′)-II provides templates for rational inhibitor development or for predicting evolvability of resistance; the 2017 structural study resolved complexes with nucleotides and diverse macrolides, defining a drug-binding pocket and key residues that could be targeted. (fong2017structuralbasisfor pages 1-3, fong2017structuralbasisfor pages 5-6, fong2017structuralbasisfor media bf5dafa2)</p>
+<h2 id="7-expert-synthesis-and-authoritative-interpretation">7. Expert synthesis and authoritative interpretation</h2>
+<p>Across mechanistic enzymology and structural biology, authoritative sources converge on the model that MphB/MPH(2′)-II is a <strong>kinase-like macrolide inactivation enzyme</strong> that targets the <strong>desosamine 2′-OH</strong> and accommodates a broad macrolide spectrum via a binding pocket shaped by an interdomain linker and conserved catalytic residues. (pawlowski2018theevolutionof pages 4-6, fong2017structuralbasisfor pages 1-3, fong2017structuralbasisfor pages 5-6)</p>
+<p>A notable expert-level update is the reassessment of MphB specificity: contrary to earlier assumptions of narrow spectrum, experimental evidence indicates it can inactivate <strong>azithromycin and telithromycin</strong> and confer resistance across tested macrolides, highlighting the potential clinical relevance of mphB beyond erythromycin-only contexts. (pawlowski2018theevolutionof pages 3-4, pawlowski2018theevolutionof pages 4-6)</p>
+<h2 id="8-evidence-summary-table">8. Evidence summary table</h2>
+<table>
+<thead>
+<tr>
+<th>Feature/Question</th>
+<th>Evidence summary</th>
+<th>Key source(s) with year, URL/DOI, and Citation ID</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>Reaction catalyzed</td>
+<td>A0A0H3EUF3 matches the characterized MphB/MPH(2')-II class: a macrolide 2'-phosphotransferase that inactivates macrolide antibiotics by O-phosphorylation. The reaction transfers a phosphate from a nucleoside triphosphate to the drug, abolishing activity.</td>
+<td>Taniguchi et al., 2004, <em>FEMS Microbiology Letters</em>; https://doi.org/10.1016/S0378-1097(03)00961-3 (taniguchi2004theroleof pages 1-2, taniguchi2004theroleof pages 2-4); Fong et al., 2017, <em>Structure</em>; https://doi.org/10.1016/j.str.2017.03.007 (fong2017structuralbasisfor pages 1-3)</td>
+</tr>
+<tr>
+<td>Phosphorylation site</td>
+<td>The modified position is the desosamine 2'-OH of the macrolide. Tandem-MS-supported work identified MphB as phosphorylating the desosamine 2'-OH of erythromycin, and related figures mark the same 2'-OH site on azithromycin.</td>
+<td>Pawlowski et al., 2018, <em>Nature Communications</em>; https://doi.org/10.1038/s41467-017-02680-0 (pawlowski2018theevolutionof pages 4-6, pawlowski2018theevolutionof pages 3-4, pawlowski2018theevolutionof pages 6-7)</td>
+</tr>
+<tr>
+<td>Nucleotide donor preference</td>
+<td>The donor specificity is somewhat mixed across studies: biochemical mutagenesis assays used ATP and describe transfer of the γ-phosphate of ATP, whereas structural/enzymology work reported that MPH(2')-II shows a preference for GTP over ATP. Together, these data support that MphB is a kinase-like phosphotransferase with strong purine nucleotide usage, with GTP preference highlighted by the 2017 structural study.</td>
+<td>Taniguchi et al., 2004; https://doi.org/10.1016/S0378-1097(03)00961-3 (taniguchi2004theroleof pages 1-2, taniguchi2004theroleof pages 2-4); Fong et al., 2017; https://doi.org/10.1016/j.str.2017.03.007 (fong2017structuralbasisfor pages 1-3, fong2017structuralbasisfor pages 16-17)</td>
+</tr>
+<tr>
+<td>Metal/cofactor</td>
+<td>Divalent metal is required/implicated in catalysis and nucleotide binding. Structural work observed at least one metal ion (Mg2+ or Ca2+) in the nucleotide pocket, and mutational analysis linked His205 to ATP binding via Mg-mediated interactions.</td>
+<td>Fong et al., 2017; https://doi.org/10.1016/j.str.2017.03.007 (fong2017structuralbasisfor pages 5-6); Taniguchi et al., 2004; https://doi.org/10.1016/S0378-1097(03)00961-3 (taniguchi2004theroleof pages 2-4)</td>
+</tr>
+<tr>
+<td>Substrate spectrum</td>
+<td>MphB is broad-spectrum among macrolides. Reported substrates include 14-, 15-, and 16-membered macrolides such as oleandomycin, troleandomycin, erythromycin, clarithromycin, roxithromycin, azithromycin, kitasamycin, spiramycin, josamycin, rokitamycin, tylosin, and the ketolide telithromycin; one study explicitly states MphB conferred resistance to all tested macrolides and inactivated azithromycin and telithromycin.</td>
+<td>Taniguchi et al., 2004; https://doi.org/10.1016/S0378-1097(03)00961-3 (taniguchi2004theroleof pages 2-4); Fong et al., 2017; https://doi.org/10.1016/j.str.2017.03.007 (fong2017structuralbasisfor pages 1-3, fong2017structuralbasisfor pages 16-17); Pawlowski et al., 2018; https://doi.org/10.1038/s41467-017-02680-0 (pawlowski2018theevolutionof pages 4-6, pawlowski2018theevolutionof pages 3-4)</td>
+</tr>
+<tr>
+<td>Resistance phenotype data</td>
+<td>Expression of mphB increases macrolide resistance in bacterial hosts. Quantitatively, mutating conserved residues reduced MICs relative to wild type (H198A to about one-half and H205A to about one-eighth of wild-type MIC), and a related mphB-like plasmid ORF conferred a 32-fold increase in erythromycin resistance when expressed in <em>E. coli</em>; an additional surveillance paper cites prior <em>E. coli</em> mphB with erythromycin MIC 128 µg/mL.</td>
+<td>Taniguchi et al., 2004; https://doi.org/10.1016/S0378-1097(03)00961-3 (taniguchi2004theroleof pages 2-4); Yang et al., 2014; https://doi.org/10.1128/AEM.03257-13 (yang2014characterizationofa pages 9-13); Wang et al., 2023; https://doi.org/10.3389/fcimb.2023.1116172 (wang2023characterizationofresistance pages 7-9)</td>
+</tr>
+<tr>
+<td>Key catalytic residues</td>
+<td>Functionally important residues include Asp200, His205, and Asp219 in/near the nucleotide-binding catalytic region. Mutagenesis showed H205 is critical: H205A dropped activity to &lt;1% with oleandomycin, whereas H198A and H205N retained substantial activity, indicating H205 is especially important for catalysis/nucleotide handling.</td>
+<td>Fong et al., 2017; https://doi.org/10.1016/j.str.2017.03.007 (fong2017structuralbasisfor pages 5-6); Taniguchi et al., 2004; https://doi.org/10.1016/S0378-1097(03)00961-3 (taniguchi2004theroleof pages 1-2, taniguchi2004theroleof pages 2-4)</td>
+</tr>
+<tr>
+<td>Structural fold/domains</td>
+<td>MphB has a kinase-like aminoglycoside phosphotransferase-related fold with two lobes/domains. Structural studies describe an N-terminal β-sheet-rich lobe, a linker segment, and a mainly α-helical C-terminal lobe/subdomains forming a deep macrolide-binding cleft; this aligns well with the UniProt/APH-family domain assignment for A0A0H3EUF3.</td>
+<td>Fong et al., 2017; https://doi.org/10.1016/j.str.2017.03.007 (fong2017structuralbasisfor pages 1-3, fong2017structuralbasisfor pages 5-6, fong2017structuralbasisfor media bf5dafa2); Pawlowski et al., 2018; https://doi.org/10.1038/s41467-017-02680-0 (pawlowski2018theevolutionof pages 6-7)</td>
+</tr>
+<tr>
+<td>Genetic context/mobility</td>
+<td>mphB is mobile and has been found on transferable multidrug-resistance plasmids in <em>E. coli</em>. A transferable hybrid plasmid pAPEC-O103-ColBM carries mphB in extraintestinal <em>E. coli</em>, and broader literature/evidence links mph-family genes to plasmids, transposon-associated regions, and mosaic mobile elements, supporting horizontal spread across taxa.</td>
+<td>Johnson et al., 2010, <em>Infection and Immunity</em>; https://doi.org/10.1128/IAI.01174-09 (johnson2010sequenceanalysisand pages 7-8); Yang et al., 2014; https://doi.org/10.1128/AEM.03257-13 (yang2014characterizationofa pages 9-13)</td>
+</tr>
+<tr>
+<td>Real-world surveillance/WGS notes</td>
+<td>Recent WGS-based surveillance continues to detect mphB in clinically relevant Gram-negative pathogens, although most 2023–2024 azithromycin surveillance emphasizes mphA rather than mphB. A 2024 hospital-isolate genomics study identified mphB in multidrug-resistant <em>Klebsiella pneumoniae</em>, and 2023 Salmonella plasmid surveillance cited prior mphB-associated high MICs in <em>E. coli</em> while illustrating how WGS/hybrid assembly is used to track mobile macrolide resistance determinants across Enterobacterales.</td>
+<td>Dinda et al., 2024, <em>Access Microbiology</em>; https://doi.org/10.1099/acmi.0.000667.v4 (wang2023characterizationofresistance pages 7-9); Wang et al., 2023; https://doi.org/10.3389/fcimb.2023.1116172 (wang2023characterizationofresistance pages 7-9)</td>
+</tr>
+</tbody>
+</table>
+<p><em>Table: This table summarizes the experimentally supported functional annotation of UniProt A0A0H3EUF3 as MphB/macrolide 2'-phosphotransferase type II. It compiles reaction chemistry, substrate range, catalytic features, structural biology, mobility, and recent surveillance relevance using only the cited evidence contexts.</em></p>
+<h2 id="9-limitations-and-confidence">9. Limitations and confidence</h2>
+<ol>
+<li><strong>Strain-specific information</strong>: No strain-specific primary literature was retrieved directly linking UniProt A0A0H3EUF3 / locus NRG857_30123 in <em>E. coli</em> O83:H1 (NRG 857C/AIEC) to phenotype or genomic neighborhood; functional inference is therefore made at the <strong>MphB homolog</strong> level using well-characterized MphB/MPH(2′)-II literature. (fong2017structuralbasisfor pages 1-3, taniguchi2004theroleof pages 2-4)</li>
+<li><strong>Localization</strong>: No direct experimental subcellular localization evidence for MphB was found in the retrieved excerpts; localization is inferred as intracellular/cytosolic based on enzyme class and assay context. (fong2017structuralbasisfor pages 16-17, taniguchi2004theroleof pages 2-4)</li>
+<li><strong>Recent (2023–2024) mechanistic advances</strong>: Retrieved 2023–2024 sources were predominantly surveillance/genomics; the most detailed mechanistic/structural evidence remains from 2004–2018 foundational studies. (wang2023characterizationofresistance pages 7-9, fong2017structuralbasisfor pages 1-3, pawlowski2018theevolutionof pages 4-6)</li>
+</ol>
+<h2 id="10-key-references-with-publication-dates-and-urls">10. Key references (with publication dates and URLs)</h2>
+<ul>
+<li>Taniguchi K. et al. (2004-03). <em>FEMS Microbiology Letters</em>. “The role of histidine residues conserved in the putative ATP-binding region of macrolide 2′-phosphotransferase II.” https://doi.org/10.1016/S0378-1097(03)00961-3 (taniguchi2004theroleof pages 1-2, taniguchi2004theroleof pages 2-4)</li>
+<li>Fong D.H. et al. (2017-05). <em>Structure</em>. “Structural basis for kinase-mediated macrolide antibiotic resistance.” https://doi.org/10.1016/j.str.2017.03.007 (fong2017structuralbasisfor pages 1-3, fong2017structuralbasisfor pages 5-6, fong2017structuralbasisfor pages 16-17, fong2017structuralbasisfor media bf5dafa2, fong2017structuralbasisfor media 8aeb75cf, fong2017structuralbasisfor media 7b5acc3d, fong2017structuralbasisfor media 53437096)</li>
+<li>Pawlowski A.C. et al. (2018-01). <em>Nature Communications</em>. “The evolution of substrate discrimination in macrolide antibiotic resistance enzymes.” https://doi.org/10.1038/s41467-017-02680-0 (pawlowski2018theevolutionof pages 4-6, pawlowski2018theevolutionof pages 3-4, pawlowski2018theevolutionof pages 6-7)</li>
+<li>Johnson T.J. et al. (2010-05). <em>Infection and Immunity</em>. “Sequence analysis and characterization of a transferable hybrid plasmid encoding multidrug resistance…” https://doi.org/10.1128/IAI.01174-09 (johnson2010sequenceanalysisand pages 7-8)</li>
+<li>Wang H. et al. (2023-03). <em>Frontiers in Cellular and Infection Microbiology</em>. “Characterization of resistance genes and plasmids…” https://doi.org/10.3389/fcimb.2023.1116172 (wang2023characterizationofresistance pages 7-9)</li>
+<li>Dinda V. et al. (2024-01). <em>Access Microbiology</em>. “Whole genome sequencing and genotyping Klebsiella pneumoniae multi-drug resistant hospital isolates…” https://doi.org/10.1099/acmi.0.000667.v4 (wang2023characterizationofresistance pages 7-9)</li>
+</ul>
+<p>References</p>
+<ol>
+<li>
+<p>(taniguchi2004theroleof pages 1-2): Kazuo Taniguchi, Akio Nakamura, Kazue Tsurubuchi, Koji O'Hara, and Tetsuo Sawai. The role of histidine residues conserved in the putative atp-binding region of macrolide 2â²-phosphotransferase ii. FEMS Microbiology Letters, 232:123-126, Mar 2004. URL: https://doi.org/10.1016/s0378-1097(03)00961-3, doi:10.1016/s0378-1097(03)00961-3. This article has 7 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(taniguchi2004theroleof pages 2-4): Kazuo Taniguchi, Akio Nakamura, Kazue Tsurubuchi, Koji O'Hara, and Tetsuo Sawai. The role of histidine residues conserved in the putative atp-binding region of macrolide 2â²-phosphotransferase ii. FEMS Microbiology Letters, 232:123-126, Mar 2004. URL: https://doi.org/10.1016/s0378-1097(03)00961-3, doi:10.1016/s0378-1097(03)00961-3. This article has 7 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(fong2017structuralbasisfor pages 1-3): Desiree H. Fong, David L. Burk, Jonathan Blanchet, Amy Y. Yan, and Albert M. Berghuis. Structural basis for kinase-mediated macrolide antibiotic resistance. Structure, 25 5:750-761.e5, May 2017. URL: https://doi.org/10.1016/j.str.2017.03.007, doi:10.1016/j.str.2017.03.007. This article has 40 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(pawlowski2018theevolutionof pages 4-6): Andrew C. Pawlowski, Peter J. Stogios, Kalinka Koteva, Tatiana Skarina, Elena Evdokimova, Alexei Savchenko, and Gerard D. Wright. The evolution of substrate discrimination in macrolide antibiotic resistance enzymes. Nature Communications, Jan 2018. URL: https://doi.org/10.1038/s41467-017-02680-0, doi:10.1038/s41467-017-02680-0. This article has 102 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(pawlowski2018theevolutionof pages 6-7): Andrew C. Pawlowski, Peter J. Stogios, Kalinka Koteva, Tatiana Skarina, Elena Evdokimova, Alexei Savchenko, and Gerard D. Wright. The evolution of substrate discrimination in macrolide antibiotic resistance enzymes. Nature Communications, Jan 2018. URL: https://doi.org/10.1038/s41467-017-02680-0, doi:10.1038/s41467-017-02680-0. This article has 102 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(fong2017structuralbasisfor pages 5-6): Desiree H. Fong, David L. Burk, Jonathan Blanchet, Amy Y. Yan, and Albert M. Berghuis. Structural basis for kinase-mediated macrolide antibiotic resistance. Structure, 25 5:750-761.e5, May 2017. URL: https://doi.org/10.1016/j.str.2017.03.007, doi:10.1016/j.str.2017.03.007. This article has 40 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(fong2017structuralbasisfor pages 16-17): Desiree H. Fong, David L. Burk, Jonathan Blanchet, Amy Y. Yan, and Albert M. Berghuis. Structural basis for kinase-mediated macrolide antibiotic resistance. Structure, 25 5:750-761.e5, May 2017. URL: https://doi.org/10.1016/j.str.2017.03.007, doi:10.1016/j.str.2017.03.007. This article has 40 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(pawlowski2018theevolutionof pages 3-4): Andrew C. Pawlowski, Peter J. Stogios, Kalinka Koteva, Tatiana Skarina, Elena Evdokimova, Alexei Savchenko, and Gerard D. Wright. The evolution of substrate discrimination in macrolide antibiotic resistance enzymes. Nature Communications, Jan 2018. URL: https://doi.org/10.1038/s41467-017-02680-0, doi:10.1038/s41467-017-02680-0. This article has 102 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(wang2023characterizationofresistance pages 7-9): Hongmei Wang, Hang Cheng, Baoxing Huang, Xiumei Hu, Yunsheng Chen, Lei Zheng, Liang Yang, Jikui Deng, and Qian Wang. Characterization of resistance genes and plasmids from sick children caused by salmonella enterica resistance to azithromycin in shenzhen, china. Frontiers in Cellular and Infection Microbiology, Mar 2023. URL: https://doi.org/10.3389/fcimb.2023.1116172, doi:10.3389/fcimb.2023.1116172. This article has 26 citations.</p>
+</li>
+<li>
+<p>(fong2017structuralbasisfor media bf5dafa2): Desiree H. Fong, David L. Burk, Jonathan Blanchet, Amy Y. Yan, and Albert M. Berghuis. Structural basis for kinase-mediated macrolide antibiotic resistance. Structure, 25 5:750-761.e5, May 2017. URL: https://doi.org/10.1016/j.str.2017.03.007, doi:10.1016/j.str.2017.03.007. This article has 40 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(fong2017structuralbasisfor media 8aeb75cf): Desiree H. Fong, David L. Burk, Jonathan Blanchet, Amy Y. Yan, and Albert M. Berghuis. Structural basis for kinase-mediated macrolide antibiotic resistance. Structure, 25 5:750-761.e5, May 2017. URL: https://doi.org/10.1016/j.str.2017.03.007, doi:10.1016/j.str.2017.03.007. This article has 40 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(fong2017structuralbasisfor media 7b5acc3d): Desiree H. Fong, David L. Burk, Jonathan Blanchet, Amy Y. Yan, and Albert M. Berghuis. Structural basis for kinase-mediated macrolide antibiotic resistance. Structure, 25 5:750-761.e5, May 2017. URL: https://doi.org/10.1016/j.str.2017.03.007, doi:10.1016/j.str.2017.03.007. This article has 40 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(fong2017structuralbasisfor media 53437096): Desiree H. Fong, David L. Burk, Jonathan Blanchet, Amy Y. Yan, and Albert M. Berghuis. Structural basis for kinase-mediated macrolide antibiotic resistance. Structure, 25 5:750-761.e5, May 2017. URL: https://doi.org/10.1016/j.str.2017.03.007, doi:10.1016/j.str.2017.03.007. This article has 40 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(johnson2010sequenceanalysisand pages 7-8): Timothy J. Johnson, Dianna Jordan, Subhashinie Kariyawasam, Adam L. Stell, Nathan P. Bell, Yvonne M. Wannemuehler, Claudia Fernández Alarcón, Ganwu Li, Kelly A. Tivendale, Catherine M. Logue, and Lisa K. Nolan. Sequence analysis and characterization of a transferable hybrid plasmid encoding multidrug resistance and enabling zoonotic potential for extraintestinal <i>escherichia coli</i>. May 2010. URL: https://doi.org/10.1128/iai.01174-09, doi:10.1128/iai.01174-09. This article has 108 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(yang2014characterizationofa pages 9-13): Jing Yang, Chao Wang, Jinyu Wu, Li Liu, Gang Zhang, and Jie Feng. Characterization of a multiresistant mosaic plasmid from a fish farm sediment exiguobacterium sp. isolate reveals aggregation of functional clinic-associated antibiotic resistance genes. Applied and Environmental Microbiology, 80:1482-1488, Feb 2014. URL: https://doi.org/10.1128/aem.03257-13, doi:10.1128/aem.03257-13. This article has 28 citations and is from a peer-reviewed journal.</p>
+</li>
+</ol>
+<h2 id="artifacts">Artifacts</h2>
+<ul>
+<li><a href="A0A0H3EUF3_ECO8N-deep-research-falcon_artifacts/artifact-00.md">Edison artifact artifact-00</a><br />
+<img alt="## Context ID: pqac-00000008 The structural architecture and active site details for macrolide 2'-phosphotransferase (specifically MPH(2')-II, also known as Mph" src="A0A0H3EUF3_ECO8N-deep-research-falcon_artifacts/image-1.png" /></li>
+</ul>
+<h2 id="citations">Citations</h2>
+<ol>
+<li>pawlowski2018theevolutionof pages 4-6</li>
+<li>fong2017structuralbasisfor pages 5-6</li>
+<li>taniguchi2004theroleof pages 2-4</li>
+<li>wang2023characterizationofresistance pages 7-9</li>
+<li>johnson2010sequenceanalysisand pages 7-8</li>
+<li>yang2014characterizationofa pages 9-13</li>
+<li>fong2017structuralbasisfor pages 1-3</li>
+<li>pawlowski2018theevolutionof pages 6-7</li>
+<li>taniguchi2004theroleof pages 1-2</li>
+<li>fong2017structuralbasisfor pages 16-17</li>
+<li>pawlowski2018theevolutionof pages 3-4</li>
+<li>https://doi.org/10.1016/S0378-1097(03</li>
+<li>https://doi.org/10.1016/j.str.2017.03.007</li>
+<li>https://doi.org/10.1038/s41467-017-02680-0</li>
+<li>https://doi.org/10.1128/AEM.03257-13</li>
+<li>https://doi.org/10.3389/fcimb.2023.1116172</li>
+<li>https://doi.org/10.1128/IAI.01174-09</li>
+<li>https://doi.org/10.1099/acmi.0.000667.v4</li>
+<li>https://doi.org/10.1016/s0378-1097(03</li>
+<li>https://doi.org/10.1016/j.str.2017.03.007,</li>
+<li>https://doi.org/10.1038/s41467-017-02680-0,</li>
+<li>https://doi.org/10.3389/fcimb.2023.1116172,</li>
+<li>https://doi.org/10.1128/iai.01174-09,</li>
+<li>https://doi.org/10.1128/aem.03257-13,</li>
+</ol>
+            </div>
+        </details>
+        
+    </div>
+    
+
+    <!-- Additional Documentation Sections -->
+    
+    <div class="section">
+        <h2 class="section-title">📚 Additional Documentation</h2>
+        
+        <details class="markdown-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; cursor: pointer;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Notes</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(A0A0H3EUF3_ECO8N-notes.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="A0A0H3EUF3" data-a="DOC: Notes" data-r="" data-act="DOCUMENTATION" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This documentation is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This documentation needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+                <h1 id="notes-a0a0h3euf3_eco8n-mphb-macrolide-2-phosphotransferase-ii">Notes: A0A0H3EUF3_ECO8N (MphB, macrolide 2'-phosphotransferase II)</h1>
+<h2 id="identity">Identity</h2>
+<ul>
+<li>UniProt: A0A0H3EUF3 (TrEMBL, unreviewed), 302 aa, ~34.5 kDa.</li>
+<li>Organism: <em>Escherichia coli</em> O83:H1 strain NRG 857C (adherent-invasive E. coli, AIEC). NCBITaxon:685038.</li>
+<li>Encoded on plasmid pO83_CORR (OrderedLocusName NRG857_30123). Mobile/plasmid-borne resistance gene.</li>
+<li>UniProt SubName: "Macrolide 2'-phosphotransferase II protein MphB".</li>
+<li>CARD/ARO: ARO:3000318 (mphB); resistance mechanism = antibiotic inactivation [DR line in uniprot.txt].</li>
+<li>NCBIfam HMM: NF000242 (macrolide_MphB) — a curated family HMM specifically for MphB.</li>
+<li>RefSeq WP_000031017.1 (widely distributed, conserved sequence).</li>
+</ul>
+<h2 id="domain-fold">Domain / fold</h2>
+<ul>
+<li>Pfam PF01636 (APH, aminoglycoside phosphotransferase) domain, aa 23–265.</li>
+<li>PANTHER PTHR21310 (Aminoglycoside Phosphotransferase Enzymes), subfamily SF15.</li>
+<li>CDD cd05152 (MPH2).</li>
+<li>Gene3D 3.90.1200.10 + 3.30.200.20 (Phosphorylase Kinase domain 1); SUPFAM SSF56112 Protein kinase-like (PK-like).</li>
+<li>=&gt; Protein-kinase-like (ePK/APH) fold; this is the structural superfamily shared by aminoglycoside<br />
+  phosphotransferases and Ser/Thr/Tyr protein kinases. MphB is a small-molecule (macrolide) kinase, NOT a<br />
+  protein kinase and NOT an aminoglycoside kinase despite the family name.</li>
+</ul>
+<h2 id="function-well-established-in-literature">Function (well established in literature)</h2>
+<ul>
+<li>MphB = macrolide 2'-phosphotransferase II (MPH(2')II). Transfers the γ-phosphate of a purine nucleoside<br />
+  triphosphate to the 2'-OH of macrolide antibiotics, producing the inactive macrolide 2'-O-phosphate. This<br />
+  detoxifies/inactivates the antibiotic and confers macrolide resistance.<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/10428938 &quot;Macrolide 2" title="-phosphotransferase [MPH(2">PMID:10428938</a>] transfers the gamma phosphate of ATP to the 2'-OH group of macrolide antibiotics.")</li>
+<li>Reaction matches GO:0050073 "macrolide 2'-kinase activity": ATP + oleandomycin = ADP + 2 H+ + oleandomycin 2'-O-phosphate.</li>
+<li>Inactivated product confirmed as oleandomycin 2'-phosphate by TLC.<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/1330822" title="Inactivated oleandomycin was identified as oleandomycin 2'-phosphate by thin-layer chromatography.">PMID:1330822</a></li>
+</ul>
+<h2 id="substrate-cofactor-specificity">Substrate / cofactor specificity</h2>
+<ul>
+<li>Broad macrolide substrate range: active on BOTH 14-membered (e.g. oleandomycin, erythromycin) AND<br />
+  16-membered (e.g. spiramycin, tylosin, josamycin) ring macrolides; also 15-membered. mphB confers<br />
+  high-level resistance to spiramycin (16-membered) when expressed in S. aureus.<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/1330822" title="MPH(2')II ... showed high levels of activity with both 14-member-ring and 16-member-ring macrolides.">PMID:1330822</a><br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/9503630" title="The gene endowed S. aureus with high-level resistance to spiramycin, a macrolide antibiotic with a 16-membered ring.">PMID:9503630</a></li>
+<li>Phosphate donor: purine nucleotides ITP, GTP and ATP all effective as cofactors.<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/1330822" title="Purine nucleotides, such as ITP, GTP and ATP, were effective as cofactors in the inactivation of macrolides.">PMID:1330822</a></li>
+<li>Divalent metal cation involvement: activity affected by iodine, EDTA, or divalent cations (EDTA inhibition<br />
+  is consistent with a Mg2+-dependent phosphotransfer, as for the protein-kinase-like fold).<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/1330822" title="An inhibitory effect of iodine, EDTA, or divalent cations on MPH(2')II activity was observed.">PMID:1330822</a></li>
+<li>Constitutive, intracellular enzyme; pI 5.3, optimum pH 8.2, optimum temp 40°C.<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/1330822" title="MPH(2')II was a constitutive intracellular enzyme ...">PMID:1330822</a></li>
+</ul>
+<h2 id="catalytic-residues-site-directed-mutagenesis">Catalytic residues (site-directed mutagenesis)</h2>
+<ul>
+<li>Conserved aspartates in the ATP-binding/catalytic region are essential:<br />
+  D200, D209, D219, D231 — alanine substitution abolishes oleandomycin inactivation.<br />
+  D227A retains ~7% activity (non-essential; involved in recognizing 16-membered macrolides).<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/10428938" title="D200A, D209A, D219A, and D231A mutant strains were unable to inactivate the substrate oleandomycin, while a D227A mutant retained 7% of the activity of the original enzyme.">PMID:10428938</a><br />
+  (D200 proposed as catalytic base activating the 2'-OH; D219/D231 implicated in ATP binding — consistent with<br />
+  the protein-kinase-like fold catalytic/Mg2+-binding aspartates.)</li>
+</ul>
+<h2 id="mpha-vs-mphb">mphA vs mphB</h2>
+<ul>
+<li>Two distinct enzymes in E. coli: mphA (type I, MPH(2')I) and mphB (type II, MPH(2')II). Both phosphorylate<br />
+  the macrolide 2'-OH. mphA is inducible and is regulated by a repressor mphR(A); mphB (this gene) is<br />
+  constitutive. mphB has broad activity across 14/15/16-membered macrolides.<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/9503630" title="The genes mphA and mphB encode macrolide 2'-phosphotransferases I and II, respectively, and they confer resistance to macrolide antibiotics in Escherichia coli.">PMID:9503630</a></li>
+</ul>
+<h2 id="goa-status">GOA status</h2>
+<ul>
+<li>QuickGO GOA file is EMPTY (header only) for this TrEMBL accession → existing_annotations starts empty.</li>
+<li>The only electronic GO term on the UniProt record is GO:0016740 "transferase activity" (IEA:UniProtKB-KW),<br />
+  which is far too general. The correct specific MF is GO:0050073 (macrolide 2'-kinase activity).</li>
+</ul>
+<h2 id="go-terms-to-assign-new">GO terms to assign (NEW)</h2>
+<ul>
+<li>MF: GO:0050073 macrolide 2'-kinase activity (exact; supported by all biochemical refs).</li>
+<li>BP: GO:0046677 response to antibiotic (resistance/detoxification). Possibly GO:0017001 antibiotic catabolic<br />
+  process — but phosphorylation inactivates (modifies) rather than catabolizes/degrades the macrolide, so<br />
+  "response to antibiotic" is the safer/standard resistance BP; antibiotic catabolic process is arguable.</li>
+<li>MF supporting: GO:0016301 kinase activity / phosphotransferase; ATP binding (GO:0005524) — but uses<br />
+  ITP/GTP too, so a narrow ATP-binding term is not ideal; the specific GO:0050073 already captures the activity.</li>
+</ul>
+<h2 id="references-pmids-cached">References (PMIDs cached)</h2>
+<ul>
+<li>PMID:21108814 — AIEC NRG857C genome (source of this sequence/accession).</li>
+<li>PMID:1330822 — Purification &amp; characterization of MPH(2')II (Kono et al. 1992). KEY biochemistry.</li>
+<li>PMID:9503630 — mphB expression in S. aureus; 16-membered macrolide (spiramycin) resistance (Noguchi 1998).</li>
+<li>PMID:10428938 — Functional amino acids (catalytic Asp residues) of MPH(2')II (Taniguchi 1999). KEY mechanism.</li>
+</ul>
+<h2 id="update-falcon-deep-research-2026-06-12-additional-references-incorporated">Update: falcon deep research (2026-06-12) — additional references incorporated</h2>
+<p>Falcon deep research completed (genes/ECO8N/.../A0A0H3EUF3_ECO8N-deep-research-falcon.md, 24 citations)<br />
+and surfaced three additional high-value primary papers, now cached and added to the review:</p>
+<ul>
+<li>PMID:28416110 — Fong et al. 2017, Structure. "Structural Basis for Kinase-Mediated Macrolide Antibiotic<br />
+  Resistance." First crystal structures of MPH(2')-I and MPH(2')-II (the MphB class), apo and with GTP analogs</li>
+<li>six macrolides. Confirms the bi-lobed APH/protein-kinase-like fold with a large interdomain linker forming<br />
+  an expanded, hydrophobic macrolide-binding pocket (conserved aspartate negative patch) → rationalizes broad<br />
+  spectrum. Structures captured with GTP analogs (GTP a preferred donor in vitro).<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/28416110 &quot;We present structures for MPH(2" title=")-I and MPH(2">PMID:28416110</a>-II in the apo state, and in complex with GTP analogs and six different macrolides.")</li>
+<li>PMID:29317655 — Pawlowski et al. 2018, Nat Commun (PMC5760710, full text). "The evolution of substrate<br />
+  discrimination in macrolide antibiotic resistance enzymes." Mass-spec confirms MphB phosphorylates the<br />
+  desosamine 2'-OH of erythromycin; revises older narrow-spectrum view — MphB inactivates azithromycin AND<br />
+  telithromycin and confers resistance to all macrolides tested. MphB widespread/mobilized in Gram-negatives.<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/29317655" title="we found that MphB confers resistance to all macrolides tested...and inactivates both telithromycin and azithromycin">PMID:29317655</a><br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/29317655" title="Using tandem mass spectrometry, we also confirmed that MphB phosphorylates the desosamine 2′-OH of erythromycin">PMID:29317655</a></li>
+<li>PMID:15033229 — Taniguchi et al. 2004, FEMS Microbiol Lett. "The role of histidine residues conserved in the<br />
+  putative ATP-binding region of macrolide 2'-phosphotransferase II." His205 critical (H205A &lt;1% activity).<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/15033229" title="the specific activity of the H205A mutant enzyme was reduced to less than 1% of that of the wild enzyme.">PMID:15033229</a></li>
+</ul>
+<p>Net effect on review: description strengthened (broad spectrum incl. azithromycin/telithromycin; crystal<br />
+structures; GTP preference; His205). GO calls unchanged (GO:0050073 MF, GO:0046677 BP) — now multiply<br />
+supported. suggested_questions/experiments revised since the structure (Fong 2017) and broad-spectrum<br />
+question (Pawlowski 2018) are now answered.</p>
+<p>Note on providers: perplexity not configured in this container (only openai/falcon); openai API key invalid<br />
+(401). falcon's wrapper reported a 600s timeout but the Edison run actually completed and wrote the report +<br />
+artifacts. <code>just</code> is not installed here, so underlying <code>uv run ai-gene-review ...</code> commands were used directly.</p>
+<h2 id="update-card-aro3000318-mphb-curated-amr-data-incorporated">Update: CARD ARO:3000318 (mphB) — curated AMR data incorporated</h2>
+<p>CARD entry https://card.mcmaster.ca/ARO:3000318 (AMR Gene Family: Macrolide phosphotransferase (MPH);<br />
+mechanism: antibiotic inactivation; Protein Homolog Model, BLASTP bitscore cutoff 600). Curated drug list:<br />
+erythromycin, roxithromycin, clarithromycin, dirithromycin, oleandomycin (14-membered), azithromycin<br />
+(15-membered), spiramycin, tylosin (16-membered), and the ketolide telithromycin. Mechanism: phosphorylation<br />
+at the 2'-OH of the desosamine sugar of 14- and 16-membered macrolides. Two CARD-cited PMIDs newly added:</p>
+<ul>
+<li>PMID:8900063 — Noguchi et al. 1996, FEMS Microbiol Lett. Original cloning/sequencing of mphB. KEY identity<br />
+  anchor: encodes a 302-aa / 34483-Da protein, matching this UniProt entry (302 aa, 34485 MW) exactly.<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/8900063" title="mphB encoded a protein of 302 amino acids with a molecular mass of 34483 Da.">PMID:8900063</a></li>
+<li>PMID:17302923 — Chesneau et al. 2007, FEMS Microbiol Lett. Resistance phenotypes of mph genes in an<br />
+  efflux-deficient E. coli AG100A host. mphB confers spiramycin + telithromycin resistance; in this older<br />
+  study azithromycin resistance was attributed uniquely to mphA — the narrow-spectrum view of MphB later<br />
+  overturned by Pawlowski 2018 (PMID:29317655).<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/17302923" title="The mph(C) gene, as reported for mph(B), also conferred resistance to spiramycin">PMID:17302923</a><br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/17302923" title="The four investigated genes conferred resistance to telithromycin.">PMID:17302923</a></li>
+</ul>
+<p>Net effect: identity now triple-anchored (UniProt SubName + CARD ARO:3000318 + cloning paper exact 302aa/<br />
+34483Da match + NCBIfam NF000242 macrolide_MphB HMM). Description substrate range expanded to the full<br />
+curated CARD drug list and the historical narrow→broad spectrum reassessment documented. GO calls unchanged.</p>
+            </div>
+        </details>
+        
+    </div>
+    
+
+    <!-- YAML Preview Section -->
+    <div class="section">
+        <details class="yaml-preview">
+            <summary>
+                <h2 style="display: inline;">📄 View Raw YAML</h2>
+            </summary>
+            <div class="yaml-content">
+                <pre><code>id: A0A0H3EUF3
+gene_symbol: mphB
+aliases:
+- MphB
+- macrolide 2&#39;-phosphotransferase II
+- MPH(2&#39;)II
+product_type: PROTEIN
+status: DRAFT
+taxon:
+  id: NCBITaxon:685038
+  label: Escherichia coli O83:H1 (strain NRG 857C / AIEC)
+description: &gt;-
+  MphB (macrolide 2&#39;-phosphotransferase II, MPH(2&#39;)II) is a plasmid-encoded macrolide
+  kinase that inactivates macrolide antibiotics. It transfers the gamma-phosphate of a
+  purine nucleoside triphosphate (ATP, GTP or ITP) to the 2&#39;-hydroxyl group of the desosamine
+  sugar of macrolides, producing an inactive macrolide 2&#39;-O-phosphate that can no longer bind
+  the bacterial ribosome; this enzymatic detoxification confers macrolide resistance. MphB acts
+  on a broad range of substrates spanning 14-membered (e.g. oleandomycin, erythromycin, clarithromycin,
+  roxithromycin, dirithromycin), 15-membered (azithromycin), and 16-membered (e.g. spiramycin, tylosin,
+  josamycin) macrolides as well as the ketolide telithromycin (CARD ARO:3000318). Early phenotyping placed
+  MphB as relatively narrow (with azithromycin resistance attributed specifically to MphA), but later
+  enzymatic and mass-spectrometric work showed MphB inactivates essentially all macrolides tested, including
+  azithromycin and telithromycin. The cloned mphB encodes a 302-residue, ~34.5 kDa protein matching this
+  UniProt entry exactly.
+  Crystal structures of the MphB class (MPH(2&#39;)-II) reveal the bi-lobed protein-kinase-like fold of the
+  aminoglycoside phosphotransferase (APH) superfamily, distinguished by a large interdomain linker that
+  forms an expanded, largely hydrophobic macrolide-binding pocket; nucleotide is bound in the kinase
+  pocket (structures captured with GTP analogs, and GTP is a preferred donor in vitro, though ATP, GTP
+  and ITP can all serve). Catalysis depends on conserved active-site residues — aspartates D200/D209/D219/
+  D231 and the conserved His205 — and on a divalent metal (activity is EDTA-inhibited), consistent with the
+  Mg2+-dependent phosphotransfer chemistry of this fold; D227 contributes to recognition of 16-membered
+  macrolides. In this organism the gene is carried on plasmid pO83_CORR of the adherent-invasive
+  Escherichia coli strain NRG 857C, making it part of the mobile macrolide-resistance gene pool of enteric
+  bacteria.
+references:
+- id: PMID:8900063
+  title: &#34;Cloning and nucleotide sequence of the mphB gene for macrolide 2&#39;-phosphotransferase II in Escherichia coli&#34;
+  findings:
+  - statement: &gt;-
+      The mphB gene encoding MPH(2&#39;)II was cloned and sequenced from E. coli; it encodes a 302-aa protein of
+      34483 Da, matching this UniProt entry (302 aa, ~34485 Da).
+    supporting_text: &#34;mphB encoded a protein of 302 amino acids with a molecular mass of 34483 Da.&#34;
+  - statement: &gt;-
+      The C-terminal region resembles the conserved functional domain of aminoglycoside phosphotransferases
+      (the APH/protein-kinase-like fold).
+    supporting_text: &#34;The carboxy terminal region of the deduced protein contained a sequence that resembled a conserved functional domain in aminoglycoside phosphotransferases.&#34;
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      PubMed-verified (Noguchi et al., FEMS Microbiol Lett 1996). Foundational cloning/sequencing of mphB; the
+      reported 302-aa / 34483-Da product matches this exact UniProt sequence, anchoring gene identity, and the
+      APH-domain note matches the Pfam PF01636 annotation.
+- id: PMID:17302923
+  title: &#34;Resistance phenotypes conferred by macrolide phosphotransferases&#34;
+  findings:
+  - statement: &gt;-
+      mph genes were assayed in a macrolide/ketolide-susceptible E. coli AG100A background (AcrAB efflux pump
+      disrupted), enabling clean comparison of phosphotransferase-conferred resistance.
+    supporting_text: &#34;The mph genes were cloned into Escherichia coli AG100A susceptible to macrolides and ketolides following disruption of the AcrAB pump.&#34;
+  - statement: &gt;-
+      mph(B) confers resistance to spiramycin (16-membered) and, like the other mph genes, to telithromycin.
+    supporting_text: &#34;The mph(C) gene, as reported for mph(B), also conferred resistance to spiramycin...The four investigated genes conferred resistance to telithromycin.&#34;
+  - statement: &gt;-
+      In this 2007 comparison mph(A) was reported as uniquely conferring azithromycin resistance — the older
+      narrow-spectrum view of mph(B) later revised by Pawlowski et al. 2018 (PMID:29317655).
+    supporting_text: &#34;The mph(A) gene was unique in conferring resistance to azithromycin.&#34;
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      PubMed-verified (Chesneau et al., FEMS Microbiol Lett 2007). Phenotypic comparison of mph genes in an
+      efflux-deficient host; documents mph(B) spiramycin/telithromycin resistance and the historical view that
+      azithromycin resistance was mph(A)-specific (subsequently overturned for MphB by PMID:29317655).
+- id: PMID:1330822
+  title: &#34;Purification and characterization of macrolide 2&#39;-phosphotransferase type II from a strain of Escherichia coli highly resistant to macrolide antibiotics&#34;
+  findings:
+  - statement: &gt;-
+      MPH(2&#39;)II inactivates macrolides by phosphorylation of the 2&#39;-hydroxyl; the inactivated
+      oleandomycin product was identified as oleandomycin 2&#39;-phosphate.
+    supporting_text: &#34;Inactivated oleandomycin was identified as oleandomycin 2&#39;-phosphate by thin-layer chromatography.&#34;
+  - statement: &gt;-
+      MPH(2&#39;)II is a constitutive intracellular enzyme active on both 14- and 16-membered macrolides.
+    supporting_text: &#34;MPH(2&#39;)II was a constitutive intracellular enzyme which showed high levels of activity with both 14-member-ring and 16-member-ring macrolides.&#34;
+  - statement: &gt;-
+      Purine nucleotides (ITP, GTP, ATP) serve as phosphate donors; activity is metal-dependent (EDTA-inhibited).
+    supporting_text: &#34;Purine nucleotides, such as ITP, GTP and ATP, were effective as cofactors in the inactivation of macrolides. An inhibitory effect of iodine, EDTA, or divalent cations on MPH(2&#39;)II activity was observed.&#34;
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      PubMed-verified (Kono et al., FEMS Microbiol Lett 1992). Original biochemical purification and
+      characterization of MPH(2&#39;)II; directly establishes the macrolide 2&#39;-phosphotransferase activity,
+      product identity, broad substrate range, and nucleotide/metal requirements.
+- id: PMID:9503630
+  title: &#34;Expression of the mphB gene for macrolide 2&#39;-phosphotransferase II from Escherichia coli in Staphylococcus aureus&#34;
+  findings:
+  - statement: &gt;-
+      mphA and mphB encode macrolide 2&#39;-phosphotransferases I and II and confer macrolide resistance in E. coli.
+    supporting_text: &#34;The genes mphA and mphB encode macrolide 2&#39;-phosphotransferases I and II, respectively, and they confer resistance to macrolide antibiotics in Escherichia coli.&#34;
+  - statement: &gt;-
+      mphB conferred high-level resistance to the 16-membered-ring macrolide spiramycin when expressed in S. aureus.
+    supporting_text: &#34;The gene endowed S. aureus with high-level resistance to spiramycin, a macrolide antibiotic with a 16-membered ring.&#34;
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      PubMed-verified (Noguchi et al., FEMS Microbiol Lett 1998). Demonstrates that mphB is a transferable
+      resistance determinant that functions across species and is active against 16-membered macrolides.
+- id: PMID:10428938
+  title: &#34;Identification of functional amino acids in the macrolide 2&#39;-phosphotransferase II&#34;
+  findings:
+  - statement: &gt;-
+      MPH(2&#39;) transfers the gamma-phosphate of ATP to the 2&#39;-OH group of macrolide antibiotics.
+    supporting_text: &#34;Macrolide 2&#39;-phosphotransferase [MPH(2&#39;)] transfers the gamma phosphate of ATP to the 2&#39;-OH group of macrolide antibiotics.&#34;
+  - statement: &gt;-
+      Active-site aspartates D200, D209, D219 and D231 are essential for catalysis; D227 is non-essential
+      and contributes to 16-membered-ring macrolide recognition.
+    supporting_text: &#34;D200A, D209A, D219A, and D231A mutant strains were unable to inactivate the substrate oleandomycin, while a D227A mutant retained 7% of the activity of the original enzyme.&#34;
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      PubMed-verified (Taniguchi et al., Antimicrob Agents Chemother 1999). Site-directed mutagenesis
+      defines the catalytic/ATP-binding aspartates of MPH(2&#39;)II, confirming the phosphotransfer mechanism.
+- id: PMID:15033229
+  title: &#34;The role of histidine residues conserved in the putative ATP-binding region of macrolide 2&#39;-phosphotransferase II&#34;
+  findings:
+  - statement: &gt;-
+      MPH(2&#39;)II catalyzes transfer of the gamma-phosphate of ATP to the 2&#39;-hydroxyl group of macrolides.
+    supporting_text: &#34;Macrolide 2&#39;-phosphotransferase (MPH(2&#39;)) catalyzes the transfer of the gamma-phosphate of ATP to the 2&#39;-hydroxyl group of macrolide antibiotics.&#34;
+  - statement: &gt;-
+      His205 in the ATP-binding motif is critical for catalysis (H205A retains &lt;1% activity).
+    supporting_text: &#34;the specific activity of the H205A mutant enzyme was reduced to less than 1% of that of the wild enzyme.&#34;
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      PubMed-verified (Taniguchi et al., FEMS Microbiol Lett 2004). Identifies the conserved His205 as
+      essential for MPH(2&#39;)II catalysis, complementing the earlier aspartate mutagenesis (PMID:10428938).
+- id: PMID:28416110
+  title: &#34;Structural Basis for Kinase-Mediated Macrolide Antibiotic Resistance&#34;
+  findings:
+  - statement: &gt;-
+      Crystal structures of MPH(2&#39;)-II (the MphB class) were solved in the apo state and in complex with
+      GTP analogs and six macrolides.
+    supporting_text: &#34;We present structures for MPH(2&#39;)-I and MPH(2&#39;)-II in the apo state, and in complex with GTP analogs and six different macrolides.&#34;
+  - statement: &gt;-
+      Mph enzymes share the aminoglycoside-phosphotransferase (protein-kinase-like) fold but have a large
+      interdomain linker forming an expanded antibiotic-binding pocket.
+    supporting_text: &#34;the enzymes are related to the aminoglycoside phosphotransferases, but are distinguished from them by the presence of a large interdomain linker that contributes to an expanded antibiotic binding pocket.&#34;
+  - statement: &gt;-
+      A hydrophobic, partly negatively charged binding pocket (with a conserved aspartate) rationalizes the
+      broad-spectrum macrolide resistance.
+    supporting_text: &#34;This pocket is largely hydrophobic, with a negatively charged patch located at a conserved aspartate residue, rationalizing the broad-spectrum resistance conferred by the enzymes.&#34;
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      PubMed-verified (Fong et al., Structure 2017). First crystal structures of the MphB class (MPH(2&#39;)-II);
+      directly establishes the kinase-like fold, GTP-analog/macrolide binding, and structural basis for broad
+      macrolide specificity. Structures determined with GTP analogs, consistent with purine-NTP donor use.
+- id: PMID:29317655
+  title: &#34;The evolution of substrate discrimination in macrolide antibiotic resistance enzymes&#34;
+  findings:
+  - statement: &gt;-
+      Contrary to earlier reports of a narrow range, MphB confers resistance to all macrolides tested and
+      inactivates both telithromycin and azithromycin.
+    supporting_text: &#34;we found that MphB confers resistance to all macrolides tested...and inactivates both telithromycin and azithromycin&#34;
+  - statement: &gt;-
+      Tandem mass spectrometry confirmed that MphB phosphorylates the desosamine 2&#39;-OH of erythromycin.
+    supporting_text: &#34;Using tandem mass spectrometry, we also confirmed that MphB phosphorylates the desosamine 2′-OH of erythromycin&#34;
+  - statement: &gt;-
+      MphB is one of the mobilized Mph homologs widespread in Gram-negative bacteria.
+    supporting_text: &#34;MphA, MphB, and MphE are widespread in Gram-negative bacteria&#34;
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      PubMed-verified (Pawlowski et al., Nat Commun 2018; PMC5760710, full text). Mass-spec confirmation of
+      the 2&#39;-OH phosphorylation site and broad substrate range of MphB (including azithromycin and the
+      ketolide telithromycin), revising the older narrow-spectrum view.
+- id: PMID:21108814
+  title: &#34;Genome sequence of adherent-invasive Escherichia coli and comparative genomic analysis with other E. coli pathotypes&#34;
+  findings:
+  - statement: &gt;-
+      Source genome of strain NRG 857C (AIEC); the mphB gene reviewed here (locus NRG857_30123) is carried
+      on plasmid pO83_CORR.
+    supporting_text: &#34;Genome sequence of adherent-invasive Escherichia coli&#34;
+  reference_review:
+    relevance: LOW
+    correctness: VERIFIED
+    review_notes: &gt;-
+      PubMed-verified (Nash et al., BMC Genomics 2010). Genome/provenance reference for this UniProt entry;
+      provides the strain and plasmid context but no functional characterization of mphB.
+- id: PMID:30177927
+  title: &#34;Look and Outlook on Enzyme-Mediated Macrolide Resistance&#34;
+  findings:
+  - statement: &gt;-
+      MPH(2&#39;)-II (MphB) inactivates 16-membered macrolides and the ketolide telithromycin in addition to
+      14-/15-membered macrolides, distinguishing it from the narrower MPH(2&#39;)-I (MphA).
+    supporting_text: &#34;MPH(2′)-I can only efficiently inactivate 14- and 15-membered lactone macrolides, whereas MPH(2′)-II can additionally inactivate 16-membered lactone macrolides and the ketolide, telithromycin&#34;
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      PubMed-verified (Golkar et al., Front Microbiol 2018). Authoritative review providing a clean
+      secondary-source statement of the MPH(2&#39;)-II (MphB) broad substrate range vs the narrower MPH(2&#39;)-I.
+existing_annotations:
+# NOTE: The QuickGO GOA export for this TrEMBL accession is empty (no curated annotations).
+# The only electronic GO term on the UniProt record is the over-general GO:0016740 &#34;transferase
+# activity&#34; (IEA from the UniProtKB Transferase keyword), which is not in GOA. The annotations
+# below (action: NEW) capture the specific, experimentally established function that should be
+# annotated for MphB, replacing/refining that uninformative keyword-derived term.
+- term:
+    id: GO:0050073
+    label: macrolide 2&#39;-kinase activity
+  evidence_type: IDA
+  original_reference_id: PMID:1330822
+  review:
+    summary: &gt;-
+      MphB phosphorylates the 2&#39;-OH of macrolides using a purine NTP, producing inactive macrolide
+      2&#39;-O-phosphate. This is the core, experimentally demonstrated molecular function and exactly matches
+      the GO:0050073 definition (ATP + oleandomycin = ADP + 2 H+ + oleandomycin 2&#39;-O-phosphate).
+    action: NEW
+    reason: &gt;-
+      The purified enzyme was shown biochemically to phosphorylate macrolides at the 2&#39;-position, and the
+      product was identified as oleandomycin 2&#39;-phosphate by TLC; the mechanism (gamma-phosphate transfer
+      from ATP to the macrolide 2&#39;-OH) and catalytic aspartates were confirmed by mutagenesis. No curated
+      GOA annotation exists for this TrEMBL entry, so this specific MF should be added.
+    additional_reference_ids:
+    - PMID:8900063
+    - PMID:10428938
+    - PMID:15033229
+    - PMID:28416110
+    - PMID:29317655
+    supported_by:
+    - reference_id: PMID:1330822
+      supporting_text: &#34;Inactivated oleandomycin was identified as oleandomycin 2&#39;-phosphate by thin-layer chromatography.&#34;
+    - reference_id: PMID:10428938
+      supporting_text: &#34;transfers the gamma phosphate of ATP to the 2&#39;-OH group of macrolide antibiotics.&#34;
+    - reference_id: PMID:29317655
+      supporting_text: &#34;Using tandem mass spectrometry, we also confirmed that MphB phosphorylates the desosamine 2′-OH of erythromycin&#34;
+- term:
+    id: GO:0046677
+    label: response to antibiotic
+  evidence_type: IMP
+  original_reference_id: PMID:9503630
+  review:
+    summary: &gt;-
+      By enzymatically inactivating macrolides, MphB confers macrolide antibiotic resistance; expression of
+      mphB renders host bacteria resistant to 14-, 15- and 16-membered macrolides (e.g. high-level spiramycin
+      resistance when expressed in S. aureus).
+    action: NEW
+    reason: &gt;-
+      Resistance is the biological process in which this enzyme participates: mphB expression confers macrolide
+      resistance in both E. coli and a heterologous host. &#34;response to antibiotic&#34; is the standard, well-supported
+      BP for an antibiotic-modifying resistance enzyme. (Note: phosphorylation inactivates/modifies rather than
+      degrades the drug, so an &#34;antibiotic catabolic process&#34; term would be less accurate.)
+    additional_reference_ids:
+    - PMID:1330822
+    - PMID:29317655
+    - PMID:17302923
+    supported_by:
+    - reference_id: PMID:9503630
+      supporting_text: &#34;The gene endowed S. aureus with high-level resistance to spiramycin, a macrolide antibiotic with a 16-membered ring.&#34;
+    - reference_id: PMID:9503630
+      supporting_text: &#34;The genes mphA and mphB encode macrolide 2&#39;-phosphotransferases I and II, respectively, and they confer resistance to macrolide antibiotics in Escherichia coli.&#34;
+    - reference_id: PMID:29317655
+      supporting_text: &#34;we found that MphB confers resistance to all macrolides tested...and inactivates both telithromycin and azithromycin&#34;
+    - reference_id: PMID:17302923
+      supporting_text: &#34;The mph(C) gene, as reported for mph(B), also conferred resistance to spiramycin...The four investigated genes conferred resistance to telithromycin.&#34;
+- term:
+    id: GO:0005737
+    label: cytoplasm
+  evidence_type: IDA
+  original_reference_id: PMID:1330822
+  review:
+    summary: &gt;-
+      MphB was characterized as a soluble, intracellular (cytoplasmic) enzyme upon purification from E. coli,
+      consistent with cytoplasmic detoxification of macrolides before they reach the ribosome.
+    action: NEW
+    reason: &gt;-
+      The purified enzyme was reported as a constitutive intracellular enzyme, indicating cytoplasmic
+      localization — the expected compartment for a soluble macrolide-inactivating kinase.
+    supported_by:
+    - reference_id: PMID:1330822
+      supporting_text: &#34;MPH(2&#39;)II was a constitutive intracellular enzyme&#34;
+core_functions:
+- description: &gt;-
+    MphB is a macrolide 2&#39;-phosphotransferase (macrolide kinase): it transfers the gamma-phosphate of a
+    purine nucleoside triphosphate to the 2&#39;-hydroxyl of the desosamine sugar of macrolide antibiotics,
+    generating an inactive macrolide 2&#39;-O-phosphate. This enzymatic modification detoxifies the drug and is
+    the molecular basis of macrolide resistance conferred by the gene. The enzyme has broad macrolide substrate
+    specificity (14-, 15- and 16-membered rings) and uses the conserved active-site aspartates of the
+    protein-kinase-like/APH fold for metal-dependent phosphoryl transfer.
+  molecular_function:
+    id: GO:0050073
+    label: macrolide 2&#39;-kinase activity
+  directly_involved_in:
+  - id: GO:0046677
+    label: response to antibiotic
+  locations:
+  - id: GO:0005737
+    label: cytoplasm
+  # Substrate specificity is recorded at finer granularity than the GO MF term: MphB acts on
+  # 14-, 15- AND 16-membered macrolides. The 16-membered substrates (josamycin, tylosin) are the
+  # key discriminator from MphA, which does not efficiently modify 16-membered macrolides.
+  substrates:
+  - id: CHEBI:48923   # 14-membered
+    label: erythromycin
+  - id: CHEBI:16869   # 14-membered (classic in vitro assay substrate)
+    label: oleandomycin
+  - id: CHEBI:2955    # 15-membered
+    label: azithromycin
+  - id: CHEBI:31739   # 16-membered (MphB-specific vs MphA)
+    label: josamycin
+  - id: CHEBI:17658   # 16-membered (MphB-specific vs MphA)
+    label: tylosin
+  - id: CHEBI:29688   # ketolide
+    label: telithromycin
+  supported_by:
+  - reference_id: PMID:1330822
+    supporting_text: &#34;Inactivated oleandomycin was identified as oleandomycin 2&#39;-phosphate by thin-layer chromatography.&#34;
+  - reference_id: PMID:10428938
+    supporting_text: &#34;transfers the gamma phosphate of ATP to the 2&#39;-OH group of macrolide antibiotics.&#34;
+  - reference_id: PMID:29317655
+    supporting_text: &#34;Using tandem mass spectrometry, we also confirmed that MphB phosphorylates the desosamine 2′-OH of erythromycin&#34;
+  - reference_id: PMID:30177927
+    supporting_text: &#34;MPH(2′)-I can only efficiently inactivate 14- and 15-membered lactone macrolides, whereas MPH(2′)-II can additionally inactivate 16-membered lactone macrolides and the ketolide, telithromycin&#34;
+suggested_questions:
+- question: &gt;-
+    Does the plasmid-borne mphB in this AIEC strain (NRG 857C) contribute meaningfully to clinical macrolide
+    resistance in vivo, and is its expression constitutive or induced under macrolide exposure?
+- question: &gt;-
+    Is the in vitro preference for GTP over ATP as phosphate donor (seen structurally) physiologically
+    relevant in the cell, where ATP is far more abundant than GTP?
+suggested_experiments:
+- description: &gt;-
+    Measure steady-state kinetics (kcat/Km) of purified MphB against a panel of 14-, 15- and 16-membered
+    macrolides and ketolides, comparing ATP vs GTP/ITP donors, to quantify substrate and cofactor preferences.
+- description: &gt;-
+    Construct an mphB deletion in E. coli O83:H1 NRG 857C and measure MICs across macrolides/ketolides to
+    quantify the gene&#39;s contribution to resistance in its native genetic background.
+</code></pre>
+            </div>
+        </details>
+    </div>
+
+    <!-- Pathway Visualization Link -->
+    
+
+    <style>
+        /* Markdown Section Styles */
+        .markdown-section {
+            margin-bottom: 1rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .markdown-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .markdown-section summary h3 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.1rem;
+        }
+
+        .markdown-section summary:hover h3 {
+            color: #007bff;
+        }
+
+        .markdown-section[open] {
+            background-color: #fff;
+        }
+
+        .markdown-content {
+            margin-top: 1rem;
+            padding: 1rem;
+            border-top: 1px solid #dee2e6;
+        }
+
+        /* Markdown content styling */
+        .markdown-content h1 { font-size: 1.5rem; margin-top: 1.5rem; }
+        .markdown-content h2 { font-size: 1.3rem; margin-top: 1.3rem; }
+        .markdown-content h3 { font-size: 1.1rem; margin-top: 1.1rem; }
+        .markdown-content h4 { font-size: 1rem; margin-top: 1rem; }
+
+        .markdown-content pre {
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .markdown-content code {
+            background-color: #f8f9fa;
+            padding: 0.2rem 0.4rem;
+            border-radius: 3px;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+        }
+
+        .markdown-content pre code {
+            background: none;
+            padding: 0;
+        }
+
+        .markdown-content table {
+            border-collapse: collapse;
+            width: 100%;
+            margin: 1rem 0;
+        }
+
+        .markdown-content table th,
+        .markdown-content table td {
+            border: 1px solid #dee2e6;
+            padding: 0.5rem;
+            text-align: left;
+        }
+
+        .markdown-content table th {
+            background-color: #f8f9fa;
+            font-weight: bold;
+        }
+
+        .markdown-content blockquote {
+            border-left: 4px solid #007bff;
+            padding-left: 1rem;
+            margin-left: 0;
+            color: #666;
+        }
+
+        /* YAML Preview Styles */
+        .yaml-preview {
+            margin-top: 2rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .yaml-preview summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .yaml-preview summary h2 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.3rem;
+        }
+
+        .yaml-preview summary:hover h2 {
+            color: #007bff;
+        }
+
+        .yaml-preview[open] {
+            background-color: #fff;
+        }
+
+        .yaml-content {
+            margin-top: 1rem;
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .yaml-content pre {
+            margin: 0;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+            line-height: 1.4;
+        }
+
+        .yaml-content code {
+            color: #333;
+            background: none;
+            padding: 0;
+        }
+
+        /* Pathway Link Styles */
+        .pathway-link {
+            margin: 1rem 0;
+        }
+
+        .btn-link {
+            display: inline-block;
+            padding: 0.5rem 1rem;
+            background-color: #007bff;
+            color: white !important;
+            text-decoration: none;
+            border-radius: 4px;
+            font-weight: 500;
+            transition: background-color 0.2s;
+        }
+
+        .btn-link:hover {
+            background-color: #0056b3;
+            text-decoration: none;
+        }
+
+        /* Voting buttons */
+        .vote-buttons {
+            display: inline-block;
+            margin-left: 0.5rem;
+        }
+
+        .vote-btn {
+            background: none;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 2px 6px;
+            margin: 0 2px;
+            cursor: pointer;
+            font-size: 0.9rem;
+            transition: all 0.2s;
+            opacity: 0.6;
+        }
+
+        .vote-btn:hover {
+            opacity: 1;
+            transform: scale(1.1);
+        }
+
+        .vote-btn.voted {
+            opacity: 1;
+            border-color: #28a745;
+            background-color: #d4edda;
+        }
+
+        .vote-btn.voted-down {
+            border-color: #dc3545;
+            background-color: #f8d7da;
+        }
+
+        .vote-btn-small {
+            font-size: 0.7rem;
+            padding: 1px 4px;
+            margin: 0 1px;
+        }
+    </style>
+
+    <script>
+        // Add collapsible functionality
+        document.querySelectorAll('.collapsible').forEach(element => {
+            element.addEventListener('click', function() {
+                this.classList.toggle('collapsed');
+            });
+        });
+
+        // Voting functionality
+        const VOTE_URL = 'https://script.google.com/macros/s/AKfycbwPKH7d3seuPNBtB0ugVjqGeTiByyOGD5vkqB_Ck6K8eOcPQYbJqBOuz6GFgXHKBNWK/exec';
+
+        // Get or create session ID
+        let sessionId = localStorage.getItem('review_session_id');
+        if (!sessionId) {
+            sessionId = 's' + Date.now() + '_' + Math.random().toString(36).substr(2, 9);
+            localStorage.setItem('review_session_id', sessionId);
+        }
+
+        // Show previous votes on page load
+        document.addEventListener('DOMContentLoaded', function() {
+            document.querySelectorAll('.vote-buttons').forEach(container => {
+                const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+                const previousVote = localStorage.getItem(key);
+                if (previousVote) {
+                    const btn = container.querySelector(`[data-v="${previousVote}"]`);
+                    if (btn) btn.classList.add(previousVote === 'up' ? 'voted' : 'voted-down');
+                }
+            });
+        });
+
+        // Handle vote clicks - Simple image beacon approach
+        document.addEventListener('click', function(e) {
+            if (!e.target.classList.contains('vote-btn')) return;
+
+            // Prevent the click from bubbling to parent elements (like summary)
+            e.preventDefault();
+            e.stopPropagation();
+
+            const btn = e.target;
+            const container = btn.closest('.vote-buttons');
+            if (!container) return;
+
+            const voteType = btn.dataset.v;
+
+            // Check if already voted (locally)
+            const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+            const previousVote = localStorage.getItem(key);
+
+            if (previousVote === voteType) {
+                // Same vote - do nothing
+                btn.style.animation = 'shake 0.5s';
+                setTimeout(() => btn.style.animation = '', 500);
+                return;
+            }
+
+            // Build URL
+            const params = new URLSearchParams({
+                gene_id: container.dataset.g,
+                annotation_id: container.dataset.a,
+                ref_id: container.dataset.r || '',
+                action: container.dataset.act,
+                vote: voteType,
+                session_id: sessionId,
+                ua: navigator.userAgent.substring(0, 100)
+            });
+
+            // Clear previous vote styling
+            container.querySelectorAll('.vote-btn').forEach(b => {
+                b.classList.remove('voted', 'voted-down');
+            });
+
+            // Apply new vote styling immediately (optimistic UI)
+            btn.classList.add(voteType === 'up' ? 'voted' : 'voted-down');
+
+            // Store locally
+            localStorage.setItem(key, voteType);
+
+            // Send vote using fetch with no-cors mode (fire and forget)
+            const fullUrl = VOTE_URL + '?' + params;
+            console.log('Sending vote to:', fullUrl);
+
+            // Use fetch in no-cors mode - we won't get a response but the request will be sent
+            fetch(fullUrl, {
+                mode: 'no-cors',
+                method: 'GET'
+            }).then(() => {
+                console.log('Vote request sent (no response due to no-cors mode)');
+            }).catch(err => {
+                console.warn('Vote may not have been recorded, but saved locally:', err);
+
+                // Fallback: try image beacon as well
+                const img = new Image();
+                img.src = fullUrl;
+            });
+        });
+
+        // Optional: Add shake animation for feedback
+        const style = document.createElement('style');
+        style.textContent = `
+            @keyframes shake {
+                0%, 100% { transform: translateX(0); }
+                25% { transform: translateX(-5px); }
+                75% { transform: translateX(5px); }
+            }
+        `;
+        document.head.appendChild(style);
+    </script>
+</body>
+</html>

--- a/genes/ECOLX/Q47396_ECOLX/Q47396_ECOLX-ai-review.html
+++ b/genes/ECOLX/Q47396_ECOLX/Q47396_ECOLX-ai-review.html
@@ -1,0 +1,2650 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>mphA - AI Gene Review</title>
+    <style>
+        :root {
+            --color-accept: #22c55e;
+            --color-remove: #ef4444;
+            --color-modify: #f97316;
+            --color-keep-non-core: #3b82f6;
+            --color-undecided: #6b7280;
+            --color-new: #8b5cf6;
+            --color-mark-over: #eab308;
+            --bg-light: #f9fafb;
+            --border-color: #e5e7eb;
+            --text-muted: #6b7280;
+            --text-primary: #111827;
+        }
+
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+            line-height: 1.6;
+            color: var(--text-primary);
+            background-color: #ffffff;
+            padding: 2rem;
+            max-width: 1400px;
+            margin: 0 auto;
+        }
+
+        .header {
+            border-bottom: 2px solid var(--border-color);
+            padding-bottom: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        h1 {
+            font-size: 2.5rem;
+            font-weight: 700;
+            margin-bottom: 0.5rem;
+            color: #1f2937;
+        }
+
+        .gene-info {
+            display: flex;
+            gap: 2rem;
+            flex-wrap: wrap;
+            margin-top: 1rem;
+        }
+
+        .info-item {
+            display: flex;
+            gap: 0.5rem;
+        }
+
+        .info-label {
+            font-weight: 600;
+            color: var(--text-muted);
+        }
+
+        .aliases {
+            display: flex;
+            gap: 0.5rem;
+            flex-wrap: wrap;
+        }
+
+        .badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.875rem;
+            font-weight: 500;
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+        }
+
+        .status-badge {
+            padding: 0.375rem 0.875rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .status-initialized {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fde68a;
+        }
+
+        .status-in-progress {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+        }
+
+        .status-draft {
+            background-color: #fce7f3;
+            color: #831843;
+            border: 1px solid #fbcfe8;
+        }
+
+        .status-complete {
+            background-color: #d1fae5;
+            color: #065f46;
+            border: 1px solid #a7f3d0;
+        }
+
+        .description-card {
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        .description-card h2 {
+            font-size: 1.25rem;
+            margin-bottom: 1rem;
+            color: #374151;
+        }
+
+        .section {
+            margin-bottom: 2.5rem;
+        }
+
+        .section-title {
+            font-size: 1.5rem;
+            font-weight: 600;
+            margin-bottom: 1.5rem;
+            color: #1f2937;
+            border-bottom: 1px solid var(--border-color);
+            padding-bottom: 0.5rem;
+        }
+
+        .annotations-table {
+            width: 100%;
+            border-collapse: collapse;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            overflow: hidden;
+        }
+
+        .annotations-table thead {
+            background-color: var(--bg-light);
+        }
+
+        .annotations-table th {
+            text-align: left;
+            padding: 1rem;
+            font-weight: 600;
+            border-bottom: 2px solid var(--border-color);
+            font-size: 0.875rem;
+            text-transform: uppercase;
+            letter-spacing: 0.05em;
+            color: var(--text-muted);
+        }
+
+        .annotations-table td {
+            padding: 1rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .annotations-table tbody tr:hover {
+            background-color: #f9fafb;
+        }
+
+        .action-badge {
+            display: inline-block;
+            padding: 0.375rem 0.75rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .action-accept {
+            background-color: var(--color-accept);
+            color: white;
+        }
+
+        .action-remove {
+            background-color: var(--color-remove);
+            color: white;
+        }
+
+        .action-modify {
+            background-color: var(--color-modify);
+            color: white;
+        }
+
+        .action-keep_as_non_core {
+            background-color: var(--color-keep-non-core);
+            color: white;
+        }
+
+        .action-undecided {
+            background-color: var(--color-undecided);
+            color: white;
+        }
+
+        .action-new {
+            background-color: var(--color-new);
+            color: white;
+        }
+
+        .action-mark_as_over_annotated {
+            background-color: var(--color-mark-over);
+            color: white;
+        }
+
+        .term-info {
+            display: flex;
+            flex-direction: column;
+            gap: 0.25rem;
+        }
+
+        .term-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .term-label {
+            font-weight: 500;
+        }
+
+        .evidence-code {
+            font-family: monospace;
+            background-color: var(--bg-light);
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .not-badge {
+            display: inline-block;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-weight: 600;
+            margin-left: 0.25rem;
+        }
+
+        .isoform-badge {
+            display: inline-block;
+            background-color: #eff6ff;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            margin-top: 0.25rem;
+        }
+
+        .core-function-card {
+            background-color: white;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 1rem;
+        }
+
+        .core-function-card h3 {
+            font-size: 1.125rem;
+            margin-bottom: 1rem;
+            color: #1f2937;
+        }
+
+        .core-function-statement {
+            margin-bottom: 1rem;
+            padding: 0.75rem;
+            background-color: var(--bg-light);
+            border-left: 4px solid var(--color-accept);
+            border-radius: 0.25rem;
+        }
+
+        .function-annotations {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin-top: 1rem;
+        }
+
+        .reference-item {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+        }
+
+        .reference-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: start;
+            margin-bottom: 0.75rem;
+        }
+
+        .reference-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #2563eb;
+        }
+
+        .supported-by {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f3f4f6;
+            border-left: 3px solid #3b82f6;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .supported-by-title {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .support-item {
+            margin-bottom: 0.5rem;
+        }
+
+        .support-ref {
+            font-weight: 500;
+            color: #2563eb;
+        }
+
+        .support-text {
+            color: #6b7280;
+            font-style: italic;
+            margin-left: 1rem;
+        }
+
+        a.term-link {
+            color: #2563eb;
+            text-decoration: none;
+        }
+
+        a.term-link:hover {
+            text-decoration: underline;
+        }
+
+        .core-function-terms {
+            margin-top: 1rem;
+        }
+
+        .function-term-group {
+            margin-bottom: 1rem;
+        }
+
+        .function-term-label {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .reference-title {
+            font-weight: 500;
+            margin-bottom: 0.5rem;
+        }
+
+        .findings-list {
+            margin-top: 1rem;
+            padding-left: 1.5rem;
+        }
+
+        .finding-item {
+            margin-bottom: 0.75rem;
+        }
+
+        .finding-statement {
+            font-weight: 500;
+            margin-bottom: 0.25rem;
+        }
+
+        .finding-text {
+            color: var(--text-muted);
+            font-size: 0.95rem;
+            font-style: italic;
+        }
+
+        .proposed-term {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #fef3c7;
+        }
+
+        .question-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #dbeafe;
+        }
+
+        .experiment-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #f3e8ff;
+        }
+
+        .prediction-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: white;
+        }
+
+        .prediction-card .prediction-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+        }
+
+        .prediction-source {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+        }
+
+        .assessment-badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.8rem;
+            font-weight: 600;
+            text-transform: uppercase;
+        }
+
+        .assessment-cor { background-color: #dcfce7; color: #166534; }
+        .assessment-cnn { background-color: #dbeafe; color: #1e40af; }
+        .assessment-lsp { background-color: #fef9c3; color: #854d0e; }
+        .assessment-unc { background-color: #f3f4f6; color: #374151; }
+        .assessment-pli { background-color: #fee2e2; color: #991b1b; }
+        .assessment-npi { background-color: #fecaca; color: #7f1d1d; }
+        .assessment-rep { background-color: #fde68a; color: #92400e; }
+
+        .confidence-score {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+            margin-left: 0.5rem;
+        }
+
+        .error-type-badge {
+            font-size: 0.75rem;
+            padding: 0.125rem 0.5rem;
+            border-radius: 0.25rem;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+        }
+
+        .isoforms-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fill, minmax(400px, 1fr));
+            gap: 1rem;
+        }
+
+        .isoform-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            background-color: white;
+            transition: box-shadow 0.2s;
+        }
+
+        .isoform-card:hover {
+            box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+        }
+
+        .functional-isoform-type {
+            display: inline-block;
+            padding: 0.2rem 0.5rem;
+            border-radius: 0.25rem;
+            font-size: 0.7rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.03em;
+        }
+
+        .type-SPLICE_VARIANT, .type-SPLICE_CLASS {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #93c5fd;
+        }
+
+        .type-CLEAVAGE_PRODUCT {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fcd34d;
+        }
+
+        .type-MODIFICATION_STATE {
+            background-color: #f3e8ff;
+            color: #6b21a8;
+            border: 1px solid #c4b5fd;
+        }
+
+        .type-CONFORMATIONAL_STATE {
+            background-color: #dcfce7;
+            color: #166534;
+            border: 1px solid #86efac;
+        }
+
+        .functional-isoform-mappings {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+            font-size: 0.85rem;
+        }
+
+        .functional-isoform-mappings .mapping-type {
+            font-weight: 600;
+            color: var(--text-muted);
+            font-size: 0.75rem;
+        }
+
+        .functional-isoform-go {
+            margin-top: 0.5rem;
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.25rem;
+        }
+
+        .go-chip {
+            display: inline-block;
+            padding: 0.15rem 0.4rem;
+            background-color: #ecfdf5;
+            color: #047857;
+            border: 1px solid #a7f3d0;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-family: monospace;
+        }
+
+        .isoform-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+            padding-bottom: 0.5rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .isoform-name {
+            font-weight: 600;
+            font-size: 1.1rem;
+            color: #1f2937;
+        }
+
+        .isoform-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .isoform-sequence-note {
+            font-size: 0.875rem;
+            color: var(--text-muted);
+            margin-bottom: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+        }
+
+        .isoform-description {
+            font-size: 0.95rem;
+            line-height: 1.5;
+        }
+
+        .collapsible {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .collapsible:after {
+            content: ' ▼';
+            font-size: 0.75rem;
+        }
+
+        .collapsible.collapsed:after {
+            content: ' ►';
+        }
+
+        .collapse-content {
+            transition: max-height 0.3s ease;
+            overflow: hidden;
+        }
+
+        .collapsed + .collapse-content {
+            max-height: 0;
+        }
+
+        .no-data {
+            color: var(--text-muted);
+            font-style: italic;
+            padding: 1rem;
+            text-align: center;
+            background-color: var(--bg-light);
+            border-radius: 0.5rem;
+        }
+
+        /* Styling for markdown section summaries with voting */
+        .markdown-section summary {
+            padding: 0.75rem;
+            background: var(--bg-light);
+            border-radius: 0.5rem;
+            margin-bottom: 0.5rem;
+        }
+
+        .markdown-section summary:hover {
+            background: #e5e7eb;
+        }
+
+        .markdown-section summary .vote-buttons {
+            margin-left: auto;
+        }
+
+        .deep-research-section {
+            margin-bottom: 1rem;
+            border: 1px solid #c7d2fe;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8faff;
+        }
+
+        .deep-research-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .deep-research-section summary h3 {
+            margin: 0;
+            color: #3730a3;
+            font-size: 1.1rem;
+        }
+
+        .report-meta {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin: 0.75rem 0 1rem;
+            align-items: center;
+        }
+
+        .report-badge {
+            display: inline-flex;
+            align-items: center;
+            border: 1px solid #c7d2fe;
+            border-radius: 999px;
+            background: #eef2ff;
+            color: #4338ca;
+            font-size: 0.78rem;
+            font-weight: 600;
+            padding: 0.2rem 0.6rem;
+        }
+
+        .report-meta-text {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+        }
+
+        .artifact-list {
+            display: grid;
+            gap: 0.75rem;
+            margin: 0.75rem 0 1rem;
+        }
+
+        .artifact-link {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+            margin-top: 0.5rem;
+            word-break: break-word;
+        }
+
+        @media print {
+            body {
+                padding: 1rem;
+            }
+
+            .collapsible:after {
+                display: none;
+            }
+
+            .collapsed + .collapse-content {
+                max-height: none !important;
+            }
+        }
+
+        @media (max-width: 768px) {
+            body {
+                padding: 1rem;
+            }
+
+            h1 {
+                font-size: 2rem;
+            }
+
+            .annotations-table {
+                font-size: 0.875rem;
+            }
+
+            .annotations-table th,
+            .annotations-table td {
+                padding: 0.5rem;
+            }
+        }
+    </style>
+</head>
+<body>
+    <div class="header">
+        <h1>mphA</h1>
+        <div class="gene-info">
+            
+            <div class="info-item">
+                
+                <span class="info-label">UniProt ID:</span>
+                <span>
+                    <a href="https://www.uniprot.org/uniprotkb/Q47396" target="_blank" class="term-link">
+                        Q47396
+                    </a>
+                </span>
+                
+            </div>
+            
+            
+            <div class="info-item">
+                <span class="info-label">Organism:</span>
+                <span>Escherichia coli</span>
+            </div>
+            
+            
+            <div class="info-item">
+                <span class="info-label">Review Status:</span>
+                <span class="status-badge status-draft">
+                    DRAFT
+                </span>
+            </div>
+            
+            
+            <div class="info-item">
+                <span class="info-label">Aliases:</span>
+                <div class="aliases">
+                    
+                    <span class="badge">MphA</span>
+                    
+                    <span class="badge">mph(A)</span>
+                    
+                    <span class="badge">macrolide 2&#39;-phosphotransferase I</span>
+                    
+                    <span class="badge">MPH(2&#39;)I</span>
+                    
+                </div>
+            </div>
+            
+        </div>
+        <div style="margin-top: 1rem; text-align: center;">
+            <a id="feedback-form-link"
+               href="#"
+               target="_blank"
+               style="display: inline-block; padding: 10px 20px; background-color: #4CAF50; color: white; text-decoration: none; border-radius: 5px; font-weight: 600;">
+                📝 Provide Detailed Feedback
+            </a>
+            <script>
+                // Construct the form URL with proper encoding
+                // Extract organism code from the current page path (e.g., /genes/ARATH/APO1/ -> ARATH)
+                const pathParts = window.location.pathname.split('/');
+                const genesIndex = pathParts.indexOf('genes');
+                let organism = '';
+                if (genesIndex !== -1 && pathParts[genesIndex + 1]) {
+                    organism = pathParts[genesIndex + 1].toUpperCase();
+                }
+                const geneSymbol = "mphA";
+                const speciesGene = organism + ' ' + geneSymbol;
+                const formBaseUrl = 'https://docs.google.com/forms/d/e/1FAIpQLSdTot9L6GVkkZYgLQT0E8ZdAJv8RiN5ZgOVkgWNcKSbYvxxzQ/viewform';
+                const entryId = '1226477767'; // Correct entry ID for Species/Gene field
+                const formUrl = formBaseUrl + '?entry.' + entryId + '=' + encodeURIComponent(speciesGene);
+                const feedbackLink = document.getElementById('feedback-form-link');
+                feedbackLink.href = formUrl;
+                // Add tooltip showing the pre-filled value
+                feedbackLink.title = 'Opens form with pre-filled: ' + speciesGene;
+            </script>
+        </div>
+    </div>
+
+    
+    <div class="description-card">
+        <div style="display: flex; justify-content: space-between; align-items: center;">
+            <h2>Gene Description</h2>
+            <span class="vote-buttons" data-g="Q47396" data-a="DESCRIPTION: MphA (macrolide 2&#39;-phosphotransferase I, MPH(2&#39;)I)..." data-r="" data-act="DESCRIPTION">
+                <button class="vote-btn" data-v="up" title="Agree with this description">👍</button>
+                <button class="vote-btn" data-v="down" title="Disagree with this description">👎</button>
+            </span>
+        </div>
+        <p>MphA (macrolide 2&#39;-phosphotransferase I, MPH(2&#39;)I) is a macrolide kinase that inactivates macrolide antibiotics by transferring the gamma-phosphate of a purine nucleoside triphosphate (GTP, ITP or ATP, with GTP favored) to the 2&#39;-hydroxyl of the desosamine sugar, producing an inactive macrolide 2&#39;-O-phosphate that no longer binds the bacterial ribosome. In contrast to the broad-spectrum MphB (MPH(2&#39;)II), MphA is comparatively narrow: it acts efficiently on 14-membered (erythromycin, oleandomycin, clarithromycin, roxithromycin) and 15-membered (azithromycin) macrolides but only very weakly on 16-membered macrolides (spiramycin, josamycin, tylosin). A second distinction is regulation: MphA synthesis is inducible by erythromycin via the upstream TetR-family repressor MphR(A), whereas MphB is constitutive. High-level erythromycin resistance from the original determinant requires mphA together with the adjacent mrx gene (an accessory membrane protein). The enzyme adopts the bi-lobed protein-kinase-like fold of the aminoglycoside phosphotransferase (APH) superfamily (crystal structures solved for MPH(2&#39;)-I with a guanine nucleotide and macrolides). MphA is the most clinically prevalent plasmid-borne macrolide-resistance determinant in Enterobacterales and is frequently associated with reduced susceptibility to azithromycin. In contemporary isolates it is typically carried as a mobile IS26/IS6100-bounded composite transposon spanning the mphA-mrx(A)-mphR(A) operon, predominantly on IncF plasmids, which drives its wide horizontal dissemination.</p>
+    </div>
+    
+
+    
+
+    
+
+    
+    <div class="section">
+        <h2 class="section-title">Existing Annotations Review</h2>
+        <table class="annotations-table">
+            <thead>
+                <tr>
+                    <th>GO Term</th>
+                    <th>Evidence</th>
+                    <th>Action</th>
+                    <th>Reason</th>
+                </tr>
+            </thead>
+            <tbody>
+                
+                <tr>
+                    <td>
+                        <div class="term-info">
+                            
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0050073" target="_blank" class="term-link">
+                                    GO:0050073
+                                </a>
+                            </span>
+                            <span class="term-label">macrolide 2&#39;-kinase activity</span>
+                            
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+                        
+                        
+                        
+                        <br>
+                        <span style="font-size: 0.75rem;">
+                            
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/2478074" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:2478074
+                            </a>
+                            
+                                
+                                
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Purification and characterization of macrolide 2&#39;-phosphotra...
+                                </span>
+                                
+                            
+                            
+                        </span>
+                        
+                    </td>
+                    <td>
+                        <span class="action-badge action-new">
+                            NEW
+                        </span>
+                        <span class="vote-buttons" data-g="Q47396" data-a="GO:0050073" data-r="PMID:2478074" data-act="NEW">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+                        
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> MphA phosphorylates the 2&#39;-OH of macrolides using a purine NTP, producing inactive macrolide 2&#39;-O-phosphate. The purified enzyme is highly active on 14-membered (and 15-membered) macrolides; this matches the GO:0050073 definition (ATP + oleandomycin = ADP + 2 H+ + oleandomycin 2&#39;-O-phosphate).
+                        </div>
+                        
+                        
+                        <div>
+                            <strong>Reason:</strong> The purified enzyme was biochemically characterized as a macrolide 2&#39;-phosphotransferase, and crystal structures of MPH(2&#39;)-I confirm the kinase mechanism. No curated GOA annotation exists for this TrEMBL entry, so this specific MF should be added.
+                        </div>
+                        
+                        
+                        
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+                            
+                            <div class="support-item">
+                                <span class="support-ref">
+                                    
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/2478074" target="_blank" class="term-link">
+                                        PMID:2478074
+                                    </a>
+                                    
+                                </span>
+                                
+                                <div class="support-text">MPH(2&#39;) is an inducible intracellular enzyme which showed high levels of activity with 14-member-ring macrolides and extremely low levels with 16-member-ring macrolides.</div>
+                                
+                            </div>
+                            
+                            <div class="support-item">
+                                <span class="support-ref">
+                                    
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/28416110" target="_blank" class="term-link">
+                                        PMID:28416110
+                                    </a>
+                                    
+                                </span>
+                                
+                                <div class="support-text">We present structures for MPH(2&#39;)-I and MPH(2&#39;)-II in the apo state, and in complex with GTP analogs and six different macrolides.</div>
+                                
+                            </div>
+                            
+                        </div>
+                        
+                    </td>
+                </tr>
+                
+                <tr>
+                    <td>
+                        <div class="term-info">
+                            
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0046677" target="_blank" class="term-link">
+                                    GO:0046677
+                                </a>
+                            </span>
+                            <span class="term-label">response to antibiotic</span>
+                            
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IMP</span>
+                        
+                        
+                        
+                        <br>
+                        <span style="font-size: 0.75rem;">
+                            
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/8619599" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:8619599
+                            </a>
+                            
+                                
+                                
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Nucleotide sequence and characterization of erythromycin res...
+                                </span>
+                                
+                            
+                            
+                        </span>
+                        
+                    </td>
+                    <td>
+                        <span class="action-badge action-new">
+                            NEW
+                        </span>
+                        <span class="vote-buttons" data-g="Q47396" data-a="GO:0046677" data-r="PMID:8619599" data-act="NEW">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+                        
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> MphA confers macrolide (notably erythromycin and azithromycin) resistance by enzymatically inactivating the drug; high-level resistance from the native determinant additionally requires mrx. Expression is inducible by erythromycin via the MphR(A) repressor.
+                        </div>
+                        
+                        
+                        <div>
+                            <strong>Reason:</strong> Resistance is the biological process this enzyme participates in. &#34;response to antibiotic&#34; is the standard, well-supported BP for an antibiotic-modifying resistance enzyme (the drug is modified, not degraded, so &#34;antibiotic catabolic process&#34; would be less accurate).
+                        </div>
+                        
+                        
+                        
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+                            
+                            <div class="support-item">
+                                <span class="support-ref">
+                                    
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/8619599" target="_blank" class="term-link">
+                                        PMID:8619599
+                                    </a>
+                                    
+                                </span>
+                                
+                                <div class="support-text">the expression of high-level resistance to erythromycin requires two genes, mphA and mrx, which encode macrolide 2&#39;-phosphotransferase I and an unidentified hydrophobic protein, respectively.</div>
+                                
+                            </div>
+                            
+                            <div class="support-item">
+                                <span class="support-ref">
+                                    
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/17302923" target="_blank" class="term-link">
+                                        PMID:17302923
+                                    </a>
+                                    
+                                </span>
+                                
+                                <div class="support-text">The mph(A) gene was unique in conferring resistance to azithromycin.</div>
+                                
+                            </div>
+                            
+                            <div class="support-item">
+                                <span class="support-ref">
+                                    
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/38521802" target="_blank" class="term-link">
+                                        PMID:38521802
+                                    </a>
+                                    
+                                </span>
+                                
+                                <div class="support-text">The MIC of azithromycin was ≥ 256 µg/ml for all transconjugants.</div>
+                                
+                            </div>
+                            
+                        </div>
+                        
+                    </td>
+                </tr>
+                
+                <tr>
+                    <td>
+                        <div class="term-info">
+                            
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005737" target="_blank" class="term-link">
+                                    GO:0005737
+                                </a>
+                            </span>
+                            <span class="term-label">cytoplasm</span>
+                            
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+                        
+                        
+                        
+                        <br>
+                        <span style="font-size: 0.75rem;">
+                            
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/2478074" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:2478074
+                            </a>
+                            
+                                
+                                
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Purification and characterization of macrolide 2&#39;-phosphotra...
+                                </span>
+                                
+                            
+                            
+                        </span>
+                        
+                    </td>
+                    <td>
+                        <span class="action-badge action-new">
+                            NEW
+                        </span>
+                        <span class="vote-buttons" data-g="Q47396" data-a="GO:0005737" data-r="PMID:2478074" data-act="NEW">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+                        
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> MphA was characterized as a soluble, intracellular (cytoplasmic) enzyme upon purification from E. coli, consistent with cytoplasmic inactivation of macrolides.
+                        </div>
+                        
+                        
+                        <div>
+                            <strong>Reason:</strong> The purified enzyme was reported as an inducible intracellular enzyme, indicating cytoplasmic localization — the expected compartment for a soluble macrolide-inactivating kinase.
+                        </div>
+                        
+                        
+                        
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+                            
+                            <div class="support-item">
+                                <span class="support-ref">
+                                    
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/2478074" target="_blank" class="term-link">
+                                        PMID:2478074
+                                    </a>
+                                    
+                                </span>
+                                
+                                <div class="support-text">MPH(2&#39;) is an inducible intracellular enzyme</div>
+                                
+                            </div>
+                            
+                        </div>
+                        
+                    </td>
+                </tr>
+                
+            </tbody>
+        </table>
+    </div>
+    
+
+    
+    <div class="section">
+        <h2 class="section-title">Core Functions</h2>
+        
+        <div class="core-function-card">
+            
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+                <h3>MphA is a macrolide 2&#39;-phosphotransferase (macrolide kinase): it transfers the gamma-phosphate of a purine nucleoside triphosphate (GTP/ITP/ATP) to the 2&#39;-hydroxyl of the desosamine sugar of macrolide antibiotics, producing an inactive macrolide 2&#39;-O-phosphate. This detoxifies the drug and is the basis of the macrolide resistance it confers. Its substrate range is narrower than MphB: it is highly active on 14- and 15-membered macrolides but only weakly on 16-membered macrolides. Expression is inducible by erythromycin (via MphR(A)). The enzyme uses the conserved active-site residues of the protein-kinase-like/ APH fold for metal-dependent phosphoryl transfer.</h3>
+                <span class="vote-buttons" data-g="Q47396" data-a="FUNCTION: MphA is a macrolide 2&#39;-phosphotransferase (macroli..." data-r="" data-act="CORE_FUNCTION">
+                    <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
+                    <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
+                </span>
+            </div>
+            
+
+            <div class="core-function-terms">
+                
+                <div class="function-term-group">
+                    <div class="function-term-label">Molecular Function:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0050073" target="_blank" class="term-link">
+                            macrolide 2&#39;-kinase activity
+                        </a>
+                    </span>
+                </div>
+                
+
+                
+                <div class="function-term-group">
+                    <div class="function-term-label">Directly Involved In:</div>
+                    <div class="function-annotations">
+                        
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0046677" target="_blank" class="term-link">
+                                response to antibiotic
+                            </a>
+                        </span>
+                        
+                    </div>
+                </div>
+                
+
+                
+                <div class="function-term-group">
+                    <div class="function-term-label">Cellular Locations:</div>
+                    <div class="function-annotations">
+                        
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005737" target="_blank" class="term-link">
+                                cytoplasm
+                            </a>
+                        </span>
+                        
+                    </div>
+                </div>
+                
+
+                
+
+                
+                <div class="function-term-group">
+                    <div class="function-term-label">Substrates:</div>
+                    <div class="function-annotations">
+                        
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/chebi/searchId.do?chebiId=CHEBI:48923" target="_blank" class="term-link">
+                                erythromycin
+                            </a>
+                        </span>
+                        
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/chebi/searchId.do?chebiId=CHEBI:16869" target="_blank" class="term-link">
+                                oleandomycin
+                            </a>
+                        </span>
+                        
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/chebi/searchId.do?chebiId=CHEBI:3732" target="_blank" class="term-link">
+                                clarithromycin
+                            </a>
+                        </span>
+                        
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/chebi/searchId.do?chebiId=CHEBI:48844" target="_blank" class="term-link">
+                                roxithromycin
+                            </a>
+                        </span>
+                        
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/chebi/searchId.do?chebiId=CHEBI:2955" target="_blank" class="term-link">
+                                azithromycin
+                            </a>
+                        </span>
+                        
+                    </div>
+                </div>
+                
+            </div>
+
+            
+            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
+                <strong>Supporting Evidence:</strong>
+                <ul class="findings-list">
+                    
+                    <li class="finding-item">
+                        <span class="reference-id">
+                            
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/2478074" target="_blank" class="term-link">
+                                PMID:2478074
+                            </a>
+                            
+                        </span>
+                        
+                        <div class="finding-text">MPH(2&#39;) is an inducible intracellular enzyme which showed high levels of activity with 14-member-ring macrolides and extremely low levels with 16-member-ring macrolides.</div>
+                        
+                    </li>
+                    
+                    <li class="finding-item">
+                        <span class="reference-id">
+                            
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/17302923" target="_blank" class="term-link">
+                                PMID:17302923
+                            </a>
+                            
+                        </span>
+                        
+                        <div class="finding-text">The mph(A) gene was unique in conferring resistance to azithromycin.</div>
+                        
+                    </li>
+                    
+                    <li class="finding-item">
+                        <span class="reference-id">
+                            
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/30177927" target="_blank" class="term-link">
+                                PMID:30177927
+                            </a>
+                            
+                        </span>
+                        
+                        <div class="finding-text">MPH(2′)-I can only efficiently inactivate 14- and 15-membered lactone macrolides, whereas MPH(2′)-II can additionally inactivate 16-membered lactone macrolides and the ketolide, telithromycin</div>
+                        
+                    </li>
+                    
+                </ul>
+            </div>
+            
+        </div>
+        
+    </div>
+    
+
+    
+    <div class="section">
+        <h2 class="section-title collapsible">References</h2>
+        <div class="collapse-content">
+            
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+                        
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/2478074" target="_blank" class="term-link">
+                            PMID:2478074
+                        </a>
+                        
+                    </span>
+                </div>
+                
+                <div class="reference-title">Purification and characterization of macrolide 2&#39;-phosphotransferase from a strain of Escherichia coli that is highly resistant to erythromycin</div>
+                
+                
+                <ul class="findings-list">
+                    
+                    <li class="finding-item">
+                        <div class="finding-statement">MPH(2&#39;)I is an inducible intracellular enzyme that is highly active on 14-membered macrolides but shows extremely low activity on 16-membered macrolides — the defining narrow specificity vs MphB.</div>
+                        
+                        <div class="finding-text">"MPH(2&#39;) is an inducible intracellular enzyme which showed high levels of activity with 14-member-ring macrolides and extremely low levels with 16-member-ring macrolides."</div>
+                        
+                    </li>
+                    
+                    <li class="finding-item">
+                        <div class="finding-statement">Purine nucleotides GTP, ITP and ATP serve as phosphate donors.</div>
+                        
+                        <div class="finding-text">"Purine nucleotides, such as GTP, ITP, and ATP, were effective as cofactors in the inactivation of macrolides."</div>
+                        
+                    </li>
+                    
+                </ul>
+                
+            </div>
+            
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+                        
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/8619599" target="_blank" class="term-link">
+                            PMID:8619599
+                        </a>
+                        
+                    </span>
+                </div>
+                
+                <div class="reference-title">Nucleotide sequence and characterization of erythromycin resistance determinant that encodes macrolide 2&#39;-phosphotransferase I in Escherichia coli</div>
+                
+                
+                <ul class="findings-list">
+                    
+                    <li class="finding-item">
+                        <div class="finding-statement">High-level erythromycin resistance from this determinant requires two genes, mphA (encoding MPH(2&#39;)I) and mrx (an accessory hydrophobic protein).</div>
+                        
+                        <div class="finding-text">"the expression of high-level resistance to erythromycin requires two genes, mphA and mrx, which encode macrolide 2&#39;-phosphotransferase I and an unidentified hydrophobic protein, respectively."</div>
+                        
+                    </li>
+                    
+                </ul>
+                
+            </div>
+            
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+                        
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/10960087" target="_blank" class="term-link">
+                            PMID:10960087
+                        </a>
+                        
+                    </span>
+                </div>
+                
+                <div class="reference-title">Regulation of transcription of the mph(A) gene for macrolide 2&#39;-phosphotransferase I in Escherichia coli: characterization of the regulatory gene mphR(A)</div>
+                
+                
+                <ul class="findings-list">
+                    
+                    <li class="finding-item">
+                        <div class="finding-statement">MphA synthesis is inducible by erythromycin and is controlled by the regulatory gene mphR(A) — unlike the constitutive MphB.</div>
+                        
+                        <div class="finding-text">"The synthesis of macrolide 2&#39;-phosphotransferase I [Mph(A)], which inactivates erythromycin, is inducible by erythromycin."</div>
+                        
+                    </li>
+                    
+                </ul>
+                
+            </div>
+            
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+                        
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/17302923" target="_blank" class="term-link">
+                            PMID:17302923
+                        </a>
+                        
+                    </span>
+                </div>
+                
+                <div class="reference-title">Resistance phenotypes conferred by macrolide phosphotransferases</div>
+                
+                
+                <ul class="findings-list">
+                    
+                    <li class="finding-item">
+                        <div class="finding-statement">Among the mph genes compared in an efflux-deficient host, mph(A) was uniquely able to confer resistance to azithromycin (a 15-membered macrolide).</div>
+                        
+                        <div class="finding-text">"The mph(A) gene was unique in conferring resistance to azithromycin."</div>
+                        
+                    </li>
+                    
+                </ul>
+                
+            </div>
+            
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+                        
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/28416110" target="_blank" class="term-link">
+                            PMID:28416110
+                        </a>
+                        
+                    </span>
+                </div>
+                
+                <div class="reference-title">Structural Basis for Kinase-Mediated Macrolide Antibiotic Resistance</div>
+                
+                
+                <ul class="findings-list">
+                    
+                    <li class="finding-item">
+                        <div class="finding-statement">Crystal structures of MPH(2&#39;)-I (MphA) were determined apo and in complex with GTP analogs and macrolides, revealing the kinase-like fold.</div>
+                        
+                        <div class="finding-text">"We present structures for MPH(2&#39;)-I and MPH(2&#39;)-II in the apo state, and in complex with GTP analogs and six different macrolides."</div>
+                        
+                    </li>
+                    
+                </ul>
+                
+            </div>
+            
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+                        
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/29317655" target="_blank" class="term-link">
+                            PMID:29317655
+                        </a>
+                        
+                    </span>
+                </div>
+                
+                <div class="reference-title">The evolution of substrate discrimination in macrolide antibiotic resistance enzymes</div>
+                
+                
+                <ul class="findings-list">
+                    
+                    <li class="finding-item">
+                        <div class="finding-statement">MphA is one of the mobilized Mph homologs that are widespread in Gram-negative bacteria.</div>
+                        
+                        <div class="finding-text">"MphA, MphB, and MphE are widespread in Gram-negative bacteria"</div>
+                        
+                    </li>
+                    
+                </ul>
+                
+            </div>
+            
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+                        
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/30177927" target="_blank" class="term-link">
+                            PMID:30177927
+                        </a>
+                        
+                    </span>
+                </div>
+                
+                <div class="reference-title">Look and Outlook on Enzyme-Mediated Macrolide Resistance</div>
+                
+                
+                <ul class="findings-list">
+                    
+                    <li class="finding-item">
+                        <div class="finding-statement">MPH(2&#39;)-I (MphA) efficiently inactivates only 14- and 15-membered macrolides, whereas MPH(2&#39;)-II (MphB) additionally inactivates 16-membered macrolides and telithromycin — the explicit MphA/MphB contrast.</div>
+                        
+                        <div class="finding-text">"MPH(2′)-I can only efficiently inactivate 14- and 15-membered lactone macrolides, whereas MPH(2′)-II can additionally inactivate 16-membered lactone macrolides and the ketolide, telithromycin"</div>
+                        
+                    </li>
+                    
+                    <li class="finding-item">
+                        <div class="finding-statement">Mph enzymes transfer the gamma-phosphate of GTP onto macrolide substrates; mph(A), (B) and (C) are mobile-element-encoded and found in clinical E. coli.</div>
+                        
+                        <div class="finding-text">"These MPHs all mediate the transfer of the γ-phosphate group from GTP onto the macrolide substrates...mph(A), (B), and (C), which are encoded on mobile genetic elements, are found in clinical isolates of E."</div>
+                        
+                    </li>
+                    
+                </ul>
+                
+            </div>
+            
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+                        
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/38318209" target="_blank" class="term-link">
+                            PMID:38318209
+                        </a>
+                        
+                    </span>
+                </div>
+                
+                <div class="reference-title">Whole-Genome Sequencing of an Escherichia coli ST69 Strain Harboring bla(CTX-M-27) on a Hybrid Plasmid</div>
+                
+                
+                <ul class="findings-list">
+                    
+                    <li class="finding-item">
+                        <div class="finding-statement">In a clinical E. coli isolate, the mphA-mrx(A)-mphR(A) operon is carried within an IS26/IS6100-bounded composite transposon, the mobile unit that disseminates mphA on IncF plasmids.</div>
+                        
+                        <div class="finding-text">"the mphA-mrx(A)-mphR(A) operon conferring macrolide resistance was flanked by IS26 and IS6100, forming the IS26-mphA-mrx(A)-mphR(A)-IS6100 transposable structure"</div>
+                        
+                    </li>
+                    
+                </ul>
+                
+            </div>
+            
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+                        
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/38521802" target="_blank" class="term-link">
+                            PMID:38521802
+                        </a>
+                        
+                    </span>
+                </div>
+                
+                <div class="reference-title">Multidrug-resistant conjugative plasmid carrying mphA confers increased antimicrobial resistance in Shigella</div>
+                
+                
+                <ul class="findings-list">
+                    
+                    <li class="finding-item">
+                        <div class="finding-statement">A conjugative plasmid carrying mphA transferred high-level azithromycin resistance; all transconjugants reached azithromycin MIC &gt;=256 ug/ml, demonstrating mphA-mediated, plasmid-borne resistance.</div>
+                        
+                        <div class="finding-text">"The MIC of azithromycin was ≥ 256 µg/ml for all transconjugants."</div>
+                        
+                    </li>
+                    
+                    <li class="finding-item">
+                        <div class="finding-statement">Plasmid-borne mphA inactivates macrolides by modifying the drug&#39;s molecular structure.</div>
+                        
+                        <div class="finding-text">"Several reports suggested that plasmid-mediated macrolide 2&#39;-phosphotransferase (mphA) mostly and esterase (ermB) for some instances inactivate macrolide through modifying its molecular structure"</div>
+                        
+                    </li>
+                    
+                </ul>
+                
+            </div>
+            
+        </div>
+    </div>
+    
+
+
+    
+    <div class="section">
+        <h2 class="section-title">Suggested Questions for Experts</h2>
+        
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> What is the structural basis for MphA&#39;s discrimination against 16-membered macrolides, and could 16-membered macrolides or derivatives evade MphA-mediated resistance clinically?</p>
+                    
+                </div>
+                <span class="vote-buttons" data-g="Q47396" data-a="Q: What is the structural basis for MphA&#39;s discrimina..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+        
+    </div>
+    
+
+    
+    <div class="section">
+        <h2 class="section-title">Suggested Experiments</h2>
+        
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    
+                    <p><strong>Experiment:</strong> Measure steady-state kinetics (kcat/Km) of purified MphA against 14-, 15- and 16-membered macrolides with GTP vs ATP donors to quantify the substrate and cofactor preferences relative to MphB.</p>
+                    
+                    
+                    
+                </div>
+                <span class="vote-buttons" data-g="Q47396" data-a="EXPERIMENT: Measure steady-state kinetics (kcat/Km) of purifie..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+        
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    
+                    <p><strong>Experiment:</strong> Test whether the accessory mrx gene is required for full resistance in a clean E. coli background and determine its molecular role (e.g. membrane association / enzyme stability).</p>
+                    
+                    
+                    
+                </div>
+                <span class="vote-buttons" data-g="Q47396" data-a="EXPERIMENT: Test whether the accessory mrx gene is required fo..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+        
+    </div>
+    
+
+    
+
+    <!-- Computational Predictions Section -->
+    
+
+    <!-- Deep Research Sections -->
+    
+    <div class="section">
+        <h2 class="section-title">Deep Research</h2>
+        
+        <details class="deep-research-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; gap: 1rem;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Falcon</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(Q47396_ECOLX-deep-research-falcon.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="Q47396" data-a="DEEP_RESEARCH: Falcon" data-r="" data-act="DEEP_RESEARCH" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This deep research is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This deep research needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+                
+                <div class="report-meta">
+                    
+                    <span class="report-meta-text">Research Report: **mphA / Mph(A)** (UniProt **Q47396**) in *Escherichia coli* (ECOLX)</span>
+                    
+                    
+                    <span class="report-badge">Falcon</span>
+                    
+                    
+                    <span class="report-badge">Edison Scientific Literature</span>
+                    
+                    
+                    <span class="report-badge">30 citations</span>
+                    
+                    
+                    <span class="report-badge">2 artifacts</span>
+                    
+                    
+                    <span class="report-meta-text">2026-06-12T06:57:32.714341</span>
+                    
+                    
+                    
+                </div>
+                
+                
+                <div class="artifact-list">
+                    
+                    
+                    
+                    <div class="artifact-link">
+                        <a href="Q47396_ECOLX-deep-research-falcon_artifacts/artifact-00.md" class="term-link">Edison artifact artifact-00</a>
+                        <span>(text/markdown)</span>
+                    </div>
+                    
+                    
+                    
+                    
+                    <div class="artifact-link">
+                        <a href="Q47396_ECOLX-deep-research-falcon_artifacts/image-1.png" class="term-link">## Context ID: pqac-00000016 I have extracted the two tables that provide the information you requested. Both are located on page 4 of the document. - Table 2 r</a>
+                        <span>(image/png)</span>
+                    </div>
+                    
+                    
+                </div>
+                
+                <p>The research report should be a detailed narrative explaining the function, biological processes, and localization of the gene product. Citations should be given for all claims.</p>
+<p>You should prioritize authoritative reviews and primary scientific literature when conducting research. You can supplement<br />
+this with annotations you find in gene/protein databases, but these can be outdated or inaccurate.</p>
+<p>We are specifically interested in the primary function of the gene - for enzymes, what reaction is catalyzed, and what is the substrate specificity? For transporters, what is the substrate? For structural proteins or adapters, what is the broader structural role? For signaling molecules, what is the role in the pathway.</p>
+<p>We are interested in where in or outside the cell the gene product carries out its function.</p>
+<p>We are also interested in the signaling or biochemical pathways in which the gene functions. We are less interested in broad pleiotropic effects, except where these elucidate the precise role.</p>
+<p>Include evidence where possible. We are interested in both experimental evidence as well as inference from structure, evolution, or bioinformatic analysis. Precise studies should be prioritized over high-throughput, where available.</p>
+<h1 id="research-report-mpha-mpha-uniprot-q47396-in-escherichia-coli-ecolx">Research Report: <strong>mphA / Mph(A)</strong> (UniProt <strong>Q47396</strong>) in <em>Escherichia coli</em> (ECOLX)</h1>
+<h2 id="0-target-verification-geneprotein-identity">0. Target verification (gene/protein identity)</h2>
+<p>The UniProt target <strong>Q47396</strong> corresponds to <strong>mphA / mph(A)</strong> encoding a <strong>macrolide 2′-phosphotransferase (Mph(A); also described as MPH(2′)-I)</strong> in <em>Escherichia coli</em>, a kinase-like enzyme related to aminoglycoside phosphotransferases that inactivates macrolide antibiotics by phosphorylation. This matches the core literature describing <strong>E. coli mph(A)</strong> as macrolide 2′-phosphotransferase I with an inducible <strong>mph(A)-mrx-mphR(A)</strong> regulatory cluster. (noguchi2000regulationoftranscription pages 1-2, fong2017structuralbasisfor pages 1-3)</p>
+<h2 id="1-key-concepts-and-definitions-current-understanding">1. Key concepts and definitions (current understanding)</h2>
+<h3 id="11-what-mpha-is">1.1 What Mph(A) is</h3>
+<p><strong>Mph(A)</strong> is an enzyme-mediated macrolide resistance determinant that functions as a <strong>macrolide 2′-phosphotransferase/kinase</strong>. In contrast to target-site resistance (e.g., rRNA methylation) or efflux, Mph(A) <strong>chemically modifies</strong> the drug, rendering it inactive. (golkar2018lookandoutlook pages 6-8, fong2017structuralbasisfor pages 1-3)</p>
+<h3 id="12-reaction-catalyzed-and-donoracceptor-specificity">1.2 Reaction catalyzed and donor/acceptor specificity</h3>
+<p><strong>Biochemical reaction (conceptual):</strong><br />
+- <strong>Donor:</strong> guanosine triphosphate (<strong>GTP</strong>) (γ-phosphate donor)<br />
+- <strong>Acceptor:</strong> a hydroxyl group on the macrolide’s amino sugar (classically described as the <strong>2′-OH</strong> on desosamine/mycaminose)<br />
+- <strong>Outcome:</strong> <strong>phosphorylated macrolide</strong> with reduced ribosome-binding activity (functional inactivation). (golkar2018lookandoutlook pages 6-8, fong2017structuralbasisfor pages 1-3)</p>
+<p>A key biochemical distinction noted for <strong>MPH(2′)-I/Mph(A)</strong> is that it is <strong>unusual in using GTP exclusively</strong> as the phosphate donor. (fong2017structuralbasisfor pages 1-3)</p>
+<h3 id="13-substrate-spectrum-macrolide-classes">1.3 Substrate spectrum (macrolide classes)</h3>
+<p>Mph(A) efficiently inactivates <strong>14-membered macrolides</strong> such as <strong>erythromycin</strong> and also the <strong>15-membered</strong> macrolide <strong>azithromycin</strong>. (noguchi2000regulationoftranscription pages 1-2, fong2017structuralbasisfor pages 1-3)</p>
+<p>At the broader family level, macrolide phosphotransferases (including mph(A) subtypes) are described as acting most efficiently on <strong>14- and 15-membered lactone macrolides</strong>, while other MPH variants can extend activity to additional macrolide scaffolds. (golkar2018lookandoutlook pages 6-8)</p>
+<h3 id="14-regulation-inducible-mpha-mrx-mphra-module">1.4 Regulation: inducible mph(A)-mrx-mphR(A) module</h3>
+<p>In <em>E. coli</em>, <strong>mph(A)</strong> is commonly found in an inducible, locally regulated cluster:<br />
+- <strong>mph(A)</strong>: encodes the macrolide phosphotransferase<br />
+- <strong>mrx</strong>: hydrophobic protein of unclear molecular function but required for high-level resistance phenotype<br />
+- <strong>mphR(A)</strong>: a <strong>TetR/AcrR-family repressor</strong> controlling transcription (negative regulator). (noguchi2000regulationoftranscription pages 1-2, noguchi2000regulationoftranscription pages 5-6)</p>
+<p>Mechanistically, <strong>MphR(A)</strong> binds the <strong>mph(A) promoter</strong> and represses transcription; exposure to macrolides (notably <strong>14-membered</strong> macrolides) reduces MphR(A)-DNA binding, consistent with <strong>derepression/induction</strong>. (noguchi2000regulationoftranscription pages 5-6)</p>
+<h3 id="15-cellular-localization-what-can-be-stated-from-retrieved-evidence">1.5 Cellular localization (what can be stated from retrieved evidence)</h3>
+<p>The retrieved sources establish Mph(A) as a cytosolic enzyme that acts on intracellular antibiotic, but they do <strong>not</strong> provide a direct experimental localization assay (e.g., fractionation/microscopy) for Mph(A) in <em>E. coli</em> in the excerpts available here. Therefore, localization is best stated conservatively as <strong>intracellular enzymatic drug modification</strong> consistent with its soluble kinase-like function. (fong2017structuralbasisfor pages 1-3, golkar2018lookandoutlook pages 6-8)</p>
+<h2 id="2-molecular-mechanism-and-structure-function-insights">2. Molecular mechanism and structure-function insights</h2>
+<p>Structural work on MPH(2′) enzymes describes a <strong>kinase-like fold</strong> related to aminoglycoside phosphotransferases but with a <strong>large interdomain linker</strong> that expands the antibiotic-binding pocket; the pocket is largely hydrophobic and positions the macrolide’s amino sugar for phosphorylation. (fong2017structuralbasisfor pages 1-3)</p>
+<p>Catalysis is consistent with a proximal <strong>carboxylate acting as a catalytic base</strong> to activate the reactive hydroxyl prior to phosphate transfer, and structural comparisons help explain why different MPH enzymes vary in their activity against different macrolide ring sizes. (fong2017structuralbasisfor pages 8-9)</p>
+<h2 id="3-recent-developments-prioritizing-20232024">3. Recent developments (prioritizing 2023–2024)</h2>
+<h3 id="31-2024-surveillance-scale-wgs-evidence-linking-mpha-to-azithromycin-resistance">3.1 2024: Surveillance-scale WGS evidence linking mph(A) to azithromycin resistance</h3>
+<p>A 2024 European analysis of WGS data from food-producing animals and meat investigated <strong>1007 <em>E. coli</em></strong> isolates (including <strong>165 azithromycin-resistant isolates</strong>, defined as MIC &gt;16 mg/L) and <strong>269 <em>Salmonella</em></strong> isolates. mph(A) is highlighted among the major genetic determinants considered for high-level azithromycin resistance (alongside erm genes), and the study emphasizes that <strong>operon structure/architecture</strong> can matter for predicting phenotype from WGS data. (ivanova2024azithromycinresistancein pages 1-2)</p>
+<p>The same study reported that the presence of known macrolide resistance genes/mutations was associated with the azithromycin-resistant phenotype in <strong>159 (66%) of <em>E. coli</em></strong> and <strong>24 (92%) of <em>Salmonella</em></strong> isolates, illustrating both the utility and current limitations of WGS-only prediction when gene context/expression is not fully resolved. (ivanova2024azithromycinresistancein pages 2-3)</p>
+<h3 id="32-2024-mobile-element-architecture-in-e-coliis26-composite-transposons-carrying-mpha">3.2 2024: Mobile element architecture in <em>E. coli</em>—IS26 composite transposons carrying mphA</h3>
+<p>A 2024 genomic characterization of an <em>E. coli</em> ST69 isolate showed mphA embedded in an IS-element-bounded cassette <strong>IS26–mphA–mrx(A)–mphR(A)–IS6100</strong>, within an ~<strong>18.9 kb IS26 composite transposon</strong> on an IncF-family hybrid plasmid. This is important for functional annotation because it ties mphA to a <strong>mobilizable unit</strong> that can disseminate across lineages and species. (wang2024wholegenomesequencingof pages 4-8)</p>
+<p>In a comparative analysis cited in that work, among plasmids carrying the 18.9-kb structure, <strong>75/77 (97.4%)</strong> were <strong>IncF plasmids</strong> in <em>E. coli</em>, consistent with IncF plasmids as a dominant vehicle for mphA cassette propagation in <em>E. coli</em>. (wang2024wholegenomesequencingof pages 4-8)</p>
+<h3 id="33-2024-experimental-plasmid-transfer-to-e-coli-and-high-azithromycin-mics">3.3 2024: Experimental plasmid transfer to <em>E. coli</em> and high azithromycin MICs</h3>
+<p>A 2024 study in <em>Shigella</em> (clinically relevant enteric pathogen) provided a clear experimental demonstration of horizontal transfer relevant to <em>E. coli</em>: conjugation transferred a <strong>63 MDa plasmid</strong> carrying <strong>mphA</strong> into <em>E. coli</em> K-12, and <strong>all transconjugants displayed azithromycin MIC ≥256 µg/mL</strong>, confirming mphA-linked, plasmid-mediated high-level resistance transfer into <em>E. coli</em>. (asad2024multidrugresistantconjugativeplasmid pages 4-5, asad2024multidrugresistantconjugativeplasmid media 75fd2a0d)</p>
+<p>The same paper includes tabulated MIC and conjugation results supporting the genotype→phenotype relationship for mphA-positive strains and transconjugants. (asad2024multidrugresistantconjugativeplasmid media a1f352af, asad2024multidrugresistantconjugativeplasmid media 75fd2a0d)</p>
+<h3 id="34-2024-modulation-of-mpha-associated-resistance-by-combination-therapy-strategies">3.4 2024: Modulation of mph(A)-associated resistance by combination therapy strategies</h3>
+<p>A 2024 <em>Microbiology Spectrum</em> study using multidrug-resistant <em>E. coli</em> reported that colistin combined with azithromycin changed membrane- and resistance-associated gene expression and included <strong>downregulation of mph(A)</strong> under combination treatment relative to azithromycin alone, consistent with the concept that mph(A)-mediated resistance may be partly mitigated by strategies that alter permeability and/or suppress effective Mph(A) activity in specific contexts. (pawlowski2018theevolutionof pages 6-7)</p>
+<h3 id="35-2023-high-mic-phenotypes-and-plasmid-diversity-of-mpha-bearing-enterobacterales">3.5 2023: High-MIC phenotypes and plasmid diversity of mphA-bearing Enterobacterales</h3>
+<p>A 2023 pediatric study of azithromycin-resistant <em>Salmonella enterica</em> isolates found azithromycin MICs ranging from <strong>32 to 256 µg/mL</strong>, with <strong>mphA present in all resistant isolates</strong>, and documented diverse mphA-bearing plasmids with IS-associated core structures, including evidence of cross-Enterobacterales plasmid homology with <em>E. coli</em> plasmids. While not <em>E. coli</em> isolates, these data matter for mphA annotation in <em>E. coli</em> because they show mphA’s <strong>plasmid mobility</strong> and association with high MICs in closely related Enterobacterales. (wang2023characterizationofresistance pages 7-9, wang2023characterizationofresistance pages 5-7)</p>
+<h2 id="4-current-applications-and-real-world-implementations">4. Current applications and real-world implementations</h2>
+<h3 id="41-wgs-based-amr-prediction-in-surveillance-and-public-health-microbiology">4.1 WGS-based AMR prediction in surveillance and public health microbiology</h3>
+<p>The 2024 European surveillance analysis provides an example of real-world implementation where <strong>WGS and AMR gene callers</strong> (e.g., ResFinder/AMRFinder-style workflows described in the paper’s methods) are used to infer macrolide resistance determinants (including <strong>mph(A)</strong>) across national surveillance collections, and where interpretation is refined by considering <strong>operon structures</strong> rather than gene presence alone. (ivanova2024azithromycinresistancein pages 1-2, ivanova2024azithromycinresistancein pages 2-3)</p>
+<h3 id="42-plasmidtransposon-tracking-for-infection-control-and-one-health">4.2 Plasmid/transposon tracking for infection control and One Health</h3>
+<p>Recent plasmid-focused work demonstrates that mphA often occurs as part of a reusable mobile cassette (e.g., the <strong>IS26–mphA–mrx(A)–mphR(A)–IS6100</strong> module), enabling <strong>genetic epidemiology</strong> approaches that track not only a gene but the <strong>translocatable unit</strong> across isolates, plasmids, and even chromosomal integrations in Enterobacterales. This is directly applicable to infection control, source attribution, and One Health tracking of resistance mobilomes. (wang2024wholegenomesequencingof pages 4-8)</p>
+<h3 id="43-experimental-conjugation-assays-to-validate-transfer-risk">4.3 Experimental conjugation assays to validate transfer risk</h3>
+<p>The 2024 conjugation results provide a practical model used in microbiology labs to validate the transferability and phenotypic effect of mphA-bearing plasmids into <em>E. coli</em> recipients, bridging genomic findings and functional risk assessment. (asad2024multidrugresistantconjugativeplasmid pages 4-5, asad2024multidrugresistantconjugativeplasmid media 75fd2a0d)</p>
+<h2 id="5-expert-synthesis-and-analysis-authoritative-interpretations">5. Expert synthesis and analysis (authoritative interpretations)</h2>
+<h3 id="51-why-mpha-is-clinically-important">5.1 Why mphA is clinically important</h3>
+<p>A detailed review of enzyme-mediated macrolide resistance emphasizes that macrolide phosphotransferases are increasingly important because they provide <strong>direct drug detoxification</strong>, and mph(A)-type genes are frequently associated with <strong>mobile genetic elements</strong> enabling dissemination among pathogens (including Enterobacterales). This supports mphA annotation as a high-impact, horizontally transferable resistance factor rather than a strain-restricted trait. (golkar2018lookandoutlook pages 6-8)</p>
+<h3 id="52-how-regulation-and-gene-context-affect-phenotype">5.2 How regulation and gene context affect phenotype</h3>
+<p>Primary regulatory work shows that mphA can be <strong>inducible</strong> via MphR(A)-mediated repression and macrolide-triggered derepression, and that high-level resistance may require co-occurrence of <strong>mrx</strong> with mph(A). This helps explain why WGS-based prediction can be imperfect when it ignores gene context, operon integrity, and regulatory function. (noguchi2000regulationoftranscription pages 1-2, noguchi2000regulationoftranscription pages 5-6, ivanova2024azithromycinresistancein pages 2-3)</p>
+<h3 id="53-mechanistic-implications-for-inhibitortherapy-design">5.3 Mechanistic implications for inhibitor/therapy design</h3>
+<p>Structural insights identifying the expanded macrolide-binding pocket and GTP specificity (in MPH(2′)-I/Mph(A)) provide a rational basis for exploring inhibitors that target the nucleotide-binding pocket or macrolide-binding cleft, or for designing macrolide analogs less susceptible to Mph(A)-mediated phosphorylation. (fong2017structuralbasisfor pages 1-3, fong2017structuralbasisfor pages 8-9)</p>
+<h2 id="6-key-quantitative-data-points-recent-studies">6. Key quantitative data points (recent studies)</h2>
+<ul>
+<li>European surveillance WGS dataset: <strong>1007 <em>E. coli</em></strong> total, <strong>165 azithromycin-resistant</strong> (MIC &gt;16 mg/L). (Ivanova et al., 2024-05; JAC; https://doi.org/10.1093/jac/dkae161) (ivanova2024azithromycinresistancein pages 1-2)</li>
+<li>Genotype-phenotype association in that dataset: macrolide resistance genes/mutations explained resistance in <strong>159 (66%) of <em>E. coli</em></strong> and <strong>24 (92%) of <em>Salmonella</em></strong> isolates. (Ivanova et al., 2024-05) (ivanova2024azithromycinresistancein pages 2-3)</li>
+<li>IncF dominance for a disseminating mphA mobile unit: <strong>75/77 (97.4%)</strong> of <em>E. coli</em> plasmids carrying the <strong>18.9 kb IS26 composite transposon</strong> were <strong>IncF</strong> plasmids. (Wang et al., 2024-02; Infection and Drug Resistance; https://doi.org/10.2147/idr.s427571) (wang2024wholegenomesequencingof pages 4-8)</li>
+<li>Experimental transfer into <em>E. coli</em> and MIC impact: conjugation of a <strong>63 MDa mphA plasmid</strong> into <em>E. coli</em> K-12 produced transconjugants with <strong>azithromycin MIC ≥256 µg/mL</strong>. (Asad et al., 2024-03; Scientific Reports; https://doi.org/10.1038/s41598-024-57423-1) (asad2024multidrugresistantconjugativeplasmid media 75fd2a0d)</li>
+</ul>
+<h2 id="7-evidence-map-summary-table">7. Evidence map (summary table)</h2>
+<p>The following table consolidates the most directly supported claims (mechanism, regulation, dissemination, and quantitative evidence).</p>
+<table>
+<thead>
+<tr>
+<th>Topic</th>
+<th>Key finding</th>
+<th>Study/system</th>
+<th>Quantitative data</th>
+<th>Publication (year, journal) and URL</th>
+<th>Citation ID</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>Reaction/substrate</td>
+<td>E. coli Mph(A) is a macrolide 2'-phosphotransferase/kinase that phosphorylates the amino sugar of macrolides and efficiently inactivates 14-membered macrolides such as erythromycin and the 15-membered macrolide azithromycin; Mph(A) uses GTP exclusively as phosphate donor.</td>
+<td>Structural/biochemical characterization of MPH(2')-I from E. coli and Mph family enzymes</td>
+<td>Qualitative substrate scope: 14- and 15-membered macrolides; exclusive GTP use</td>
+<td>Fong et al., 2017, <em>Structure</em>; https://doi.org/10.1016/j.str.2017.03.007</td>
+<td>(fong2017structuralbasisfor pages 1-3)</td>
+</tr>
+<tr>
+<td>Reaction/substrate</td>
+<td>Mph-family enzymes catalyze transfer of the γ-phosphate from GTP to the 2'-OH of macrolides; Mph(A) belongs to the clinically important mobile mph(A)-mph(O) family and is associated mainly with resistance to 14- and 15-membered macrolides.</td>
+<td>Review of enzyme-mediated macrolide resistance</td>
+<td>Qualitative family-level mechanistic summary</td>
+<td>Golkar et al., 2018, <em>Frontiers in Microbiology</em>; https://doi.org/10.3389/fmicb.2018.01942</td>
+<td>(golkar2018lookandoutlook pages 6-8)</td>
+</tr>
+<tr>
+<td>Regulation</td>
+<td>The E. coli mph(A)-mrx-mphR(A) cluster is inducible by erythromycin; MphR(A) is a TetR/AcrR-like repressor that binds the mph(A) promoter and is released by macrolides, causing derepression.</td>
+<td>E. coli mph(A) regulatory locus</td>
+<td>2.9-kb inducible transcript detected; 14-membered macrolides inhibited MphR(A)-DNA binding at ~100-fold lower concentrations than representative 16-membered macrolides</td>
+<td>Noguchi et al., 2000, <em>Journal of Bacteriology</em>; https://doi.org/10.1128/jb.182.18.5052-5058.2000</td>
+<td>(noguchi2000regulationoftranscription pages 1-2, noguchi2000regulationoftranscription pages 5-6, noguchi2000regulationoftranscription pages 2-4)</td>
+</tr>
+<tr>
+<td>Regulation/phenotype</td>
+<td>mph(A) alone confers low-level erythromycin resistance, while co-carriage with mrx yields high-level resistance; mrx is hydrophobic and required for full Mph(A) expression/resistance phenotype.</td>
+<td>E. coli plasmid constructs carrying mph(A) with/without mrx</td>
+<td>Qualitative comparison: low-level vs high-level EM resistance depending on mrx presence</td>
+<td>Noguchi et al., 2000, <em>Journal of Bacteriology</em>; https://doi.org/10.1128/jb.182.18.5052-5058.2000</td>
+<td>(noguchi2000regulationoftranscription pages 1-2)</td>
+</tr>
+<tr>
+<td>Genetic context</td>
+<td>In a clinical E. coli ST69 isolate, mphA occurred in an IS26-composite transposon as the module IS26-mphA-mrx(A)-mphR(A)-IS6100 on a hybrid IncF plasmid carrying multiple resistance genes.</td>
+<td>E. coli EC6868 (ST69), hospital isolate</td>
+<td>~18.9-kb IS26 composite transposon; isolate year 2017</td>
+<td>Wang et al., 2024, <em>Infection and Drug Resistance</em>; https://doi.org/10.2147/idr.s427571</td>
+<td>(wang2024wholegenomesequencingof pages 4-8)</td>
+</tr>
+<tr>
+<td>Genetic context</td>
+<td>The same 18.9-kb mphA module is widely disseminated across Enterobacterales plasmids/chromosomes, especially IncF plasmids in E. coli, indicating strong mobility of the mphA-mrx(A)-mphR(A) cassette.</td>
+<td>Comparative plasmid/genome analysis across Enterobacterales</td>
+<td>75/77 plasmids harboring the 18.9-kb structure were IncF (97.4%); 81 plasmids analyzed overall</td>
+<td>Wang et al., 2024, <em>Infection and Drug Resistance</em>; https://doi.org/10.2147/idr.s427571</td>
+<td>(wang2024wholegenomesequencingof pages 4-8)</td>
+</tr>
+<tr>
+<td>Surveillance/prevalence</td>
+<td>Large-scale European surveillance found mph(A) among the principal azithromycin-resistance determinants in E. coli and Salmonella and showed that different mph(A) operon structures were associated with susceptible versus resistant isolates.</td>
+<td>EU harmonized AMR surveillance plus Danish surveillance</td>
+<td>1,007 E. coli analyzed, including 165 azithromycin-resistant isolates (MIC &gt;16 mg/L); 269 Salmonella, including 29 resistant isolates; overall genotype-phenotype concordance 69% in E. coli and 92% in Salmonella</td>
+<td>Ivanova et al., 2024, <em>Journal of Antimicrobial Chemotherapy</em>; https://doi.org/10.1093/jac/dkae161</td>
+<td>(ivanova2024azithromycinresistancein pages 1-2, ivanova2024azithromycinresistancein pages 2-3)</td>
+</tr>
+<tr>
+<td>MIC/phenotype</td>
+<td>In pediatric azithromycin-resistant Salmonella, all resistant isolates carried mphA and showed high AZM MICs, supporting mphA as a major high-level azithromycin resistance determinant in Enterobacterales.</td>
+<td>15 azithromycin-resistant Salmonella enterica isolates from children, Shenzhen</td>
+<td>Resistance rate 3.08% (15/487); MIC distribution: 53.33% at 32 µg/mL, 20.0% at 64 µg/mL, 26.67% at 256 µg/mL; all 15/15 carried mphA</td>
+<td>Wang et al., 2023, <em>Frontiers in Cellular and Infection Microbiology</em>; https://doi.org/10.3389/fcimb.2023.1116172</td>
+<td>(wang2023characterizationofresistance pages 3-5, wang2023characterizationofresistance pages 7-9)</td>
+</tr>
+<tr>
+<td>Genetic context</td>
+<td>mphA-bearing plasmids in Salmonella showed a conserved mobile backbone centered on an IS-mphA-tap structure and occurred on multiple plasmid types, with evidence for cross-species exchange with E. coli plasmids.</td>
+<td>Shenzhen Salmonella plasmid analysis</td>
+<td>All 15 mphA-positive contigs shared a core IS-mphA-tap structure; 8 distinct plasmids among 15 isolates; some homologous to E. coli plasmids at &gt;99.9% identity</td>
+<td>Wang et al., 2023, <em>Frontiers in Cellular and Infection Microbiology</em>; https://doi.org/10.3389/fcimb.2023.1116172</td>
+<td>(wang2023characterizationofresistance pages 5-7)</td>
+</tr>
+<tr>
+<td>MIC/phenotype</td>
+<td>In Bangladesh Shigella, plasmid-borne mphA was associated with very high azithromycin resistance and was experimentally transferable into E. coli, confirming phenotype transfer by horizontal gene transfer.</td>
+<td>Shigella donors and E. coli K-12 transconjugants</td>
+<td>42/59 isolates were AZM-resistant; MRP plasmid more frequent in resistant vs susceptible strains (60%, 25/42 vs 24%, 4/17; p&lt;0.0001); transferred plasmid size 63 MDa; all transconjugants had AZM MIC ≥256 µg/mL</td>
+<td>Asad et al., 2024, <em>Scientific Reports</em>; https://doi.org/10.1038/s41598-024-57423-1</td>
+<td>(asad2024multidrugresistantconjugativeplasmid pages 4-5, asad2024multidrugresistantconjugativeplasmid media a1f352af, asad2024multidrugresistantconjugativeplasmid media 75fd2a0d)</td>
+</tr>
+<tr>
+<td>Interventions</td>
+<td>Combination treatment that increased outer-membrane permeability (colistin plus azithromycin) reduced mph(A) expression/activity and restored azithromycin susceptibility in multidrug-resistant E. coli, suggesting Mph(A)-linked resistance can be partly overcome pharmacologically.</td>
+<td>Multidrug-resistant E. coli T28R</td>
+<td>48 differentially expressed genes under combination treatment; mph(A) downregulated relative to azithromycin alone</td>
+<td>Luo et al., 2024, <em>Microbiology Spectrum</em>; https://doi.org/10.1128/spectrum.03918-23</td>
+<td>(pawlowski2018theevolutionof pages 6-7)</td>
+</tr>
+</tbody>
+</table>
+<p><em>Table: This table compiles mechanistic, regulatory, epidemiologic, and phenotypic evidence for the Enterobacterales macrolide resistance gene mphA/Mph(A), emphasizing E. coli where possible. It is useful as a concise evidence map linking biochemical function to mobile genetic context and recent surveillance findings.</em></p>
+<h2 id="8-practical-functional-annotation-summary-for-ecolx-mpha-uniprot-q47396">8. Practical functional annotation summary (for ECOLX mphA / UniProt Q47396)</h2>
+<p><strong>Recommended functional name:</strong> macrolide 2′-phosphotransferase (Mph(A); MPH(2′)-I). (fong2017structuralbasisfor pages 1-3)</p>
+<p><strong>Molecular function:</strong> GTP-dependent macrolide kinase/phosphotransferase that phosphorylates a hydroxyl on the macrolide amino sugar (commonly described as the 2′-OH), inactivating macrolides. (golkar2018lookandoutlook pages 6-8, fong2017structuralbasisfor pages 1-3)</p>
+<p><strong>Primary substrates (supported here):</strong> erythromycin (14-membered) and azithromycin (15-membered). (noguchi2000regulationoftranscription pages 1-2, fong2017structuralbasisfor pages 1-3)</p>
+<p><strong>Biological process:</strong> antibiotic resistance via drug inactivation (macrolide detoxification). (golkar2018lookandoutlook pages 6-8)</p>
+<p><strong>Regulatory context:</strong> often part of inducible operon <strong>mph(A)-mrx-mphR(A)</strong>; MphR(A) is a repressor released by macrolides; mrx required for high-level resistance. (noguchi2000regulationoftranscription pages 1-2, noguchi2000regulationoftranscription pages 5-6)</p>
+<p><strong>Typical genetic context in contemporary isolates:</strong> mobilizable IS-element-bounded modules such as <strong>IS26–mphA–mrx(A)–mphR(A)–IS6100</strong> on IncF plasmids (and also found across Enterobacterales). (wang2024wholegenomesequencingof pages 4-8)</p>
+<h2 id="9-limitations-of-this-evidence-package">9. Limitations of this evidence package</h2>
+<ul>
+<li><strong>Direct subcellular localization</strong> (e.g., cytosol vs periplasm) for Mph(A) in <em>E. coli</em> is not explicitly demonstrated in the retrieved excerpts; therefore, localization is inferred only at a high level (intracellular enzymatic modification) and should be refined with additional primary localization experiments if required. (fong2017structuralbasisfor pages 1-3)</li>
+<li>Some quantitative phenotype links (e.g., <em>E. coli</em>-specific azithromycin MIC distributions stratified by mphA module integrity) are only partially available in the retrieved text; however, strong experimental MIC evidence for mphA transfer into <em>E. coli</em> is available via conjugation. (asad2024multidrugresistantconjugativeplasmid media 75fd2a0d)</li>
+</ul>
+<h2 id="10-key-references-urls-and-publication-dates">10. Key references (URLs and publication dates)</h2>
+<ul>
+<li>Noguchi et al. <strong>2000-09</strong>. <em>Journal of Bacteriology</em>. “Regulation of transcription of the mph(A) gene…” https://doi.org/10.1128/jb.182.18.5052-5058.2000 (noguchi2000regulationoftranscription pages 1-2, noguchi2000regulationoftranscription pages 5-6)</li>
+<li>Fong et al. <strong>2017-05</strong>. <em>Structure</em>. “Structural basis for kinase-mediated macrolide antibiotic resistance.” https://doi.org/10.1016/j.str.2017.03.007 (fong2017structuralbasisfor pages 1-3)</li>
+<li>Golkar et al. <strong>2018-08</strong>. <em>Frontiers in Microbiology</em>. “Look and outlook on enzyme-mediated macrolide resistance.” https://doi.org/10.3389/fmicb.2018.01942 (golkar2018lookandoutlook pages 6-8)</li>
+<li>Wang et al. <strong>2024-02</strong>. <em>Infection and Drug Resistance</em>. “WGS of an <em>E. coli</em> ST69 strain…” https://doi.org/10.2147/idr.s427571 (wang2024wholegenomesequencingof pages 4-8)</li>
+<li>Ivanova et al. <strong>2024-05</strong>. <em>Journal of Antimicrobial Chemotherapy</em>. “Azithromycin resistance in <em>E. coli</em> and <em>Salmonella</em>…” https://doi.org/10.1093/jac/dkae161 (ivanova2024azithromycinresistancein pages 1-2, ivanova2024azithromycinresistancein pages 2-3)</li>
+<li>Asad et al. <strong>2024-03</strong>. <em>Scientific Reports</em>. “Multidrug-resistant conjugative plasmid carrying mphA…” https://doi.org/10.1038/s41598-024-57423-1 (asad2024multidrugresistantconjugativeplasmid pages 4-5, asad2024multidrugresistantconjugativeplasmid media 75fd2a0d)</li>
+<li>Luo et al. <strong>2024-04</strong>. <em>Microbiology Spectrum</em>. “Upregulation of outer membrane porin gene ompC…” https://doi.org/10.1128/spectrum.03918-23 (pawlowski2018theevolutionof pages 6-7)</li>
+</ul>
+<p>References</p>
+<ol>
+<li>
+<p>(noguchi2000regulationoftranscription pages 1-2): Norihisa Noguchi, Katsutoshi Takada, Jin Katayama, Ayako Emura, and Masanori Sasatsu. Regulation of transcription of themph(a) gene for macrolide 2′-phosphotransferase i inescherichia coli: characterization of the regulatory gene mphr(a). Journal of Bacteriology, 182:5052-5058, Sep 2000. URL: https://doi.org/10.1128/jb.182.18.5052-5058.2000, doi:10.1128/jb.182.18.5052-5058.2000. This article has 113 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(fong2017structuralbasisfor pages 1-3): Desiree H. Fong, David L. Burk, Jonathan Blanchet, Amy Y. Yan, and Albert M. Berghuis. Structural basis for kinase-mediated macrolide antibiotic resistance. Structure, 25 5:750-761.e5, May 2017. URL: https://doi.org/10.1016/j.str.2017.03.007, doi:10.1016/j.str.2017.03.007. This article has 40 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(golkar2018lookandoutlook pages 6-8): Tolou Golkar, Michał Zieliński, and Albert M. Berghuis. Look and outlook on enzyme-mediated macrolide resistance. Frontiers in Microbiology, Aug 2018. URL: https://doi.org/10.3389/fmicb.2018.01942, doi:10.3389/fmicb.2018.01942. This article has 172 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(noguchi2000regulationoftranscription pages 5-6): Norihisa Noguchi, Katsutoshi Takada, Jin Katayama, Ayako Emura, and Masanori Sasatsu. Regulation of transcription of themph(a) gene for macrolide 2′-phosphotransferase i inescherichia coli: characterization of the regulatory gene mphr(a). Journal of Bacteriology, 182:5052-5058, Sep 2000. URL: https://doi.org/10.1128/jb.182.18.5052-5058.2000, doi:10.1128/jb.182.18.5052-5058.2000. This article has 113 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(fong2017structuralbasisfor pages 8-9): Desiree H. Fong, David L. Burk, Jonathan Blanchet, Amy Y. Yan, and Albert M. Berghuis. Structural basis for kinase-mediated macrolide antibiotic resistance. Structure, 25 5:750-761.e5, May 2017. URL: https://doi.org/10.1016/j.str.2017.03.007, doi:10.1016/j.str.2017.03.007. This article has 40 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(ivanova2024azithromycinresistancein pages 1-2): Mirena Ivanova, A. Ovsepian, P. Leekitcharoenphon, A. Seyfarth, H. Mordhorst, Saria Otani, Sandra Koeberl-Jelovcan, M. Milanov, G. Kompes, Maria Liapi, Tomás Cerný, Camilla Thougaard Vester, A. Perrin-Guyomard, J. Hammerl, Mirjam Grobbel, Eleni Valkanou, Szilárd Jánosi, Rosemarie Slowey, Patricia Alba, Virginia Carfora, J. Avsejenko, A. Pereckienė, D. Claude, Renato Zerafa, K. Veldman, Cécile Boland, C. Garcı́a-Graells, P. Wattiau, Patrick Butaye, M. Zając, A. Amaro, L. Clemente, Angela M Vaduva, L. Romaşcu, N. Miliţă, Andrea Mojžišová, Irena Zdovc, Maria Jesús Zamora Escribano, Cristina De Frutos Escobar, G. Overesch, Christopher Teale, Guy H Loneragan, Beatriz Guerra, P. Beloeil, Amanda M. V. Brown, R. Hendriksen, Valeria Bortolaia, and J. Kjeldgaard. Azithromycin resistance in escherichia coli and salmonella from food-producing animals and meat in europe. Journal of Antimicrobial Chemotherapy, 79:1657-1667, May 2024. URL: https://doi.org/10.1093/jac/dkae161, doi:10.1093/jac/dkae161. This article has 28 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(ivanova2024azithromycinresistancein pages 2-3): Mirena Ivanova, A. Ovsepian, P. Leekitcharoenphon, A. Seyfarth, H. Mordhorst, Saria Otani, Sandra Koeberl-Jelovcan, M. Milanov, G. Kompes, Maria Liapi, Tomás Cerný, Camilla Thougaard Vester, A. Perrin-Guyomard, J. Hammerl, Mirjam Grobbel, Eleni Valkanou, Szilárd Jánosi, Rosemarie Slowey, Patricia Alba, Virginia Carfora, J. Avsejenko, A. Pereckienė, D. Claude, Renato Zerafa, K. Veldman, Cécile Boland, C. Garcı́a-Graells, P. Wattiau, Patrick Butaye, M. Zając, A. Amaro, L. Clemente, Angela M Vaduva, L. Romaşcu, N. Miliţă, Andrea Mojžišová, Irena Zdovc, Maria Jesús Zamora Escribano, Cristina De Frutos Escobar, G. Overesch, Christopher Teale, Guy H Loneragan, Beatriz Guerra, P. Beloeil, Amanda M. V. Brown, R. Hendriksen, Valeria Bortolaia, and J. Kjeldgaard. Azithromycin resistance in escherichia coli and salmonella from food-producing animals and meat in europe. Journal of Antimicrobial Chemotherapy, 79:1657-1667, May 2024. URL: https://doi.org/10.1093/jac/dkae161, doi:10.1093/jac/dkae161. This article has 28 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(wang2024wholegenomesequencingof pages 4-8): Ling Wang, Yuee Guan, Xu Lin, Jie Wei, Qinghuan Zhang, Limei Zhang, Jing Tan, Jie Jiang, Caiqin Ling, Lei Cai, Xiaobin Li, Xiong Liang, Wei Wei, and Rui-Man Li. Whole-genome sequencing of an escherichia coli st69 strain harboring blactx-m-27 on a hybrid plasmid. Infection and Drug Resistance, 17:365-375, Feb 2024. URL: https://doi.org/10.2147/idr.s427571, doi:10.2147/idr.s427571. This article has 7 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(asad2024multidrugresistantconjugativeplasmid pages 4-5): Asaduzzaman Asad, Israt Jahan, Moriam Akter Munni, Ruma Begum, Morium Akter Mukta, Kazi Saif, Shah Nayeem Faruque, Shoma Hayat, and Zhahirul Islam. Multidrug-resistant conjugative plasmid carrying mpha confers increased antimicrobial resistance in shigella. Scientific Reports, Mar 2024. URL: https://doi.org/10.1038/s41598-024-57423-1, doi:10.1038/s41598-024-57423-1. This article has 26 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(asad2024multidrugresistantconjugativeplasmid media 75fd2a0d): Asaduzzaman Asad, Israt Jahan, Moriam Akter Munni, Ruma Begum, Morium Akter Mukta, Kazi Saif, Shah Nayeem Faruque, Shoma Hayat, and Zhahirul Islam. Multidrug-resistant conjugative plasmid carrying mpha confers increased antimicrobial resistance in shigella. Scientific Reports, Mar 2024. URL: https://doi.org/10.1038/s41598-024-57423-1, doi:10.1038/s41598-024-57423-1. This article has 26 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(asad2024multidrugresistantconjugativeplasmid media a1f352af): Asaduzzaman Asad, Israt Jahan, Moriam Akter Munni, Ruma Begum, Morium Akter Mukta, Kazi Saif, Shah Nayeem Faruque, Shoma Hayat, and Zhahirul Islam. Multidrug-resistant conjugative plasmid carrying mpha confers increased antimicrobial resistance in shigella. Scientific Reports, Mar 2024. URL: https://doi.org/10.1038/s41598-024-57423-1, doi:10.1038/s41598-024-57423-1. This article has 26 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(pawlowski2018theevolutionof pages 6-7): Andrew C. Pawlowski, Peter J. Stogios, Kalinka Koteva, Tatiana Skarina, Elena Evdokimova, Alexei Savchenko, and Gerard D. Wright. The evolution of substrate discrimination in macrolide antibiotic resistance enzymes. Nature Communications, Jan 2018. URL: https://doi.org/10.1038/s41467-017-02680-0, doi:10.1038/s41467-017-02680-0. This article has 102 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(wang2023characterizationofresistance pages 7-9): Hongmei Wang, Hang Cheng, Baoxing Huang, Xiumei Hu, Yunsheng Chen, Lei Zheng, Liang Yang, Jikui Deng, and Qian Wang. Characterization of resistance genes and plasmids from sick children caused by salmonella enterica resistance to azithromycin in shenzhen, china. Frontiers in Cellular and Infection Microbiology, Mar 2023. URL: https://doi.org/10.3389/fcimb.2023.1116172, doi:10.3389/fcimb.2023.1116172. This article has 26 citations.</p>
+</li>
+<li>
+<p>(wang2023characterizationofresistance pages 5-7): Hongmei Wang, Hang Cheng, Baoxing Huang, Xiumei Hu, Yunsheng Chen, Lei Zheng, Liang Yang, Jikui Deng, and Qian Wang. Characterization of resistance genes and plasmids from sick children caused by salmonella enterica resistance to azithromycin in shenzhen, china. Frontiers in Cellular and Infection Microbiology, Mar 2023. URL: https://doi.org/10.3389/fcimb.2023.1116172, doi:10.3389/fcimb.2023.1116172. This article has 26 citations.</p>
+</li>
+<li>
+<p>(noguchi2000regulationoftranscription pages 2-4): Norihisa Noguchi, Katsutoshi Takada, Jin Katayama, Ayako Emura, and Masanori Sasatsu. Regulation of transcription of themph(a) gene for macrolide 2′-phosphotransferase i inescherichia coli: characterization of the regulatory gene mphr(a). Journal of Bacteriology, 182:5052-5058, Sep 2000. URL: https://doi.org/10.1128/jb.182.18.5052-5058.2000, doi:10.1128/jb.182.18.5052-5058.2000. This article has 113 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(wang2023characterizationofresistance pages 3-5): Hongmei Wang, Hang Cheng, Baoxing Huang, Xiumei Hu, Yunsheng Chen, Lei Zheng, Liang Yang, Jikui Deng, and Qian Wang. Characterization of resistance genes and plasmids from sick children caused by salmonella enterica resistance to azithromycin in shenzhen, china. Frontiers in Cellular and Infection Microbiology, Mar 2023. URL: https://doi.org/10.3389/fcimb.2023.1116172, doi:10.3389/fcimb.2023.1116172. This article has 26 citations.</p>
+</li>
+</ol>
+<h2 id="artifacts">Artifacts</h2>
+<ul>
+<li><a href="Q47396_ECOLX-deep-research-falcon_artifacts/artifact-00.md">Edison artifact artifact-00</a><br />
+<img alt="## Context ID: pqac-00000016 I have extracted the two tables that provide the information you requested. Both are located on page 4 of the document. - Table 2 r" src="Q47396_ECOLX-deep-research-falcon_artifacts/image-1.png" /></li>
+</ul>
+<h2 id="citations">Citations</h2>
+<ol>
+<li>fong2017structuralbasisfor pages 1-3</li>
+<li>golkar2018lookandoutlook pages 6-8</li>
+<li>noguchi2000regulationoftranscription pages 5-6</li>
+<li>fong2017structuralbasisfor pages 8-9</li>
+<li>ivanova2024azithromycinresistancein pages 1-2</li>
+<li>ivanova2024azithromycinresistancein pages 2-3</li>
+<li>wang2024wholegenomesequencingof pages 4-8</li>
+<li>pawlowski2018theevolutionof pages 6-7</li>
+<li>noguchi2000regulationoftranscription pages 1-2</li>
+<li>wang2023characterizationofresistance pages 5-7</li>
+<li>asad2024multidrugresistantconjugativeplasmid pages 4-5</li>
+<li>wang2023characterizationofresistance pages 7-9</li>
+<li>noguchi2000regulationoftranscription pages 2-4</li>
+<li>wang2023characterizationofresistance pages 3-5</li>
+<li>https://doi.org/10.1093/jac/dkae161</li>
+<li>https://doi.org/10.2147/idr.s427571</li>
+<li>https://doi.org/10.1038/s41598-024-57423-1</li>
+<li>https://doi.org/10.1016/j.str.2017.03.007</li>
+<li>https://doi.org/10.3389/fmicb.2018.01942</li>
+<li>https://doi.org/10.1128/jb.182.18.5052-5058.2000</li>
+<li>https://doi.org/10.3389/fcimb.2023.1116172</li>
+<li>https://doi.org/10.1128/spectrum.03918-23</li>
+<li>https://doi.org/10.1128/jb.182.18.5052-5058.2000,</li>
+<li>https://doi.org/10.1016/j.str.2017.03.007,</li>
+<li>https://doi.org/10.3389/fmicb.2018.01942,</li>
+<li>https://doi.org/10.1093/jac/dkae161,</li>
+<li>https://doi.org/10.2147/idr.s427571,</li>
+<li>https://doi.org/10.1038/s41598-024-57423-1,</li>
+<li>https://doi.org/10.1038/s41467-017-02680-0,</li>
+<li>https://doi.org/10.3389/fcimb.2023.1116172,</li>
+</ol>
+            </div>
+        </details>
+        
+    </div>
+    
+
+    <!-- Additional Documentation Sections -->
+    
+    <div class="section">
+        <h2 class="section-title">📚 Additional Documentation</h2>
+        
+        <details class="markdown-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; cursor: pointer;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Notes</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(Q47396_ECOLX-notes.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="Q47396" data-a="DOC: Notes" data-r="" data-act="DOCUMENTATION" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This documentation is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This documentation needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+                <h1 id="notes-q47396_ecolx-mpha-macrolide-2-phosphotransferase-i">Notes: Q47396_ECOLX (MphA, macrolide 2'-phosphotransferase I)</h1>
+<p>Curated alongside MphB (A0A0H3EUF3_ECO8N) to capture the MphA vs MphB substrate-specificity contrast.</p>
+<h2 id="identity">Identity</h2>
+<ul>
+<li>UniProt: Q47396 (TrEMBL, unreviewed), 301 aa. Organism: <em>Escherichia coli</em> (NCBITaxon:562). PE 1 (protein level).</li>
+<li>Gene name mphA / mph(A) / mph2. The canonical, heavily-studied E. coli macrolide 2'-phosphotransferase I.</li>
+<li>NCBIfam HMM: NF000254 (macrolide_MphA) — curated MphA-specific HMM (cf. NF000242 macrolide_MphB).</li>
+<li>CDD cd05152 (MPH2); Pfam PF01636 (APH); InterPro IPR002575 / IPR011009 (kinase-like); PANTHER PTHR21310.</li>
+<li>3D structure: PDB 5IGH, 5IGI (MPH(2')-I with guanosine + azithromycin), from Fong et al. 2017.</li>
+<li>Only electronic GO term: GO:0016740 transferase activity (IEA:UniProtKB-KW) — over-general. GOA export EMPTY.</li>
+</ul>
+<h2 id="function-the-key-mpha-vs-mphb-distinction">Function &amp; the key MphA vs MphB distinction</h2>
+<ul>
+<li>MphA = macrolide 2'-phosphotransferase I (MPH(2')I). Phosphorylates the desosamine 2'-OH of macrolides<br />
+  using a purine NTP (GTP/ITP/ATP, GTP favored) → inactive macrolide 2'-O-phosphate → resistance.</li>
+<li>SUBSTRATE SPECIFICITY (the granular point, beyond GO MF GO:0050073):</li>
+<li>MphA: HIGH on 14-membered macrolides, EXTREMELY LOW on 16-membered. Also active on 15-membered<br />
+    (azithromycin).<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/2478074" title="MPH(2') is an inducible intracellular enzyme which showed high levels of activity with 14-member-ring macrolides and extremely low levels with 16-member-ring macrolides.">PMID:2478074</a><br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/17302923" title="The mph(A) gene was unique in conferring resistance to azithromycin.">PMID:17302923</a></li>
+<li>MphB (contrast): HIGH on BOTH 14- and 16-membered (adds spiramycin/josamycin/tylosin), constitutive.<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/1330822" title="MPH(2')II ... showed high levels of activity with both 14-member-ring and 16-member-ring macrolides.">PMID:1330822</a></li>
+<li>REGULATION: MphA is INDUCIBLE by erythromycin via the TetR-family repressor MphR(A); MphB is constitutive.<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/10960087" title="The synthesis of macrolide 2'-phosphotransferase I [Mph(A)], which inactivates erythromycin, is inducible by erythromycin.">PMID:10960087</a></li>
+<li>GENETIC CONTEXT: high-level erythromycin resistance from the native determinant needs mphA + mrx (accessory<br />
+  hydrophobic/membrane protein).<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/8619599" title="the expression of high-level resistance to erythromycin requires two genes, mphA and mrx, which encode macrolide 2'-phosphotransferase I and an unidentified hydrophobic protein, respectively.">PMID:8619599</a></li>
+<li>Cofactor/metal: GTP/ITP/ATP donors; EDTA/iodine/divalent-cation inhibition (metal-dependent), pI 5.3, MW ~34 kDa.<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/2478074" title="Purine nucleotides, such as GTP, ITP, and ATP, were effective as cofactors in the inactivation of macrolides.">PMID:2478074</a></li>
+</ul>
+<h2 id="go-calls-new-goa-empty">GO calls (NEW; GOA empty)</h2>
+<ul>
+<li>MF: GO:0050073 macrolide 2'-kinase activity (IDA, PMID:2478074; structure PMID:28416110).</li>
+<li>BP: GO:0046677 response to antibiotic (IMP, PMID:8619599; regulation PMID:10960087; azithromycin PMID:17302923).</li>
+<li>substrates (core_function, ChEBI, 14-/15-membered only): erythromycin (CHEBI:48923), oleandomycin<br />
+  (CHEBI:16869), clarithromycin (CHEBI:3732), roxithromycin (CHEBI:48844), azithromycin (CHEBI:2955).<br />
+  Deliberately EXCLUDES 16-membered (josamycin/tylosin/spiramycin) — the discriminator from MphB.</li>
+</ul>
+<h2 id="references-cached">References cached</h2>
+<ul>
+<li>PMID:2478074 — O'Hara et al. 1989, AAC. Original MPH(2')I purification + specificity. KEY.</li>
+<li>PMID:8619599 — Noguchi et al. 1995, AAC. mphA cloning; mphA+mrx requirement.</li>
+<li>PMID:10960087 — Noguchi et al. 2000, J Bacteriol. mphR(A) regulation (inducible).</li>
+<li>PMID:17302923 — Chesneau et al. 2007. Comparative phenotypes; mphA-unique azithromycin resistance.</li>
+<li>PMID:28416110 — Fong et al. 2017, Structure. MPH(2')-I crystal structures (5IGH/5IGI).</li>
+<li>PMID:29317655 — Pawlowski et al. 2018, Nat Commun. Mph phylogeny/specificity; MphA widespread in Gram-negatives.</li>
+</ul>
+<p>Initial curation used primary literature directly; falcon deep research was subsequently run (see Update<br />
+below). <code>just</code> not installed in container — used <code>uv run ai-gene-review ...</code> directly.</p>
+<h2 id="update-falcon-deep-research-2026-06-12-additional-references-incorporated">Update: falcon deep research (2026-06-12) — additional references incorporated</h2>
+<p>Falcon deep research completed (Q47396_ECOLX-deep-research-falcon.md). New verifiable findings added:</p>
+<ul>
+<li>PMID:30177927 — Golkar et al. 2018, Front Microbiol. Review of enzyme-mediated macrolide resistance.<br />
+  KEY secondary-source confirmation of the MphA/MphB distinction and GTP donor:<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/30177927" title="MPH(2′)-I can only efficiently inactivate 14- and 15-membered lactone macrolides, whereas MPH(2′)-II can additionally inactivate 16-membered lactone macrolides and the ketolide, telithromycin">PMID:30177927</a><br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/30177927" title="These MPHs all mediate the transfer of the γ-phosphate group from GTP onto the macrolide substrates">PMID:30177927</a></li>
+<li>PMID:38318209 — Wang et al. 2024, Infect Drug Resist. Contemporary mobile genetic context: mphA carried in<br />
+  an IS26/IS6100 composite transposon (IS26-mphA-mrx(A)-mphR(A)-IS6100), predominantly on IncF plasmids.<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/38318209" title="the mphA-mrx(A)-mphR(A) operon conferring macrolide resistance was flanked by IS26 and IS6100, forming the IS26-mphA-mrx(A)-mphR(A)-IS6100 transposable structure">PMID:38318209</a></li>
+</ul>
+<p>Other deep-research points (clinical/epidemiology, not added as GO-supporting): mphA is the major azithromycin<br />
+resistance determinant in Enterobacterales with high MICs (≥256 µg/mL); MphR(A) derepressed ~100× more<br />
+effectively by 14-membered than 16-membered macrolides; mphA alone = low-level, mphA+mrx = high-level<br />
+resistance (Noguchi 2000). The Golkar quote was also added to the MphB review to reinforce the I-vs-II contrast.</p>
+<p>The "GTP exclusively" claim (deep research, attributed to Fong 2017 full text) was NOT asserted in the review —<br />
+cached Fong is abstract-only and O'Hara 1989 shows GTP/ITP/ATP all function (GTP listed first), so the review<br />
+states "GTP favored" rather than "exclusive" (verify-don't-trust).</p>
+            </div>
+        </details>
+        
+    </div>
+    
+
+    <!-- YAML Preview Section -->
+    <div class="section">
+        <details class="yaml-preview">
+            <summary>
+                <h2 style="display: inline;">📄 View Raw YAML</h2>
+            </summary>
+            <div class="yaml-content">
+                <pre><code>id: Q47396
+gene_symbol: mphA
+aliases:
+- MphA
+- mph(A)
+- macrolide 2&#39;-phosphotransferase I
+- MPH(2&#39;)I
+product_type: PROTEIN
+status: DRAFT
+taxon:
+  id: NCBITaxon:562
+  label: Escherichia coli
+description: &gt;-
+  MphA (macrolide 2&#39;-phosphotransferase I, MPH(2&#39;)I) is a macrolide kinase that inactivates
+  macrolide antibiotics by transferring the gamma-phosphate of a purine nucleoside triphosphate
+  (GTP, ITP or ATP, with GTP favored) to the 2&#39;-hydroxyl of the desosamine sugar, producing an
+  inactive macrolide 2&#39;-O-phosphate that no longer binds the bacterial ribosome. In contrast to the
+  broad-spectrum MphB (MPH(2&#39;)II), MphA is comparatively narrow: it acts efficiently on 14-membered
+  (erythromycin, oleandomycin, clarithromycin, roxithromycin) and 15-membered (azithromycin)
+  macrolides but only very weakly on 16-membered macrolides (spiramycin, josamycin, tylosin). A
+  second distinction is regulation: MphA synthesis is inducible by erythromycin via the upstream
+  TetR-family repressor MphR(A), whereas MphB is constitutive. High-level erythromycin resistance
+  from the original determinant requires mphA together with the adjacent mrx gene (an accessory
+  membrane protein). The enzyme adopts the bi-lobed protein-kinase-like fold of the aminoglycoside
+  phosphotransferase (APH) superfamily (crystal structures solved for MPH(2&#39;)-I with a guanine
+  nucleotide and macrolides). MphA is the most clinically prevalent plasmid-borne macrolide-resistance
+  determinant in Enterobacterales and is frequently associated with reduced susceptibility to
+  azithromycin. In contemporary isolates it is typically carried as a mobile IS26/IS6100-bounded
+  composite transposon spanning the mphA-mrx(A)-mphR(A) operon, predominantly on IncF plasmids,
+  which drives its wide horizontal dissemination.
+references:
+- id: PMID:2478074
+  title: &#34;Purification and characterization of macrolide 2&#39;-phosphotransferase from a strain of Escherichia coli that is highly resistant to erythromycin&#34;
+  findings:
+  - statement: &gt;-
+      MPH(2&#39;)I is an inducible intracellular enzyme that is highly active on 14-membered macrolides but
+      shows extremely low activity on 16-membered macrolides — the defining narrow specificity vs MphB.
+    supporting_text: &#34;MPH(2&#39;) is an inducible intracellular enzyme which showed high levels of activity with 14-member-ring macrolides and extremely low levels with 16-member-ring macrolides.&#34;
+  - statement: &gt;-
+      Purine nucleotides GTP, ITP and ATP serve as phosphate donors.
+    supporting_text: &#34;Purine nucleotides, such as GTP, ITP, and ATP, were effective as cofactors in the inactivation of macrolides.&#34;
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      PubMed-verified (O&#39;Hara et al., Antimicrob Agents Chemother 1989). Original purification and
+      characterization of MPH(2&#39;)I; the primary source for MphA&#39;s 14-membered (not 16-membered) substrate
+      specificity, inducibility, and purine-NTP donor usage — the direct contrast to MphB (PMID:1330822).
+- id: PMID:8619599
+  title: &#34;Nucleotide sequence and characterization of erythromycin resistance determinant that encodes macrolide 2&#39;-phosphotransferase I in Escherichia coli&#34;
+  findings:
+  - statement: &gt;-
+      High-level erythromycin resistance from this determinant requires two genes, mphA (encoding MPH(2&#39;)I)
+      and mrx (an accessory hydrophobic protein).
+    supporting_text: &#34;the expression of high-level resistance to erythromycin requires two genes, mphA and mrx, which encode macrolide 2&#39;-phosphotransferase I and an unidentified hydrophobic protein, respectively.&#34;
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      PubMed-verified (Noguchi et al., Antimicrob Agents Chemother 1995). Cloning/sequencing of the mphA
+      determinant; establishes mphA identity and the mphA+mrx requirement for high-level resistance.
+- id: PMID:10960087
+  title: &#34;Regulation of transcription of the mph(A) gene for macrolide 2&#39;-phosphotransferase I in Escherichia coli: characterization of the regulatory gene mphR(A)&#34;
+  findings:
+  - statement: &gt;-
+      MphA synthesis is inducible by erythromycin and is controlled by the regulatory gene mphR(A) — unlike
+      the constitutive MphB.
+    supporting_text: &#34;The synthesis of macrolide 2&#39;-phosphotransferase I [Mph(A)], which inactivates erythromycin, is inducible by erythromycin.&#34;
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      PubMed-verified (Noguchi et al., J Bacteriol 2000). Characterizes the mphR(A) repressor controlling
+      inducible mphA expression; supports the regulatory distinction from constitutive mphB.
+- id: PMID:17302923
+  title: &#34;Resistance phenotypes conferred by macrolide phosphotransferases&#34;
+  findings:
+  - statement: &gt;-
+      Among the mph genes compared in an efflux-deficient host, mph(A) was uniquely able to confer
+      resistance to azithromycin (a 15-membered macrolide).
+    supporting_text: &#34;The mph(A) gene was unique in conferring resistance to azithromycin.&#34;
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      PubMed-verified (Chesneau et al., FEMS Microbiol Lett 2007). Comparative phenotyping of mph genes;
+      documents mph(A)&#39;s azithromycin activity, consistent with its 14-/15-membered specificity.
+- id: PMID:28416110
+  title: &#34;Structural Basis for Kinase-Mediated Macrolide Antibiotic Resistance&#34;
+  findings:
+  - statement: &gt;-
+      Crystal structures of MPH(2&#39;)-I (MphA) were determined apo and in complex with GTP analogs and
+      macrolides, revealing the kinase-like fold.
+    supporting_text: &#34;We present structures for MPH(2&#39;)-I and MPH(2&#39;)-II in the apo state, and in complex with GTP analogs and six different macrolides.&#34;
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      PubMed-verified (Fong et al., Structure 2017). Provides the MphA (MPH(2&#39;)-I) crystal structures
+      (PDB 5IGH/5IGI), confirming the APH/protein-kinase-like fold and GTP-analog/macrolide binding.
+- id: PMID:29317655
+  title: &#34;The evolution of substrate discrimination in macrolide antibiotic resistance enzymes&#34;
+  findings:
+  - statement: &gt;-
+      MphA is one of the mobilized Mph homologs that are widespread in Gram-negative bacteria.
+    supporting_text: &#34;MphA, MphB, and MphE are widespread in Gram-negative bacteria&#34;
+  reference_review:
+    relevance: MEDIUM
+    correctness: VERIFIED
+    review_notes: &gt;-
+      PubMed-verified (Pawlowski et al., Nat Commun 2018). Phylogenetic/functional survey of Mph enzymes
+      placing MphA among the clinically mobilized, widespread Gram-negative resistance kinases.
+- id: PMID:30177927
+  title: &#34;Look and Outlook on Enzyme-Mediated Macrolide Resistance&#34;
+  findings:
+  - statement: &gt;-
+      MPH(2&#39;)-I (MphA) efficiently inactivates only 14- and 15-membered macrolides, whereas MPH(2&#39;)-II (MphB)
+      additionally inactivates 16-membered macrolides and telithromycin — the explicit MphA/MphB contrast.
+    supporting_text: &#34;MPH(2′)-I can only efficiently inactivate 14- and 15-membered lactone macrolides, whereas MPH(2′)-II can additionally inactivate 16-membered lactone macrolides and the ketolide, telithromycin&#34;
+  - statement: &gt;-
+      Mph enzymes transfer the gamma-phosphate of GTP onto macrolide substrates; mph(A), (B) and (C) are
+      mobile-element-encoded and found in clinical E. coli.
+    supporting_text: &#34;These MPHs all mediate the transfer of the γ-phosphate group from GTP onto the macrolide substrates...mph(A), (B), and (C), which are encoded on mobile genetic elements, are found in clinical isolates of E.&#34;
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      PubMed-verified (Golkar et al., Front Microbiol 2018). Authoritative review of enzyme-mediated macrolide
+      resistance; provides a clean secondary-source statement of the MPH(2&#39;)-I vs -II substrate-specificity
+      distinction and the GTP phosphate-donor mechanism.
+- id: PMID:38318209
+  title: &#34;Whole-Genome Sequencing of an Escherichia coli ST69 Strain Harboring bla(CTX-M-27) on a Hybrid Plasmid&#34;
+  findings:
+  - statement: &gt;-
+      In a clinical E. coli isolate, the mphA-mrx(A)-mphR(A) operon is carried within an IS26/IS6100-bounded
+      composite transposon, the mobile unit that disseminates mphA on IncF plasmids.
+    supporting_text: &#34;the mphA-mrx(A)-mphR(A) operon conferring macrolide resistance was flanked by IS26 and IS6100, forming the IS26-mphA-mrx(A)-mphR(A)-IS6100 transposable structure&#34;
+  reference_review:
+    relevance: MEDIUM
+    correctness: VERIFIED
+    review_notes: &gt;-
+      PubMed-verified (Wang et al., Infect Drug Resist 2024). Documents the contemporary mobile genetic
+      context of mphA (IS26 composite transposon, IncF plasmids), supporting its horizontal dissemination.
+- id: PMID:38521802
+  title: &#34;Multidrug-resistant conjugative plasmid carrying mphA confers increased antimicrobial resistance in Shigella&#34;
+  findings:
+  - statement: &gt;-
+      A conjugative plasmid carrying mphA transferred high-level azithromycin resistance; all transconjugants
+      reached azithromycin MIC &gt;=256 ug/ml, demonstrating mphA-mediated, plasmid-borne resistance.
+    supporting_text: &#34;The MIC of azithromycin was ≥ 256 µg/ml for all transconjugants.&#34;
+  - statement: &gt;-
+      Plasmid-borne mphA inactivates macrolides by modifying the drug&#39;s molecular structure.
+    supporting_text: &#34;Several reports suggested that plasmid-mediated macrolide 2&#39;-phosphotransferase (mphA) mostly and esterase (ermB) for some instances inactivate macrolide through modifying its molecular structure&#34;
+  reference_review:
+    relevance: MEDIUM
+    correctness: VERIFIED
+    review_notes: &gt;-
+      PubMed-verified (Asad et al., Sci Rep 2024). Experimental conjugation/MIC evidence that plasmid-borne
+      mphA confers high-level azithromycin resistance transferable into recipient Enterobacterales.
+existing_annotations:
+# NOTE: The QuickGO GOA export for this TrEMBL accession is empty (no curated annotations).
+# The only electronic GO term on the UniProt record is the over-general GO:0016740 &#34;transferase
+# activity&#34; (IEA from the UniProtKB Transferase keyword), which is not in GOA. The annotations
+# below (action: NEW) capture the specific, experimentally established function of MphA.
+- term:
+    id: GO:0050073
+    label: macrolide 2&#39;-kinase activity
+  evidence_type: IDA
+  original_reference_id: PMID:2478074
+  review:
+    summary: &gt;-
+      MphA phosphorylates the 2&#39;-OH of macrolides using a purine NTP, producing inactive macrolide
+      2&#39;-O-phosphate. The purified enzyme is highly active on 14-membered (and 15-membered) macrolides; this
+      matches the GO:0050073 definition (ATP + oleandomycin = ADP + 2 H+ + oleandomycin 2&#39;-O-phosphate).
+    action: NEW
+    reason: &gt;-
+      The purified enzyme was biochemically characterized as a macrolide 2&#39;-phosphotransferase, and crystal
+      structures of MPH(2&#39;)-I confirm the kinase mechanism. No curated GOA annotation exists for this TrEMBL
+      entry, so this specific MF should be added.
+    additional_reference_ids:
+    - PMID:8619599
+    - PMID:28416110
+    supported_by:
+    - reference_id: PMID:2478074
+      supporting_text: &#34;MPH(2&#39;) is an inducible intracellular enzyme which showed high levels of activity with 14-member-ring macrolides and extremely low levels with 16-member-ring macrolides.&#34;
+    - reference_id: PMID:28416110
+      supporting_text: &#34;We present structures for MPH(2&#39;)-I and MPH(2&#39;)-II in the apo state, and in complex with GTP analogs and six different macrolides.&#34;
+- term:
+    id: GO:0046677
+    label: response to antibiotic
+  evidence_type: IMP
+  original_reference_id: PMID:8619599
+  review:
+    summary: &gt;-
+      MphA confers macrolide (notably erythromycin and azithromycin) resistance by enzymatically
+      inactivating the drug; high-level resistance from the native determinant additionally requires mrx.
+      Expression is inducible by erythromycin via the MphR(A) repressor.
+    action: NEW
+    reason: &gt;-
+      Resistance is the biological process this enzyme participates in. &#34;response to antibiotic&#34; is the
+      standard, well-supported BP for an antibiotic-modifying resistance enzyme (the drug is modified, not
+      degraded, so &#34;antibiotic catabolic process&#34; would be less accurate).
+    additional_reference_ids:
+    - PMID:10960087
+    - PMID:17302923
+    - PMID:38521802
+    supported_by:
+    - reference_id: PMID:8619599
+      supporting_text: &#34;the expression of high-level resistance to erythromycin requires two genes, mphA and mrx, which encode macrolide 2&#39;-phosphotransferase I and an unidentified hydrophobic protein, respectively.&#34;
+    - reference_id: PMID:17302923
+      supporting_text: &#34;The mph(A) gene was unique in conferring resistance to azithromycin.&#34;
+    - reference_id: PMID:38521802
+      supporting_text: &#34;The MIC of azithromycin was ≥ 256 µg/ml for all transconjugants.&#34;
+- term:
+    id: GO:0005737
+    label: cytoplasm
+  evidence_type: IDA
+  original_reference_id: PMID:2478074
+  review:
+    summary: &gt;-
+      MphA was characterized as a soluble, intracellular (cytoplasmic) enzyme upon purification from E. coli,
+      consistent with cytoplasmic inactivation of macrolides.
+    action: NEW
+    reason: &gt;-
+      The purified enzyme was reported as an inducible intracellular enzyme, indicating cytoplasmic
+      localization — the expected compartment for a soluble macrolide-inactivating kinase.
+    supported_by:
+    - reference_id: PMID:2478074
+      supporting_text: &#34;MPH(2&#39;) is an inducible intracellular enzyme&#34;
+core_functions:
+- description: &gt;-
+    MphA is a macrolide 2&#39;-phosphotransferase (macrolide kinase): it transfers the gamma-phosphate of a
+    purine nucleoside triphosphate (GTP/ITP/ATP) to the 2&#39;-hydroxyl of the desosamine sugar of macrolide
+    antibiotics, producing an inactive macrolide 2&#39;-O-phosphate. This detoxifies the drug and is the basis
+    of the macrolide resistance it confers. Its substrate range is narrower than MphB: it is highly active
+    on 14- and 15-membered macrolides but only weakly on 16-membered macrolides. Expression is inducible by
+    erythromycin (via MphR(A)). The enzyme uses the conserved active-site residues of the protein-kinase-like/
+    APH fold for metal-dependent phosphoryl transfer.
+  molecular_function:
+    id: GO:0050073
+    label: macrolide 2&#39;-kinase activity
+  directly_involved_in:
+  - id: GO:0046677
+    label: response to antibiotic
+  locations:
+  - id: GO:0005737
+    label: cytoplasm
+  # Substrate specificity recorded at finer granularity than the GO MF term: MphA acts on 14- and
+  # 15-membered macrolides but is essentially inactive on 16-membered macrolides (the discriminator
+  # from MphB, which additionally modifies josamycin/tylosin/spiramycin).
+  substrates:
+  - id: CHEBI:48923   # 14-membered
+    label: erythromycin
+  - id: CHEBI:16869   # 14-membered (classic in vitro assay substrate)
+    label: oleandomycin
+  - id: CHEBI:3732    # 14-membered
+    label: clarithromycin
+  - id: CHEBI:48844   # 14-membered
+    label: roxithromycin
+  - id: CHEBI:2955    # 15-membered
+    label: azithromycin
+  supported_by:
+  - reference_id: PMID:2478074
+    supporting_text: &#34;MPH(2&#39;) is an inducible intracellular enzyme which showed high levels of activity with 14-member-ring macrolides and extremely low levels with 16-member-ring macrolides.&#34;
+  - reference_id: PMID:17302923
+    supporting_text: &#34;The mph(A) gene was unique in conferring resistance to azithromycin.&#34;
+  - reference_id: PMID:30177927
+    supporting_text: &#34;MPH(2′)-I can only efficiently inactivate 14- and 15-membered lactone macrolides, whereas MPH(2′)-II can additionally inactivate 16-membered lactone macrolides and the ketolide, telithromycin&#34;
+suggested_questions:
+- question: &gt;-
+    What is the structural basis for MphA&#39;s discrimination against 16-membered macrolides, and could
+    16-membered macrolides or derivatives evade MphA-mediated resistance clinically?
+suggested_experiments:
+- description: &gt;-
+    Measure steady-state kinetics (kcat/Km) of purified MphA against 14-, 15- and 16-membered macrolides
+    with GTP vs ATP donors to quantify the substrate and cofactor preferences relative to MphB.
+- description: &gt;-
+    Test whether the accessory mrx gene is required for full resistance in a clean E. coli background and
+    determine its molecular role (e.g. membrane association / enzyme stability).
+</code></pre>
+            </div>
+        </details>
+    </div>
+
+    <!-- Pathway Visualization Link -->
+    
+
+    <style>
+        /* Markdown Section Styles */
+        .markdown-section {
+            margin-bottom: 1rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .markdown-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .markdown-section summary h3 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.1rem;
+        }
+
+        .markdown-section summary:hover h3 {
+            color: #007bff;
+        }
+
+        .markdown-section[open] {
+            background-color: #fff;
+        }
+
+        .markdown-content {
+            margin-top: 1rem;
+            padding: 1rem;
+            border-top: 1px solid #dee2e6;
+        }
+
+        /* Markdown content styling */
+        .markdown-content h1 { font-size: 1.5rem; margin-top: 1.5rem; }
+        .markdown-content h2 { font-size: 1.3rem; margin-top: 1.3rem; }
+        .markdown-content h3 { font-size: 1.1rem; margin-top: 1.1rem; }
+        .markdown-content h4 { font-size: 1rem; margin-top: 1rem; }
+
+        .markdown-content pre {
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .markdown-content code {
+            background-color: #f8f9fa;
+            padding: 0.2rem 0.4rem;
+            border-radius: 3px;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+        }
+
+        .markdown-content pre code {
+            background: none;
+            padding: 0;
+        }
+
+        .markdown-content table {
+            border-collapse: collapse;
+            width: 100%;
+            margin: 1rem 0;
+        }
+
+        .markdown-content table th,
+        .markdown-content table td {
+            border: 1px solid #dee2e6;
+            padding: 0.5rem;
+            text-align: left;
+        }
+
+        .markdown-content table th {
+            background-color: #f8f9fa;
+            font-weight: bold;
+        }
+
+        .markdown-content blockquote {
+            border-left: 4px solid #007bff;
+            padding-left: 1rem;
+            margin-left: 0;
+            color: #666;
+        }
+
+        /* YAML Preview Styles */
+        .yaml-preview {
+            margin-top: 2rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .yaml-preview summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .yaml-preview summary h2 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.3rem;
+        }
+
+        .yaml-preview summary:hover h2 {
+            color: #007bff;
+        }
+
+        .yaml-preview[open] {
+            background-color: #fff;
+        }
+
+        .yaml-content {
+            margin-top: 1rem;
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .yaml-content pre {
+            margin: 0;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+            line-height: 1.4;
+        }
+
+        .yaml-content code {
+            color: #333;
+            background: none;
+            padding: 0;
+        }
+
+        /* Pathway Link Styles */
+        .pathway-link {
+            margin: 1rem 0;
+        }
+
+        .btn-link {
+            display: inline-block;
+            padding: 0.5rem 1rem;
+            background-color: #007bff;
+            color: white !important;
+            text-decoration: none;
+            border-radius: 4px;
+            font-weight: 500;
+            transition: background-color 0.2s;
+        }
+
+        .btn-link:hover {
+            background-color: #0056b3;
+            text-decoration: none;
+        }
+
+        /* Voting buttons */
+        .vote-buttons {
+            display: inline-block;
+            margin-left: 0.5rem;
+        }
+
+        .vote-btn {
+            background: none;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 2px 6px;
+            margin: 0 2px;
+            cursor: pointer;
+            font-size: 0.9rem;
+            transition: all 0.2s;
+            opacity: 0.6;
+        }
+
+        .vote-btn:hover {
+            opacity: 1;
+            transform: scale(1.1);
+        }
+
+        .vote-btn.voted {
+            opacity: 1;
+            border-color: #28a745;
+            background-color: #d4edda;
+        }
+
+        .vote-btn.voted-down {
+            border-color: #dc3545;
+            background-color: #f8d7da;
+        }
+
+        .vote-btn-small {
+            font-size: 0.7rem;
+            padding: 1px 4px;
+            margin: 0 1px;
+        }
+    </style>
+
+    <script>
+        // Add collapsible functionality
+        document.querySelectorAll('.collapsible').forEach(element => {
+            element.addEventListener('click', function() {
+                this.classList.toggle('collapsed');
+            });
+        });
+
+        // Voting functionality
+        const VOTE_URL = 'https://script.google.com/macros/s/AKfycbwPKH7d3seuPNBtB0ugVjqGeTiByyOGD5vkqB_Ck6K8eOcPQYbJqBOuz6GFgXHKBNWK/exec';
+
+        // Get or create session ID
+        let sessionId = localStorage.getItem('review_session_id');
+        if (!sessionId) {
+            sessionId = 's' + Date.now() + '_' + Math.random().toString(36).substr(2, 9);
+            localStorage.setItem('review_session_id', sessionId);
+        }
+
+        // Show previous votes on page load
+        document.addEventListener('DOMContentLoaded', function() {
+            document.querySelectorAll('.vote-buttons').forEach(container => {
+                const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+                const previousVote = localStorage.getItem(key);
+                if (previousVote) {
+                    const btn = container.querySelector(`[data-v="${previousVote}"]`);
+                    if (btn) btn.classList.add(previousVote === 'up' ? 'voted' : 'voted-down');
+                }
+            });
+        });
+
+        // Handle vote clicks - Simple image beacon approach
+        document.addEventListener('click', function(e) {
+            if (!e.target.classList.contains('vote-btn')) return;
+
+            // Prevent the click from bubbling to parent elements (like summary)
+            e.preventDefault();
+            e.stopPropagation();
+
+            const btn = e.target;
+            const container = btn.closest('.vote-buttons');
+            if (!container) return;
+
+            const voteType = btn.dataset.v;
+
+            // Check if already voted (locally)
+            const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+            const previousVote = localStorage.getItem(key);
+
+            if (previousVote === voteType) {
+                // Same vote - do nothing
+                btn.style.animation = 'shake 0.5s';
+                setTimeout(() => btn.style.animation = '', 500);
+                return;
+            }
+
+            // Build URL
+            const params = new URLSearchParams({
+                gene_id: container.dataset.g,
+                annotation_id: container.dataset.a,
+                ref_id: container.dataset.r || '',
+                action: container.dataset.act,
+                vote: voteType,
+                session_id: sessionId,
+                ua: navigator.userAgent.substring(0, 100)
+            });
+
+            // Clear previous vote styling
+            container.querySelectorAll('.vote-btn').forEach(b => {
+                b.classList.remove('voted', 'voted-down');
+            });
+
+            // Apply new vote styling immediately (optimistic UI)
+            btn.classList.add(voteType === 'up' ? 'voted' : 'voted-down');
+
+            // Store locally
+            localStorage.setItem(key, voteType);
+
+            // Send vote using fetch with no-cors mode (fire and forget)
+            const fullUrl = VOTE_URL + '?' + params;
+            console.log('Sending vote to:', fullUrl);
+
+            // Use fetch in no-cors mode - we won't get a response but the request will be sent
+            fetch(fullUrl, {
+                mode: 'no-cors',
+                method: 'GET'
+            }).then(() => {
+                console.log('Vote request sent (no response due to no-cors mode)');
+            }).catch(err => {
+                console.warn('Vote may not have been recorded, but saved locally:', err);
+
+                // Fallback: try image beacon as well
+                const img = new Image();
+                img.src = fullUrl;
+            });
+        });
+
+        // Optional: Add shake animation for feedback
+        const style = document.createElement('style');
+        style.textContent = `
+            @keyframes shake {
+                0%, 100% { transform: translateX(0); }
+                25% { transform: translateX(-5px); }
+                75% { transform: translateX(5px); }
+            }
+        `;
+        document.head.appendChild(style);
+    </script>
+</body>
+</html>

--- a/genes/yeast/CCT3/CCT3-ai-review.html
+++ b/genes/yeast/CCT3/CCT3-ai-review.html
@@ -2040,6 +2040,15 @@
                 <div class="reference-title">Gene Ontology annotation through association of InterPro records with GO terms</div>
                 
                 
+                <ul class="findings-list">
+                    
+                    <li class="finding-item">
+                        <div class="finding-statement">InterPro2GO mapping methodology. Source of IEA annotations for CCT3 derived from its InterPro chaperonin (Cpn60/TCP-1) family/domain signatures and consistent with the AAA+/group II chaperonin architecture.</div>
+                        
+                    </li>
+                    
+                </ul>
+                
             </div>
             
             <div class="reference-item">
@@ -2055,6 +2064,15 @@
                 
                 <div class="reference-title">Annotation inferences using phylogenetic trees</div>
                 
+                
+                <ul class="findings-list">
+                    
+                    <li class="finding-item">
+                        <div class="finding-statement">PAINT/IBA methodology propagating experimental annotations through the PANTHER phylogenetic tree. Source of CCT3 IBA annotations to protein folding, unfolded protein binding, and chaperonin-containing T-complex membership, all consistent with conserved TRiC/CCT subunit function.</div>
+                        
+                    </li>
+                    
+                </ul>
                 
             </div>
             
@@ -2072,6 +2090,15 @@
                 <div class="reference-title">Gene Ontology annotation based on UniProtKB/Swiss-Prot keyword mapping</div>
                 
                 
+                <ul class="findings-list">
+                    
+                    <li class="finding-item">
+                        <div class="finding-statement">UniProt keyword-to-GO mapping methodology. Source of IEA ATP-binding/ chaperone keyword-derived annotations on CCT3, consistent with the Swiss-Prot annotation of CCT3 as an ATP-binding T-complex protein.</div>
+                        
+                    </li>
+                    
+                </ul>
+                
             </div>
             
             <div class="reference-item">
@@ -2087,6 +2114,15 @@
                 
                 <div class="reference-title">Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location vocabulary mapping, accompanied by conservative changes to GO terms applied by UniProt</div>
                 
+                
+                <ul class="findings-list">
+                    
+                    <li class="finding-item">
+                        <div class="finding-statement">UniProt subcellular-location-to-GO mapping methodology. Source of the IEA cytoplasm/cytosol localization for CCT3, consistent with the experimentally established cytosolic localization of TRiC/CCT.</div>
+                        
+                    </li>
+                    
+                </ul>
                 
             </div>
             
@@ -2104,6 +2140,15 @@
                 <div class="reference-title">Electronic Gene Ontology annotations created by ARBA machine learning models</div>
                 
                 
+                <ul class="findings-list">
+                    
+                    <li class="finding-item">
+                        <div class="finding-statement">ARBA machine-learning rule mining methodology. Source of additional IEA molecular-function and biological-process annotations on CCT3 derived from UniProtKB feature evidence in the chaperonin family.</div>
+                        
+                    </li>
+                    
+                </ul>
+                
             </div>
             
             <div class="reference-item">
@@ -2119,6 +2164,15 @@
                 
                 <div class="reference-title">Combined Automated Annotation using Multiple IEA Methods</div>
                 
+                
+                <ul class="findings-list">
+                    
+                    <li class="finding-item">
+                        <div class="finding-statement">Combined automated annotation pipeline that aggregates multiple electronic GO assignment methods. Source of redundant IEA annotations on CCT3 that largely recapitulate the experimentally established chaperonin functions.</div>
+                        
+                    </li>
+                    
+                </ul>
                 
             </div>
             
@@ -2216,6 +2270,17 @@
                 
                 <div class="reference-title">The social and structural architecture of the yeast protein interactome.</div>
                 
+                
+                <ul class="findings-list">
+                    
+                    <li class="finding-item">
+                        <div class="finding-statement">Quantitative AP-MS interactome of yeast: the CCT chaperonin was recovered as the full 8-subunit ring by profile-correlation analysis (CCT is non-taggable), together with a discrete set of ~21 interactors including tubulin/actin-related folding substrates (Tub1, Tub3, Arp1) and two catalytic subunits of PP2A, supporting a restricted rather than broad CCT substrate spectrum.</div>
+                        
+                        <div class="finding-text">"For some proteins—for example, the members of the chaperonin containing t-complex (CCT)—tagging is not possible because it interferes with protein stability or function [...] CCT was nevertheless fully recovered (Fig. 2d). Besides the 8 conserved, ring-forming members, we also detected a distinct set of 21 interacting proteins, about half of which were previously unreported. Two of these were catalytic subunits of protein phosphatase 2A, suggesting regulatory functions, and others, such as tubulin and actin-related proteins (Tub1, Tub3 and Arp1) were major known folding substrates."</div>
+                        
+                    </li>
+                    
+                </ul>
                 
             </div>
             
@@ -2589,24 +2654,49 @@ description: &gt;-
 references:
 - id: GO_REF:0000002
   title: Gene Ontology annotation through association of InterPro records with GO terms
-  findings: []
+  findings:
+  - statement: &gt;-
+      InterPro2GO mapping methodology. Source of IEA annotations for CCT3
+      derived from its InterPro chaperonin (Cpn60/TCP-1) family/domain signatures
+      and consistent with the AAA+/group II chaperonin architecture.
 - id: GO_REF:0000033
   title: Annotation inferences using phylogenetic trees
-  findings: []
+  findings:
+  - statement: &gt;-
+      PAINT/IBA methodology propagating experimental annotations through the
+      PANTHER phylogenetic tree. Source of CCT3 IBA annotations to protein
+      folding, unfolded protein binding, and chaperonin-containing T-complex
+      membership, all consistent with conserved TRiC/CCT subunit function.
 - id: GO_REF:0000043
   title: Gene Ontology annotation based on UniProtKB/Swiss-Prot keyword mapping
-  findings: []
+  findings:
+  - statement: &gt;-
+      UniProt keyword-to-GO mapping methodology. Source of IEA ATP-binding/
+      chaperone keyword-derived annotations on CCT3, consistent with the
+      Swiss-Prot annotation of CCT3 as an ATP-binding T-complex protein.
 - id: GO_REF:0000044
   title: &gt;-
     Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location vocabulary mapping, accompanied
     by conservative changes to GO terms applied by UniProt
-  findings: []
+  findings:
+  - statement: &gt;-
+      UniProt subcellular-location-to-GO mapping methodology. Source of the
+      IEA cytoplasm/cytosol localization for CCT3, consistent with the
+      experimentally established cytosolic localization of TRiC/CCT.
 - id: GO_REF:0000117
   title: Electronic Gene Ontology annotations created by ARBA machine learning models
-  findings: []
+  findings:
+  - statement: &gt;-
+      ARBA machine-learning rule mining methodology. Source of additional IEA
+      molecular-function and biological-process annotations on CCT3 derived
+      from UniProtKB feature evidence in the chaperonin family.
 - id: GO_REF:0000120
   title: Combined Automated Annotation using Multiple IEA Methods
-  findings: []
+  findings:
+  - statement: &gt;-
+      Combined automated annotation pipeline that aggregates multiple electronic
+      GO assignment methods. Source of redundant IEA annotations on CCT3 that
+      largely recapitulate the experimentally established chaperonin functions.
 - id: PMID:15704212
   title: Physiological effects of unassembled chaperonin Cct subunits in the yeast Saccharomyces cerevisiae.
   findings:
@@ -2638,7 +2728,25 @@ references:
       and not direct binary interactions.
 - id: PMID:37968396
   title: The social and structural architecture of the yeast protein interactome.
-  findings: []
+  findings:
+  - statement: &gt;-
+      Quantitative AP-MS interactome of yeast: the CCT chaperonin was recovered
+      as the full 8-subunit ring by profile-correlation analysis (CCT is
+      non-taggable), together with a discrete set of ~21 interactors including
+      tubulin/actin-related folding substrates (Tub1, Tub3, Arp1) and two
+      catalytic subunits of PP2A, supporting a restricted rather than broad
+      CCT substrate spectrum.
+    supporting_text: &gt;-
+      For some proteins—for example, the members of the chaperonin containing
+      t-complex (CCT)—tagging is not possible because it interferes with
+      protein stability or function [...] CCT was nevertheless fully recovered
+      (Fig. 2d). Besides the 8 conserved, ring-forming members, we also
+      detected a distinct set of 21 interacting proteins, about half of which
+      were previously unreported. Two of these were catalytic subunits of
+      protein phosphatase 2A, suggesting regulatory functions, and others,
+      such as tubulin and actin-related proteins (Tub1, Tub3 and Arp1) were
+      major known folding substrates.
+    reference_section_type: RESULTS
 - id: file:yeast/CCT3/CCT3-deep-research-falcon.md
   title: Falcon deep research report for CCT3
   findings:

--- a/genes/yeast/HSC82/HSC82-ai-review.html
+++ b/genes/yeast/HSC82/HSC82-ai-review.html
@@ -5234,6 +5234,15 @@
                 <div class="reference-title">Falcon deep research report for S. cerevisiae HSC82 GO annotation review</div>
                 
                 
+                <ul class="findings-list">
+                    
+                    <li class="finding-item">
+                        <div class="finding-statement">Falcon deep research synthesis covering the core HSC82 functions (ATP-dependent Hsp90 chaperone cycle, cytosolic localization, client/ co-chaperone complexes, calcineurin/CNA2 stabilization) and adjudicating non-core or questionable annotations (plasma membrane, perinuclear region, mitochondrion, generic protein-containing complex/nucleotide binding, unfolded protein binding vs. ATP-dependent protein folding chaperone, box C/D snoRNP/R2TP, kinetochore/SGT1, broad stress-response terms), with explicit distinction from the inducible HSP82 paralog.</div>
+                        
+                    </li>
+                    
+                </ul>
+                
             </div>
             
             <div class="reference-item">
@@ -5247,6 +5256,15 @@
                 
                 <div class="reference-title">UniProtKB record for S. cerevisiae HSC82 (P15108)</div>
                 
+                
+                <ul class="findings-list">
+                    
+                    <li class="finding-item">
+                        <div class="finding-statement">Reviewed Swiss-Prot entry describing HSC82 as the constitutive cytosolic Hsp90 isoform &#34;ATP-dependent molecular chaperone HSC82&#34; (705 aa). Source of UniProt-curated cross-references and the IEA mappings (GO_REF:0000043, GO_REF:0000044, GO_REF:0000117) used in the GOA file.</div>
+                        
+                    </li>
+                    
+                </ul>
                 
             </div>
             
@@ -6884,10 +6902,24 @@ references:
     reference_section_type: ABSTRACT
 - id: file:yeast/HSC82/HSC82-deep-research-falcon.md
   title: Falcon deep research report for S. cerevisiae HSC82 GO annotation review
-  findings: []
+  findings:
+  - statement: &gt;-
+      Falcon deep research synthesis covering the core HSC82 functions
+      (ATP-dependent Hsp90 chaperone cycle, cytosolic localization, client/
+      co-chaperone complexes, calcineurin/CNA2 stabilization) and adjudicating
+      non-core or questionable annotations (plasma membrane, perinuclear
+      region, mitochondrion, generic protein-containing complex/nucleotide
+      binding, unfolded protein binding vs. ATP-dependent protein folding
+      chaperone, box C/D snoRNP/R2TP, kinetochore/SGT1, broad stress-response
+      terms), with explicit distinction from the inducible HSP82 paralog.
 - id: file:yeast/HSC82/HSC82-uniprot.txt
   title: UniProtKB record for S. cerevisiae HSC82 (P15108)
-  findings: []
+  findings:
+  - statement: &gt;-
+      Reviewed Swiss-Prot entry describing HSC82 as the constitutive cytosolic
+      Hsp90 isoform &#34;ATP-dependent molecular chaperone HSC82&#34; (705 aa). Source
+      of UniProt-curated cross-references and the IEA mappings (GO_REF:0000043,
+      GO_REF:0000044, GO_REF:0000117) used in the GOA file.
 suggested_questions:
 - question: Under non-stress conditions, which Hsp90 clients are predominantly chaperoned by the
     constitutive HSC82 isoform versus the inducible HSP82, and how does the relative paralog

--- a/genes/yeast/HSP104/HSP104-ai-review.html
+++ b/genes/yeast/HSP104/HSP104-ai-review.html
@@ -4428,6 +4428,15 @@
                 <div class="reference-title">Annotation inferences using phylogenetic trees</div>
                 
                 
+                <ul class="findings-list">
+                    
+                    <li class="finding-item">
+                        <div class="finding-statement">PAINT/IBA methodology propagates experimental annotations within a phylogenetic tree. Source of all 8 IBA annotations on HSP104: cytoplasm (GO:0005737), ATP hydrolysis activity (GO:0016887), protein refolding (GO:0042026), protein unfolding (GO:0043335), cytosol (GO:0005829), unfolded protein binding (GO:0051082), protein-folding chaperone binding (GO:0051087), and cellular heat acclimation (GO:0070370). All are consistent with the well-established HSP100/Clp disaggregase family function.</div>
+                        
+                    </li>
+                    
+                </ul>
+                
             </div>
             
             <div class="reference-item">
@@ -4443,6 +4452,15 @@
                 
                 <div class="reference-title">Gene Ontology annotation based on UniProtKB/Swiss-Prot keyword mapping</div>
                 
+                
+                <ul class="findings-list">
+                    
+                    <li class="finding-item">
+                        <div class="finding-statement">UniProt keyword-to-GO mapping methodology. Source of the IEA &#34;nucleotide binding&#34; (GO:0000166) annotation for HSP104, derived from a Swiss-Prot keyword and consistent with the AAA+ ATPase architecture of the protein.</div>
+                        
+                    </li>
+                    
+                </ul>
                 
             </div>
             
@@ -4460,6 +4478,15 @@
                 <div class="reference-title">Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location vocabulary mapping, accompanied by conservative changes to GO terms applied by UniProt</div>
                 
                 
+                <ul class="findings-list">
+                    
+                    <li class="finding-item">
+                        <div class="finding-statement">UniProt subcellular-location-to-GO mapping methodology. Source of the IEA &#34;nucleus&#34; (GO:0005634) and &#34;cytoplasm&#34; (GO:0005737) annotations for HSP104, both consistent with the experimentally established localization of the disaggregase (PMID:10467108).</div>
+                        
+                    </li>
+                    
+                </ul>
+                
             </div>
             
             <div class="reference-item">
@@ -4476,6 +4503,15 @@
                 <div class="reference-title">Electronic Gene Ontology annotations created by ARBA machine learning models</div>
                 
                 
+                <ul class="findings-list">
+                    
+                    <li class="finding-item">
+                        <div class="finding-statement">ARBA machine-learning rule-mining methodology that propagates GO terms from UniProtKB feature evidence. Source of six IEA annotations on HSP104: cytosol (GO:0005829), protein folding (GO:0006457), cellular response to heat (GO:0034605), identical protein binding (GO:0042802), protein unfolding (GO:0043335), and intracellular organelle lumen (GO:0070013).</div>
+                        
+                    </li>
+                    
+                </ul>
+                
             </div>
             
             <div class="reference-item">
@@ -4491,6 +4527,15 @@
                 
                 <div class="reference-title">Combined Automated Annotation using Multiple IEA Methods</div>
                 
+                
+                <ul class="findings-list">
+                    
+                    <li class="finding-item">
+                        <div class="finding-statement">Combined automated annotation pipeline that aggregates multiple electronic GO assignment methods. Source of the IEA &#34;ATP binding&#34; (GO:0005524) and &#34;ATP hydrolysis activity&#34; (GO:0016887) annotations on HSP104, which are redundant with experimental evidence for the ATP-dependent disaggregase activity.</div>
+                        
+                    </li>
+                    
+                </ul>
                 
             </div>
             
@@ -6790,22 +6835,54 @@ existing_annotations:
 references:
 - id: GO_REF:0000033
   title: Annotation inferences using phylogenetic trees
-  findings: []
+  findings:
+  - statement: &gt;-
+      PAINT/IBA methodology propagates experimental annotations within a
+      phylogenetic tree. Source of all 8 IBA annotations on HSP104: cytoplasm
+      (GO:0005737), ATP hydrolysis activity (GO:0016887), protein refolding
+      (GO:0042026), protein unfolding (GO:0043335), cytosol (GO:0005829),
+      unfolded protein binding (GO:0051082), protein-folding chaperone binding
+      (GO:0051087), and cellular heat acclimation (GO:0070370). All are
+      consistent with the well-established HSP100/Clp disaggregase family
+      function.
 - id: GO_REF:0000043
   title: Gene Ontology annotation based on UniProtKB/Swiss-Prot keyword mapping
-  findings: []
+  findings:
+  - statement: &gt;-
+      UniProt keyword-to-GO mapping methodology. Source of the IEA
+      &#34;nucleotide binding&#34; (GO:0000166) annotation for HSP104, derived from
+      a Swiss-Prot keyword and consistent with the AAA+ ATPase architecture
+      of the protein.
 - id: GO_REF:0000044
   title: &gt;-
     Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular
     Location vocabulary mapping, accompanied by conservative changes to GO
     terms applied by UniProt
-  findings: []
+  findings:
+  - statement: &gt;-
+      UniProt subcellular-location-to-GO mapping methodology. Source of the
+      IEA &#34;nucleus&#34; (GO:0005634) and &#34;cytoplasm&#34; (GO:0005737) annotations for
+      HSP104, both consistent with the experimentally established localization
+      of the disaggregase (PMID:10467108).
 - id: GO_REF:0000117
   title: Electronic Gene Ontology annotations created by ARBA machine learning models
-  findings: []
+  findings:
+  - statement: &gt;-
+      ARBA machine-learning rule-mining methodology that propagates GO terms
+      from UniProtKB feature evidence. Source of six IEA annotations on
+      HSP104: cytosol (GO:0005829), protein folding (GO:0006457), cellular
+      response to heat (GO:0034605), identical protein binding (GO:0042802),
+      protein unfolding (GO:0043335), and intracellular organelle lumen
+      (GO:0070013).
 - id: GO_REF:0000120
   title: Combined Automated Annotation using Multiple IEA Methods
-  findings: []
+  findings:
+  - statement: &gt;-
+      Combined automated annotation pipeline that aggregates multiple
+      electronic GO assignment methods. Source of the IEA &#34;ATP binding&#34;
+      (GO:0005524) and &#34;ATP hydrolysis activity&#34; (GO:0016887) annotations on
+      HSP104, which are redundant with experimental evidence for the
+      ATP-dependent disaggregase activity.
 - id: PMID:2188365
   title: HSP104 required for induced thermotolerance.
   findings:

--- a/genes/yeast/HSP26/HSP26-ai-review.html
+++ b/genes/yeast/HSP26/HSP26-ai-review.html
@@ -2470,6 +2470,15 @@
                 <div class="reference-title">Electronic Gene Ontology annotations created by ARBA machine learning models</div>
                 
                 
+                <ul class="findings-list">
+                    
+                    <li class="finding-item">
+                        <div class="finding-statement">Machine-learning-based association rule mining methodology that propagates GO terms from UniProtKB feature evidence. Used here as the source of the IEA &#34;protein folding&#34; annotation for HSP26; the rule is broader than the experimentally supported holdase activity and is over-annotated in this case.</div>
+                        
+                    </li>
+                    
+                </ul>
+                
             </div>
             
             <div class="reference-item">
@@ -2836,6 +2845,75 @@
     </div>
     
 
+    
+    <div class="section">
+        <h2 class="section-title">Suggested Experiments</h2>
+        
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    
+                    <p><strong>Experiment:</strong> In vivo identification of HSP26 substrates by stress-induced cross-linking immunoprecipitation (e.g., crosslink-MS in heat-shocked cells) to define the physiological holdase clientele and compare with the substrate spectrum of HSP42 and HSP104.</p>
+                    
+                    
+                    
+                </div>
+                <span class="vote-buttons" data-g="P15992" data-a="EXPERIMENT: In vivo identification of HSP26 substrates by stre..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+        
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    
+                    <p><strong>Experiment:</strong> Reconstitute the HSP26 -&gt; HSP70 (Ssa) -&gt; HSP104 substrate hand-off in vitro with defined model substrates (e.g., luciferase, MDH) to determine whether HSP26 holdase complexes are productively channeled into the disaggregase/refolding pathway and to quantify the rate enhancement over spontaneous reactivation.</p>
+                    
+                    
+                    
+                </div>
+                <span class="vote-buttons" data-g="P15992" data-a="EXPERIMENT: Reconstitute the HSP26 -&gt; HSP70 (Ssa) -&gt; HSP104 su..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+        
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    
+                    <p><strong>Experiment:</strong> Test whether HSP26 mRNA-binding (PMID:20844764) has functional consequences by CLIP-seq in heat-shocked cells with and without an HSP26 oligomer-dissociation mutant, and by measuring translation/stability of candidate target mRNAs in hsp26 deletion vs. wild-type.</p>
+                    
+                    
+                    
+                </div>
+                <span class="vote-buttons" data-g="P15992" data-a="EXPERIMENT: Test whether HSP26 mRNA-binding (PMID:20844764) ha..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+        
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    
+                    <p><strong>Experiment:</strong> Use temperature-sensitive HSP26 oligomer-interface variants to test whether the 24-mer to active-species transition is required for stress granule recruitment (PMID:24291094) and whether stress granule HSP26 colocalizes with misfolded protein aggregates in real time by live-cell fluorescence imaging.</p>
+                    
+                    
+                    
+                </div>
+                <span class="vote-buttons" data-g="P15992" data-a="EXPERIMENT: Use temperature-sensitive HSP26 oligomer-interface..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+        
+    </div>
     
 
     
@@ -3632,7 +3710,12 @@ references:
       suppresses aggregation.
 - id: GO_REF:0000117
   title: Electronic Gene Ontology annotations created by ARBA machine learning models
-  findings: []
+  findings:
+  - statement: &gt;-
+      Machine-learning-based association rule mining methodology that propagates
+      GO terms from UniProtKB feature evidence. Used here as the source of the
+      IEA &#34;protein folding&#34; annotation for HSP26; the rule is broader than the
+      experimentally supported holdase activity and is over-annotated in this case.
 - id: PMID:10581247
   title: &#39;Hsp26: a temperature-regulated chaperone.&#39;
   findings:
@@ -3784,6 +3867,25 @@ suggested_questions:
 - question: Does HSP26 mRNA binding activity (PMID:20844764) have a physiological role, or is it an artifact of the broad substrate-binding properties of chaperones?
 - question: How does HSP26 holdase activity coordinate with HSP104 disaggregase and HSP70 foldase during stress recovery?
 - question: Is the temperature-dependent oligomer dissociation mechanism conserved across yeast sHSPs (e.g., Hsp42)?
+suggested_experiments:
+- description: &gt;-
+    In vivo identification of HSP26 substrates by stress-induced cross-linking immunoprecipitation
+    (e.g., crosslink-MS in heat-shocked cells) to define the physiological holdase clientele and
+    compare with the substrate spectrum of HSP42 and HSP104.
+- description: &gt;-
+    Reconstitute the HSP26 -&gt; HSP70 (Ssa) -&gt; HSP104 substrate hand-off in vitro with defined
+    model substrates (e.g., luciferase, MDH) to determine whether HSP26 holdase complexes are
+    productively channeled into the disaggregase/refolding pathway and to quantify the rate
+    enhancement over spontaneous reactivation.
+- description: &gt;-
+    Test whether HSP26 mRNA-binding (PMID:20844764) has functional consequences by CLIP-seq
+    in heat-shocked cells with and without an HSP26 oligomer-dissociation mutant, and by
+    measuring translation/stability of candidate target mRNAs in hsp26 deletion vs. wild-type.
+- description: &gt;-
+    Use temperature-sensitive HSP26 oligomer-interface variants to test whether the 24-mer to
+    active-species transition is required for stress granule recruitment (PMID:24291094) and
+    whether stress granule HSP26 colocalizes with misfolded protein aggregates in real time
+    by live-cell fluorescence imaging.
 </code></pre>
             </div>
         </details>

--- a/genes/yeast/SAN1/SAN1-ai-review.html
+++ b/genes/yeast/SAN1/SAN1-ai-review.html
@@ -2654,6 +2654,15 @@
                 <div class="reference-title">Annotation inferences using phylogenetic trees</div>
                 
                 
+                <ul class="findings-list">
+                    
+                    <li class="finding-item">
+                        <div class="finding-statement">PAINT/IBA methodology propagating experimental annotations within the PANTHER phylogenetic tree. Source of the SAN1 IBA annotations (ubiquitin protein ligase activity, ubiquitin-dependent protein catabolic process, and cytoplasm), consistent with experimentally established San1 function as a nuclear E3 ligase for misfolded substrates.</div>
+                        
+                    </li>
+                    
+                </ul>
+                
             </div>
             
             <div class="reference-item">
@@ -2669,6 +2678,15 @@
                 
                 <div class="reference-title">Gene Ontology annotation based on UniProtKB/Swiss-Prot keyword mapping</div>
                 
+                
+                <ul class="findings-list">
+                    
+                    <li class="finding-item">
+                        <div class="finding-statement">UniProt keyword-to-GO mapping methodology. Source of the IEA annotations on SAN1 derived from Swiss-Prot keywords (Zinc / Metal- binding / Zinc-finger), mapping to zinc ion binding (KW-0863) and metal ion binding (KW-0479) — consistent with the experimentally established RING-type zinc finger of San1.</div>
+                        
+                    </li>
+                    
+                </ul>
                 
             </div>
             
@@ -2913,6 +2931,75 @@
     </div>
     
 
+    
+    <div class="section">
+        <h2 class="section-title">Suggested Experiments</h2>
+        
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    
+                    <p><strong>Experiment:</strong> Map the substrate-recognition repertoire of San1 in vivo by ubiquitin-AP-MS in san1-delta vs. wild-type strains under proteostatic stress (heat shock, azetidine, canavanine) to define the physiological misfolded-substrate spectrum and test whether all substrates engage the same disordered N-/C-terminal recognition sites characterized in PMID:21211726.</p>
+                    
+                    
+                    
+                </div>
+                <span class="vote-buttons" data-g="P22470" data-a="EXPERIMENT: Map the substrate-recognition repertoire of San1 i..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+        
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    
+                    <p><strong>Experiment:</strong> Define the structural basis of San1 misfolded-protein recognition by AlphaFold- Multimer prediction and HDX-MS of San1 disordered-domain peptides bound to model misfolded substrates (e.g., te-Spt16, sir4-9), with mutational validation of the conserved sequence segments interspersed among the disordered regions.</p>
+                    
+                    
+                    
+                </div>
+                <span class="vote-buttons" data-g="P22470" data-a="EXPERIMENT: Define the structural basis of San1 misfolded-prot..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+        
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    
+                    <p><strong>Experiment:</strong> Quantitatively dissect the nuclear- vs. cytoplasmic-PQC division of labor between San1 and Ubr1 (PMID:20080635) by single-cell live imaging of fluorescent reporter misfolded substrates in san1-delta, ubr1-delta, and double-deletion strains under matched stress, scoring nuclear import kinetics and degradation half-lives.</p>
+                    
+                    
+                    
+                </div>
+                <span class="vote-buttons" data-g="P22470" data-a="EXPERIMENT: Quantitatively dissect the nuclear- vs. cytoplasmi..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+        
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    
+                    <p><strong>Experiment:</strong> Test whether the HDA peroxisomal signal (PMID:35563734) reflects bona fide San1 localization or an overexpression artifact by tagging endogenous SAN1 with split-GFP at the C-terminus and co-imaging with a peroxisomal marker (Pex3-mCherry) under non-stress and PQC-stress conditions.</p>
+                    
+                    
+                    
+                </div>
+                <span class="vote-buttons" data-g="P22470" data-a="EXPERIMENT: Test whether the HDA peroxisomal signal (PMID:3556..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+        
+    </div>
     
 
     
@@ -3582,10 +3669,23 @@ existing_annotations:
 references:
 - id: GO_REF:0000033
   title: Annotation inferences using phylogenetic trees
-  findings: []
+  findings:
+  - statement: &gt;-
+      PAINT/IBA methodology propagating experimental annotations within
+      the PANTHER phylogenetic tree. Source of the SAN1 IBA annotations
+      (ubiquitin protein ligase activity, ubiquitin-dependent protein
+      catabolic process, and cytoplasm), consistent with experimentally
+      established San1 function as a nuclear E3 ligase for misfolded
+      substrates.
 - id: GO_REF:0000043
   title: Gene Ontology annotation based on UniProtKB/Swiss-Prot keyword mapping
-  findings: []
+  findings:
+  - statement: &gt;-
+      UniProt keyword-to-GO mapping methodology. Source of the IEA
+      annotations on SAN1 derived from Swiss-Prot keywords (Zinc / Metal-
+      binding / Zinc-finger), mapping to zinc ion binding (KW-0863) and
+      metal ion binding (KW-0479) — consistent with the experimentally
+      established RING-type zinc finger of San1.
 - id: PMID:15078868
   title: Sir Antagonist 1 (San1) is a ubiquitin ligase.
   findings:
@@ -3761,6 +3861,28 @@ suggested_questions:
 - question: &gt;-
     Should the peroxisomal localization (HDA, PMID:35563734) be retained as a possible
     minor localization site, or should it be removed as an overexpression artifact?
+suggested_experiments:
+- description: &gt;-
+    Map the substrate-recognition repertoire of San1 in vivo by ubiquitin-AP-MS in
+    san1-delta vs. wild-type strains under proteostatic stress (heat shock, azetidine,
+    canavanine) to define the physiological misfolded-substrate spectrum and test
+    whether all substrates engage the same disordered N-/C-terminal recognition sites
+    characterized in PMID:21211726.
+- description: &gt;-
+    Define the structural basis of San1 misfolded-protein recognition by AlphaFold-
+    Multimer prediction and HDX-MS of San1 disordered-domain peptides bound to model
+    misfolded substrates (e.g., te-Spt16, sir4-9), with mutational validation of the
+    conserved sequence segments interspersed among the disordered regions.
+- description: &gt;-
+    Quantitatively dissect the nuclear- vs. cytoplasmic-PQC division of labor between
+    San1 and Ubr1 (PMID:20080635) by single-cell live imaging of fluorescent reporter
+    misfolded substrates in san1-delta, ubr1-delta, and double-deletion strains under
+    matched stress, scoring nuclear import kinetics and degradation half-lives.
+- description: &gt;-
+    Test whether the HDA peroxisomal signal (PMID:35563734) reflects bona fide
+    San1 localization or an overexpression artifact by tagging endogenous SAN1 with
+    split-GFP at the C-terminus and co-imaging with a peroxisomal marker (Pex3-mCherry)
+    under non-stress and PQC-stress conditions.
 </code></pre>
             </div>
         </details>


### PR DESCRIPTION
## Summary

Automated regeneration of static assets after gene review or template changes.

## Generated Assets

| Asset | Count/Status |
|-------|--------------|
| Gene review YAML files | 2333 |
| Gene review HTML pages | 2333 |
| Project pages | 133 |
| Module pages | 3 |
| Browser app (data.js) | Updated |
| Validation report | Updated |

## Trigger

This PR was triggered by changes to:
- genes/**/*.yaml - gene review data files
- src/ai_gene_review/schema/** - LinkML schema files
- src/ai_gene_review/templates/** - Jinja2 templates
- src/ai_gene_review/render.py - rendering code
- src/ai_gene_review/render_modules.py - module rendering code
- src/ai_gene_review/export/** - export code
- src/ai_gene_review/browser/** - browser app assets
- src/ai_gene_review/tools/minify_linkml_browser_data.py - browser data compaction
- projects/*.md - project definitions
- modules/**/*.yaml - module definitions
- project.justfile - just recipes used by CI
- .github/workflows/generate-pages.yaml - workflow definition

## Review

- [ ] Spot-check a few gene review HTML pages render correctly
- [ ] Spot-check module tree browser pages render correctly
- [ ] Verify browser app loads and filters work
- [ ] Check validation report for new issues