### PR TITLE
[do not merge] Ablate DET prediction review blocks

### DIFF
--- a/genes/ECOLI/fepE/fepE-det-predictions-review.yaml
+++ b/genes/ECOLI/fepE/fepE-det-predictions-review.yaml
@@ -29,22 +29,3 @@ predictions:
       id: EC:2.7.13.3
       label: histidine kinase
     predicted_term_type: EC
-    review:
-      assessment: REP
-      confidence_score: 0
-      error_type: FREQUENCY_BIAS
-      summary: >-
-        Repetition/frequency bias error. FepE was one of 12 proteins incorrectly annotated
-        as histidine kinase (EC 2.7.13.3) by DeepECTF. None of these 12 have sequence
-        similarity to histidine kinase families, and 8 have been annotated with different
-        experimentally validated functions. E. coli has 29 actual histidine kinases, making
-        this a high-frequency label in the training data. The model appears to default to
-        this common EC number when it cannot identify informative sequence features.
-        FepE is actually a Wzz-family polysaccharide co-polymerase (PCP-1 class) that
-        determines very-long modal O-antigen chain length. It has no kinase domain and
-        functions through structural oligomerization, not catalysis.
-      supported_by:
-        - reference_id: PMID:40703034
-          supporting_text: "out of the 12 proteins annotated as histidine kinase (EC 2.7.13.3) in the 453 DeepECTF predictions, none of them have sequence similarity to histidine kinase families, and 8 have been annotated with different and experimentally validated functions (such as ferric enterobactin transport protein FepE for b0587)"
-        - reference_id: PMID:40703034
-          supporting_text: "This type of error may be due to inherent limitations in how AI methods operate...the model is expected to make frequency-dependent predictions that reflect the training data, as demonstrated with histidine kinases"

--- a/genes/ECOLI/yciO/yciO-det-predictions-review.yaml
+++ b/genes/ECOLI/yciO/yciO-det-predictions-review.yaml
@@ -27,23 +27,3 @@ predictions:
       id: EC:2.7.7.87
       label: L-threonylcarbamoyladenylate synthase
     predicted_term_type: EC
-    review:
-      assessment: PLI
-      confidence_score: 0
-      error_type: PARALOG_OVERANNOTATION
-      summary: >-
-        Paralog incorrect. YciO is a member of the same Pfam family (PF01300) as TsaC/Sua5,
-        and DeepECTF assigns the same EC number. However: (1) In vitro activity is 10,000x
-        weaker than TsaC (0.14 nM/min vs 2.8 uM/min). (2) YciO does not complement tsaC
-        deletion in vivo. (3) YciO has a conserved positively charged surface patch absent
-        in TsaC, suggesting RNA-binding function. (4) yciO genes co-localize with rnm
-        (RNase AM) genes, suggesting a role in rRNA metabolism rather than tRNA modification.
-        The weak in vitro activity likely represents residual ancestral catalytic activity
-        from TsaC, not the evolved biological function.
-      supported_by:
-        - reference_id: PMID:40703034
-          supporting_text: "the activity reported (0.14 nM/min TC-AMP production rate) for E. coli YciO is more than 4 orders of magnitude weaker than that of E. coli TsaC (2.8 μM/min)"
-        - reference_id: PMID:40703034
-          supporting_text: "YciO does not perform the same function as TsaC/Susa5 in vivo experiments"
-        - reference_id: PMID:40703034
-          supporting_text: "the structure of YciO exhibits a large positively charged surface predicted to interact with RNA...This large positively charged surface is conserved in YciO proteins and is absent in TsaC proteins"

--- a/genes/ECOLI/yegV/yegV-det-predictions-review.yaml
+++ b/genes/ECOLI/yegV/yegV-det-predictions-review.yaml
@@ -23,19 +23,3 @@ predictions:
       id: EC:2.7.1.92
       label: dehydro-2-deoxygluconokinase
     predicted_term_type: EC
-    review:
-      assessment: PLI
-      confidence_score: 0
-      error_type: PARALOG_OVERANNOTATION
-      summary: >-
-        Paralog incorrect. YegV is annotated as an uncharacterized sugar kinase (EC 2.7.1.-)
-        in UniProt, so DeepECTF correctly predicted the first 3 digits of the EC number but
-        assigned the wrong substrate specificity. The dehydro-2-deoxygluconokinase (EC 2.7.1.92)
-        activity is already encoded by KdgK/b3526, a different member of the same sugar kinase
-        superfamily. This is a classic overpropagation mistake (error type 6) - failing to
-        distinguish nonisofunctional paralogous subgroups within the superfamily.
-      supported_by:
-        - reference_id: PMID:40703034
-          supporting_text: "b2100 was annotated as a dehydro-2-deoxygluconokinase (EC 2.7.1.92) using DeepECTF...The dehydro-2-deoxygluconokinase (EC 2.7.1.92) activity is encoded by another member of this superfamily KdgK/b3526"
-        - reference_id: PMID:40703034
-          supporting_text: "Here, DeepECTF predicted correctly the first 3 digits of the EC number but not the last, making an overpropagation mistake"

--- a/genes/ECOLI/ygfF/ygfF-det-predictions-review.yaml
+++ b/genes/ECOLI/ygfF/ygfF-det-predictions-review.yaml
@@ -22,15 +22,3 @@ predictions:
       id: EC:1.1.1.47
       label: glucose 1-dehydrogenase
     predicted_term_type: EC
-    review:
-      assessment: COR
-      confidence_score: 2
-      summary: >-
-        Correct prediction. YgfF belongs to the SDR63C/Glucose 1-dehydrogenase subgroup
-        of the SDR superfamily (IPR002347), as classified by the Oppermann/Persson HMM-based
-        nomenclature system. The DeepECTF prediction matches this classification and was
-        validated by in vitro assay. However, the actual in vivo substrate is NAD+ not NADP+,
-        and the physiological substrate may be D-gluconate rather than glucose.
-      supported_by:
-        - reference_id: PMID:40703034
-          supporting_text: "YgfF is a member of the large short-chain dehydrogenase/reductase (SDR) superfamily (IPR002347)...This resource predicts YgfF is part of the SDR63C/Glucose 1-dehydrogenase subgroup, the activity predicted and validated in the Kim et al. (2023) study. This prediction demonstrates the accurate propagation of functional annotation and is a successful prediction."

--- a/genes/ECOLI/yjdM/yjdM-det-predictions-review.yaml
+++ b/genes/ECOLI/yjdM/yjdM-det-predictions-review.yaml
@@ -28,25 +28,3 @@ predictions:
       id: EC:3.11.1.2
       label: phosphonoacetate hydrolase
     predicted_term_type: EC
-    review:
-      assessment: UNC
-      confidence_score: 1
-      error_type: IN_VITRO_NOT_IN_VIVO
-      summary: >-
-        Uncertain. YjdM was shown to catalyze phosphonoacetate hydrolase activity in vitro,
-        but multiple lines of evidence suggest this is not its biological function:
-        (1) The initial report linking YjdM to phosphonate catabolism was refuted by
-        additional genetic analyses (Metcalf and Wanner 1993).
-        (2) The experimentally validated PhnA belongs to a nonhomologous family, and
-        expression of that family in E. coli showed PhnA activity was absent.
-        (3) Genome neighborhood analysis shows yjdM genes are generally NOT near
-        phosphonate catabolism or transport genes except in E. coli, where it happens
-        to be upstream of the phn operon.
-        (4) True phnA genes cluster with phosphonoacetate transporters and regulators.
-        The in vitro activity may represent promiscuous hydrolytic activity rather than
-        the evolved biological function.
-      supported_by:
-        - reference_id: PMID:40703034
-          supporting_text: "except for E. coli, yjdM genes are generally not close to phosphonate catabolism or transport genes"
-        - reference_id: PMID:40703034
-          supporting_text: "the PhnA activity observed in vitro is not supported, and additional in vivo experiments are required to confirm the biological role of this enzyme. This prediction was given a CS of 1"

--- a/genes/ECOLI/yjhQ/yjhQ-det-predictions-review.yaml
+++ b/genes/ECOLI/yjhQ/yjhQ-det-predictions-review.yaml
@@ -23,17 +23,3 @@ predictions:
       id: EC:2.3.1.189
       label: mycothiol synthase
     predicted_term_type: EC
-    review:
-      assessment: NPI
-      confidence_score: 0
-      error_type: PATHWAY_CONTEXT_IGNORED
-      summary: >-
-        Nonparalog incorrect. Mycothiol is not a molecule synthesized by E. coli.
-        The mycothiol biosynthesis pathway (BioCyc ID: PWY1G-0) is absent from E. coli -
-        none of the other pathway enzymes are encoded in the genome. Mycothiol is produced
-        by Actinobacteria (e.g., Mycobacterium). YjhQ is actually an N-acetyltransferase
-        that functions as an antitoxin in the TopAI-YjhQ type IV toxin-antitoxin system,
-        sequestering the TopAI toxin to prevent translation inhibition.
-      supported_by:
-        - reference_id: PMID:40703034
-          supporting_text: "YjhQ/b4307 is predicted to be a mycothiol synthase (EC 2.3.1.189), but mycothiol is not a molecule synthesized by E. coli, and the remaining pathway genes are absent from the genome (BioCyc ID: PWY1G-0)"

--- a/genes/ECOLI/yrhB/yrhB-det-predictions-review.yaml
+++ b/genes/ECOLI/yrhB/yrhB-det-predictions-review.yaml
@@ -25,17 +25,3 @@ predictions:
       id: EC:4.1.2.50
       label: 6-carboxytetrahydropterin synthase
     predicted_term_type: EC
-    review:
-      assessment: NPI
-      confidence_score: 0
-      error_type: PATHWAY_CONTEXT_IGNORED
-      summary: >-
-        Nonparalog incorrect. The 6-carboxytetrahydropterin synthase (EC 4.1.2.50) activity
-        in E. coli is catalyzed by QueD/b2765. A queD mutant completely lacks this activity,
-        demonstrating that YrhB does not serve as a redundant enzyme for this function.
-        YrhB has no sequence similarity to the QueD family. Instead, YrhB contains an
-        Imm35 domain (IPR028622) suggesting a role in bacteriocin immunity, which is an
-        entirely different biological function.
-      supported_by:
-        - reference_id: PMID:40703034
-          supporting_text: "YrhB/b3446 is predicted to be a 6-carboxytetrahydropterin synthase (EC 4.1.2.50), but E. coli already encodes this enzyme (QueD/b2765) and a queD mutant lacks this activity"


### PR DESCRIPTION
Transparency-only PR documenting the deliberate removal of nested review blocks from seven ECOLI DET prediction review YAML files.\n\nThis branch is not intended to be merged. Please close this PR without merging after review/visibility.\n\nValidation:\n- YAML syntax parses successfully.\n- PredictionReview schema validation fails as expected because review is currently required under predictions.