### PR TITLE
Fix red CI on main: frontmatter test scope, ruff exclude projects/, mcrA term (#1520)

### DIFF
--- a/genes/METAC/mcrA/mcrA-ai-review.yaml
+++ b/genes/METAC/mcrA/mcrA-ai-review.yaml
@@ -200,8 +200,8 @@ core_functions:
     label: nickel cation binding
   description: Binds coenzyme F430 (nickel-containing tetrapyrrole) essential for
     catalytic activity
-- molecular_function:
-    id: GO:0051291
+- directly_involved_in:
+  - id: GO:0051291
     label: protein heterooligomerization
   description: Forms the heterohexameric MCR complex as the alpha subunit (alpha2beta2gamma2)
   supported_by:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -139,7 +139,7 @@ ignore_errors = true
 
 [tool.ruff]
 # Exclude data files, standalone scripts, and auto-generated code from linting
-extend-exclude = ["genes/", "scripts/", "src/ai_gene_review/datamodel/"]
+extend-exclude = ["genes/", "scripts/", "projects/", "src/ai_gene_review/datamodel/"]
 
 [tool.uv.workspace]
 members = ["genes/human/RBFOX3/RBFOX3-bioinformatics/rbfox3_analysis", "genes/yeast/MTC7/MTC7-bioinformatics", "genes/human/CFAP418/CFAP418-bioinformatics", "genes/pombe/Epe1/Epe1-bioinformatics", "genes/pombe/tam10/tam10-bioinformatics", "genes/PSEPK/pedH/pedH-bioinformatics", "genes/human/C18orf21/C18orf21-bioinformatics", "genes/human/C18orf21/C18orf21-bioinformatics/genes/human/C18orf21/C18orf21-bioinformatics", "genes/fly/CG6051/CG6051-bioinformatics", "genes/PENCH/aatA/aatA-bioinformatics", "genes/METBS/Pks1/Pks1-bioinformatics", "genes/human/GATA3/GATA3-bioinformatics", "genes/RAMVA/RvY_13070/RvY_13070-bioinformatics"]

--- a/tests/test_project_frontmatter.py
+++ b/tests/test_project_frontmatter.py
@@ -1,9 +1,9 @@
 """Enforce that project markdown files carry YAML frontmatter with a title.
 
-Every authored project page under ``projects/`` must begin with a YAML
-frontmatter block that defines a non-empty ``title``. Auto-generated artifacts
-(deep-research dumps and ``*.citations.md`` sidecars) are exempt because they are
-machine-written and must not be hand-edited.
+Only top-level project pages (``projects/*.md``) must begin with a YAML
+frontmatter block that defines a non-empty ``title``. Files nested inside a
+project's subdirectories (sub-pages, generated reports/dossiers, deep-research
+dumps, ``*.citations.md`` sidecars) are not required to carry frontmatter.
 """
 
 from pathlib import Path
@@ -22,7 +22,7 @@ def _is_exempt(path: Path) -> bool:
 def _project_markdown_files() -> list[Path]:
     if not PROJECTS_DIR.is_dir():
         return []
-    return sorted(p for p in PROJECTS_DIR.rglob("*.md") if not _is_exempt(p))
+    return sorted(p for p in PROJECTS_DIR.glob("*.md") if not _is_exempt(p))
 
 
 def _parse_frontmatter_title(text: str) -> str | None:


### PR DESCRIPTION
Fixes #1520 — `main`'s full gate (`just test` + `validate-all`) was red, hidden by the
paths-filter scoping. Applies the three fixes per your comments on the issue.

## Changes

1. **Frontmatter test → top-level pages only.** `test_project_file_has_frontmatter_title`
   now globs `projects/*.md` (direct children) instead of `rglob`-ing the whole
   `projects/` tree. Nested/generated content (e.g. the 742 PROTEOSTASIS phase-1 dossiers
   under `reports/phase1_dossiers/`) is no longer required to carry frontmatter. Clears
   **743** pre-existing failures.

2. **ruff: exclude `projects/`.** Added `projects/` to `[tool.ruff] extend-exclude`
   alongside the already-excluded `scripts/` and `genes/` (project scripts are ad-hoc).
   Clears **8** lint errors in `projects/PROTEOSTASIS/scripts/build_phase1_dossiers.py`.

3. **`mcrA` term fix.** `genes/METAC/mcrA` `core_functions[2].molecular_function` used
   `GO:0051291` "protein heterooligomerization", which is a **biological process** →
   moved to `directly_involved_in`. This was the lone blocking term error in `validate-all`.

## Verification

- `just test` (pytest + doctest + mypy + ruff) passes (493 passed; frontmatter test 112 passed).
- `mcrA` passes `linkml-term-validator`.

Once this lands, the in-flight LRV batch-reference-validation branch rebases on top.

Note: the deeper CI gap from #1520 (project/gene-only PRs skip `just test`, so this kind of
breakage merges undetected) is left for a separate discussion — optionally run `just test`
when `projects/**` changes.
