### PR TITLE
Audit/correct ABCD3 GO annotation review

### DIFF
--- a/genes/human/ABCD3/ABCD3-ai-review.yaml
+++ b/genes/human/ABCD3/ABCD3-ai-review.yaml
@@ -281,13 +281,16 @@ existing_annotations:
   original_reference_id: PMID:10704444
   review:
     summary: Demonstrates interaction of ABCD3 with PEX19, which is required for targeting ABCD3 to peroxisomes
-      [PMID:10704444]. PEX19 is a peroxisomal membrane protein chaperone/import receptor.
+      [PMID:10704444]. PEX19 is a cytosolic chaperone/import receptor for class I peroxisomal membrane
+      proteins, of which ABCD3 is a client.
     action: MODIFY
-    reason: Specific interaction with PEX19 (peroxisomal biogenesis factor) is well-characterized but
-      'protein binding' is uninformative. A more specific binding term is warranted.
+    reason: Specific interaction with PEX19 (a peroxisomal biogenesis chaperone/import receptor) is well-characterized
+      but 'protein binding' is uninformative. PEX19 is a distinct protein (not ABCD3 itself), so homo-/heterodimerization
+      terms are inappropriate. ABCD3 binds PEX19 as a client of this chaperone, so a chaperone-binding term
+      is the more informative molecular function.
     proposed_replacement_terms:
-    - id: GO:0042803
-      label: protein homodimerization activity
+    - id: GO:0051087
+      label: protein-folding chaperone binding
     additional_reference_ids:
     - PMID:16344115
     - PMID:17761678
@@ -1034,21 +1037,22 @@ existing_annotations:
     action: ACCEPT
     reason: Core localization.
 - term:
-    id: GO:0015727
-    label: bile acid transmembrane transport
+    id: GO:0015125
+    label: bile acid transmembrane transporter activity
   evidence_type: IMP
   original_reference_id: PMID:25168382
   review:
     summary: ABCD3 specifically transports C27-bile acid CoA-ester intermediates (DHCA-CoA, THCA-CoA)
       across the peroxisomal membrane. Loss of ABCD3 causes accumulation of these intermediates in patient
       plasma [PMID:25168382] and in Abcd3 KO mice [PMID:25168382, PMID:34564857]. Cryo-EM structural data
-      identifies these bile acid intermediates as ABCD3-specific substrates [PMID:39223112]. This is more
-      specific than GO:0015721 (bile acid and bile salt transport) and directly reflects the transport
-      function.
+      identifies these bile acid intermediates as ABCD3-specific substrates [PMID:39223112]. The existing
+      annotations capture the bile acid transport process (GO:0015721) but no molecular function term for
+      bile acid transporter activity is present.
     action: NEW
     reason: ABCD3 catalyzes transmembrane transport of bile acid CoA-esters across the peroxisomal membrane.
-      The existing annotation GO:0015721 covers the broader process. This more specific MF term captures
-      the direct transport activity.
+      The existing process annotation GO:0015721 (bile acid and bile salt transport) covers the broader
+      biological process. This molecular function term captures the direct transporter activity and is supported
+      by patient genetics, KO mice, and cryo-EM substrate-binding data.
     supported_by:
     - reference_id: PMID:25168382
       supporting_text: ABCD3 is involved in transport of branched-chain fatty acids and C27 bile acids
@@ -1283,9 +1287,13 @@ core_functions:
   - reference_id: PMID:29397936
     supporting_text: ABCD1-4 displayed stable ATPase activity, which was inhibited by AlF3
   - reference_id: PMID:39223112
-    supporting_text: ''
+    supporting_text: Upon ATP binding, ABCD3 exhibits a conformation that is open towards the peroxisomal
+      matrix, leaving two extra densities corresponding to two CoA molecules deeply embedded in the translocation
+      cavity
   - reference_id: PMID:40501884
-    supporting_text: ''
+    supporting_text: Structural comparison of the apo and substrate bound states demonstrate that the substrate
+      interaction brings nucleotide-binding domains closer, providing a mechanistic basis of substrate
+      induced ATPase activity
 - molecular_function:
     id: GO:0005324
     label: long-chain fatty acid transmembrane transporter activity


### PR DESCRIPTION
Fix three errors found while auditing the existing ABCD3 review:

- NEW annotation used GO:0015727 (actually "lactate transport") with a
  "bile acid transmembrane transport" label. Corrected to GO:0015125
  "bile acid transmembrane transporter activity" (the intended MF term).
- PMID:10704444 ABCD3-PEX19 MODIFY proposed GO:0042803 protein
  homodimerization activity, which is wrong since PEX19 is a distinct
  chaperone, not ABCD3 itself. Corrected to GO:0051087 protein-folding
  chaperone binding.
- Filled two empty supporting_text fields in core_functions with verbatim
  quotes from PMID:39223112 and PMID:40501884.

Validates cleanly (term labels confirmed).

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Gu8UpjpWUSH7Npr1BpMhsv