### PR TITLE
Review PHTF1 annotations: add protein-membrane adaptor activity

### DIFF
--- a/genes/human/PHTF1/PHTF1-ai-review.yaml
+++ b/genes/human/PHTF1/PHTF1-ai-review.yaml
@@ -82,7 +82,10 @@ existing_annotations:
     - reference_id: PMID:15601915
       full_text_unavailable: true
     - reference_id: PMID:36803935
-      full_text_unavailable: true
+      reference_section_type: RESULTS
+      supporting_text: >-
+        rat (Rattus norvegicus) PHTF1 protein from primary spermatocytes to the end of
+        spermatogenesis, predominantly localized to the endoplasmic reticulum
     - reference_id: file:human/PHTF1/PHTF1-uniprot.txt
       supporting_text: >-
         SUBCELLULAR LOCATION: Endoplasmic reticulum membrane {ECO:0000250|UniProtKB:F1M8G0};
@@ -125,6 +128,43 @@ existing_annotations:
         Experimental evidence in rodent germ cells places PHTF1 in the endoplasmic
         reticulum (ER) adjacent to the Golgi ("Golgi pole") during meiosis and
         spermiogenesis
+- term:
+    id: GO:0043495
+    label: protein-membrane adaptor activity
+  evidence_type: ISS
+  original_reference_id: PMID:15601915
+  review:
+    summary: >-
+      No molecular function is currently annotated in GOA for PHTF1 (only three cellular
+      component terms). The best experimentally characterized molecular activity is a
+      membrane-adaptor role: the N-terminal PHTF region of PHTF1 binds FEM1B and recruits/anchors
+      it to the ER membrane, increasing the membrane-associated FEM1B pool (~1.8-fold). This
+      was demonstrated for the rodent ortholog (Y2H, co-IP, fractionation) [PMID:15601915] and
+      is conserved by sequence similarity in human (UniProt SUBUNIT "Interacts with FEM1B",
+      ECO:0000250). The eLife structural review restates that the PHTF1 N-terminus "is suggested
+      to recruit [FEM1B] to the endoplasmic reticulum" [PMID:36803935].
+    action: NEW
+    reason: >-
+      Proposed novel molecular function annotation capturing the only experimentally supported
+      biochemical activity of PHTF1 (recruiting/anchoring FEM1B to the ER membrane). Marked ISS
+      because the direct experiments were performed on the rodent ortholog and the human
+      interaction is asserted by UniProt on similarity evidence. The alternative 7TMIC/ion-channel
+      hypothesis from structural modeling is explicitly speculative and is NOT proposed as an
+      annotation here pending direct functional evidence.
+    supported_by:
+    - reference_id: PMID:15601915
+      supporting_text: >-
+        we have identified FEM1B, an ortholog of the C. elegans feminization factor 1 (FEM-1),
+        as a binding partner for PHTF1
+      full_text_unavailable: true
+      reference_section_type: ABSTRACT
+    - reference_id: PMID:36803935
+      supporting_text: >-
+        The N-terminal region of mouse (M. musculus) PHTF1 associates with the testis-enriched
+        FEM1B E3 ubiquitin ligase and is suggested to recruit it to the endoplasmic reticulum
+      reference_section_type: RESULTS
+    - reference_id: file:human/PHTF1/PHTF1-uniprot.txt
+      supporting_text: "SUBUNIT: Interacts with FEM1B."
 references:
 - id: GO_REF:0000002
   title: Gene Ontology annotation through association of InterPro records with GO terms.
@@ -157,13 +197,64 @@ references:
     homolog fem1b in male germ cells.
   full_text_unavailable: true
   findings: []
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: >-
+      PubMed-verified (Oyhenart, Benichou, Raich; Biol Reprod 2005). Primary source for
+      the PHTF1-FEM1B interaction (Y2H + co-IP) and integral ER membrane localization in
+      male germ cells. Only the abstract is cached (full_text_available: false), so
+      quantitative claims (e.g. ~1.8-fold FEM1B membrane enrichment) are corroborated via
+      the eLife review (PMID:36803935) and deep research rather than the full text.
 - id: PMID:36803935
   title: >-
     Structural screens identify candidate human homologs of insect chemoreceptors and
     cryptic Drosophila gustatory receptor-like proteins.
-  full_text_unavailable: true
   findings: []
-core_functions: []
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: >-
+      PMC full text available (PMC9998090; Benton & Himmel, eLife 2023). Establishes PHTF1
+      as a deeply conserved eukaryotic 7TMIC-superfamily candidate by AlphaFold2/Dali
+      structural comparison (split TM7 core), summarizes human expression (cerebellum,
+      testis), and recapitulates the mouse PHTF1-FEM1B ER-recruitment finding. The ion
+      channel role is explicitly framed as a hypothesis ("we suggest they also act as ion
+      channels"), not a demonstrated activity.
+core_functions:
+- description: >-
+    PHTF1 is a deeply conserved, multi-pass integral membrane protein of the endoplasmic
+    reticulum and cis-Golgi network membranes whose biochemical activity remains
+    incompletely defined. Its best experimentally characterized molecular role is as a
+    membrane adaptor: the N-terminal PHTF region binds the substrate-receptor FEM1B and
+    recruits/anchors it to the ER membrane in male germ cells, increasing the
+    membrane-associated pool of FEM1B (~1.8-fold in fractionation experiments). Structural
+    modeling additionally places PHTF1 as a candidate member of the 7TMIC (insect
+    chemoreceptor-like) superfamily, raising the as-yet-untested hypothesis of a channel-like
+    activity; no ion channel, transporter, or catalytic activity has been demonstrated in any
+    organism, and the protein is explicitly NOT a transcription factor despite its historical name.
+  molecular_function:
+    id: GO:0043495
+    label: protein-membrane adaptor activity
+  locations:
+  - id: GO:0005789
+    label: endoplasmic reticulum membrane
+  - id: GO:0033106
+    label: cis-Golgi network membrane
+  supported_by:
+  - reference_id: PMID:15601915
+    supporting_text: >-
+      we have identified FEM1B, an ortholog of the C. elegans feminization factor 1 (FEM-1),
+      as a binding partner for PHTF1
+    full_text_unavailable: true
+    reference_section_type: ABSTRACT
+  - reference_id: PMID:36803935
+    supporting_text: >-
+      The N-terminal region of mouse (M. musculus) PHTF1 associates with the testis-enriched
+      FEM1B E3 ubiquitin ligase and is suggested to recruit it to the endoplasmic reticulum
+    reference_section_type: RESULTS
+  - reference_id: file:human/PHTF1/PHTF1-uniprot.txt
+    supporting_text: "SUBUNIT: Interacts with FEM1B."
 proposed_new_terms: []
 suggested_questions:
 - question: >-

--- a/genes/human/PHTF1/PHTF1-ai-review.yaml
+++ b/genes/human/PHTF1/PHTF1-ai-review.yaml
@@ -84,8 +84,8 @@ existing_annotations:
     - reference_id: PMID:36803935
       reference_section_type: RESULTS
       supporting_text: >-
-        rat (Rattus norvegicus) PHTF1 protein from primary spermatocytes to the end of
-        spermatogenesis, predominantly localized to the endoplasmic reticulum
+        ...detection of rat (Rattus norvegicus) PHTF1 protein from primary spermatocytes to
+        the end of spermatogenesis, predominantly localized to the endoplasmic reticulum
     - reference_id: file:human/PHTF1/PHTF1-uniprot.txt
       supporting_text: >-
         SUBCELLULAR LOCATION: Endoplasmic reticulum membrane {ECO:0000250|UniProtKB:F1M8G0};
@@ -138,8 +138,10 @@ existing_annotations:
       No molecular function is currently annotated in GOA for PHTF1 (only three cellular
       component terms). The best experimentally characterized molecular activity is a
       membrane-adaptor role: the N-terminal PHTF region of PHTF1 binds FEM1B and recruits/anchors
-      it to the ER membrane, increasing the membrane-associated FEM1B pool (~1.8-fold). This
-      was demonstrated for the rodent ortholog (Y2H, co-IP, fractionation) [PMID:15601915] and
+      it to the ER membrane, increasing the membrane-associated FEM1B pool (reported as ~1.8-fold
+      by fractionation densitometry; this figure derives from the falcon deep-research summary of
+      the full text and is not verifiable from our cached abstract). This membrane-recruitment
+      role was demonstrated for the rodent ortholog (Y2H, co-IP, fractionation) [PMID:15601915] and
       is conserved by sequence similarity in human (UniProt SUBUNIT "Interacts with FEM1B",
       ECO:0000250). The eLife structural review restates that the PHTF1 N-terminus "is suggested
       to recruit [FEM1B] to the endoplasmic reticulum" [PMID:36803935].
@@ -203,9 +205,11 @@ references:
     review_notes: >-
       PubMed-verified (Oyhenart, Benichou, Raich; Biol Reprod 2005). Primary source for
       the PHTF1-FEM1B interaction (Y2H + co-IP) and integral ER membrane localization in
-      male germ cells. Only the abstract is cached (full_text_available: false), so
-      quantitative claims (e.g. ~1.8-fold FEM1B membrane enrichment) are corroborated via
-      the eLife review (PMID:36803935) and deep research rather than the full text.
+      male germ cells. Only the abstract is cached (full_text_available: false). The eLife
+      review (PMID:36803935) confirms the FEM1B ER-recruitment role qualitatively but not the
+      quantitative magnitude; the specific ~1.8-fold membrane-enrichment figure comes from the
+      falcon deep-research AI summary of the full text and is not independently verifiable from
+      our cached sources.
 - id: PMID:36803935
   title: >-
     Structural screens identify candidate human homologs of insect chemoreceptors and
@@ -228,7 +232,8 @@ core_functions:
     incompletely defined. Its best experimentally characterized molecular role is as a
     membrane adaptor: the N-terminal PHTF region binds the substrate-receptor FEM1B and
     recruits/anchors it to the ER membrane in male germ cells, increasing the
-    membrane-associated pool of FEM1B (~1.8-fold in fractionation experiments). Structural
+    membrane-associated pool of FEM1B (reported as a ~1.8-fold enrichment by fractionation;
+    the specific figure is from the deep-research summary, not our cached abstract). Structural
     modeling additionally places PHTF1 as a candidate member of the 7TMIC (insect
     chemoreceptor-like) superfamily, raising the as-yet-untested hypothesis of a channel-like
     activity; no ion channel, transporter, or catalytic activity has been demonstrated in any


### PR DESCRIPTION
## Summary

Complete AI review of PHTF1 gene annotations with the following key changes:

- **New molecular function annotation**: Added `GO:0043495` (protein-membrane adaptor activity) as an ISS annotation, capturing PHTF1's experimentally characterized role in recruiting and anchoring FEM1B to the ER membrane
- **Enhanced reference documentation**: Updated PMID:36803935 with full supporting text and reference review metadata; added reference reviews for both primary literature sources (PMID:15601915 and PMID:36803935) with relevance and correctness assessments
- **Core functions summary**: Populated the previously empty `core_functions` section with a comprehensive description of PHTF1's biochemical role, subcellular localization, and structural classification, including explicit clarification that the ion-channel hypothesis remains untested
- **Improved annotation evidence**: Added supporting text and section types to existing annotations, providing better traceability to source literature

The new annotation is grounded in direct experimental evidence from rodent orthologs (Y2H, co-IP, fractionation) with human conservation asserted by UniProt, while explicitly excluding the speculative 7TMIC/ion-channel hypothesis pending direct functional evidence.

## Validation

```
just validate human PHTF1
```

## Test plan

- [ ] Validation passes with no schema or best-practice errors
- [ ] All reference_ids (PMID and file paths) are resolvable
- [ ] Supporting text accurately reflects source material
- [ ] Core functions description is biologically accurate and project-independent

https://claude.ai/code/session_01SBw2pwjgReipEp2kEznUMs