### PR TITLE
Speed up validate-all: batch reference validation in one LRV process

### DIFF
--- a/genes/ACET2/celA/celA-ai-review.yaml
+++ b/genes/ACET2/celA/celA-ai-review.yaml
@@ -42,7 +42,7 @@ existing_annotations:
         and is more specific, this broader term is somewhat redundant but not incorrect.
         For IEA annotations, broader parent terms are acceptable to retain alongside
         more specific ones.
-      additional_reference_ids: [file:ACET2/celA/celA-deep-research-falcon.md]
+      additional_reference_ids: ["file:ACET2/celA/celA-deep-research-falcon.md"]
   - term:
       id: GO:0004553
       label: hydrolase activity, hydrolyzing O-glycosyl compounds
@@ -59,7 +59,7 @@ existing_annotations:
         rule ARBA00027782 and InterPro domains IPR002037 (Glyco_hydro_8) and IPR002105
         (Dockerin). While GO:0008810 (cellulase activity) is more specific, this parent
         term is acceptable for an IEA annotation and provides a useful grouping term.
-      additional_reference_ids: [file:ACET2/celA/celA-deep-research-falcon.md]
+      additional_reference_ids: ["file:ACET2/celA/celA-deep-research-falcon.md"]
   - term:
       id: GO:0005975
       label: carbohydrate metabolic process
@@ -75,7 +75,7 @@ existing_annotations:
         IPR012341 (6hp_glycosidase-like_sf). While the more specific GO:0030245 (cellulose
         catabolic process) better captures CelA's function, this broader term is not
         incorrect and acceptable for an IEA annotation derived from domain membership.
-      additional_reference_ids: [file:ACET2/celA/celA-deep-research-falcon.md]
+      additional_reference_ids: ["file:ACET2/celA/celA-deep-research-falcon.md"]
   - term:
       id: GO:0008810
       label: cellulase activity
@@ -123,7 +123,7 @@ existing_annotations:
         informative functional information. This IEA annotation derived from UniProtKB
         keyword KW-0378 (Hydrolase) is acceptable but provides minimal functional
         insight beyond what is captured by more specific terms.
-      additional_reference_ids: [file:ACET2/celA/celA-deep-research-falcon.md]
+      additional_reference_ids: ["file:ACET2/celA/celA-deep-research-falcon.md"]
   - term:
       id: GO:0016798
       label: hydrolase activity, acting on glycosyl bonds
@@ -138,7 +138,7 @@ existing_annotations:
         beta-1,4 glucosidic bonds in cellulose). The annotation is inferred from UniProtKB
         keyword KW-0326 (Glycosidase). While more specific terms are available and
         already annotated, this intermediate-level term is acceptable for an IEA.
-      additional_reference_ids: [file:ACET2/celA/celA-deep-research-falcon.md]
+      additional_reference_ids: ["file:ACET2/celA/celA-deep-research-falcon.md"]
   - term:
       id: GO:0030245
       label: cellulose catabolic process

--- a/genes/ACET2/celK/celK-ai-review.yaml
+++ b/genes/ACET2/celK/celK-ai-review.yaml
@@ -60,7 +60,7 @@ existing_annotations:
         as it provides correct hierarchical coverage. IEA annotations often propagate
         from broader InterPro signatures and this is consistent with the enzyme's
         function.
-      additional_reference_ids: [file:ACET2/celK/celK-deep-research-falcon.md]
+      additional_reference_ids: ["file:ACET2/celK/celK-deep-research-falcon.md"]
       supported_by:
         - reference_id: PMID:29075324
           supporting_text: exo-acting cellobiohydrolases thread the cellulose molecule
@@ -108,7 +108,7 @@ existing_annotations:
         exist (GO:0030245 cellulose catabolic process), this broad term is acceptable
         as hierarchical context but not informative as a standalone annotation. IEA
         from InterPro is appropriate for this level of granularity.
-      additional_reference_ids: [file:ACET2/celK/celK-deep-research-falcon.md]
+      additional_reference_ids: ["file:ACET2/celK/celK-deep-research-falcon.md"]
   - term:
       id: GO:0008810
       label: cellulase activity
@@ -174,7 +174,7 @@ existing_annotations:
         GO:0004553, GO:0016798) are already present and preferred. This broad term
         is acceptable as it provides hierarchical consistency but is not informative
         as a standalone annotation.
-      additional_reference_ids: [file:ACET2/celK/celK-deep-research-falcon.md]
+      additional_reference_ids: ["file:ACET2/celK/celK-deep-research-falcon.md"]
   - term:
       id: GO:0016798
       label: hydrolase activity, acting on glycosyl bonds
@@ -189,7 +189,7 @@ existing_annotations:
         level of specificity. While GO:0016162 is more specific, this parent term
         is correctly applied. IEA annotation from InterPro domain signatures appropriately
         captures this level of function.
-      additional_reference_ids: [file:ACET2/celK/celK-deep-research-falcon.md]
+      additional_reference_ids: ["file:ACET2/celK/celK-deep-research-falcon.md"]
   - term:
       id: GO:0030245
       label: cellulose catabolic process

--- a/genes/ACET2/cipA/cipA-ai-review.yaml
+++ b/genes/ACET2/cipA/cipA-ai-review.yaml
@@ -231,7 +231,7 @@ existing_annotations:
         - reference_id: PMID:14623971
           supporting_text: The data show that the beta-sheet cohesin domain interacts
             predominantly with one of the helices of the dockerin.
-      additional_reference_ids: [PMID:14623971]
+      additional_reference_ids: ["PMID:14623971"]
   - term:
       id: GO:0005515
       label: protein binding
@@ -260,7 +260,7 @@ existing_annotations:
             its neighboring X module from the cellulosome scaffold of Clostridium
             thermocellum, and a type II Coh module associated with the bacterial cell
             surface.
-      additional_reference_ids: [PMID:16384918]
+      additional_reference_ids: ["PMID:16384918"]
   - term:
       id: GO:0005515
       label: protein binding
@@ -285,7 +285,7 @@ existing_annotations:
           supporting_text: The dual binding mode is predicted to impart significant
             plasticity into the orientation of the catalytic subunits within this
             supramolecular assembly
-      additional_reference_ids: [PMID:17360613]
+      additional_reference_ids: ["PMID:17360613"]
   - term:
       id: GO:0043263
       label: cellulosome
@@ -307,7 +307,7 @@ existing_annotations:
         - reference_id: PMID:14623971
           supporting_text: This megadalton catalytic machine organizes an enzymatic
             consortium on a multifaceted molecular scaffold
-      additional_reference_ids: [cipA-deep-research-falcon.md]
+      additional_reference_ids: ["cipA-deep-research-falcon.md"]
   - term:
       id: GO:0044575
       label: cellulosome assembly
@@ -330,7 +330,7 @@ existing_annotations:
           supporting_text: This megadalton catalytic machine organizes an enzymatic
             consortium on a multifaceted molecular scaffold whose "cohesin" domains
             interact with corresponding "dockerin" domains of the enzymes.
-      additional_reference_ids: [cipA-deep-research-falcon.md]
+      additional_reference_ids: ["cipA-deep-research-falcon.md"]
   - term:
       id: GO:0005198
       label: structural molecule activity
@@ -350,7 +350,7 @@ existing_annotations:
         - reference_id: PMID:14623971
           supporting_text: This megadalton catalytic machine organizes an enzymatic
             consortium on a multifaceted molecular scaffold
-      additional_reference_ids: [cipA-deep-research-falcon.md]
+      additional_reference_ids: ["cipA-deep-research-falcon.md"]
 core_functions:
   - description: CipA's nine type I cohesin domains bind type I dockerin domains on
       catalytic enzymes (cellulases, hemicellulases), recruiting them to the cellulosome

--- a/genes/ARATH/AT5G02500/AT5G02500-ai-review.yaml
+++ b/genes/ARATH/AT5G02500/AT5G02500-ai-review.yaml
@@ -641,7 +641,7 @@ existing_annotations:
       reason: IMP evidence supports HSC70-1's role in ABA-mediated germination control.
         This is retained as a non-core, ABA-linked physiological effect rather than
         as the central molecular function of this Hsp70 chaperone.
-      additional_reference_ids: [PMID:21586649]
+      additional_reference_ids: ["PMID:21586649"]
       supported_by:
         - reference_id: PMID:21586649
           supporting_text: Plants overexpressing HSC70-1 or with reduced HSP90.2 activity

--- a/genes/ARATH/GIP1/GIP1-ai-review.yaml
+++ b/genes/ARATH/GIP1/GIP1-ai-review.yaml
@@ -1,7 +1,7 @@
 id: Q9M0N8
 gene_symbol: GIP1
 product_type: PROTEIN
-status: DRAFT
+status: COMPLETE
 taxon:
   id: NCBITaxon:3702
   label: Arabidopsis thaliana
@@ -536,4 +536,3 @@ suggested_experiments:
 - description: Use degron-based conditional depletion of GIP1/GIP2 in synchronized cells
     with live imaging of CENH3 and gamma-TuC markers to separate the timing of CENH3
     loading defects from microtubule nucleation defects.
-status: COMPLETE

--- a/genes/BACSU/swrD/swrD-ai-review.yaml
+++ b/genes/BACSU/swrD/swrD-ai-review.yaml
@@ -90,7 +90,7 @@ existing_annotations:
         FliK) but makes no mention of swrD or its synonym ylzI. This annotation should
         be removed as it attributes experimental evidence from a paper that does not
         study or mention SwrD.
-      additional_reference_ids: [PMID:25313396]
+      additional_reference_ids: ["PMID:25313396"]
       supported_by:
         - reference_id: PMID:25313396
           supporting_text: FlgM is secreted by the flagellar export apparatus in Bacillus

--- a/genes/DROME/CRY/CRY-ai-review.yaml
+++ b/genes/DROME/CRY/CRY-ai-review.yaml
@@ -69,7 +69,7 @@ existing_annotations:
         significantly affect pacemaker-neuron or behavioral rhythms; the core DmCRY function
         is light input via TIM degradation, not transcriptional repression. Distinct from the
         mammalian type II cryptochrome repressor role that drives this phylogenetic inference.
-      additional_reference_ids: [file:DROME/CRY/CRY-deep-research-falcon.md]
+      additional_reference_ids: ["file:DROME/CRY/CRY-deep-research-falcon.md"]
       supported_by:
         - reference_id: UniProtKB:O77059
           supporting_text: Genes directly activated by the transcription factors Clock
@@ -126,7 +126,7 @@ existing_annotations:
       action: ACCEPT
       reason: Core biological process. CRY is the primary photoreceptor for entrainment of the
         fly circadian clock and acts by light-dependent TIM degradation.
-      additional_reference_ids: [file:DROME/CRY/CRY-deep-research-falcon.md]
+      additional_reference_ids: ["file:DROME/CRY/CRY-deep-research-falcon.md"]
       supported_by:
         - reference_id: UniProtKB:O77059
           supporting_text: Flies exhibit poor synchronization to light-dark cycles
@@ -161,7 +161,7 @@ existing_annotations:
       action: ACCEPT
       reason: Core molecular function. UniProt-curated cofactor annotations specify one FAD
         per subunit, and FAD binding is essential for both photoreception and folding.
-      additional_reference_ids: [file:DROME/CRY/CRY-deep-research-falcon.md]
+      additional_reference_ids: ["file:DROME/CRY/CRY-deep-research-falcon.md"]
       supported_by:
         - reference_id: UniProtKB:O77059
           supporting_text: Binds 1 FAD per subunit.
@@ -252,7 +252,7 @@ existing_annotations:
       reason: UniProt function description explicitly identifies CRY as a blue-light-dependent
         regulator in the circadian loop; falcon synthesis confirms photoreceptor activity as
         the core molecular function.
-      additional_reference_ids: [file:DROME/CRY/CRY-deep-research-falcon.md]
+      additional_reference_ids: ["file:DROME/CRY/CRY-deep-research-falcon.md"]
       supported_by:
         - reference_id: UniProtKB:O77059
           supporting_text: Blue light-dependent regulator that is the input of the
@@ -309,7 +309,7 @@ existing_annotations:
       reason: Protein binding is overly generic and the PMID cited does not provide
         direct binding evidence for CRY. Specific interactions (e.g., CRY–TIM) are
         better captured with partner-specific evidence when available.
-      additional_reference_ids: [PMID:10417378]
+      additional_reference_ids: ["PMID:10417378"]
       supported_by:
         - reference_id: PMID:17418796
           supporting_text: Previous work in Drosophila has defined two populations
@@ -328,7 +328,7 @@ existing_annotations:
       action: ACCEPT
       reason: Cytoplasmic accumulation is documented in studies of CRY localization;
         nuclear localization does not exclude cytosolic presence.
-      additional_reference_ids: [PMID:14960620]
+      additional_reference_ids: ["PMID:14960620"]
       supported_by:
         - reference_id: PMID:10417378
           supporting_text: PER/TIM and CRY influence the subcellular distribution
@@ -461,7 +461,7 @@ existing_annotations:
       action: ACCEPT
       reason: Photoentrainment phenotypes in cry mutants support circadian regulation,
         and CRY represses CLK/CYC-driven transcription.
-      additional_reference_ids: [PMID:16527739]
+      additional_reference_ids: ["PMID:16527739"]
       supported_by:
         - reference_id: PMID:28489826
           supporting_text: "Loss of either cry or \nrh7 caused minor defects in photoentrainment,\
@@ -479,7 +479,7 @@ existing_annotations:
       action: ACCEPT
       reason: cry-dependent photoentrainment plus CRY transcriptional repression supports
         circadian regulation of gene expression.
-      additional_reference_ids: [PMID:16527739]
+      additional_reference_ids: ["PMID:16527739"]
       supported_by:
         - reference_id: PMID:28489826
           supporting_text: "Loss of either cry or \nrh7 caused minor defects in photoentrainment,\
@@ -750,7 +750,7 @@ existing_annotations:
         Genuine but non-core. Magnetosensitivity is a proposed/secondary CRY function relative
         to the canonical circadian photoreceptor / TIM-degradation role, and the underlying
         radical-pair mechanism remains a hypothesis.
-      additional_reference_ids: [file:DROME/CRY/CRY-deep-research-falcon.md]
+      additional_reference_ids: ["file:DROME/CRY/CRY-deep-research-falcon.md"]
       supported_by:
         - reference_id: PMID:20098414
           supporting_text: the light-dependent magnetic sense of Drosophila melanogaster
@@ -772,7 +772,7 @@ existing_annotations:
       reason: |-
         CRY-dependent magnetosensory responses under UV-A/blue light are genuine but secondary
         to the core circadian photoreceptor / TIM-degradation function.
-      additional_reference_ids: [file:DROME/CRY/CRY-deep-research-falcon.md]
+      additional_reference_ids: ["file:DROME/CRY/CRY-deep-research-falcon.md"]
       supported_by:
         - reference_id: PMID:20098414
           supporting_text: the light-dependent magnetic sense of Drosophila melanogaster
@@ -838,7 +838,7 @@ existing_annotations:
       action: MARK_AS_OVER_ANNOTATED
       reason: The evidence supports specific light-dependent CRY-TIM interaction rather than
         nonspecific protein binding.
-      additional_reference_ids: [file:DROME/CRY/CRY-deep-research-falcon.md]
+      additional_reference_ids: ["file:DROME/CRY/CRY-deep-research-falcon.md"]
       supported_by:
         - reference_id: PMID:10417378
           supporting_text: CRY and TIM are part of the same complex and directly interact
@@ -859,7 +859,7 @@ existing_annotations:
       reason: |-
         Cry-deficient flies lack magnetic responses under light, but magnetosensitivity is a
         secondary function relative to the core circadian photoreceptor / TIM-degradation role.
-      additional_reference_ids: [file:DROME/CRY/CRY-deep-research-falcon.md]
+      additional_reference_ids: ["file:DROME/CRY/CRY-deep-research-falcon.md"]
       supported_by:
         - reference_id: PMID:18641630
           supporting_text: the ultraviolet-A/blue-light photoreceptor cryptochrome
@@ -882,7 +882,7 @@ existing_annotations:
       action: ACCEPT
       reason: Light-activated CRY binding to TIM promotes degradation and clock resetting,
         supporting entrainment. Core biological process.
-      additional_reference_ids: [file:DROME/CRY/CRY-deep-research-falcon.md]
+      additional_reference_ids: ["file:DROME/CRY/CRY-deep-research-falcon.md"]
       supported_by:
         - reference_id: PMID:18044989
           supporting_text: Light-activated CRY binds to the TIMELESS (TIM) protein
@@ -904,7 +904,7 @@ existing_annotations:
       reason: |-
         Magnetic field effects on the clock are light- and CRY-dependent, but magnetosensitivity
         is a secondary/proposed function, not the core circadian photoreceptor role.
-      additional_reference_ids: [file:DROME/CRY/CRY-deep-research-falcon.md]
+      additional_reference_ids: ["file:DROME/CRY/CRY-deep-research-falcon.md"]
       supported_by:
         - reference_id: PMID:19355790
           supporting_text: "Drosophila's circadian clock is sensitive to magnetic\
@@ -922,7 +922,7 @@ existing_annotations:
       summary: CRY localizes to the nucleus in light/dark conditions.
       action: ACCEPT
       reason: Independent evidence shows nuclear accumulation of CRY in brain neurons.
-      additional_reference_ids: [PMID:14960620]
+      additional_reference_ids: ["PMID:14960620"]
       supported_by:
         - reference_id: PMID:14960620
           supporting_text: it accumulated in both the nucleus and the cytoplasm, including
@@ -937,7 +937,7 @@ existing_annotations:
       action: ACCEPT
       reason: Independent evidence shows cytoplasmic accumulation of CRY in light/dark
         conditions.
-      additional_reference_ids: [PMID:14960620]
+      additional_reference_ids: ["PMID:14960620"]
       supported_by:
         - reference_id: PMID:14960620
           supporting_text: it accumulated in both the nucleus and the cytoplasm, including
@@ -1012,7 +1012,7 @@ existing_annotations:
       action: ACCEPT
       reason: Recombinant CRY lacks photolyase activity and is characterized as a blue-light
         photoreceptor; this is the core molecular function.
-      additional_reference_ids: [file:DROME/CRY/CRY-deep-research-falcon.md]
+      additional_reference_ids: ["file:DROME/CRY/CRY-deep-research-falcon.md"]
       supported_by:
         - reference_id: PMID:10063806
           supporting_text: suggesting that the protein is not a DNA repair enzyme
@@ -1138,7 +1138,7 @@ existing_annotations:
         Direct experimental evidence (IMP) for repressor activity is solid, but it is a
         peripheral-clock-specific, non-core function in Drosophila. The canonical core function
         is light input via TIM degradation, not transcriptional repression.
-      additional_reference_ids: [file:DROME/CRY/CRY-deep-research-falcon.md]
+      additional_reference_ids: ["file:DROME/CRY/CRY-deep-research-falcon.md"]
       supported_by:
         - reference_id: PMID:16527739
           supporting_text: Drosophila CRY also functions as a transcriptional repressor.
@@ -1198,7 +1198,7 @@ existing_annotations:
       reason: |-
         CRY is necessary for light-dependent magnetic responses, but this magnetosensory
         detection is secondary to the core circadian photoreceptor / TIM-degradation function.
-      additional_reference_ids: [file:DROME/CRY/CRY-deep-research-falcon.md]
+      additional_reference_ids: ["file:DROME/CRY/CRY-deep-research-falcon.md"]
       supported_by:
         - reference_id: PMID:18641630
           supporting_text: the ultraviolet-A/blue-light photoreceptor cryptochrome
@@ -1218,7 +1218,7 @@ existing_annotations:
       action: ACCEPT
       reason: Pacemaker neuron light responses are consistent with CRY-dependent circadian
         regulation supported by additional literature.
-      additional_reference_ids: [PMID:9845369]
+      additional_reference_ids: ["PMID:9845369"]
       supported_by:
         - reference_id: PMID:16510731
           supporting_text: respond differently to light and can be completely desynchronized

--- a/genes/DROME/Ced-12/Ced-12-ai-review.yaml
+++ b/genes/DROME/Ced-12/Ced-12-ai-review.yaml
@@ -146,7 +146,7 @@ existing_annotations:
       in Drosophila has not yet specifically addressed - the focus has been on migration
       and fusion,
       but phagocytic function is expected based on conservation.
-    additional_reference_ids: [PMID:11703939]
+    additional_reference_ids: ["PMID:11703939"]
     supported_by:
     - reference_id: PMID:11703939
       supporting_text: The C. elegans gene ced-12 functions in the engulfment of
@@ -657,7 +657,7 @@ existing_annotations:
       evidence in Drosophila is limited, this function is expected based on strong
       phylogenetic
       conservation and could be annotated via IBA.
-    additional_reference_ids: [PMID:11703939]
+    additional_reference_ids: ["PMID:11703939"]
     supported_by:
     - reference_id: PMID:11703939
       supporting_text: CED-12 acts in engulfing cells for cell corpse engulfment
@@ -695,7 +695,7 @@ existing_annotations:
       activity)
       and accurately reflects ELMO's adapter role in the DOCK-ELMO-Rac signaling
       module.
-    additional_reference_ids: [PMID:21283588]
+    additional_reference_ids: ["PMID:21283588"]
     supported_by:
     - reference_id: PMID:18163987
       supporting_text: Mass spectrometry confirms the presence of an MBC/ELMO 

--- a/genes/MOOTH/acsD/acsD-ai-review.yaml
+++ b/genes/MOOTH/acsD/acsD-ai-review.yaml
@@ -107,7 +107,7 @@ existing_annotations:
       proposed_replacement_terms:
         - id: GO:0046982
           label: protein heterodimerization activity
-      additional_reference_ids: [PMID:22419154]
+      additional_reference_ids: ["PMID:22419154"]
       supported_by:
         - reference_id: PMID:22419154
           supporting_text: Two CFeSPs are present in the complex, each containing

--- a/genes/human/ATP5MC1/ATP5MC1-ai-review.yaml
+++ b/genes/human/ATP5MC1/ATP5MC1-ai-review.yaml
@@ -392,7 +392,7 @@ existing_annotations:
       interaction with TMEM70 assembly factor that facilitates c-ring incorporation.
       More specific annotation would be ideal but generic protein binding captures
       the basic interaction.
-    additional_reference_ids: [PMID:31652072]
+    additional_reference_ids: ["PMID:31652072"]
     supported_by:
     - reference_id: PMID:33359711
       supporting_text: TMEM70 forms oligomeric scaffolds within mitochondrial cristae
@@ -413,7 +413,7 @@ existing_annotations:
       interaction with TMEM70 assembly factor that facilitates c-ring incorporation.
       More specific annotation would be ideal but generic protein binding captures
       the basic interaction.
-    additional_reference_ids: [PMID:33359711]
+    additional_reference_ids: ["PMID:33359711"]
     supported_by:
     - reference_id: PMID:31652072
       supporting_text: Oct 25. TMEM70 facilitates biogenesis of mammalian ATP synthase

--- a/genes/human/CAMK2A/CAMK2A-ai-review.yaml
+++ b/genes/human/CAMK2A/CAMK2A-ai-review.yaml
@@ -118,7 +118,7 @@ existing_annotations:
     proposed_replacement_terms:
     - id: GO:0035255
       label: ionotropic glutamate receptor binding
-    additional_reference_ids: [PMID:19453375]
+    additional_reference_ids: ["PMID:19453375"]
     supported_by:
     - reference_id: PMID:19453375
       supporting_text: Phosphorylation status of the NR2B subunit of NMDA 
@@ -383,7 +383,7 @@ existing_annotations:
       label: ionotropic glutamate receptor binding
     - id: GO:0097110
       label: scaffold protein binding
-    additional_reference_ids: [PMID:28130356]
+    additional_reference_ids: ["PMID:28130356"]
     supported_by:
     - reference_id: PMID:28130356
       supporting_text: CaMKIIα phosphorylates NMDA ( Omkumar et al., 1996 ; 

--- a/genes/human/CASP9/CASP9-ai-review.yaml
+++ b/genes/human/CASP9/CASP9-ai-review.yaml
@@ -331,7 +331,7 @@ existing_annotations:
       proposed_replacement_terms:
         - id: GO:0004197
           label: cysteine-type endopeptidase activity
-      additional_reference_ids: [PMID:10206961]
+      additional_reference_ids: ["PMID:10206961"]
       supported_by:
         - reference_id: PMID:10206961
           supporting_text: Such a complex can be isolated using gel filtration chromatography

--- a/genes/human/CHMP1A/CHMP1A-ai-review.yaml
+++ b/genes/human/CHMP1A/CHMP1A-ai-review.yaml
@@ -1480,7 +1480,7 @@ existing_annotations:
         UniProt explicitly notes this was "based on a wrong translation of the ORF
         which gave rise to a putative protein of 318 AA containing a pattern
         reminiscent of zinc metalloproteases." CHMP1A has no metallopeptidase activity.
-      additional_reference_ids: [UniProt:Q9HD42]
+      additional_reference_ids: ["UniProt:Q9HD42"]
       supported_by:
         - reference_id: PMID:8863740
           supporting_text: Molecular cloning, expression and chromosomal localization

--- a/genes/human/CKAP2/CKAP2-ai-review.yaml
+++ b/genes/human/CKAP2/CKAP2-ai-review.yaml
@@ -27,7 +27,7 @@ existing_annotations:
         protein. Extensive evidence from biochemical studies and cellular experiments
         demonstrates CKAP2s direct interaction with and stabilization of microtubules,
         making this a core annotation.
-      additional_reference_ids: [CKAP2-deep-research.md]
+      additional_reference_ids: ["CKAP2-deep-research.md"]
       supported_by:
         - reference_id: file:human/CKAP2/CKAP2-deep-research-falcon.md
           supporting_text: 'CKAP2 is one of the most powerful microtubule nucleation
@@ -49,7 +49,7 @@ existing_annotations:
         Multiple studies demonstrate that CKAP2 strongly suppresses microtubule catastrophes
         and prevents depolymerization, which is essential for maintaining spindle
         integrity during mitosis.
-      additional_reference_ids: [CKAP2-deep-research.md]
+      additional_reference_ids: ["CKAP2-deep-research.md"]
       supported_by:
         - reference_id: file:human/CKAP2/CKAP2-deep-research-falcon.md
           supporting_text: CKAP2 strongly suppresses microtubule catastrophes (shrinkage
@@ -69,7 +69,7 @@ existing_annotations:
         showing CKAP2 localization and function at spindle poles. CKAP2 is essential
         for maintaining focused spindle poles and proper bipolar spindle assembly,
         making this a core cellular component annotation.
-      additional_reference_ids: [CKAP2-deep-research.md]
+      additional_reference_ids: ["CKAP2-deep-research.md"]
       supported_by:
         - reference_id: file:human/CKAP2/CKAP2-deep-research-falcon.md
           supporting_text: CKAP2 is required for maintaining focused spindle poles
@@ -105,7 +105,7 @@ existing_annotations:
         during its period of peak activity. CKAP2 is essential for mitotic spindle
         assembly and organization, representing a core function supported by extensive
         experimental evidence.
-      additional_reference_ids: [CKAP2-deep-research.md]
+      additional_reference_ids: ["CKAP2-deep-research.md"]
       supported_by:
         - reference_id: file:human/CKAP2/CKAP2-deep-research-falcon.md
           supporting_text: CKAP2 is strongly enriched at the mitotic spindle and is
@@ -141,7 +141,7 @@ existing_annotations:
         microtubule-binding protein. Direct biochemical and cellular evidence demonstrates
         CKAP2s specific association with microtubules, making this a core annotation
         supported by multiple experimental approaches.
-      additional_reference_ids: [CKAP2-deep-research.md]
+      additional_reference_ids: ["CKAP2-deep-research.md"]
       supported_by:
         - reference_id: file:human/CKAP2/CKAP2-deep-research-falcon.md
           supporting_text: CKAP2 directly associates with microtubules as a microtubule-binding
@@ -228,7 +228,7 @@ existing_annotations:
         role. CKAP2 localization to centrosomes is supported by experimental evidence
         and is functionally relevant to its role in spindle organization and centrosome
         integrity maintenance.
-      additional_reference_ids: [CKAP2-deep-research.md]
+      additional_reference_ids: ["CKAP2-deep-research.md"]
       supported_by:
         - reference_id: file:human/CKAP2/CKAP2-deep-research-falcon.md
           supporting_text: CKAP2 localizes to centrosomes during interphase and mitosis
@@ -298,7 +298,7 @@ existing_annotations:
         mitotic spindle rather than general spindle. CKAP2s functions are specifically
         critical during mitosis, and this annotation accurately captures the temporal
         and functional specificity of CKAP2s role.
-      additional_reference_ids: [CKAP2-deep-research.md]
+      additional_reference_ids: ["CKAP2-deep-research.md"]
       supported_by:
         - reference_id: file:human/CKAP2/CKAP2-deep-research-falcon.md
           supporting_text: CKAP2 is strongly enriched at the mitotic spindle during

--- a/genes/human/COPS2/COPS2-ai-review.yaml
+++ b/genes/human/COPS2/COPS2-ai-review.yaml
@@ -92,7 +92,7 @@ existing_annotations:
     reason: >-
       IEA annotation is consistent with direct experimental evidence from
       multiple studies showing nuclear localization of COPS2 and the CSN complex.
-    additional_reference_ids: [PMID:24421388, PMID:10207062]
+    additional_reference_ids: ["PMID:24421388", "PMID:10207062"]
     supported_by:
     - reference_id: PMID:24421388
       supporting_text: >-
@@ -115,7 +115,7 @@ existing_annotations:
     reason: >-
       IEA annotation is consistent with direct experimental evidence showing
       cytoplasmic localization of COPS2/CSN2 and the CSN complex.
-    additional_reference_ids: [PMID:9535219, PMID:24421388]
+    additional_reference_ids: ["PMID:9535219", "PMID:24421388"]
     supported_by:
     - reference_id: PMID:9535219
       supporting_text: >-
@@ -420,7 +420,7 @@ existing_annotations:
       IEA annotation consistent with experimental evidence. COPS2 as
       Alien/TRIP15 is a well-established corepressor for nuclear receptors,
       mediating transcriptional repression.
-    additional_reference_ids: [PMID:10207062, PMID:10713076]
+    additional_reference_ids: ["PMID:10207062", "PMID:10713076"]
     supported_by:
     - reference_id: PMID:10207062
       supporting_text: >-
@@ -658,7 +658,7 @@ existing_annotations:
     reason: >-
       CSN complex has documented nucleoplasmic localization and role
       in DNA damage response [PMID:24421388].
-    additional_reference_ids: [PMID:24421388]
+    additional_reference_ids: ["PMID:24421388"]
 - term:
     id: GO:0005654
     label: nucleoplasm

--- a/genes/human/COX4I1/COX4I1-ai-review.yaml
+++ b/genes/human/COX4I1/COX4I1-ai-review.yaml
@@ -929,7 +929,7 @@ existing_annotations:
         COX4I1's key regulatory function - allosteric inhibition of Complex IV
         at high ATP/ADP ratios. This is a subunit-specific MF annotation
         distinct from the complex-level cytochrome-c oxidase activity.
-      additional_reference_ids: [PMID:21641552]
+      additional_reference_ids: ["PMID:21641552"]
       supported_by:
         - reference_id: PMID:21641552
           supporting_text: >-
@@ -962,7 +962,7 @@ existing_annotations:
         distinguishing role. The deep research review emphasizes this:
         "noncatalytic, COX4-1 regulates complex IV turnover and assembly...
         integrates metabolic signals via adenine nucleotide binding."
-      additional_reference_ids: [PMID:21641552]
+      additional_reference_ids: ["PMID:21641552"]
       supported_by:
         - reference_id: PMID:21641552
           supporting_text: >-
@@ -993,7 +993,7 @@ existing_annotations:
         Multiple Reactome pathways describe COX4I1's role in assembly steps.
         This is a core biological process annotation that is missing from the
         current set.
-      additional_reference_ids: [PMID:23260140, PMID:26321642]
+      additional_reference_ids: ["PMID:23260140", "PMID:26321642"]
       supported_by:
         - reference_id: PMID:23260140
           supporting_text: >-

--- a/genes/human/CRY1/CRY1-ai-review.yaml
+++ b/genes/human/CRY1/CRY1-ai-review.yaml
@@ -161,7 +161,7 @@ existing_annotations:
       summary: Phosphatase binding evidence is for hCRY2, not CRY1.
       action: REMOVE
       reason: The cited interaction involves hCRY2 rather than CRY1.
-      additional_reference_ids: [PMID:9383998]
+      additional_reference_ids: ["PMID:9383998"]
       supported_by:
         - reference_id: PMID:9383998
           supporting_text: specifically interacted with hCRY2.
@@ -263,7 +263,7 @@ existing_annotations:
       action: REMOVE
       reason: Available human evidence supports cytoplasmic/nuclear localization;
         mitochondrial localization is from mouse CRY1.
-      additional_reference_ids: [PMID:9801304]
+      additional_reference_ids: ["PMID:9801304"]
       supported_by:
         - reference_id: UniProtKB:Q16526
           supporting_text: 'SUBCELLULAR LOCATION: Cytoplasm. Nucleus {ECO:0000269|PubMed:22798407,'
@@ -1087,7 +1087,7 @@ existing_annotations:
       action: REMOVE
       reason: Mammalian CRY is reported not to be required for photo-entrainment,
         so blue-light signaling is unsupported.
-      additional_reference_ids: [PMID:23133559]
+      additional_reference_ids: ["PMID:23133559"]
       supported_by:
         - reference_id: PMID:23133559
           supporting_text: Arabidopsis and Drosophila CRY is a major circadian photoreceptor
@@ -1103,7 +1103,7 @@ existing_annotations:
       action: MARK_AS_OVER_ANNOTATED
       reason: The photoreceptor role is speculative for mammals; later evidence indicates
         CRY is not required for photo-entrainment.
-      additional_reference_ids: [PMID:23133559]
+      additional_reference_ids: ["PMID:23133559"]
       supported_by:
         - reference_id: PMID:8909283
           supporting_text: may function as blue-light photoreceptors in humans.
@@ -1123,7 +1123,7 @@ existing_annotations:
       proposed_replacement_terms:
         - id: GO:0140297
           label: DNA-binding transcription factor binding
-      additional_reference_ids: [PMID:21613214]
+      additional_reference_ids: ["PMID:21613214"]
       supported_by:
         - reference_id: PMID:21613214
           supporting_text: CRY binds stably to the CLOCK:BMAL1:E-box ternary
@@ -1180,7 +1180,7 @@ existing_annotations:
       proposed_replacement_terms:
         - id: GO:0140297
           label: DNA-binding transcription factor binding
-      additional_reference_ids: [PMID:21613214]
+      additional_reference_ids: ["PMID:21613214"]
       supported_by:
         - reference_id: PMID:21613214
           supporting_text: CRY binds stably to the CLOCK:BMAL1:E-box ternary

--- a/genes/human/CYCS/CYCS-ai-review.yaml
+++ b/genes/human/CYCS/CYCS-ai-review.yaml
@@ -1289,7 +1289,7 @@ existing_annotations:
         incorrectly linked (it is about RPTPkappa signaling, not cytochrome c), but
         the annotation
         itself is valid and supported by extensive other evidence.
-      additional_reference_ids: [PMID:9515723]
+      additional_reference_ids: ["PMID:9515723"]
       supported_by:
         - reference_id: PMID:9515723
           supporting_text: >-

--- a/genes/human/GLRX5/GLRX5-ai-review.yaml
+++ b/genes/human/GLRX5/GLRX5-ai-review.yaml
@@ -27,7 +27,7 @@ existing_annotations:
         by extensive experimental evidence from multiple studies. This is the primary
         site where GLRX5 carries out its iron-sulfur cluster transfer function, positioned
         optimally within the ISC assembly machinery in the matrix compartment.
-      additional_reference_ids: [PMID:20364084]
+      additional_reference_ids: ["PMID:20364084"]
       supported_by:
         - reference_id: PMID:20364084
           supporting_text: GLRX5 is essential for iron-sulfur cluster biosynthesis
@@ -46,7 +46,7 @@ existing_annotations:
       reason: The IEA annotation based on UniProtKB subcellular location mapping is
         accurate and consistent with experimental data. While redundant with the IBA
         annotation, having both evidence codes is acceptable.
-      additional_reference_ids: [PMID:20364084]
+      additional_reference_ids: ["PMID:20364084"]
       supported_by:
         - reference_id: PMID:20364084
           supporting_text: Glutaredoxin 5 deficiency causes sideroblastic anemia by
@@ -101,7 +101,7 @@ existing_annotations:
         cluster binding protein. The term is well-supported by extensive structural
         and biochemical characterization showing specific [2Fe-2S] cluster binding
         coordinated by Cys67 and glutathione ligands.
-      additional_reference_ids: [PMID:20364084, PMID:23615440]
+      additional_reference_ids: ["PMID:20364084", "PMID:23615440"]
       supported_by:
         - reference_id: PMID:20364084
           supporting_text: GLRX5, a mitochondrial protein that is highly expressed
@@ -122,7 +122,7 @@ existing_annotations:
         The protein exclusively binds [2Fe-2S] clusters, which are subsequently transferred
         to recipient proteins. The specificity for [2Fe-2S] rather than [4Fe-4S] clusters
         is well-established by structural and biochemical studies.
-      additional_reference_ids: [PMID:20364084, PMID:23615440]
+      additional_reference_ids: ["PMID:20364084", "PMID:23615440"]
       supported_by:
         - reference_id: PMID:20364084
           supporting_text: In the reconstituted holo-GLRX5, the catalytic residue
@@ -145,7 +145,7 @@ existing_annotations:
         matrix). The IEA annotation is acceptable as it represents automated mapping,
         but the mitochondrial matrix annotation is more informative and should be
         prioritized. Both can coexist.
-      additional_reference_ids: [PMID:20364084]
+      additional_reference_ids: ["PMID:20364084"]
       supported_by:
         - reference_id: PMID:20364084
           supporting_text: Glutaredoxin 5 deficiency causes sideroblastic anemia by
@@ -206,7 +206,7 @@ existing_annotations:
         BOLA1, BOLA3, NFU1, chaperones), this protein-protein interaction serves its
         core function as an iron-sulfur cluster transfer protein, which is already
         captured by the iron-sulfur cluster binding annotations.
-      additional_reference_ids: [PMID:24606901]
+      additional_reference_ids: ["PMID:24606901"]
       supported_by:
         - reference_id: PMID:24606901
           supporting_text: Cochaperone binding to LYR motifs confers specificity of
@@ -223,7 +223,7 @@ existing_annotations:
       action: REMOVE
       reason: Same rationale as the previous GO:0005515 annotation - "protein binding"
         is too generic and uninformative.
-      additional_reference_ids: [PMID:27499296]
+      additional_reference_ids: ["PMID:27499296"]
       supported_by:
         - reference_id: PMID:27499296
           supporting_text: 2016 Aug 4. Mitochondrial Protein Interaction Mapping Identifies
@@ -240,7 +240,7 @@ existing_annotations:
         remains uninformative.
       action: REMOVE
       reason: Same rationale - "protein binding" is too generic.
-      additional_reference_ids: [PMID:28380382]
+      additional_reference_ids: ["PMID:28380382"]
       supported_by:
         - reference_id: PMID:28380382
           supporting_text: A Single Adaptable Cochaperone-Scaffold Complex Delivers
@@ -257,7 +257,7 @@ existing_annotations:
         binding" remains uninformative.
       action: REMOVE
       reason: Same rationale - "protein binding" is too generic and uninformative.
-      additional_reference_ids: [PMID:32296183]
+      additional_reference_ids: ["PMID:32296183"]
       supported_by:
         - reference_id: PMID:32296183
           supporting_text: Apr 8. A reference map of the human binary protein interactome.
@@ -276,7 +276,7 @@ existing_annotations:
         complex formation), the generic "protein binding" term is uninformative. The
         functionally relevant aspect is GLRX5's role in iron-sulfur cluster assembly
         and transfer, not generic protein binding.
-      additional_reference_ids: [PMID:34063696, PMID:27532772]
+      additional_reference_ids: ["PMID:34063696", "PMID:27532772"]
       supported_by:
         - reference_id: PMID:34063696
           supporting_text: Molecular Basis of Multiple Mitochondrial Dysfunctions
@@ -298,7 +298,7 @@ existing_annotations:
       reason: Accurate but redundant with the more specific mitochondrial matrix annotations.
         Can be retained as it comes from a relevant publication describing GLRX5 interaction
         partners.
-      additional_reference_ids: [PMID:22746225]
+      additional_reference_ids: ["PMID:22746225"]
       supported_by:
         - reference_id: PMID:22746225
           supporting_text: BOLA1 is a mitochondrial protein that, in agreement with
@@ -320,7 +320,7 @@ existing_annotations:
         of heme biosynthesis. However, this is a secondary consequence of its primary
         role in Fe-S cluster assembly. The term is accurate but should be marked as
         non-core, with iron-sulfur cluster assembly being the core function.
-      additional_reference_ids: [PMID:20364084, PMID:27519415]
+      additional_reference_ids: ["PMID:20364084", "PMID:27519415"]
       supported_by:
         - reference_id: PMID:20364084
           supporting_text: In GLRX5-deficient cells, [Fe-S] cluster biosynthesis was
@@ -345,7 +345,7 @@ existing_annotations:
       reason: Same rationale as the previous GO:0006879 annotation. The annotation
         is accurate but represents a secondary consequence of GLRX5's core Fe-S cluster
         assembly function.
-      additional_reference_ids: [PMID:27532772]
+      additional_reference_ids: ["PMID:27532772"]
       supported_by:
         - reference_id: PMID:27532772
           supporting_text: First, components of the 'core ISC machinery' including
@@ -424,7 +424,7 @@ existing_annotations:
         the BOLA1-GLRX5 and BOLA3-GLRX5 complexes. The protein functions within multi-protein
         complexes to facilitate Fe-S cluster transfer, making this cellular component
         annotation accurate and informative.
-      additional_reference_ids: [PMID:27532772, PMID:23615440]
+      additional_reference_ids: ["PMID:27532772", "PMID:23615440"]
       supported_by:
         - reference_id: PMID:27532772
           supporting_text: Bol1 and Bol3 form dimeric complexes with both monothiol
@@ -444,7 +444,7 @@ existing_annotations:
       reason: Accurate but redundant with more specific mitochondrial matrix annotations.
         The IDA evidence from immunofluorescence is valuable, but the more specific
         mitochondrial matrix localization should be prioritized.
-      additional_reference_ids: [PMID:20364084]
+      additional_reference_ids: ["PMID:20364084"]
       supported_by:
         - reference_id: PMID:20364084
           supporting_text: Glutaredoxin 5 deficiency causes sideroblastic anemia by
@@ -463,7 +463,7 @@ existing_annotations:
       action: KEEP_AS_NON_CORE
       reason: Accurate but redundant. High-throughput proteomics data confirms mitochondrial
         localization, which supports the more specific mitochondrial matrix annotations.
-      additional_reference_ids: [PMID:34800366]
+      additional_reference_ids: ["PMID:34800366"]
       supported_by:
         - reference_id: PMID:34800366
           supporting_text: Epub 2021 Nov 19. Quantitative high-confidence human mitochondrial
@@ -483,7 +483,7 @@ existing_annotations:
         binds [2Fe-2S] clusters and mediates their assembly and transfer. This more
         specific term compared to the general "iron-sulfur cluster assembly" accurately
         captures GLRX5's direct involvement in [2Fe-2S] cluster handling.
-      additional_reference_ids: [PMID:23615440, PMID:20364084]
+      additional_reference_ids: ["PMID:23615440", "PMID:20364084"]
       supported_by:
         - reference_id: PMID:23615440
           supporting_text: The vicinity of Isu1 and Grx5 on the Hsp70 chaperone facilitates
@@ -510,7 +510,7 @@ existing_annotations:
           label: iron-sulfur cluster assembly
         - id: GO:0044571
           label: '[2Fe-2S] cluster assembly'
-      additional_reference_ids: [PMID:23615440]
+      additional_reference_ids: ["PMID:23615440"]
       supported_by:
         - reference_id: PMID:23615440
           supporting_text: Grx5 functions as a late-acting component of the core Fe/S
@@ -532,7 +532,7 @@ existing_annotations:
         additional support for mitochondrial matrix localization. While redundant
         with other mitochondrial matrix annotations, Reactome pathways provide valuable
         functional context.
-      additional_reference_ids: [Reactome:R-HSA-8878815]
+      additional_reference_ids: ["Reactome:R-HSA-8878815"]
   - term:
       id: GO:0005759
       label: mitochondrial matrix
@@ -547,7 +547,7 @@ existing_annotations:
       reason: This is direct experimental evidence (IDA) from the landmark paper characterizing
         human GLRX5. The evidence is strong and specific for mitochondrial matrix
         localization, making this a high-quality annotation.
-      additional_reference_ids: [PMID:20364084]
+      additional_reference_ids: ["PMID:20364084"]
       supported_by:
         - reference_id: PMID:20364084
           supporting_text: Here we have shown that GLRX5 is a mitochondrial protein
@@ -595,7 +595,7 @@ existing_annotations:
         plays a critical role in heme biosynthesis through regulation of ALAS2 and
         ferrochelatase, and mutations cause sideroblastic anemia. The tissue-specific
         importance in hemopoiesis is a validated aspect of GLRX5 biology.
-      additional_reference_ids: [PMID:20364084]
+      additional_reference_ids: ["PMID:20364084"]
       supported_by:
         - reference_id: PMID:20364084
           supporting_text: Decreased aminolevulinate δ, synthase 2 (ALAS2) levels
@@ -659,7 +659,7 @@ existing_annotations:
         like BOLA1/BOLA3. This term complements the existing GO:1990229 (iron-sulfur
         cluster assembly complex) annotation by specifically describing the transfer
         function of the complex.
-      additional_reference_ids: [PMID:27532772, PMID:23615440]
+      additional_reference_ids: ["PMID:27532772", "PMID:23615440"]
       supported_by:
         - reference_id: PMID:28380382
           supporting_text: A Single Adaptable Cochaperone-Scaffold Complex Delivers

--- a/genes/human/IL22/IL22-ai-review.yaml
+++ b/genes/human/IL22/IL22-ai-review.yaml
@@ -225,7 +225,7 @@ existing_annotations:
       proposed_replacement_terms:
         - id: GO:0045518
           label: interleukin-22 receptor binding
-      additional_reference_ids: [PMID:18599299]
+      additional_reference_ids: ["PMID:18599299"]
       supported_by:
         - reference_id: PMID:18599299
           supporting_text: Structure of IL-22 bound to its high-affinity IL-22R1 chain
@@ -245,7 +245,7 @@ existing_annotations:
       proposed_replacement_terms:
         - id: GO:0045518
           label: interleukin-22 receptor binding
-      additional_reference_ids: [PMID:18675809]
+      additional_reference_ids: ["PMID:18675809"]
       supported_by:
         - reference_id: PMID:18675809
           supporting_text: Crystal structure of the IL-22/IL-22R1 complex and its
@@ -268,7 +268,7 @@ existing_annotations:
           label: interleukin-22 receptor binding
         - id: GO:0005126
           label: cytokine receptor binding
-      additional_reference_ids: [PMID:20462497]
+      additional_reference_ids: ["PMID:20462497"]
       supported_by:
         - reference_id: PMID:20462497
           supporting_text: Structure and mechanism of receptor sharing by the IL-10R2

--- a/genes/human/LPCAT3/LPCAT3-ai-review.yaml
+++ b/genes/human/LPCAT3/LPCAT3-ai-review.yaml
@@ -304,7 +304,7 @@ existing_annotations:
       Reactome pathway may be capturing a related reaction step in phospholipid 
       remodeling, but the GO term may be imprecise. Need to verify the exact 
       Reactome reaction definition.
-    additional_reference_ids: [PMID:18782225]
+    additional_reference_ids: ["PMID:18782225"]
     supported_by:
     - reference_id: PMID:18782225
       supporting_text: Conversely, over-expression of MBOAT5 in human embryonic 
@@ -910,7 +910,7 @@ existing_annotations:
       core phospholipid remodeling function rather than the core molecular 
       function. Intestine-specific Lpcat3 knockout in mice impairs chylomicron 
       secretion.
-    additional_reference_ids: [doi:10.3389/fphar.2023.1097835]
+    additional_reference_ids: ["doi:10.3389/fphar.2023.1097835"]
     supported_by:
     - reference_id: PMID:22511767
       supporting_text: Lipoprotein production studies indicated that reductions 
@@ -1005,7 +1005,7 @@ existing_annotations:
     reason: This is an indirect regulatory effect through ER membrane 
       composition affecting SREBP signaling. Not a direct molecular function of 
       LPCAT3.
-    additional_reference_ids: [doi:10.1172/jci93616]
+    additional_reference_ids: ["doi:10.1172/jci93616"]
     supported_by:
     - reference_id: DOI:10.1172/jci93616
       supporting_text: LPCAT3 promotes processing of sterol regulatory protein 
@@ -1129,7 +1129,7 @@ existing_annotations:
     action: KEEP_AS_NON_CORE
     reason: Indirect effect through ER membrane composition. Lpcat3 deficiency 
       in mice exacerbates NASH partly through ER stress mechanisms.
-    additional_reference_ids: [doi:10.1097/hep.0000000000000375]
+    additional_reference_ids: ["doi:10.1097/hep.0000000000000375"]
     supported_by:
     - reference_id: DOI:10.1097/hep.0000000000000375
       supporting_text: Membrane phospholipid remodeling modulates NASH 

--- a/genes/human/LRPPRC/LRPPRC-ai-review.yaml
+++ b/genes/human/LRPPRC/LRPPRC-ai-review.yaml
@@ -293,7 +293,7 @@ existing_annotations:
       are dysfunctional due to LRPPRC deficiency, mitophagy may be triggered as
       a secondary
       response. The protein does not function as an autophagy regulator per se.
-    additional_reference_ids: [PMID:23822101]
+    additional_reference_ids: ["PMID:23822101"]
 - term:
     id: GO:0051028
     label: mRNA transport
@@ -452,7 +452,7 @@ existing_annotations:
     proposed_replacement_terms:
     - id: GO:0140693
       label: molecular condensate scaffold activity
-    additional_reference_ids: [PMID:22661577]
+    additional_reference_ids: ["PMID:22661577"]
     supported_by:
     - reference_id: PMID:22661577
       supporting_text: the LRPPRC/SLIRP complex suppresses mRNA degradation 

--- a/genes/human/NEUROD1/NEUROD1-ai-review.yaml
+++ b/genes/human/NEUROD1/NEUROD1-ai-review.yaml
@@ -19,7 +19,7 @@ existing_annotations:
     summary: NEUROD1 is a bHLH transcription factor that binds E-box DNA motifs and activates RNA polymerase II-dependent transcription. The deep research confirms NEUROD1 binds regulatory DNA and regulates transcription of neuronal and endocrine genes. Multiple experimental papers demonstrate direct transcriptional activation (PMID:19619559, PMID:14752053, PMID:10545951).
     action: ACCEPT
     reason: This accurately captures NEUROD1's core molecular function as a transcriptional activator. The IBA annotation is well-supported by phylogenetic inference and consistent with extensive experimental evidence showing NEUROD1 activates transcription through E-box binding.
-    additional_reference_ids: [PMID:19619559, PMID:14752053, PMID:10545951]
+    additional_reference_ids: ["PMID:19619559", "PMID:14752053", "PMID:10545951"]
     supported_by:
     - reference_id: PMID:10545951
       supporting_text: "NEUROD1, following its heterodimerization with the ubiquitous HLH protein E47, regulates insulin gene (INS) expression by binding to a critical E-box motif on the INS promoter."
@@ -50,7 +50,7 @@ existing_annotations:
     summary: NEUROD1 specifically binds E-box DNA motifs (CANNTG). This is well-established experimentally in PMID:14752053 and confirmed in deep research as the canonical DNA-binding specificity of NEUROD1.
     action: ACCEPT
     reason: E-box binding is NEUROD1's primary DNA-binding specificity and core molecular function. This represents a more informative molecular function than generic DNA binding and should be retained.
-    additional_reference_ids: [PMID:14752053, PMID:10545951]
+    additional_reference_ids: ["PMID:14752053", "PMID:10545951"]
     supported_by:
     - reference_id: PMID:14752053
       supporting_text: "SHP inhibited BETA2/NeuroD-dependent transactivation of an E-box reporter, whereas SHP was unable to repress the E47-mediated transactivation and the E-box mutant reporter activity."
@@ -156,7 +156,7 @@ existing_annotations:
     summary: Inferred from mouse ortholog - NEUROD1 acts as transcriptional activator.
     action: ACCEPT
     reason: NEUROD1 is well-established as a transcriptional activator. Multiple studies show it activates target genes including insulin, neuronal genes, etc. This annotation accurately captures activator function.
-    additional_reference_ids: [PMID:19619559, PMID:14752053]
+    additional_reference_ids: ["PMID:19619559", "PMID:14752053"]
     supported_by:
     - reference_id: PMID:19619559
       supporting_text: 2009 Jul 17. The LIM-homeodomain protein ISL1 activates insulin gene promoter directly through synergy with BETA2.
@@ -249,7 +249,7 @@ existing_annotations:
     summary: Protein dimerization activity inferred from InterPro domain (bHLH domain enables dimerization).
     action: ACCEPT
     reason: The HLH domain mediates dimerization. This is a fundamental property of bHLH transcription factors and is experimentally confirmed for NEUROD1 heterodimerizing with E47/TCF12.
-    additional_reference_ids: [PMID:10545951, PMID:14752053]
+    additional_reference_ids: ["PMID:10545951", "PMID:14752053"]
     supported_by:
     - reference_id: file:genes/human/NEUROD1/NEUROD1-deep-research-falcon.md
       supporting_text: "The HLH region mediates homo- and heterodimerization with other bHLH partners, shaping binding selectivity and transcriptional outcomes."
@@ -387,7 +387,7 @@ existing_annotations:
     summary: Nuclear localization inferred by phylogenetic analysis.
     action: ACCEPT
     reason: NEUROD1 is a nuclear transcription factor. Deep research confirms it functions in the nucleus where it binds DNA and chromatin. This is a core cellular component annotation.
-    additional_reference_ids: [PMID:14752053]
+    additional_reference_ids: ["PMID:14752053"]
     supported_by:
     - reference_id: file:genes/human/NEUROD1/NEUROD1-deep-research-falcon.md
       supporting_text: "As a transcription factor, NEUROD1 functions in the nucleus where it binds regulatory DNA and interacts with chromatin remodelers."
@@ -479,7 +479,7 @@ existing_annotations:
     summary: Direct evidence that NEUROD1 is part of transcription regulator complex from PMID:10545951.
     action: ACCEPT
     reason: NEUROD1 functions as part of transcriptional regulatory complexes, heterodimerizing with E47 and cooperating with other factors like ISL1, PDX1, etc. This accurately represents NEUROD1 as part of multi-protein transcriptional complexes.
-    additional_reference_ids: [PMID:19619559]
+    additional_reference_ids: ["PMID:19619559"]
     supported_by:
     - reference_id: PMID:10545951
       supporting_text: "NEUROD1, following its heterodimerization with the ubiquitous HLH protein E47, regulates insulin gene (INS) expression by binding to a critical E-box motif on the INS promoter"
@@ -496,7 +496,7 @@ existing_annotations:
     summary: Positive regulation of transcription inferred by phylogenetic analysis.
     action: ACCEPT
     reason: NEUROD1 is a transcriptional activator. This is a core biological process annotation well-supported by multiple experimental studies showing activation of neuronal and endocrine genes.
-    additional_reference_ids: [PMID:19619559, PMID:10545951]
+    additional_reference_ids: ["PMID:19619559", "PMID:10545951"]
     supported_by:
     - reference_id: file:genes/human/NEUROD1/NEUROD1-deep-research-falcon.md
       supporting_text: "NEUROD1 binds enhancers/promoters of neuronal and endocrine genes to activate lineage programs."
@@ -594,7 +594,7 @@ existing_annotations:
     summary: Positive regulation of neuron differentiation inferred from mouse ortholog.
     action: ACCEPT
     reason: NEUROD1 is essential for neuronal differentiation. Deep research confirms it was originally identified as a proneural factor that converts non-neural ectoderm to neurons and is essential for neuronal survival, differentiation, and maturation.
-    additional_reference_ids: [PMID:8786144]
+    additional_reference_ids: ["PMID:8786144"]
     supported_by:
     - reference_id: file:genes/human/NEUROD1/NEUROD1-deep-research-falcon.md
       supporting_text: "It was originally identified as a proneural factor capable of converting non-neural ectoderm to neurons, consistent with a master regulator of neuronal differentiation."
@@ -789,7 +789,7 @@ existing_annotations:
     summary: Endocrine pancreas development inferred from mouse ortholog.
     action: ACCEPT
     reason: NEUROD1 is essential for endocrine pancreas development and β-cell differentiation. Deep research and PMID:9308961 demonstrate this is a core function - mouse knockouts die perinatally from diabetes due to failed β-cell development. This is a dual-function gene with BOTH neural AND endocrine core roles. Accept as core function.
-    additional_reference_ids: [PMID:9308961]
+    additional_reference_ids: ["PMID:9308961"]
     supported_by:
     - reference_id: PMID:9308961
       supporting_text: "Homozygous BETA2 null mice had a striking reduction in the number of insulin-producing beta cells and failed to develop mature islets."
@@ -974,7 +974,7 @@ existing_annotations:
     summary: Enteroendocrine cell differentiation inferred from mouse ortholog.
     action: KEEP_AS_NON_CORE
     reason: NEUROD1 is required for secretin and CCK-producing enteroendocrine cells in intestine (shown in PMID:9308961). While this is a legitimate endocrine differentiation role, it is more peripheral than the pancreatic β-cell role. Keep as non-core tissue-specific function.
-    additional_reference_ids: [PMID:9308961]
+    additional_reference_ids: ["PMID:9308961"]
     supported_by:
     - reference_id: PMID:9308961
       supporting_text: "In addition, secretin- and cholecystokinin-producing enteroendocrine cells failed to develop in the absence of BETA2."

--- a/genes/human/UQCRC1/UQCRC1-ai-review.yaml
+++ b/genes/human/UQCRC1/UQCRC1-ai-review.yaml
@@ -60,7 +60,7 @@ existing_annotations:
         a possible candidate. Given the lack of direct mammalian evidence for
         UQCRC1 membership in an MPP complex, this annotation is removed from the
         core review set.
-      additional_reference_ids: [Reactome:R-HSA-9906017]
+      additional_reference_ids: ["Reactome:R-HSA-9906017"]
       supported_by:
         - reference_id: PMID:8407948
           supporting_text: >-

--- a/genes/worm/alx-1/alx-1-ai-review.yaml
+++ b/genes/worm/alx-1/alx-1-ai-review.yaml
@@ -50,7 +50,7 @@ existing_annotations:
         in cytokinesis is evolutionarily conserved, but the primary characterized
         functions of
         ALX-1 in worm are in endocytic recycling and MVB sorting.
-      additional_reference_ids: [file:worm/alx-1/alx-1-deep-research-falcon.md]
+      additional_reference_ids: ["file:worm/alx-1/alx-1-deep-research-falcon.md"]
       supported_by:
         - reference_id: file:worm/alx-1/alx-1-deep-research-falcon.md
           supporting_text: conserved recruitment to midbody/abscission checkpoint
@@ -276,7 +276,7 @@ existing_annotations:
         defects in endosomal organization, consistent with ALX-1's role as an ESCRT
         accessory
         protein involved in MVE biogenesis.
-      additional_reference_ids: [file:worm/alx-1/alx-1-deep-research-falcon.md]
+      additional_reference_ids: ["file:worm/alx-1/alx-1-deep-research-falcon.md"]
       supported_by:
         - reference_id: file:worm/alx-1/alx-1-deep-research-falcon.md
           supporting_text: alx-1 mutants exhibit approximately 2-fold increase in
@@ -348,7 +348,7 @@ existing_annotations:
         localization of multiple proteins to endosomal compartments. alx-1 mutants
         fail to recruit
         SDPN-1 to basolateral endosomes and show cargo mislocalization phenotypes.
-      additional_reference_ids: [file:worm/alx-1/alx-1-deep-research-falcon.md]
+      additional_reference_ids: ["file:worm/alx-1/alx-1-deep-research-falcon.md"]
       supported_by:
         - reference_id: file:worm/alx-1/alx-1-deep-research-falcon.md
           supporting_text: failure to recruit SDPN-1 to basolateral endosomes
@@ -427,7 +427,7 @@ existing_annotations:
         This annotation would capture ALX-1's mechanistic role more precisely than
         the current
         "endosome organization" annotation.
-      additional_reference_ids: [file:worm/alx-1/alx-1-deep-research-falcon.md]
+      additional_reference_ids: ["file:worm/alx-1/alx-1-deep-research-falcon.md"]
       supported_by:
         - reference_id: file:worm/alx-1/alx-1-deep-research-falcon.md
           supporting_text: alx-1 mutants exhibit approximately 2-fold increase in

--- a/genes/worm/irg-1/irg-1-ai-review.yaml
+++ b/genes/worm/irg-1/irg-1-ai-review.yaml
@@ -36,7 +36,7 @@ existing_annotations:
         \ innate immune response) are also present and more informative, retaining\
         \ the parent term does not cause harm and provides a general classification\
         \ that correctly captures irg-1's involvement in immunity.\n"
-      additional_reference_ids: [PMID:20133860]
+      additional_reference_ids: ["PMID:20133860"]
       supported_by:
         - reference_id: PMID:20133860
           supporting_text: "We focused on genes that are induced in C. elegans by\
@@ -60,7 +60,7 @@ existing_annotations:
         \ induced during pathogen infection and the protein is part of the zip-2-mediated\
         \ early innate immune response pathway. This IEA annotation is well-supported\
         \ by the literature.\n"
-      additional_reference_ids: [PMID:20133860]
+      additional_reference_ids: ["PMID:20133860"]
       supported_by:
         - reference_id: PMID:20133860
           supporting_text: "These data indicate that zip-2 is part of a specialized\

--- a/genes/worm/lin-65/lin-65-ai-review.yaml
+++ b/genes/worm/lin-65/lin-65-ai-review.yaml
@@ -149,7 +149,7 @@ existing_annotations:
         function (e.g., enzyme activity) has been experimentally characterized, so the
         ND placeholder remains appropriate. (The uninformative term "protein binding"
         is deliberately not proposed despite documented MET-2/ARLE-14 interactions.)
-      additional_reference_ids: [GO_REF:0000015]
+      additional_reference_ids: ["GO_REF:0000015"]
       supported_by:
         - reference_id: file:worm/lin-65/lin-65-deep-research-falcon.md
           supporting_text: LIN-65 is not defined by a canonical enzymatic activity or

--- a/genes/worm/mks-6/mks-6-ai-review.yaml
+++ b/genes/worm/mks-6/mks-6-ai-review.yaml
@@ -154,7 +154,7 @@ existing_annotations:
       label: non-motile cilium assembly
     evidence_type: IGI
     original_reference_id: PMID:21422230
-    supporting_entities: [WB:WBGene00007490]
+    supporting_entities: ["WB:WBGene00007490"]
     review:
       summary: Genetic interaction with mks-5 (WBGene00007490) demonstrates MKS-6's
         role in non-motile cilium assembly. MKS-5 acts as a central hub for the MKS
@@ -191,7 +191,7 @@ existing_annotations:
       label: non-motile cilium assembly
     evidence_type: IGI
     original_reference_id: PMID:21422230
-    supporting_entities: [WB:WBGene00010898]
+    supporting_entities: ["WB:WBGene00010898"]
     review:
       summary: Genetic interaction with mksr-2 (WBGene00010898) demonstrates redundant
         function in non-motile cilium assembly. The MKS module proteins (including
@@ -210,7 +210,7 @@ existing_annotations:
       label: non-motile cilium assembly
     evidence_type: IGI
     original_reference_id: PMID:21422230
-    supporting_entities: [WB:WBGene00011261]
+    supporting_entities: ["WB:WBGene00011261"]
     review:
       summary: Genetic interaction with nphp-4 (WBGene00011261) demonstrates functional
         redundancy between MKS and NPHP modules. Double mutants of mks-6 with nphp-4

--- a/genes/worm/nphp-1/nphp-1-ai-review.yaml
+++ b/genes/worm/nphp-1/nphp-1-ai-review.yaml
@@ -292,7 +292,7 @@ existing_annotations:
       proposed_replacement_terms:
         - id: GO:0035721
           label: intraciliary transport involved in cilium assembly
-      additional_reference_ids: [PMID:21422230]
+      additional_reference_ids: ["PMID:21422230"]
       supported_by:
         - reference_id: PMID:18316409
           supporting_text: In conclusion, loss of both NPHP-1 and NPHP-4 but not NPHP-1

--- a/genes/yeast/SET1/SET1-ai-review.yaml
+++ b/genes/yeast/SET1/SET1-ai-review.yaml
@@ -167,7 +167,7 @@ existing_annotations:
         initiation. Deep research [PMID:27325136] confirms SET1 involvement in transcription
         regulation. However, SET1 also has roles in transcriptional repression, making
         this annotation incomplete.
-      additional_reference_ids: [PMID:27325136]
+      additional_reference_ids: ["PMID:27325136"]
       supported_by:
         - reference_id: PMID:27325136
           supporting_text: Counteracting H3K4 methylation modulators Set1 and Jhd2
@@ -202,7 +202,7 @@ existing_annotations:
       reason: SET1 catalyzes all methylation states (me1, me2, me3) of H3K4. This
         annotation for trimethylation specifically is appropriate. Deep research confirms
         SET1 capacity for complete trimethylation [PMID:12845608, 22158900].
-      additional_reference_ids: [PMID:12845608, PMID:22158900]
+      additional_reference_ids: ["PMID:12845608", "PMID:22158900"]
       supported_by:
         - reference_id: PMID:12845608
           supporting_text: Saccharomyces cerevisiae Set1p is a methyltransferase specific
@@ -450,7 +450,7 @@ existing_annotations:
       reason: SET1 is essential for normal transcription regulation through H3K4 methylation.
         Deep research confirms H3K4me3 marks active promoters and affects transcription
         initiation and elongation [PMID:27325136]. IMP evidence appropriate.
-      additional_reference_ids: [PMID:27325136]
+      additional_reference_ids: ["PMID:27325136"]
       supported_by:
         - reference_id: PMID:16959218
           supporting_text: Different roles of histone H3 lysine 4 methylation in chromatin
@@ -634,7 +634,7 @@ existing_annotations:
         maintenance requires the Set1 catalytic core but is not strictly explained
         by H3K4 methylation status alone, implying a partially H3K4-substrate-independent
         catalytic role.
-      additional_reference_ids: [PMID:36416860]
+      additional_reference_ids: ["PMID:36416860"]
       supported_by:
         - reference_id: PMID:27911222
           supporting_text: The histone methyltransferases Set5 and Set1 have overlapping

--- a/project.justfile
+++ b/project.justfile
@@ -613,9 +613,14 @@ validate-all:
         echo "✓ Term validation: no errors (label warnings, if any, are advisory)"
     fi
     echo ""
-    echo "Reference and best practices validation..."
+    echo "Reference validation (batch; errors block, advisory warnings allowed)..."
+    # One linkml-reference-validator process over all files (schema parsed once),
+    # rather than one process per file. Requires linkml-reference-validator >= 0.2.1.
+    {{ref_validator}} validate data genes/*/*/*-ai-review.yaml --schema {{schema_path}} --target-class GeneReview --config {{ref_validator_config}} || exit_code=1
+    echo ""
+    echo "Best practices validation..."
     mkdir -p reports
-    uv run ai-gene-review validate --verbose --no-schema --tsv-output reports/validation-all.tsv "genes/*/*/*-ai-review.yaml" || exit_code=1
+    uv run ai-gene-review validate --verbose --no-schema --no-references --tsv-output reports/validation-all.tsv "genes/*/*/*-ai-review.yaml" || exit_code=1
     echo ""
     echo "Checking PMID references in all pathway markdown files..."
     uv run python src/ai_gene_review/tools/validate_pmid_references.py genes/ || exit_code=1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,7 @@ dependencies = [
   "rapidfuzz>=3.14.3",
   "scipy>=1.16.1",
   "linkml-data-qc>=0.1.0",
-  "linkml-reference-validator==0.2.0rc1",
+  "linkml-reference-validator==0.2.1rc1",
   "linkml-term-validator==0.4.0rc4",
 ]
 

--- a/scripts/run_reference_validator.sh
+++ b/scripts/run_reference_validator.sh
@@ -7,8 +7,13 @@
 # validation. The reference validator CLI doesn't know about this convention,
 # so we pre-process the YAML to remove supporting_text from those entries.
 #
-# Usage: scripts/run_reference_validator.sh [args...]
-#   e.g.: scripts/run_reference_validator.sh validate data file.yaml --schema schema.yaml --target-class GeneReview --config conf/reference_validator_config.yaml
+# Accepts one OR many data files. With many files it strips them in a single
+# pass and makes a single `linkml-reference-validator validate data F1 F2 ...`
+# call (the validator builds/parses the schema once), which is dramatically
+# faster than one process per file. Requires linkml-reference-validator >= 0.2.1
+# (multi-file `validate data`).
+#
+# Usage: scripts/run_reference_validator.sh validate data F1 [F2 ...] --schema S --target-class C --config CFG
 
 set -euo pipefail
 
@@ -35,40 +40,72 @@ run_lrv() {
     return "$exit_code"
 }
 
-# If the first two args are "validate data", pre-process the data file
+# If the first two args are "validate data", pre-process the data file(s).
 if [[ $# -ge 3 && "$1" == "validate" && "$2" == "data" ]]; then
-    data_file="$3"
-    shift 3  # remaining args: --schema ... --target-class ... --config ...
+    shift 2  # drop "validate data"; remaining = data files then options
 
-    # Create a temp copy with supporting_text stripped where full_text_unavailable
-    tmp_file="$(mktemp "${data_file}.lrv.XXXXXX")"
-    trap 'rm -f "$tmp_file"' EXIT
+    # Collect leading data-file arguments (everything up to the first option).
+    data_files=()
+    while [[ $# -gt 0 && "$1" != -* ]]; do
+        data_files+=("$1")
+        shift
+    done
+    # Remaining "$@" = options: --schema ... --target-class ... --config ...
+
+    # The validator reads the data files directly. The only preprocessing is the
+    # project's full_text_unavailable convention: for entries flagged
+    # full_text_unavailable we drop supporting_text (the quote may be from an
+    # abstract or unavailable, so it cannot be verified). Only files that actually
+    # contain such an entry get a stripped temp copy written ALONGSIDE the original
+    # (so relative `file:` references still resolve); every other file is passed to
+    # the validator unchanged. A single Python pass writes, per input, the path to
+    # validate (original or temp) to $resolved_list and any temp paths to
+    # $cleanup_list. The corpus is kept strict-YAML-valid by tests/test_gene_yaml_strict.py.
+    cleanup_list="$(mktemp)"
+    resolved_list="$(mktemp)"
+    trap 'while IFS= read -r t; do rm -f "$t"; done < "$cleanup_list"; rm -f "$cleanup_list" "$resolved_list"' EXIT
 
     uv run python -c "
-import sys, yaml, copy
-
-with open(sys.argv[1]) as f:
-    data = yaml.safe_load(f)
+import sys, os, tempfile, yaml
 
 def strip(obj):
+    changed = False
     if isinstance(obj, dict):
-        if 'supported_by' in obj and isinstance(obj['supported_by'], list):
-            for sb in obj['supported_by']:
-                if isinstance(sb, dict) and sb.get('full_text_unavailable'):
-                    sb.pop('supporting_text', None)
+        sb = obj.get('supported_by')
+        if isinstance(sb, list):
+            for entry in sb:
+                if isinstance(entry, dict) and entry.get('full_text_unavailable') and 'supporting_text' in entry:
+                    entry.pop('supporting_text', None)
+                    changed = True
         for v in obj.values():
-            strip(v)
+            changed = strip(v) or changed
     elif isinstance(obj, list):
         for item in obj:
-            strip(item)
+            changed = strip(item) or changed
+    return changed
 
-strip(data)
+with open(sys.argv[1], 'w') as cleanup, open(sys.argv[2], 'w') as resolved:
+    for src in sys.argv[3:]:
+        with open(src) as f:
+            data = yaml.safe_load(f)
+        if strip(data):
+            d = os.path.dirname(src) or '.'
+            fd, tmp = tempfile.mkstemp(prefix=os.path.basename(src) + '.lrv.', dir=d)
+            with os.fdopen(fd, 'w') as g:
+                yaml.dump(data, g, default_flow_style=False, allow_unicode=True, sort_keys=False)
+            cleanup.write(tmp + '\n')
+            resolved.write(tmp + '\n')
+        else:
+            resolved.write(src + '\n')
+" "$cleanup_list" "$resolved_list" "${data_files[@]}"
 
-with open(sys.argv[2], 'w') as f:
-    yaml.dump(data, f, default_flow_style=False, allow_unicode=True, sort_keys=False)
-" "$data_file" "$tmp_file"
+    # Read the resolved (original-or-stripped-temp) paths to validate.
+    validate_files=()
+    while IFS= read -r p; do
+        validate_files+=("$p")
+    done < "$resolved_list"
 
-    run_lrv validate data "$tmp_file" "$@"
+    run_lrv validate data "${validate_files[@]}" "$@"
 else
     run_lrv "$@"
 fi

--- a/tests/test_gene_yaml_strict.py
+++ b/tests/test_gene_yaml_strict.py
@@ -1,0 +1,34 @@
+"""Enforce that every gene-review YAML parses under the strict YAML loader.
+
+linkml-reference-validator parses data with ruamel's (libyaml C) parser, which is
+stricter than PyYAML. Constructs PyYAML silently accepts are rejected there, e.g.:
+
+- unquoted CURIE scalars in flow sequences (``additional_reference_ids: [PMID:123]``);
+  the ``:`` makes it an ambiguous plain scalar in flow context (quote the items), and
+- duplicate mapping keys (PyYAML keeps the last; ruamel errors).
+
+Keeping the corpus valid under the strict parser lets the reference validator read the
+files directly, and catches real bugs (like duplicate keys) that the lenient parser hides.
+"""
+
+from pathlib import Path
+
+from ruamel.yaml import YAML
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+GENES_DIR = REPO_ROOT / "genes"
+
+
+def test_all_gene_reviews_parse_under_strict_yaml() -> None:
+    yaml = YAML(typ="safe")
+    failures = []
+    for fp in sorted(GENES_DIR.glob("*/*/*-ai-review.yaml")):
+        try:
+            yaml.load(fp.read_text())
+        except Exception as exc:  # noqa: BLE001 - any parse failure is a failure
+            failures.append(f"{fp.relative_to(REPO_ROOT)}: {type(exc).__name__}: {exc}")
+    assert not failures, (
+        f"{len(failures)} gene-review file(s) are not valid under the strict YAML parser "
+        "used by linkml-reference-validator (quote flow-list CURIEs, remove duplicate keys):\n"
+        + "\n".join(failures[:25])
+    )

--- a/uv.lock
+++ b/uv.lock
@@ -112,7 +112,7 @@ requires-dist = [
     { name = "jupyter", specifier = ">=1.1.1" },
     { name = "linkml-browser", specifier = ">=0.1.0" },
     { name = "linkml-data-qc", specifier = ">=0.1.0" },
-    { name = "linkml-reference-validator", specifier = "==0.2.0rc1" },
+    { name = "linkml-reference-validator", specifier = "==0.2.1rc1" },
     { name = "linkml-runtime", specifier = ">=1.9.4" },
     { name = "linkml-term-validator", specifier = "==0.4.0rc4" },
     { name = "lxml", specifier = ">=6.0.1" },
@@ -2400,7 +2400,7 @@ wheels = [
 
 [[package]]
 name = "linkml-reference-validator"
-version = "0.2.0rc1"
+version = "0.2.1rc1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "beautifulsoup4" },
@@ -2409,14 +2409,15 @@ dependencies = [
     { name = "linkml-runtime" },
     { name = "lxml" },
     { name = "pydantic" },
+    { name = "pypdf" },
     { name = "rapidfuzz" },
     { name = "requests" },
     { name = "ruamel-yaml" },
     { name = "typer" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/36/1a/8f51c913047a6312f5f932209dec46e9dd104fb99fd6b0676ed16af9cea8/linkml_reference_validator-0.2.0rc1.tar.gz", hash = "sha256:93ebd3b89926930ee825521d653ae7e17d28506d34a60fab63764cb89c59f3ec", size = 450646 }
+sdist = { url = "https://files.pythonhosted.org/packages/c5/8a/5763c09a1336c768691b2ff3e61020f1b1fb9a6ca620005f771b06069e00/linkml_reference_validator-0.2.1rc1.tar.gz", hash = "sha256:9dca1597e77efd960670a27ec3a58a93411e1484a74c7f8bce4fdccabc9987ae", size = 544073 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/86/71/8c952818141cc307835a3fe28e52202f7b44de01b50a53867d89b186e943/linkml_reference_validator-0.2.0rc1-py3-none-any.whl", hash = "sha256:6caf9889610c6ebcbc549f14d6ac7935ada067905b99c0ae27b1deabec191358", size = 87317 },
+    { url = "https://files.pythonhosted.org/packages/c8/94/053c9a88a19c3048a04cc2ad5b857cc443a90b604bfdb3580afd6a3e4e1e/linkml_reference_validator-0.2.1rc1-py3-none-any.whl", hash = "sha256:bebfd2fbe64b63dc385a4b540acf8d0680611e8c13c4e865f66854c44220c0b5", size = 114994 },
 ]
 
 [[package]]
@@ -3914,6 +3915,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/bb/22/f1129e69d94ffff626bdb5c835506b3a5b4f3d070f17ea295e12c2c6f60f/pyparsing-3.2.3.tar.gz", hash = "sha256:b9c13f1ab8b3b542f72e28f634bad4de758ab3ce4546e4301970ad6fa77c38be", size = 1088608 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/05/e7/df2285f3d08fee213f2d041540fa4fc9ca6c2d44cf36d3a035bf2a8d2bcc/pyparsing-3.2.3-py3-none-any.whl", hash = "sha256:a749938e02d6fd0b59b356ca504a24982314bb090c383e3cf201c95ef7e2bfcf", size = 111120 },
+]
+
+[[package]]
+name = "pypdf"
+version = "6.13.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/17/18/9947cc201af9ccf76720fd3347bf4f70eb882ce3fcf4cb05f7443e4cf871/pypdf-6.13.3.tar.gz", hash = "sha256:f3cb822769725f1bac658c406cfc9460399043f3750c2d3e4650e0a85eacabd7", size = 6484063 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/94/56/2967e621598987905fb8cdfadd8f8de6b5c68c9351f0523c4df8409f28f1/pypdf-6.13.3-py3-none-any.whl", hash = "sha256:c6e3f86afb625791510b02ad5480e94b63970bb957df75d44657c282ecc52224", size = 347288 },
 ]
 
 [[package]]


### PR DESCRIPTION
## Why

The full `validate-all` (run on infra PRs + the weekly job) was ~80 min, dominated by
**reference validation spawning one linkml-reference-validator process per file** (~2,670×),
each re-parsing the schema and rebuilding the Validator — almost all process/import startup,
not actual work.

## What

Now that `linkml-reference-validator` `0.2.1rc1` supports multi-file `validate data`
(linkml/linkml-reference-validator#49), validate references in a **single batched process**:

- **`run_reference_validator.sh`** accepts many data files: it strips
  `full_text_unavailable` `supporting_text` across all of them in one pass (temp copies
  alongside originals so `file:` refs still resolve) and makes a single
  `linkml-reference-validator validate data F1..FN` call. Backward compatible with
  single-file use (`just validate` / `validate-changed`).
- **`validate-all`** runs references as one batch step (errors block, label-mismatch
  warnings advisory) and drops `--references` from the per-file best-practices call.
- Pins `linkml-reference-validator==0.2.1rc1`.

## Impact

Measured locally on cached files: **12 files in 2.7 s (one process) vs 12.3 s per-file
(~4.5×)**, widening with file count (schema parsed once). This should take the ~60-min
reference portion of the full `validate-all` down to a few minutes. This PR's own CI runs
the full `validate-all` (it touches `infra` paths), so its runtime is the real measure.

Note: if CI is still slow, the likely remaining factor is NCBI fetches for references not in
the committed `publications/` cache — that cost is identical for per-file and batch and is a
separate cache-completeness matter.
