### PR TITLE
Remove redundant full_text_unavailable flags where the quote is verifiable

### DIFF
--- a/genes/9BACT/HgcA/HgcA-ai-review.yaml
+++ b/genes/9BACT/HgcA/HgcA-ai-review.yaml
@@ -229,7 +229,6 @@ core_functions:
     supporting_text: The genes encode a putative corrinoid protein, HgcA, and a
       2[4Fe-4S] ferredoxin, HgcB, consistent with roles as a methyl carrier and
       an electron donor required for corrinoid cofactor reduction, respectively.
-    full_text_unavailable: true
   - reference_id: PMID:36598231
     supporting_text: Most HgcAs have a CU motif N terminal to their previously 
       accepted start sites
@@ -266,7 +265,6 @@ core_functions:
     supporting_text: The genes encode a putative corrinoid protein, HgcA, and a
       2[4Fe-4S] ferredoxin, HgcB, consistent with roles as a methyl carrier and
       an electron donor required for corrinoid cofactor reduction, respectively.
-    full_text_unavailable: true
   - reference_id: PMID:32561885
     supporting_text: Both spectra show the characteristic peaks of 
       dicyanocobalamin, demonstrating that HgcA indeed binds cobalamin

--- a/genes/ACET2/P15329/P15329-ai-review.yaml
+++ b/genes/ACET2/P15329/P15329-ai-review.yaml
@@ -94,7 +94,6 @@ existing_annotations:
         The encoded product contains a C terminus homologous to other C. thermocellum
         endoglucanases.
 
-      full_text_unavailable: true
 - term:
     id: GO:0004622
     label: phosphatidylcholine lysophospholipase A1 activity

--- a/genes/ARATH/AG/AG-ai-review.yaml
+++ b/genes/ARATH/AG/AG-ai-review.yaml
@@ -382,7 +382,6 @@ existing_annotations:
         Here we report on our studies on the interactions of the B class MADS
         proteins AP3 and PI with the E class MADS proteins SEP1, SEP2, and
         SEP3.
-      full_text_unavailable: true
       reference_section_type: ABSTRACT
 - term:
     id: GO:0005515
@@ -410,7 +409,6 @@ existing_annotations:
       supporting_text: >-
         A matrix-based yeast two-hybrid screen of >100 members of this family
         revealed a collection of specific heterodimers and a few homodimers.
-      full_text_unavailable: true
       reference_section_type: ABSTRACT
     - reference_id: PMID:22238427
       supporting_text: >-
@@ -440,7 +438,6 @@ existing_annotations:
         We analyzed almost 4500 combinations and detected more than 250
         protein-protein interactions (PPIs), resulting in a process-specific
         interaction map.
-      full_text_unavailable: true
       reference_section_type: ABSTRACT
 - term:
     id: GO:0005515
@@ -467,13 +464,11 @@ existing_annotations:
       supporting_text: >-
         Additional analysis showed that the K domain of AG alone was able to
         bind the K domains of these AGLs.
-      full_text_unavailable: true
       reference_section_type: ABSTRACT
     - reference_id: PMID:9418042
       supporting_text: >-
         These results strongly suggest that AG interacts with AGL2, AGL4, AGL6
         and AGL9 in vivo.
-      full_text_unavailable: true
       reference_section_type: ABSTRACT
 - term:
     id: GO:0005634
@@ -551,7 +546,6 @@ existing_annotations:
         Coimmunoprecipitation, two-hybrid yeast, and affinity column assays show
         that the FLOR1-VSP1 complex interacts with AGAMOUS and that this
         transcription factor directly interacts with FLOR1.
-      full_text_unavailable: true
       reference_section_type: ABSTRACT
 - term:
     id: GO:0005634
@@ -681,7 +675,6 @@ existing_annotations:
       supporting_text: >-
         MADS-box transcription factors are key regulators of several plant
         development processes.
-      full_text_unavailable: true
       reference_section_type: ABSTRACT
     - reference_id: PMID:1973265
       supporting_text: >-
@@ -760,13 +753,11 @@ existing_annotations:
       supporting_text: >-
         AG function is required for the final definition of floral meristem
         identity
-      full_text_unavailable: true
       reference_section_type: ABSTRACT
     - reference_id: PMID:9090883
       supporting_text: >-
         AG is a principal developmental switch that controls the transition of
         meristem activity from indeterminate to determinate.
-      full_text_unavailable: true
       reference_section_type: ABSTRACT
 - term:
     id: GO:0003700
@@ -794,7 +785,6 @@ existing_annotations:
       supporting_text: >-
         Arabidopsis dedicates over 5% of its genome to code for more than 1500
         transcription factors
-      full_text_unavailable: true
       reference_section_type: ABSTRACT
     - reference_id: file:ARATH/AG/AG-uniprot.txt
       supporting_text: >-
@@ -1198,7 +1188,6 @@ core_functions:
     supporting_text: >-
       Additional analysis showed that the K domain of AG alone was able to bind
       the K domains of these AGLs.
-    full_text_unavailable: true
     reference_section_type: ABSTRACT
   - reference_id: PMID:14555696
     supporting_text: >-

--- a/genes/ARATH/AP1/AP1-ai-review.yaml
+++ b/genes/ARATH/AP1/AP1-ai-review.yaml
@@ -630,7 +630,6 @@ existing_annotations:
       supporting_text: >-
         Here we report on our studies on the interactions of the B class MADS
         proteins AP3 and PI with the E class MADS proteins SEP1, SEP2, and SEP3.
-      full_text_unavailable: true
 - term:
     id: GO:0005515
     label: protein binding
@@ -826,7 +825,6 @@ existing_annotations:
         Transgenic plants that ectopically express ABS show changes in the growth
         and identity of floral organs, suggesting that ABS can interact with
         floral homeotic proteins.
-      full_text_unavailable: true
 - term:
     id: GO:0005634
     label: nucleus
@@ -1006,7 +1004,6 @@ existing_annotations:
         AP1 fused to green fluorescent protein (GFP) retained transcription
         factor activity and directed the expected terminal flower phenotype when
         ectopically expressed in transgenic Arabidopsis.
-      full_text_unavailable: true
     - reference_id: PMID:22238427
       supporting_text: >-
         MADS-domain protein complexes can coexist within the nucleus

--- a/genes/ARATH/AP2/AP2-ai-review.yaml
+++ b/genes/ARATH/AP2/AP2-ai-review.yaml
@@ -62,7 +62,6 @@ existing_annotations:
     supported_by:
     - reference_id: PMID:7919989
       supporting_text: "APETALA2 (AP2) plays a central role in the establishment of the floral meristem, the specification of floral organ identity, and the regulation of floral homeotic gene expression in Arabidopsis."
-      full_text_unavailable: true
     - reference_id: file:ARATH/AP2/AP2-deep-research-falcon.md
       supporting_text: "AP2 is described as a multifunctional **transcription factor** controlling developmental transitions and organ identity, with experimentally supported **dual molecular roles** (activation and repression)."
 - term:
@@ -88,7 +87,6 @@ existing_annotations:
     supported_by:
     - reference_id: PMID:7919989
       supporting_text: "We isolated the AP2 gene and found that it encodes a putative nuclear protein that is distinguished by an essential 68-amino acid repeated motif, the AP2 domain."
-      full_text_unavailable: true
     - reference_id: file:ARATH/AP2/AP2-deep-research-falcon.md
       supporting_text: "Molecular function: AP2-domain transcription factor; binds thousands of genomic loci; functions as activator and repressor depending on target and tissue."
 - term:
@@ -158,7 +156,6 @@ existing_annotations:
     supported_by:
     - reference_id: PMID:7919989
       supporting_text: "We isolated the AP2 gene and found that it encodes a putative nuclear protein"
-      full_text_unavailable: true
     - reference_id: file:ARATH/AP2/AP2-uniprot.txt
       supporting_text: "SUBCELLULAR LOCATION: Nucleus"
 - term:
@@ -179,7 +176,6 @@ existing_annotations:
     supported_by:
     - reference_id: PMID:7919989
       supporting_text: "the regulation of floral homeotic gene expression in Arabidopsis"
-      full_text_unavailable: true
     - reference_id: file:ARATH/AP2/AP2-deep-research-falcon.md
       supporting_text: "AP2 can **directly induce** some genes (e.g., **AGL15**) while **directly repressing** others (e.g., **SOC1**)."
 - term:
@@ -224,7 +220,6 @@ existing_annotations:
     supported_by:
     - reference_id: PMID:30356219
       supporting_text: "transcription factors that regulate the architecture of root and shoot systems"
-      full_text_unavailable: true
     - reference_id: file:ARATH/AP2/AP2-deep-research-falcon.md
       supporting_text: "AP2 directly binds the SOC1 promoter and represses SOC1 in vegetative SAM"
 - term:
@@ -264,10 +259,8 @@ existing_annotations:
     supported_by:
     - reference_id: PMID:2535466
       supporting_text: "Temperature shift experiments indicate that the wild-type AP2 gene product acts at the time of primordium initiation"
-      full_text_unavailable: true
     - reference_id: PMID:2535466
       supporting_text: "cells to determine their place in the developing flower and thus to differentiate appropriately"
-      full_text_unavailable: true
 - term:
     id: GO:0048481
     label: plant ovule development
@@ -289,10 +282,8 @@ existing_annotations:
     supported_by:
     - reference_id: PMID:22914576
       supporting_text: "the expression level of genes related to ovule development, including HLL, ANT,"
-      full_text_unavailable: true
     - reference_id: PMID:22914576
       supporting_text: "BZR1 and AP2 probably affect Arabidopsis ovule number determination"
-      full_text_unavailable: true
     - reference_id: PMID:15708976
       supporting_text: "development of the ovule and seed coat"
 - term:
@@ -331,7 +322,6 @@ existing_annotations:
     supported_by:
     - reference_id: PMID:12359889
       supporting_text: "AP2 gene is required early in floral development to direct primordia of the first and second whorls to develop as perianth rather than as reproductive organs"
-      full_text_unavailable: true
 - term:
     id: GO:0048316
     label: seed development
@@ -390,10 +380,8 @@ existing_annotations:
     supported_by:
     - reference_id: PMID:7919989
       supporting_text: "AP2 represents a new class of plant regulatory proteins"
-      full_text_unavailable: true
     - reference_id: PMID:7919989
       supporting_text: "the AP2 domain"
-      full_text_unavailable: true
 - term:
     id: GO:0003700
     label: DNA-binding transcription factor activity
@@ -413,7 +401,6 @@ existing_annotations:
     supported_by:
     - reference_id: PMID:11118137
       supporting_text: "Arabidopsis dedicates over 5% of its genome to code for more than 1500"
-      full_text_unavailable: true
     - reference_id: file:interpro/panther/PTHR32467/PTHR32467-entries.csv
       supporting_text: "P47927,Floral homeotic protein APETALA 2,protein,3702,Arabidopsis thaliana,Arabidopsis thaliana (Mouse-ear cress),AP2,432,PTHR32467:SF142,FLORAL HOMEOTIC PROTEIN APETALA 2,True"
 - term:
@@ -434,7 +421,6 @@ existing_annotations:
     supported_by:
     - reference_id: PMID:7919989
       supporting_text: "it encodes a putative nuclear protein"
-      full_text_unavailable: true
     - reference_id: file:ARATH/AP2/AP2-uniprot.txt
       supporting_text: "SUBCELLULAR LOCATION: Nucleus"
 - term:
@@ -454,7 +440,6 @@ existing_annotations:
     supported_by:
     - reference_id: PMID:7919989
       supporting_text: "the regulation of floral homeotic gene expression in Arabidopsis"
-      full_text_unavailable: true
     - reference_id: file:ARATH/AP2/AP2-deep-research-falcon.md
       supporting_text: "AP2 directly binds the SOC1 promoter and represses SOC1 transcription during vegetative development"
 - term:
@@ -479,10 +464,8 @@ existing_annotations:
     supported_by:
     - reference_id: PMID:7919989
       supporting_text: "APETALA2 (AP2) plays a central role in the establishment of the floral meristem, the specification of floral organ identity, and the regulation of floral homeotic gene expression in Arabidopsis."
-      full_text_unavailable: true
     - reference_id: PMID:2535466
       supporting_text: "cells to determine their place in the developing flower and thus to differentiate appropriately"
-      full_text_unavailable: true
 - term:
     id: GO:0005634
     label: nucleus
@@ -499,7 +482,6 @@ existing_annotations:
     supported_by:
     - reference_id: PMID:7919989
       supporting_text: "putative nuclear protein"
-      full_text_unavailable: true
     - reference_id: file:ARATH/AP2/AP2-uniprot.txt
       supporting_text: "Nuclear localization signal"
 - term:
@@ -518,10 +500,8 @@ existing_annotations:
     supported_by:
     - reference_id: PMID:7919989
       supporting_text: "in addition to its functions during flower development, AP2 activity is also required during seed development"
-      full_text_unavailable: true
     - reference_id: PMID:12359889
       supporting_text: "AP2 gene is required early in floral development"
-      full_text_unavailable: true
 references:
 - id: GO_REF:0000002
   title: Gene Ontology annotation through association of InterPro records with GO terms
@@ -674,7 +654,6 @@ core_functions:
   supported_by:
   - reference_id: PMID:7919989
     supporting_text: "APETALA2 (AP2) plays a central role in the establishment of the floral meristem, the specification of floral organ identity, and the regulation of floral homeotic gene expression in Arabidopsis."
-    full_text_unavailable: true
   - reference_id: PMID:16387832
     supporting_text: "AP2 functions in stem cell maintenance by modifying the WUS - CLV3 feedback loop"
   - reference_id: PMID:15708974

--- a/genes/ARATH/CO/CO-ai-review.yaml
+++ b/genes/ARATH/CO/CO-ai-review.yaml
@@ -332,7 +332,6 @@ existing_annotations:
       supporting_text: >-
         expression of CONSTANS (CO), a gene that accelerates flowering in response
         to long days, is modulated by the circadian clock and day length.
-      full_text_unavailable: true
     - reference_id: file:ARATH/CO/CO-deep-research-falcon.md
       supporting_text: >-
         CO is a **sequence-specific transcriptional activator** required for robust
@@ -360,7 +359,6 @@ existing_annotations:
       supporting_text: >-
         expression of CONSTANS (CO), a gene that accelerates flowering in response
         to long days, is modulated by the circadian clock and day length.
-      full_text_unavailable: true
 - term:
     id: GO:0010018
     label: far-red light signaling pathway
@@ -386,7 +384,6 @@ existing_annotations:
         Consistent with the model that FREL promotes flowering through CO, mutants
         for co or gigantea, which are required for CO transcript accumulation, are
         relatively insensitive to FREL.
-      full_text_unavailable: true
 - term:
     id: GO:0010218
     label: response to far red light
@@ -407,7 +404,6 @@ existing_annotations:
         A low red to far-red ratio required the photoperiod-pathway genes GIGANTEA
         (GI) and CONSTANS (CO) to fully accelerate flowering in long days and did
         not promote flowering in short days.
-      full_text_unavailable: true
 - term:
     id: GO:0003677
     label: DNA binding
@@ -431,7 +427,6 @@ existing_annotations:
       supporting_text: >-
         the four previously characterized cis-elements in the FT promoter proximal
         region, CORE1, CORE2, P1, and P2, are all direct CO binding sites.
-      full_text_unavailable: true
 - term:
     id: GO:0003700
     label: DNA-binding transcription factor activity
@@ -460,7 +455,6 @@ existing_annotations:
         Arabidopsis dedicates over 5% of its genome to code for more than 1500
         transcription factors, about 45% of which are from families specific to
         plants.
-      full_text_unavailable: true
     - reference_id: PMID:28526714
       supporting_text: >-
         Here, we demonstrated that the master flowering regulator CO interacts
@@ -497,7 +491,6 @@ existing_annotations:
       supporting_text: >-
         Four early target genes of CO were identified using a steroid-inducible
         version of the protein.
-      full_text_unavailable: true
 - term:
     id: GO:0005515
     label: protein binding
@@ -521,7 +514,6 @@ existing_annotations:
       supporting_text: >-
         CONSTANS (CO), which promotes Arabidopsis flowering, interacts with At
         HAP3 and At HAP5 in yeast, in vitro, and in planta.
-      full_text_unavailable: true
 - term:
     id: GO:0005515
     label: protein binding
@@ -586,7 +578,6 @@ existing_annotations:
       supporting_text: >-
         We identified CONSTANS (CO), a positive regulator of floral induction, as
         an OBF4-interacting protein, in a yeast two-hybrid library screen.
-      full_text_unavailable: true
 - term:
     id: GO:0005515
     label: protein binding
@@ -608,7 +599,6 @@ existing_annotations:
         We describe a proteome-wide binary protein-protein interaction map for the
         interactome network of the plant Arabidopsis thaliana containing about
         6200 highly reliable interactions between about 2700 proteins.
-      full_text_unavailable: true
 - term:
     id: GO:0005515
     label: protein binding
@@ -628,7 +618,6 @@ existing_annotations:
     - reference_id: PMID:24127609
       supporting_text: >-
         in the presence of phyB under red light, PHL interacted with CO as well.
-      full_text_unavailable: true
 - term:
     id: GO:0005515
     label: protein binding
@@ -648,7 +637,6 @@ existing_annotations:
     - reference_id: PMID:26801684
       supporting_text: >-
         DELLA proteins physically interact with CONSTANS (CO).
-      full_text_unavailable: true
 - term:
     id: GO:0005515
     label: protein binding
@@ -757,7 +745,6 @@ existing_annotations:
         Structural analysis of CO in complex with NUCLEAR FACTOR-YB/YC (NF-YB/YC)
         and the CORE2 or CORE1 elements revealed the molecular basis for the
         specific recognition of the shared TGTG motifs.
-      full_text_unavailable: true
 - term:
     id: GO:0008270
     label: zinc ion binding
@@ -803,7 +790,6 @@ existing_annotations:
       supporting_text: >-
         Four early target genes of CO were identified using a steroid-inducible
         version of the protein.
-      full_text_unavailable: true
 - term:
     id: GO:0009909
     label: regulation of flower development
@@ -829,7 +815,6 @@ existing_annotations:
       supporting_text: >-
         expression of CONSTANS (CO), a gene that accelerates flowering in response
         to long days, is modulated by the circadian clock and day length.
-      full_text_unavailable: true
 - term:
     id: GO:2000028
     label: regulation of photoperiodism, flowering
@@ -856,7 +841,6 @@ existing_annotations:
       supporting_text: >-
         expression of CONSTANS (CO), a gene that accelerates flowering in response
         to long days, is modulated by the circadian clock and day length.
-      full_text_unavailable: true
     - reference_id: file:interpro/panther/PTHR31319/PTHR31319-entries.csv
       supporting_text: >-
         Q39057,Zinc finger protein CONSTANS,protein,3702,Arabidopsis thaliana,Arabidopsis thaliana
@@ -924,7 +908,6 @@ existing_annotations:
         Arabidopsis thaliana proteins involved in processes such as
         photoperiodic flowering, light signaling, and regulation of circadian
         rhythms.
-      full_text_unavailable: true
     - reference_id: PMID:27015278
       supporting_text: >-
         GFP:CO localizes to sub-nuclear speckles
@@ -950,7 +933,6 @@ existing_annotations:
     - reference_id: PMID:24127609
       supporting_text: >-
         in the presence of phyB under red light, PHL interacted with CO as well.
-      full_text_unavailable: true
     - reference_id: PMID:27015278
       supporting_text: >-
         GFP:CO localizes to sub-nuclear speckles
@@ -999,12 +981,10 @@ core_functions:
     supporting_text: >-
       the four previously characterized cis-elements in the FT promoter proximal
       region, CORE1, CORE2, P1, and P2, are all direct CO binding sites.
-    full_text_unavailable: true
   - reference_id: PMID:11323677
     supporting_text: >-
       expression of CONSTANS (CO), a gene that accelerates flowering in response
       to long days, is modulated by the circadian clock and day length.
-    full_text_unavailable: true
 proposed_new_terms: []
 suggested_questions:
 - question: >-

--- a/genes/ARATH/FBL22/FBL22-ai-review.yaml
+++ b/genes/ARATH/FBL22/FBL22-ai-review.yaml
@@ -44,7 +44,6 @@ existing_annotations:
     supported_by:
       - reference_id: PMID:11077244
         supporting_text: "F-box proteins in Arabidopsis"
-        full_text_unavailable: true
       - reference_id: file:ARATH/FBL22/FBL22-deep-research-falcon.md
         supporting_text: "FBL22 is most plausibly a substrate-recognition subunit of an SCF-type E3 ubiquitin ligase, coupling SKP1 binding (via its F-box motif) to target binding (via LRRs)"
 - term:
@@ -117,7 +116,6 @@ existing_annotations:
     supported_by:
       - reference_id: PMID:11077244
         supporting_text: "F-box proteins in Arabidopsis"
-        full_text_unavailable: true
 references:
 - id: GO_REF:0000033
   title: Annotation inferences using phylogenetic trees

--- a/genes/ARATH/GI/GI-ai-review.yaml
+++ b/genes/ARATH/GI/GI-ai-review.yaml
@@ -44,7 +44,6 @@ existing_annotations:
         expression. FKF1 function is dependent on GI, which interacts with a CO
         repressor, CYCLING DOF FACTOR 1 (CDF1), and controls CDF1 stability.
         GI, FKF1, and CDF1 proteins associate with CO chromatin.
-      full_text_unavailable: true
 - term:
     id: GO:0007623
     label: circadian rhythm
@@ -79,7 +78,6 @@ existing_annotations:
         This mechanism of establishing and sustaining robust oscillations of ZTL
         results in the high-amplitude TOC1 rhythms necessary for proper clock
         function.
-      full_text_unavailable: true
 - term:
     id: GO:0009409
     label: response to cold
@@ -102,7 +100,6 @@ existing_annotations:
         GI gene was induced by cold stress, but not by salt, mannitol, and
         abscisic acid. Moreover, gi-3 plants showed an increased sensitivity to
         freezing stress.
-      full_text_unavailable: true
 - term:
     id: GO:0009637
     label: response to blue light
@@ -126,7 +123,6 @@ existing_annotations:
       supporting_text: >-
         We demonstrate that FKF1 and GI proteins form a complex in a
         blue-light-dependent manner.
-      full_text_unavailable: true
 - term:
     id: GO:0009908
     label: flower development
@@ -150,7 +146,6 @@ existing_annotations:
         Involvement of auxin polar transport in flower formation of Arabidopsis
         thaliana was studied using a pinformed (pin) mutant (Rpin) transformed
         with the indoleacetamide hydrolase (iaaH) gene
-      full_text_unavailable: true
 - term:
     id: GO:0010218
     label: response to far red light
@@ -176,7 +171,6 @@ existing_annotations:
         A low red to far-red ratio required the photoperiod-pathway genes
         GIGANTEA (GI) and CONSTANS (CO) to fully accelerate flowering in long
         days and did not promote flowering in short days.
-      full_text_unavailable: true
 - term:
     id: GO:0010378
     label: temperature compensation of the circadian clock
@@ -216,7 +210,6 @@ existing_annotations:
     - reference_id: PMID:9681039
       supporting_text: >-
         In addition, the gi-3 mutant was more tolerant to hydrogen peroxide.
-      full_text_unavailable: true
 - term:
     id: GO:0042752
     label: regulation of circadian rhythm
@@ -278,7 +271,6 @@ existing_annotations:
       supporting_text: >-
         Moreover, GI reduces histone acetylation and CBF binding at the COR15A
         promoter under cold stress, repressing COR15A gene expression.
-      full_text_unavailable: true
 - term:
     id: GO:0005515
     label: protein binding
@@ -302,7 +294,6 @@ existing_annotations:
       supporting_text: >-
         GI and SPY also interacted in Escherichia coli and in vitro pull-down
         assays.
-      full_text_unavailable: true
 - term:
     id: GO:0005515
     label: protein binding
@@ -333,7 +324,6 @@ existing_annotations:
         oscillations of ZTL by a direct protein-protein interaction. GI, a large
         plant-specific protein with a previously undefined molecular role,
         stabilizes ZTL in vivo.
-      full_text_unavailable: true
 - term:
     id: GO:0005515
     label: protein binding
@@ -362,7 +352,6 @@ existing_annotations:
       supporting_text: >-
         FKF1 function is dependent on GI, which interacts with a CO repressor,
         CYCLING DOF FACTOR 1 (CDF1), and controls CDF1 stability.
-      full_text_unavailable: true
 - term:
     id: GO:0005515
     label: protein binding
@@ -414,7 +403,6 @@ existing_annotations:
       supporting_text: >-
         We found that GI can bind to three FT repressors: SHORT VEGETATIVE
         PHASE (SVP), TEMPRANILLO (TEM)1, and TEM2.
-      full_text_unavailable: true
 - term:
     id: GO:0005515
     label: protein binding
@@ -448,7 +436,6 @@ existing_annotations:
         Here, we experimentally generated a systems-level map of the Arabidopsis
         phytohormone signalling network, consisting of more than 2,000 binary
         protein-protein interactions.
-      full_text_unavailable: true
 - term:
     id: GO:0005515
     label: protein binding
@@ -479,7 +466,6 @@ existing_annotations:
         We further demonstrate that GI forms a co-repressor with HOS15 and HD2C,
         inhibiting CBF binding and preventing COR gene activation under normal
         conditions.
-      full_text_unavailable: true
 - term:
     id: GO:2000028
     label: regulation of photoperiodism, flowering
@@ -539,7 +525,6 @@ existing_annotations:
       supporting_text: >-
         Optical sectioning by using the green fluorescent protein-GI fusion
         protein showed green fluorescence throughout the nucleoplasm.
-      full_text_unavailable: true
 - term:
     id: GO:0005634
     label: nucleus
@@ -603,7 +588,6 @@ existing_annotations:
       supporting_text: >-
         Optical sectioning by using the green fluorescent protein-GI fusion
         protein showed green fluorescence throughout the nucleoplasm.
-      full_text_unavailable: true
 - term:
     id: GO:0005737
     label: cytoplasm
@@ -643,12 +627,10 @@ existing_annotations:
     - reference_id: PMID:17872410
       supporting_text: >-
         GI, FKF1, and CDF1 proteins associate with CO chromatin.
-      full_text_unavailable: true
     - reference_id: PMID:21709243
       supporting_text: >-
         Finally, our chromatin immunoprecipitation experiments showed that GI
         binds to FT promoter regions that are near the SVP binding sites.
-      full_text_unavailable: true
 references:
 - id: GO_REF:0000002
   title: Gene Ontology annotation through association of InterPro records with GO terms
@@ -904,12 +886,10 @@ core_functions:
     supporting_text: >-
       Thus, the FKF1-GI complex forms on the CO promoter in late afternoon to
       regulate CO expression
-    full_text_unavailable: true
   - reference_id: PMID:21709243
     supporting_text: >-
       Finally, our chromatin immunoprecipitation experiments showed that GI
       binds to FT promoter regions that are near the SVP binding sites.
-    full_text_unavailable: true
 - description: >-
     GI binds ZTL/FKF1/LKP2-family F-box photoreceptors/ubiquitin ligase
     components and controls their stability or activity in a light- and
@@ -935,12 +915,10 @@ core_functions:
     supporting_text: >-
       Here we show that GIGANTEA (GI) is essential to establish and sustain
       oscillations of ZTL by a direct protein-protein interaction.
-    full_text_unavailable: true
   - reference_id: PMID:17872410
     supporting_text: >-
       We demonstrate that FKF1 and GI proteins form a complex in a
       blue-light-dependent manner.
-    full_text_unavailable: true
 proposed_new_terms: []
 suggested_questions:
 - question: >-

--- a/genes/ARATH/LFY/LFY-ai-review.yaml
+++ b/genes/ARATH/LFY/LFY-ai-review.yaml
@@ -639,7 +639,6 @@ existing_annotations:
           supporting_text: >-
             We propose several candidate genes that may underlie these QTL on
             the basis of positional information and functional arguments.
-          full_text_unavailable: true
           reference_section_type: ABSTRACT
         - reference_id: PMID:12324613
           supporting_text: >-

--- a/genes/ARATH/NEK3/NEK3-ai-review.yaml
+++ b/genes/ARATH/NEK3/NEK3-ai-review.yaml
@@ -232,7 +232,6 @@ existing_annotations:
       GFP fusion protein.
     supported_by:
     - reference_id: PMID:21605211
-      full_text_unavailable: true
       supporting_text: >-
         Here, we analyze the function of NEK6 and other members of the NEK family
         with regard to epidermal cell expansion and cortical microtubule organization

--- a/genes/ARATH/SEP3/SEP3-ai-review.yaml
+++ b/genes/ARATH/SEP3/SEP3-ai-review.yaml
@@ -57,7 +57,6 @@ existing_annotations:
       supporting_text: >-
         Triple mutant Arabidopsis plants lacking the activity of all three SEP
         genes produce flowers in which all organs develop as sepals.
-      full_text_unavailable: true
       reference_section_type: ABSTRACT
 - term:
     id: GO:0009908
@@ -80,7 +79,6 @@ existing_annotations:
       supporting_text: >-
         Taken together, these studies suggest that SEP3 interacts with AP1 to
         promote normal flower development.
-      full_text_unavailable: true
       reference_section_type: ABSTRACT
 - term:
     id: GO:0010093
@@ -103,7 +101,6 @@ existing_annotations:
       supporting_text: >-
         SEP1/2/3 are a class of organ-identity genes that is required for
         development of petals, stamens and carpels.
-      full_text_unavailable: true
       reference_section_type: ABSTRACT
 - term:
     id: GO:0010093
@@ -149,7 +146,6 @@ existing_annotations:
         The cytochrome P-450 hydroxylase, CYP86A8, and the transcription
         factors, MYB47, KNAT7 and SEP3, support the protecting role of the seed
         coat during seed ageing.
-      full_text_unavailable: true
       reference_section_type: ABSTRACT
 - term:
     id: GO:0048481
@@ -216,7 +212,6 @@ existing_annotations:
     - reference_id: PMID:32519347
       supporting_text: >-
         support the protecting role of the seed coat during seed ageing.
-      full_text_unavailable: true
       reference_section_type: ABSTRACT
 - term:
     id: GO:0000977
@@ -359,7 +354,6 @@ existing_annotations:
       supporting_text: >-
         Arabidopsis dedicates over 5% of its genome to code for more than 1500
         transcription factors
-      full_text_unavailable: true
       reference_section_type: ABSTRACT
 - term:
     id: GO:0003700
@@ -382,7 +376,6 @@ existing_annotations:
     - reference_id: PMID:11439126
       supporting_text: >-
         SEP3 interacts with AP1 to promote normal flower development.
-      full_text_unavailable: true
       reference_section_type: ABSTRACT
 - term:
     id: GO:0003700
@@ -406,7 +399,6 @@ existing_annotations:
       supporting_text: >-
         MADS-box transcription factors are key regulators of several plant
         development processes.
-      full_text_unavailable: true
       reference_section_type: ABSTRACT
 - term:
     id: GO:0005515
@@ -450,7 +442,6 @@ existing_annotations:
     - reference_id: PMID:15604664
       supporting_text: >-
         The strong PI/SEP3 (or PI/SEP1) interaction requires K2
-      full_text_unavailable: true
       reference_section_type: ABSTRACT
 - term:
     id: GO:0005515
@@ -475,7 +466,6 @@ existing_annotations:
     - reference_id: PMID:15805477
       supporting_text: >-
         revealed a collection of specific heterodimers and a few homodimers.
-      full_text_unavailable: true
       reference_section_type: ABSTRACT
 - term:
     id: GO:0005515
@@ -499,7 +489,6 @@ existing_annotations:
       supporting_text: >-
         Heterodimerization of ABS with SEP3 was confirmed by gel retardation
         assays.
-      full_text_unavailable: true
       reference_section_type: ABSTRACT
 - term:
     id: GO:0005515
@@ -522,7 +511,6 @@ existing_annotations:
       supporting_text: >-
         APETALA1 (AP1) and SEPALLATA3 (SEP3), both MADS box DNA-binding
         proteins, interacted with SEU.
-      full_text_unavailable: true
       reference_section_type: ABSTRACT
 - term:
     id: GO:0005515
@@ -546,7 +534,6 @@ existing_annotations:
       supporting_text: >-
         Protein interaction studies revealed the formation of higher-order
         complexes between B(s)-C-E and B(s)-D-E type MADS-box proteins
-      full_text_unavailable: true
       reference_section_type: ABSTRACT
 - term:
     id: GO:0005515
@@ -614,7 +601,6 @@ existing_annotations:
       supporting_text: >-
         We analyzed almost 4500 combinations and detected more than 250
         protein-protein interactions
-      full_text_unavailable: true
       reference_section_type: ABSTRACT
 - term:
     id: GO:0005515
@@ -636,7 +622,6 @@ existing_annotations:
       supporting_text: >-
         widespread, but specific, interactions between phytoplasma effectors and
         host transcription factors
-      full_text_unavailable: true
       reference_section_type: ABSTRACT
 - term:
     id: GO:0046983
@@ -818,7 +803,6 @@ existing_annotations:
       supporting_text: >-
         In this study, we comprehensively characterized the Arabidopsis nuclear
         proteome.
-      full_text_unavailable: true
       reference_section_type: ABSTRACT
     - reference_id: file:ARATH/SEP3/SEP3-uniprot.txt
       supporting_text: "SUBCELLULAR LOCATION: Nucleus"

--- a/genes/ARATH/TFL1/TFL1-ai-review.yaml
+++ b/genes/ARATH/TFL1/TFL1-ai-review.yaml
@@ -63,12 +63,10 @@ existing_annotations:
         we examined the genetic interactions of FLOWERING LOCUS T (FT)/TWIN
         SISTER OF FT (TSF) and TERMINAL FLOWER 1 (TFL1) in the determination of
         inflorescence meristem identity in Arabidopsis thaliana.
-      full_text_unavailable: true
     - reference_id: PMID:30943325
       supporting_text: >-
         we proposed that FT/TSF and TFL1 play antagonistic roles in the
         determination of inflorescence meristem identity
-      full_text_unavailable: true
     - reference_id: file:ARATH/TFL1/TFL1-deep-research-falcon.md
       supporting_text: >-
         Core definition and biological role: Arabidopsis TFL1 is a member of the
@@ -232,7 +230,6 @@ existing_annotations:
       supporting_text: >-
         TFL1 localizes to endomembrane compartments and colocalizes with the
         putative delta-subunit of the AP-3 adapter complex.
-      full_text_unavailable: true
     - reference_id: PMID:18003908
       supporting_text_fulltext: >-
         Immunogold labeling in the shoot apex and root tissue of wild-type plants
@@ -259,7 +256,6 @@ existing_annotations:
       supporting_text: >-
         TFL1 localizes to endomembrane compartments and colocalizes with the
         putative delta-subunit of the AP-3 adapter complex.
-      full_text_unavailable: true
     - reference_id: PMID:18003908
       supporting_text_fulltext: >-
         Immunogold labeling in the shoot apex and root tissue of wild-type plants
@@ -287,12 +283,10 @@ existing_annotations:
       supporting_text: >-
         The tfl1-19/mtv5 (for "modified traffic to the vacuole") mutant is
         specifically defective in trafficking of proteins to the PSV.
-      full_text_unavailable: true
     - reference_id: PMID:18003908
       supporting_text: >-
         TFL1 localizes to endomembrane compartments and colocalizes with the
         putative delta-subunit of the AP-3 adapter complex.
-      full_text_unavailable: true
     - reference_id: PMID:21890645
       supporting_text: >-
         It is possible that TFL1 has pleiotropic functions, including that of a
@@ -318,7 +312,6 @@ existing_annotations:
       supporting_text: >-
         TFL1 localizes to endomembrane compartments and colocalizes with the
         putative delta-subunit of the AP-3 adapter complex.
-      full_text_unavailable: true
     - reference_id: PMID:18003908
       supporting_text_fulltext: >-
         Immunogold labeling in the shoot apex and root tissue of wild-type plants
@@ -345,12 +338,10 @@ existing_annotations:
         The tfl1-1 mutation causes early flowering and limits the development of
         the normally indeterminate inflorescence by promoting the formation of a
         terminal floral meristem.
-      full_text_unavailable: true
     - reference_id: PMID:12324621
       supporting_text: >-
         Our results suggest that tfl1-1 perturbs the establishment and
         maintenance of the inflorescence meristem.
-      full_text_unavailable: true
     - reference_id: PMID:21890645
       supporting_text: >-
         TFL1 negatively modulates the FD-dependent transcription of target genes
@@ -378,14 +369,12 @@ existing_annotations:
       supporting_text: >-
         This inhibition was more pronounced in tfl1, an early flowering mutant,
         than in the wild type.
-      full_text_unavailable: true
     - reference_id: PMID:11553753
       supporting_text: >-
         These results suggest that sugar may affect floral transition by
         activating or inhibiting genes that act to control floral transition,
         depending on the concentration of sugars, the genetic background of the
         plants, and when the sugar is introduced.
-      full_text_unavailable: true
 references:
 - id: GO_REF:0000044
   title: >-
@@ -571,7 +560,6 @@ core_functions:
     supporting_text: >-
       we proposed that FT/TSF and TFL1 play antagonistic roles in the
       determination of inflorescence meristem identity
-    full_text_unavailable: true
   - reference_id: file:interpro/panther/PTHR11362/PTHR11362-entries.csv
     supporting_text: >-
       P93003,Protein TERMINAL FLOWER 1,protein,3702,Arabidopsis

--- a/genes/ARATH/ZTL/ZTL-ai-review.yaml
+++ b/genes/ARATH/ZTL/ZTL-ai-review.yaml
@@ -110,7 +110,6 @@ existing_annotations:
     supported_by:
     - reference_id: PMID:17704763
       supporting_text: ZEITLUPE is a circadian photoreceptor stabilized by GIGANTEA in blue light
-      full_text_unavailable: true
 - term:
     id: GO:1990756
     label: ubiquitin-like ligase-substrate adaptor activity
@@ -124,7 +123,6 @@ existing_annotations:
     supported_by:
     - reference_id: PMID:17693530
       supporting_text: ZTL targets PRR5 for degradation by 26S proteasomes in the circadian clock and in early photomorphogenesis
-      full_text_unavailable: true
     - reference_id: file:ARATH/ZTL/ZTL-deep-research-falcon.md
       supporting_text: ZTL promotes proteasome-dependent turnover of clock proteins
 - term:
@@ -140,7 +138,6 @@ existing_annotations:
     supported_by:
     - reference_id: PMID:24004949
       supporting_text: The F-box protein ZEITLUPE controls stability and nucleocytoplasmic partitioning of GIGANTEA
-      full_text_unavailable: true
     - reference_id: file:ARATH/ZTL/ZTL-deep-research-falcon.md
       supporting_text: its key demonstrated localization function is to alter GI partitioning
 core_functions:
@@ -148,7 +145,6 @@ core_functions:
   supported_by:
   - reference_id: PMID:17704763
     supporting_text: ZEITLUPE is a circadian photoreceptor stabilized by GIGANTEA in blue light
-    full_text_unavailable: true
   - reference_id: file:ARATH/ZTL/ZTL-notes.md
     supporting_text: ZTL is a blue-light photoreceptor F-box protein
   molecular_function:
@@ -164,10 +160,8 @@ core_functions:
   supported_by:
   - reference_id: PMID:17693530
     supporting_text: ZTL targets PRR5 for degradation by 26S proteasomes in the circadian clock and in early photomorphogenesis
-    full_text_unavailable: true
   - reference_id: PMID:14654842
     supporting_text: Targeted degradation of TOC1 by ZTL modulates circadian function in Arabidopsis thaliana
-    full_text_unavailable: true
   molecular_function:
     id: GO:1990756
     label: ubiquitin-like ligase-substrate adaptor activity
@@ -183,7 +177,6 @@ core_functions:
   supported_by:
   - reference_id: PMID:14654842
     supporting_text: Targeted degradation of TOC1 by ZTL modulates circadian function in Arabidopsis thaliana
-    full_text_unavailable: true
   - reference_id: file:ARATH/ZTL/ZTL-notes.md
     supporting_text: ZTL is necessary to sustain a normal circadian period
   directly_involved_in:

--- a/genes/BPT4/E/E-ai-review.yaml
+++ b/genes/BPT4/E/E-ai-review.yaml
@@ -228,7 +228,6 @@ existing_annotations:
     supported_by:
       - reference_id: PMID:4865643
         supporting_text: "Purification of bacteriophage T4 lysozyme"
-        full_text_unavailable: true
 - term:
     id: GO:0003796
     label: lysozyme activity

--- a/genes/BPT4/frd/frd-ai-review.yaml
+++ b/genes/BPT4/frd/frd-ai-review.yaml
@@ -39,7 +39,6 @@ existing_annotations:
         supporting_text: "T4 DHFR catalyzes the two-electron reduction of dihydrofolate (FH2) to tetrahydrofolate (FH4), using NADPH as the hydride donor"
       - reference_id: PMID:10818362
         supporting_text: "Dihydrofolate reductase (DHFR) from bacteriophage T4 is a homodimer consisting of 193-residue subunits"
-        full_text_unavailable: true
 
 - term:
     id: GO:0006730
@@ -172,7 +171,6 @@ existing_annotations:
     supported_by:
       - reference_id: PMID:4936128
         supporting_text: "T4 bacteriophage-specific dihydrofolate reductase: purification to homogeneity by affinity chromatography"
-        full_text_unavailable: true
 
 references:
 - id: GO_REF:0000043

--- a/genes/METEA/mxaD/mxaD-ai-review.yaml
+++ b/genes/METEA/mxaD/mxaD-ai-review.yaml
@@ -106,7 +106,6 @@ existing_annotations:
       supporting_text: FT   SIGNAL          1..19
     - reference_id: PMID:12686160
       supporting_text: The gene mxaD codes for the 17-kDa periplasmic protein
-      full_text_unavailable: true
 core_functions:
 - description: MxaD acts as an accessory facilitator that enhances electron transfer
     between methanol dehydrogenase (MxaFI) and cytochrome c(L) in the periplasm during

--- a/genes/TOBAC/PARA/PARA-ai-review.yaml
+++ b/genes/TOBAC/PARA/PARA-ai-review.yaml
@@ -88,7 +88,6 @@ existing_annotations:
         is deduced that in the 111-bp direct repeat of the par gene promoter is
         localized an auxin-responsive region, which regulates auxin-mediated
         activation of transcription.
-      full_text_unavailable: true
 # --- Current GOA annotations (2026 release) ---
 - term:
     id: GO:0004364
@@ -250,7 +249,6 @@ existing_annotations:
         beta-glucuronidase (GUS) was placed downstream of the 5' flanking
         sequences of the par gene ... elicited auxin-regulated expression of
         GUS activity.
-      full_text_unavailable: true
 - term:
     id: GO:0009617
     label: response to bacterium

--- a/genes/VITVI/STS3/STS3-ai-review.yaml
+++ b/genes/VITVI/STS3/STS3-ai-review.yaml
@@ -60,17 +60,14 @@ existing_annotations:
         The mechanisms controlling the induction of stilbene synthase and phenylalanine
         ammonia-lyase (PAL), two putative key regulatory enzymes of the biosynthetic
         pathway to stilbene phytoalexins
-      full_text_unavailable: true
     - reference_id: PMID:22961129
       supporting_text: >-
         Stilbene synthases (STSs), which catalyze the biosynthesis of the stilbene
         backbone
-      full_text_unavailable: true
     - reference_id: PMID:22961129
       supporting_text: >-
         In addition to their participation in defense mechanisms in plants, stilbenes,
         such as resveratrol, display important pharmacological properties
-      full_text_unavailable: true
 # --- Current GOA annotations (2026 release) ---
 - term:
     id: GO:0005737
@@ -173,13 +170,11 @@ existing_annotations:
         Functional characterization of nine genes representing most of the STS gene
         family diversity clearly indicated that these genes do encode for proteins with
         STS activity
-      full_text_unavailable: true
     - reference_id: PMID:15309535
       supporting_text: >-
         The phytoalexin resveratrol (trans-3,5,4'-trihydroxy-stilbene), a natural
         component of resistance to fungal diseases in many plants, is synthesized by the
         enzyme trihydroxystilbene synthase (stilbene synthase, EC 2.3.1.95)
-      full_text_unavailable: true
 # --- Suggested NEW annotation (BP not currently captured) ---
 - term:
     id: GO:0009811
@@ -219,7 +214,6 @@ existing_annotations:
       supporting_text: >-
         Stilbene synthases (STSs), which catalyze the biosynthesis of the stilbene
         backbone
-      full_text_unavailable: true
     - reference_id: file:VITVI/STS3/STS3-deep-research-falcon.md
       supporting_text: >-
         STS genes encode the enzyme that performs the **terminal committed step** to
@@ -257,13 +251,11 @@ existing_annotations:
         Stilbenic compounds are natural phytoalexins that have antimicrobial activities
         in plant defense against pathogens. Stilbene synthase (STS) is the key enzyme
         that catalyzes the biosynthesis of stilbenic compounds
-      full_text_unavailable: true
     - reference_id: PMID:15359598
       supporting_text: >-
         When present, stilbene synthase leads to the production of resveratrol
         compounds, which are major components of the phytoalexin response against fungal
         pathogens of the plant
-      full_text_unavailable: true
 core_functions:
 - description: >-
     Type III polyketide synthase that catalyzes trihydroxystilbene (resveratrol)
@@ -297,7 +289,6 @@ core_functions:
       Stilbene synthase (STS) and chalcone synthase (CHS) each catalyze the formation of
       a tetraketide intermediate from a CoA-tethered phenylpropanoid starter and three
       molecules of malonyl-CoA, but use different cyclization mechanisms
-    full_text_unavailable: true
   - reference_id: file:VITVI/STS3/STS3-deep-research-falcon.md
     supporting_text: >-
       STS3 (VvSTS3)** encodes a **type III polyketide synthase (stilbene

--- a/genes/human/AAAS/AAAS-ai-review.yaml
+++ b/genes/human/AAAS/AAAS-ai-review.yaml
@@ -247,12 +247,10 @@ existing_annotations:
     - &id001
       reference_id: PMID:12730363
       supporting_text: ALADIN localizes to nuclear pore complexes (NPCs), large multiprotein assemblies that are the sole sites of nucleocytoplasmic transport.
-      full_text_unavailable: true
       reference_section_type: ABSTRACT
     - &id002
       reference_id: PMID:19782045
       supporting_text: We identified NDC1 but not GP210 and POM121 as the main anchor of ALADIN within the NPC.
-      full_text_unavailable: true
       reference_section_type: ABSTRACT
 - term:
     id: GO:0006913
@@ -271,7 +269,6 @@ existing_annotations:
     - &id003
       reference_id: PMID:12730363
       supporting_text: We propose that ALADIN plays a cell type-specific role in regulating nucleocytoplasmic transport and that this function is essential for the proper maintenance andor development of certain tissues.
-      full_text_unavailable: true
       reference_section_type: ABSTRACT
     - &id004
       reference_id: PMID:27016207
@@ -311,7 +308,6 @@ existing_annotations:
     supported_by:
     - reference_id: PMID:19782045
       supporting_text: We identified NDC1 but not GP210 and POM121 as the main anchor of ALADIN within the NPC.
-      full_text_unavailable: true
       reference_section_type: ABSTRACT
 - term:
     id: GO:0005643
@@ -344,11 +340,9 @@ existing_annotations:
     supported_by:
     - reference_id: PMID:24315095
       supporting_text: The nuclear pore complex (NPC) is a fundamental component of all eukaryotic cells that facilitates nucleocytoplasmic exchange of macromolecules.
-      full_text_unavailable: true
       reference_section_type: ABSTRACT
     - reference_id: PMID:19782045
       supporting_text: Based on our findings we conclude that ALADIN is anchored in the nuclear envelope via NDC1 and that this interaction gets lost, if ALADIN is mutated.
-      full_text_unavailable: true
       reference_section_type: ABSTRACT
 - term:
     id: GO:0005643
@@ -395,7 +389,6 @@ existing_annotations:
     supported_by:
     - reference_id: PMID:12730363
       supporting_text: ALADIN localizes to nuclear pore complexes (NPCs), large multiprotein assemblies that are the sole sites of nucleocytoplasmic transport.
-      full_text_unavailable: true
       reference_section_type: ABSTRACT
 - term:
     id: GO:0031965
@@ -412,7 +405,6 @@ existing_annotations:
     supported_by:
     - reference_id: PMID:19782045
       supporting_text: We identified NDC1 but not GP210 and POM121 as the main anchor of ALADIN within the NPC.
-      full_text_unavailable: true
       reference_section_type: ABSTRACT
 - term:
     id: GO:0005515
@@ -427,7 +419,6 @@ existing_annotations:
     supported_by:
     - reference_id: PMID:28811369
       supporting_text: We provide evidence that TMEM18 has four, not three, transmembrane domains and that it physically interacts with key components of the nuclear pore complex.
-      full_text_unavailable: true
       reference_section_type: ABSTRACT
 - term:
     id: GO:0005515
@@ -461,7 +452,6 @@ existing_annotations:
       reference_section_type: RESULTS
     - reference_id: PMID:19782045
       supporting_text: Based on our findings we conclude that ALADIN is anchored in the nuclear envelope via NDC1 and that this interaction gets lost, if ALADIN is mutated.
-      full_text_unavailable: true
       reference_section_type: ABSTRACT
 - term:
     id: GO:0000922
@@ -544,7 +534,6 @@ existing_annotations:
     supported_by:
     - reference_id: PMID:19946888
       supporting_text: The remaining species were largely involved in cellular processes and molecular functions that could be predicted to be transiently associated with membranes.
-      full_text_unavailable: true
       reference_section_type: ABSTRACT
 - term:
     id: GO:0005634
@@ -559,7 +548,6 @@ existing_annotations:
     supported_by:
     - reference_id: PMID:21630459
       supporting_text: With this approach, 403 different proteins have been identified from the isolated sperm nuclei.
-      full_text_unavailable: true
       reference_section_type: ABSTRACT
 - term:
     id: GO:0005635
@@ -576,7 +564,6 @@ existing_annotations:
     supported_by:
     - reference_id: PMID:19782045
       supporting_text: Based on our findings we conclude that ALADIN is anchored in the nuclear envelope via NDC1 and that this interaction gets lost, if ALADIN is mutated.
-      full_text_unavailable: true
       reference_section_type: ABSTRACT
 - term:
     id: GO:0005635
@@ -593,7 +580,6 @@ existing_annotations:
     supported_by:
     - reference_id: PMID:19782045
       supporting_text: Based on our findings we conclude that ALADIN is anchored in the nuclear envelope via NDC1 and that this interaction gets lost, if ALADIN is mutated.
-      full_text_unavailable: true
       reference_section_type: ABSTRACT
 - term:
     id: GO:0005635
@@ -610,7 +596,6 @@ existing_annotations:
     supported_by:
     - reference_id: PMID:19782045
       supporting_text: Based on our findings we conclude that ALADIN is anchored in the nuclear envelope via NDC1 and that this interaction gets lost, if ALADIN is mutated.
-      full_text_unavailable: true
       reference_section_type: ABSTRACT
 - term:
     id: GO:0005635
@@ -627,7 +612,6 @@ existing_annotations:
     supported_by:
     - reference_id: PMID:19782045
       supporting_text: Based on our findings we conclude that ALADIN is anchored in the nuclear envelope via NDC1 and that this interaction gets lost, if ALADIN is mutated.
-      full_text_unavailable: true
       reference_section_type: ABSTRACT
 - term:
     id: GO:0005635
@@ -644,7 +628,6 @@ existing_annotations:
     supported_by:
     - reference_id: PMID:19782045
       supporting_text: Based on our findings we conclude that ALADIN is anchored in the nuclear envelope via NDC1 and that this interaction gets lost, if ALADIN is mutated.
-      full_text_unavailable: true
       reference_section_type: ABSTRACT
 - term:
     id: GO:0005635
@@ -661,7 +644,6 @@ existing_annotations:
     supported_by:
     - reference_id: PMID:19782045
       supporting_text: Based on our findings we conclude that ALADIN is anchored in the nuclear envelope via NDC1 and that this interaction gets lost, if ALADIN is mutated.
-      full_text_unavailable: true
       reference_section_type: ABSTRACT
 - term:
     id: GO:0005635
@@ -678,7 +660,6 @@ existing_annotations:
     supported_by:
     - reference_id: PMID:19782045
       supporting_text: Based on our findings we conclude that ALADIN is anchored in the nuclear envelope via NDC1 and that this interaction gets lost, if ALADIN is mutated.
-      full_text_unavailable: true
       reference_section_type: ABSTRACT
 - term:
     id: GO:0005635
@@ -695,7 +676,6 @@ existing_annotations:
     supported_by:
     - reference_id: PMID:19782045
       supporting_text: Based on our findings we conclude that ALADIN is anchored in the nuclear envelope via NDC1 and that this interaction gets lost, if ALADIN is mutated.
-      full_text_unavailable: true
       reference_section_type: ABSTRACT
 - term:
     id: GO:0005635
@@ -712,7 +692,6 @@ existing_annotations:
     supported_by:
     - reference_id: PMID:19782045
       supporting_text: Based on our findings we conclude that ALADIN is anchored in the nuclear envelope via NDC1 and that this interaction gets lost, if ALADIN is mutated.
-      full_text_unavailable: true
       reference_section_type: ABSTRACT
 - term:
     id: GO:0005635
@@ -729,7 +708,6 @@ existing_annotations:
     supported_by:
     - reference_id: PMID:19782045
       supporting_text: Based on our findings we conclude that ALADIN is anchored in the nuclear envelope via NDC1 and that this interaction gets lost, if ALADIN is mutated.
-      full_text_unavailable: true
       reference_section_type: ABSTRACT
 - term:
     id: GO:0005635
@@ -746,7 +724,6 @@ existing_annotations:
     supported_by:
     - reference_id: PMID:19782045
       supporting_text: Based on our findings we conclude that ALADIN is anchored in the nuclear envelope via NDC1 and that this interaction gets lost, if ALADIN is mutated.
-      full_text_unavailable: true
       reference_section_type: ABSTRACT
 - term:
     id: GO:0005635
@@ -763,7 +740,6 @@ existing_annotations:
     supported_by:
     - reference_id: PMID:19782045
       supporting_text: Based on our findings we conclude that ALADIN is anchored in the nuclear envelope via NDC1 and that this interaction gets lost, if ALADIN is mutated.
-      full_text_unavailable: true
       reference_section_type: ABSTRACT
 - term:
     id: GO:0005635
@@ -780,7 +756,6 @@ existing_annotations:
     supported_by:
     - reference_id: PMID:19782045
       supporting_text: Based on our findings we conclude that ALADIN is anchored in the nuclear envelope via NDC1 and that this interaction gets lost, if ALADIN is mutated.
-      full_text_unavailable: true
       reference_section_type: ABSTRACT
 - term:
     id: GO:0005635
@@ -797,7 +772,6 @@ existing_annotations:
     supported_by:
     - reference_id: PMID:19782045
       supporting_text: Based on our findings we conclude that ALADIN is anchored in the nuclear envelope via NDC1 and that this interaction gets lost, if ALADIN is mutated.
-      full_text_unavailable: true
       reference_section_type: ABSTRACT
 - term:
     id: GO:0005635
@@ -814,7 +788,6 @@ existing_annotations:
     supported_by:
     - reference_id: PMID:19782045
       supporting_text: Based on our findings we conclude that ALADIN is anchored in the nuclear envelope via NDC1 and that this interaction gets lost, if ALADIN is mutated.
-      full_text_unavailable: true
       reference_section_type: ABSTRACT
 - term:
     id: GO:0005635
@@ -831,7 +804,6 @@ existing_annotations:
     supported_by:
     - reference_id: PMID:19782045
       supporting_text: Based on our findings we conclude that ALADIN is anchored in the nuclear envelope via NDC1 and that this interaction gets lost, if ALADIN is mutated.
-      full_text_unavailable: true
       reference_section_type: ABSTRACT
 - term:
     id: GO:0005635
@@ -848,7 +820,6 @@ existing_annotations:
     supported_by:
     - reference_id: PMID:19782045
       supporting_text: Based on our findings we conclude that ALADIN is anchored in the nuclear envelope via NDC1 and that this interaction gets lost, if ALADIN is mutated.
-      full_text_unavailable: true
       reference_section_type: ABSTRACT
 - term:
     id: GO:0005635
@@ -865,7 +836,6 @@ existing_annotations:
     supported_by:
     - reference_id: PMID:19782045
       supporting_text: Based on our findings we conclude that ALADIN is anchored in the nuclear envelope via NDC1 and that this interaction gets lost, if ALADIN is mutated.
-      full_text_unavailable: true
       reference_section_type: ABSTRACT
 - term:
     id: GO:0005635
@@ -882,7 +852,6 @@ existing_annotations:
     supported_by:
     - reference_id: PMID:19782045
       supporting_text: Based on our findings we conclude that ALADIN is anchored in the nuclear envelope via NDC1 and that this interaction gets lost, if ALADIN is mutated.
-      full_text_unavailable: true
       reference_section_type: ABSTRACT
 - term:
     id: GO:0005635
@@ -899,7 +868,6 @@ existing_annotations:
     supported_by:
     - reference_id: PMID:19782045
       supporting_text: Based on our findings we conclude that ALADIN is anchored in the nuclear envelope via NDC1 and that this interaction gets lost, if ALADIN is mutated.
-      full_text_unavailable: true
       reference_section_type: ABSTRACT
 - term:
     id: GO:0005635
@@ -916,7 +884,6 @@ existing_annotations:
     supported_by:
     - reference_id: PMID:19782045
       supporting_text: Based on our findings we conclude that ALADIN is anchored in the nuclear envelope via NDC1 and that this interaction gets lost, if ALADIN is mutated.
-      full_text_unavailable: true
       reference_section_type: ABSTRACT
 - term:
     id: GO:0005635
@@ -933,7 +900,6 @@ existing_annotations:
     supported_by:
     - reference_id: PMID:19782045
       supporting_text: Based on our findings we conclude that ALADIN is anchored in the nuclear envelope via NDC1 and that this interaction gets lost, if ALADIN is mutated.
-      full_text_unavailable: true
       reference_section_type: ABSTRACT
 - term:
     id: GO:0005635
@@ -950,7 +916,6 @@ existing_annotations:
     supported_by:
     - reference_id: PMID:19782045
       supporting_text: Based on our findings we conclude that ALADIN is anchored in the nuclear envelope via NDC1 and that this interaction gets lost, if ALADIN is mutated.
-      full_text_unavailable: true
       reference_section_type: ABSTRACT
 - term:
     id: GO:0005635
@@ -967,7 +932,6 @@ existing_annotations:
     supported_by:
     - reference_id: PMID:19782045
       supporting_text: Based on our findings we conclude that ALADIN is anchored in the nuclear envelope via NDC1 and that this interaction gets lost, if ALADIN is mutated.
-      full_text_unavailable: true
       reference_section_type: ABSTRACT
 - term:
     id: GO:0005635
@@ -984,7 +948,6 @@ existing_annotations:
     supported_by:
     - reference_id: PMID:19782045
       supporting_text: Based on our findings we conclude that ALADIN is anchored in the nuclear envelope via NDC1 and that this interaction gets lost, if ALADIN is mutated.
-      full_text_unavailable: true
       reference_section_type: ABSTRACT
 - term:
     id: GO:0005635
@@ -1001,7 +964,6 @@ existing_annotations:
     supported_by:
     - reference_id: PMID:19782045
       supporting_text: Based on our findings we conclude that ALADIN is anchored in the nuclear envelope via NDC1 and that this interaction gets lost, if ALADIN is mutated.
-      full_text_unavailable: true
       reference_section_type: ABSTRACT
 - term:
     id: GO:0005635
@@ -1018,7 +980,6 @@ existing_annotations:
     supported_by:
     - reference_id: PMID:19782045
       supporting_text: Based on our findings we conclude that ALADIN is anchored in the nuclear envelope via NDC1 and that this interaction gets lost, if ALADIN is mutated.
-      full_text_unavailable: true
       reference_section_type: ABSTRACT
 - term:
     id: GO:0005635
@@ -1035,7 +996,6 @@ existing_annotations:
     supported_by:
     - reference_id: PMID:19782045
       supporting_text: Based on our findings we conclude that ALADIN is anchored in the nuclear envelope via NDC1 and that this interaction gets lost, if ALADIN is mutated.
-      full_text_unavailable: true
       reference_section_type: ABSTRACT
 - term:
     id: GO:0005635
@@ -1052,7 +1012,6 @@ existing_annotations:
     supported_by:
     - reference_id: PMID:19782045
       supporting_text: Based on our findings we conclude that ALADIN is anchored in the nuclear envelope via NDC1 and that this interaction gets lost, if ALADIN is mutated.
-      full_text_unavailable: true
       reference_section_type: ABSTRACT
 - term:
     id: GO:0006913
@@ -1101,11 +1060,9 @@ core_functions:
   supported_by:
   - reference_id: PMID:12730363
     supporting_text: A variety of disease-associated missense, nonsense, and frameshift mutations failed to localize to NPCs and were found predominantly in the cytoplasm.
-    full_text_unavailable: true
     reference_section_type: ABSTRACT
   - reference_id: PMID:19782045
     supporting_text: Based on our findings we conclude that ALADIN is anchored in the nuclear envelope via NDC1 and that this interaction gets lost, if ALADIN is mutated.
-    full_text_unavailable: true
     reference_section_type: ABSTRACT
   - reference_id: file:human/AAAS/AAAS-deep-research-falcon.md
     supporting_text: 'Best-supported current interpretation: ALADIN is a **scaffold/selective transport regulator at the NPC**, not an enzyme or transporter with a defined small-molecule substrate.'

--- a/genes/human/ACTB/ACTB-ai-review.yaml
+++ b/genes/human/ACTB/ACTB-ai-review.yaml
@@ -3540,7 +3540,6 @@ core_functions:
   - reference_id: PMID:18765789
     supporting_text: Regulation of muscle development by DPF3, a novel histone acetylation
       and methylation reader of the BAF chromatin remodeling complex
-    full_text_unavailable: true
 - description: Contributing to microtubule nucleation as a component of the gamma-tubulin
     ring complex
   molecular_function:

--- a/genes/human/AGR2/AGR2-ai-review.yaml
+++ b/genes/human/AGR2/AGR2-ai-review.yaml
@@ -505,7 +505,6 @@ existing_annotations:
     - reference_id: PMID:15834940
       supporting_text: the androgen-induced secretory protein AGR2 may serve as a potential therapeutic target and/or molecular marker for prostate cancer.
       reference_section_type: ABSTRACT
-      full_text_unavailable: true
 - term:
     id: GO:0042802
     label: identical protein binding
@@ -522,7 +521,6 @@ existing_annotations:
     - reference_id: PMID:23220234
       supporting_text: Herein we show that AGR2 homo-dimerizes through an intermolecular disulfide bond. Moreover, dimerization of AGR2 attenuates ER stress-induced cell death through the association with BiP/GRP78.
       reference_section_type: ABSTRACT
-      full_text_unavailable: true
 - term:
     id: GO:0042802
     label: identical protein binding
@@ -539,7 +537,6 @@ existing_annotations:
     - reference_id: PMID:23274113
       supporting_text: The protein exists in monomer-dimer equilibrium with a K(d) of 8.83μM
       reference_section_type: ABSTRACT
-      full_text_unavailable: true
 - term:
     id: GO:0005515
     label: protein binding
@@ -556,7 +553,6 @@ existing_annotations:
     - reference_id: PMID:23220234
       supporting_text: Herein we show that AGR2 homo-dimerizes through an intermolecular disulfide bond. Moreover, dimerization of AGR2 attenuates ER stress-induced cell death through the association with BiP/GRP78.
       reference_section_type: ABSTRACT
-      full_text_unavailable: true
 - term:
     id: GO:0005576
     label: extracellular region
@@ -624,7 +620,6 @@ existing_annotations:
     - reference_id: PMID:23220234
       supporting_text: Herein we show that AGR2 homo-dimerizes through an intermolecular disulfide bond. Moreover, dimerization of AGR2 attenuates ER stress-induced cell death through the association with BiP/GRP78.
       reference_section_type: ABSTRACT
-      full_text_unavailable: true
     - reference_id: PMID:31247903
       supporting_text: This was demonstrated when IREα and ATF6α were knocked down using small interfering RNA (siRNA) in HeLa cells, resulting in the decreased expression levels of the AGR2 protein
       reference_section_type: RESULTS
@@ -650,7 +645,6 @@ existing_annotations:
     - reference_id: PMID:23220234
       supporting_text: Herein we show that AGR2 homo-dimerizes through an intermolecular disulfide bond. Moreover, dimerization of AGR2 attenuates ER stress-induced cell death through the association with BiP/GRP78.
       reference_section_type: ABSTRACT
-      full_text_unavailable: true
     - reference_id: PMID:31247903
       supporting_text: The top molecules implicated in regulating the expression of AGR2 included IRE1α, ATF6α, AKT, FOXA1/2, HIF-1, TMED2, and the frequently mutated tumor suppressor p53.
       reference_section_type: DISCUSSION
@@ -702,7 +696,6 @@ existing_annotations:
     - reference_id: PMID:23274113
       supporting_text: The unstructured region is primarily responsible for the ability of AGR2 to promote cell adhesion, while dimerization is less important for this activity.
       reference_section_type: ABSTRACT
-      full_text_unavailable: true
 - term:
     id: GO:0034976
     label: response to endoplasmic reticulum stress

--- a/genes/human/AGR3/AGR3-ai-review.yaml
+++ b/genes/human/AGR3/AGR3-ai-review.yaml
@@ -40,7 +40,6 @@ existing_annotations:
         Here we report that AGR3, unlike its closest homolog AGR2, is restricted to ciliated cells in the airway epithelium
         and is not induced by ER stress.
       reference_section_type: ABSTRACT
-      full_text_unavailable: true
 - term:
     id: GO:0002162
     label: dystroglycan binding
@@ -121,7 +120,6 @@ existing_annotations:
         Here we report that AGR3, unlike its closest homolog AGR2, is restricted to ciliated cells in the airway epithelium
         and is not induced by ER stress.
       reference_section_type: ABSTRACT
-      full_text_unavailable: true
 - term:
     id: GO:0005515
     label: protein binding
@@ -207,7 +205,6 @@ existing_annotations:
         Here we report that AGR3, unlike its closest homolog AGR2, is restricted to ciliated cells in the airway epithelium
         and is not induced by ER stress.
       reference_section_type: ABSTRACT
-      full_text_unavailable: true
 - term:
     id: GO:0005515
     label: protein binding
@@ -281,12 +278,10 @@ existing_annotations:
         Mice lacking AGR3 are viable and develop ciliated cells with normal-appearing cilia. However, ciliary beat frequency
         was lower in airways from AGR3-deficient mice compared with control mice
       reference_section_type: ABSTRACT
-      full_text_unavailable: true
     - reference_id: PMID:25751668
       supporting_text: >-
         Decreased CBF was associated with impaired mucociliary clearance in AGR3-deficient airways.
       reference_section_type: ABSTRACT
-      full_text_unavailable: true
 - term:
     id: GO:0019722
     label: calcium-mediated signaling
@@ -307,7 +302,6 @@ existing_annotations:
         AGR3 deficiency had no detectable effects on ciliary beat frequency (CBF) when airways were perfused with a calcium-free
         solution, suggesting that AGR3 is required for calcium-mediated regulation of ciliary function.
       reference_section_type: ABSTRACT
-      full_text_unavailable: true
 references:
 - id: GO_REF:0000033
   title: Annotation inferences using phylogenetic trees
@@ -391,7 +385,6 @@ core_functions:
       solution, suggesting that AGR3 is required for calcium-mediated regulation of ciliary function. Decreased CBF was associated
       with impaired mucociliary clearance in AGR3-deficient airways.
     reference_section_type: ABSTRACT
-    full_text_unavailable: true
   - reference_id: file:human/AGR3/AGR3-deep-research-falcon.md
     supporting_text: >-
       AGR3 lacks the canonical PDI/thioredoxin CXXC or WCXXC motif; structure paper reports a DCYQS motif with solvent-exposed

--- a/genes/human/ASCL1/ASCL1-ai-review.yaml
+++ b/genes/human/ASCL1/ASCL1-ai-review.yaml
@@ -1789,7 +1789,6 @@ core_functions:
   - reference_id: PMID:24243019
     supporting_text: "A unique trivalent chromatin signature in the host cells predicts\
       \ the permissiveness for Ascl1 pioneering activity among different cell types"
-    full_text_unavailable: true
 - molecular_function:
     id: GO:0043425
     label: bHLH transcription factor binding

--- a/genes/human/ATP6V0D1/ATP6V0D1-ai-review.yaml
+++ b/genes/human/ATP6V0D1/ATP6V0D1-ai-review.yaml
@@ -1383,11 +1383,9 @@ existing_annotations:
     - &id017
       reference_id: PMID:11118322
       supporting_text: Structure of the VPATPD gene encoding subunit D of the human vacuolar proton ATPase
-      full_text_unavailable: true
     - &id018
       reference_id: PMID:11118322
       supporting_text: The encoded protein is 99.5% identical to mouse subunit D at the amino acid level
-      full_text_unavailable: true
     - *id016
     - *id001
 - term:

--- a/genes/human/BBS4/BBS4-ai-review.yaml
+++ b/genes/human/BBS4/BBS4-ai-review.yaml
@@ -1160,11 +1160,9 @@ core_functions:
   supported_by:
   - reference_id: PMID:15107855
     supporting_text: "it functions as an adaptor of the p150(glued) subunit of the dynein transport machinery to recruit PCM1 (pericentriolar material 1 protein) and its associated cargo to the satellites"
-    full_text_unavailable: true
     reference_section_type: ABSTRACT
   - reference_id: PMID:18762586
     supporting_text: "DISC1 and BBS4 are required for targeting PCM1 and other cargo proteins, such as ninein, to the centrosome in a synergistic manner"
-    full_text_unavailable: true
     reference_section_type: ABSTRACT
 - description: "As a core subunit of the BBSome, BBS4 contributes to a coat-like cargo adaptor that sorts and traffics membrane proteins to and within the primary cilium, supporting ciliogenesis and ciliary signalling."
   molecular_function:
@@ -1189,7 +1187,6 @@ core_functions:
   supported_by:
   - reference_id: PMID:17574030
     supporting_text: "we identify a complex composed of seven highly conserved BBS proteins. This complex, the BBSome, localizes to nonmembranous centriolar satellites in the cytoplasm but also to the membrane of the cilium"
-    full_text_unavailable: true
     reference_section_type: ABSTRACT
   - reference_id: PMID:23943788
     supporting_text: "co-localizes with CEP290 to the transition zone (TZ) of primary cilia and centriolar satellites in ciliated cells"

--- a/genes/human/CDKN1C/CDKN1C-ai-review.yaml
+++ b/genes/human/CDKN1C/CDKN1C-ai-review.yaml
@@ -176,7 +176,6 @@ existing_annotations:
       GO:0004861.
     supported_by:
     - reference_id: PMID:9106657
-      full_text_unavailable: true
       supporting_text: the CDK inhibitors p21(CIP), p27(KIP), and p57(KIP2) all promote the association
         of cdk4 with the D-type cyclins
 - term:

--- a/genes/human/CFTR/CFTR-ai-review.yaml
+++ b/genes/human/CFTR/CFTR-ai-review.yaml
@@ -3897,7 +3897,6 @@ core_functions:
   - reference_id: PMID:15010471
     supporting_text: Dynamic control of cystic fibrosis transmembrane conductance
       regulator Cl(-)/HCO3(-) selectivity by external Cl(-)
-    full_text_unavailable: true
   directly_involved_in:
   - id: GO:0015701
     label: bicarbonate transport
@@ -3918,7 +3917,6 @@ core_functions:
   - reference_id: PMID:10581360
     supporting_text: Differential function of the two nucleotide binding domains on
       cystic fibrosis transmembrane conductance regulator
-    full_text_unavailable: true
   directly_involved_in:
   - id: GO:0034220
     label: monoatomic ion transmembrane transport

--- a/genes/human/CHAF1B/CHAF1B-ai-review.yaml
+++ b/genes/human/CHAF1B/CHAF1B-ai-review.yaml
@@ -42,7 +42,6 @@ existing_annotations:
         In interphase, p150 and p60 are bound to the nucleus, but they
         predominantly dissociate from chromatin during mitosis. During S phase,
         p150 and p60 are concentrated at sites of intranuclear DNA replication.
-      full_text_unavailable: true
       reference_section_type: ABSTRACT
 - term:
     id: GO:0005634
@@ -103,7 +102,6 @@ existing_annotations:
         copurifies with a chromatin assembly complex (CAC), which contains the
         three subunits of CAF-1 (p150, p60, p48) and H3 and H4, and promotes DNA
         replication-dependent chromatin assembly.
-      full_text_unavailable: true
       reference_section_type: ABSTRACT
 - term:
     id: GO:0005515
@@ -146,7 +144,6 @@ existing_annotations:
       supporting_text: >-
         Human-chromatin-related protein interactions identify a demethylase
         complex required for chromosome segregation.
-      full_text_unavailable: true
       reference_section_type: TITLE
 - term:
     id: GO:0005515
@@ -165,7 +162,6 @@ existing_annotations:
     supported_by:
     - reference_id: PMID:27705803
       supporting_text: A High-Density Map for Navigating the Human Polycomb Complexome.
-      full_text_unavailable: true
       reference_section_type: TITLE
 - term:
     id: GO:0005515
@@ -186,7 +182,6 @@ existing_annotations:
       supporting_text: >-
         Architecture of the human interactome defines protein communities and
         disease networks.
-      full_text_unavailable: true
       reference_section_type: TITLE
 - term:
     id: GO:0005515
@@ -207,7 +202,6 @@ existing_annotations:
       supporting_text: >-
         Dual proteome-scale networks reveal cell-specific remodeling of the human
         interactome.
-      full_text_unavailable: true
       reference_section_type: TITLE
 - term:
     id: GO:0005515
@@ -228,7 +222,6 @@ existing_annotations:
       supporting_text: >-
         Multimodal cell maps as a foundation for structural and functional
         genomics.
-      full_text_unavailable: true
       reference_section_type: TITLE
 - term:
     id: GO:0006335
@@ -252,7 +245,6 @@ existing_annotations:
         The H3.1 and H3.3 complexes contain distinct histone chaperones, CAF-1 and
         HIRA, that we show are necessary to mediate DNA-synthesis-dependent and
         -independent nucleosome assembly, respectively.
-      full_text_unavailable: true
       reference_section_type: ABSTRACT
 - term:
     id: GO:0005654
@@ -272,7 +264,6 @@ existing_annotations:
     supported_by:
     - reference_id: PMID:9614144
       supporting_text: In interphase, p150 and p60 are bound to the nucleus.
-      full_text_unavailable: true
       reference_section_type: ABSTRACT
 - term:
     id: GO:0000785
@@ -295,7 +286,6 @@ existing_annotations:
         In interphase, p150 and p60 are bound to the nucleus, but they
         predominantly dissociate from chromatin during mitosis. During S phase,
         p150 and p60 are concentrated at sites of intranuclear DNA replication.
-      full_text_unavailable: true
       reference_section_type: ABSTRACT
 - term:
     id: GO:0006335
@@ -316,7 +306,6 @@ existing_annotations:
       supporting_text: >-
         Human CAF-1 efficiently mediates nucleosome assembly during complementary
         DNA strand synthesis in G1, S, and G2 phase cytosolic extracts.
-      full_text_unavailable: true
       reference_section_type: ABSTRACT
 - term:
     id: GO:0033186
@@ -337,7 +326,6 @@ existing_annotations:
       supporting_text: >-
         All three subunits of human CAF-1 (p150, p60, and p48) are present during
         the entire cell cycle.
-      full_text_unavailable: true
       reference_section_type: ABSTRACT
 - term:
     id: GO:0006335
@@ -360,7 +348,6 @@ existing_annotations:
         copurifies with a chromatin assembly complex (CAC), which contains the
         three subunits of CAF-1 (p150, p60, p48) and H3 and H4, and promotes DNA
         replication-dependent chromatin assembly.
-      full_text_unavailable: true
       reference_section_type: ABSTRACT
 - term:
     id: GO:0032991
@@ -383,7 +370,6 @@ existing_annotations:
         these complexes possess one molecule each of H3.1/H3.3 and H4, suggesting
         that histones H3 and H4 exist as dimeric units that are important
         intermediates in nucleosome formation.
-      full_text_unavailable: true
       reference_section_type: ABSTRACT
 - term:
     id: GO:0000785
@@ -406,7 +392,6 @@ existing_annotations:
         The H3.1 and H3.3 complexes contain distinct histone chaperones, CAF-1 and
         HIRA, that we show are necessary to mediate DNA-synthesis-dependent and
         -independent nucleosome assembly, respectively.
-      full_text_unavailable: true
       reference_section_type: ABSTRACT
 - term:
     id: GO:0033186
@@ -427,7 +412,6 @@ existing_annotations:
       supporting_text: >-
         a chromatin assembly complex (CAC), which contains the three subunits of
         CAF-1 (p150, p60, p48) and H3 and H4.
-      full_text_unavailable: true
       reference_section_type: ABSTRACT
 - term:
     id: GO:0005829
@@ -487,7 +471,6 @@ existing_annotations:
     supported_by:
     - reference_id: PMID:9614144
       supporting_text: In interphase, p150 and p60 are bound to the nucleus.
-      full_text_unavailable: true
       reference_section_type: ABSTRACT
 - term:
     id: GO:0005737
@@ -507,7 +490,6 @@ existing_annotations:
     - reference_id: PMID:9614144
       supporting_text: >-
         In mitosis, the p60 subunit of inactive CAF-1 is hyperphosphorylated.
-      full_text_unavailable: true
       reference_section_type: ABSTRACT
 - term:
     id: GO:0042393
@@ -529,7 +511,6 @@ existing_annotations:
       supporting_text: >-
         p150 and p60 form complexes with newly synthesized histones H3 and
         acetylated H4 in human cell extracts.
-      full_text_unavailable: true
       reference_section_type: ABSTRACT
     - reference_id: file:human/CHAF1B/CHAF1B-uniprot.txt
       supporting_text: Interacts with histones H3.1, H3.2 and H3.1t (PubMed:33857403).
@@ -553,7 +534,6 @@ existing_annotations:
       supporting_text: >-
         During S phase, p150 and p60 are concentrated at sites of intranuclear DNA
         replication.
-      full_text_unavailable: true
       reference_section_type: ABSTRACT
 - term:
     id: GO:0140713
@@ -589,7 +569,6 @@ core_functions:
     supporting_text: >-
       p150 and p60 form complexes with newly synthesized histones H3 and acetylated
       H4 in human cell extracts.
-    full_text_unavailable: true
     reference_section_type: ABSTRACT
 - description: >-
     As a subunit of CAF-1, CHAF1B mediates the first step of nucleosome assembly,
@@ -612,7 +591,6 @@ core_functions:
       a chromatin assembly complex (CAC), which contains the three subunits of
       CAF-1 (p150, p60, p48) and H3 and H4, and promotes DNA replication-dependent
       chromatin assembly.
-    full_text_unavailable: true
     reference_section_type: ABSTRACT
 - description: >-
     CHAF1B bridges the large subunit CHAF1A (p150) and the histone-binding subunit
@@ -627,7 +605,6 @@ core_functions:
       p150 and p60 directly interact and are both required for DNA
       replication-dependent assembly of nucleosomes. Deletion of the p60-binding
       domain from the p150 protein prevents chromatin assembly.
-    full_text_unavailable: true
     reference_section_type: ABSTRACT
 proposed_new_terms: []
 suggested_questions:

--- a/genes/human/COX10/COX10-ai-review.yaml
+++ b/genes/human/COX10/COX10-ai-review.yaml
@@ -394,7 +394,6 @@ core_functions:
         supporting_text: >-
           COX10 functions in the first step of the mitochondrial heme A biosynthetic pathway, catalyzing
           the conversion of protoheme (heme B) to heme O
-        full_text_unavailable: true
       - reference_id: file:human/COX10/COX10-uniprot.txt
         supporting_text: >-
           Converts protoheme IX and farnesyl diphosphate to heme O.

--- a/genes/human/COX4I2/COX4I2-ai-review.yaml
+++ b/genes/human/COX4I2/COX4I2-ai-review.yaml
@@ -376,7 +376,6 @@ core_functions:
       - reference_id: PMID:11311561
         supporting_text: >-
           Mammalian subunit IV isoforms of cytochrome c oxidase.
-        full_text_unavailable: true
       - reference_id: file:human/COX4I2/COX4I2-deep-research-falcon.md
         supporting_text: |
           COX4I2 does not create a new catalytic reaction; complex IV's canonical chemistry remains the terminal step of the respiratory chain (electron transfer to O2 with reduction to water and proton pumping). Instead, COX4I2 is best understood as a regulatory/kinetic tuning subunit that changes how complex IV responds to oxygen tension and cellular metabolic state (e.g., ATP/ADP control), thereby influencing downstream signaling (NADH/ROS) in specialized O2-sensing contexts.

--- a/genes/human/DAB2IP/DAB2IP-ai-review.yaml
+++ b/genes/human/DAB2IP/DAB2IP-ai-review.yaml
@@ -640,7 +640,6 @@ existing_annotations:
           supporting_text: A PERIOD-like domain (amino acids 591-719) of AIP1 
             binds to the intact RING finger of TRAF2, and specifically enhances 
             TRAF2-induced ASK1 activation
-          full_text_unavailable: true
   - term:
       id: GO:0033209
       label: tumor necrosis factor-mediated signaling pathway
@@ -1508,7 +1507,6 @@ existing_annotations:
         - reference_id: PMID:17389591
           supporting_text: RIP1 (the Ser/Thr protein kinase receptor-interacting
             protein) associates with the GAP domain of AIP1
-          full_text_unavailable: true
   - term:
       id: GO:0019900
       label: kinase binding
@@ -1522,7 +1520,6 @@ existing_annotations:
           supporting_text: RIP1 (the Ser/Thr protein kinase receptor-interacting
             protein) associates with the GAP domain of AIP1 and mediates 
             TNF-induced AIP1 phosphorylation at Ser-604 and JNK/p38 activation
-          full_text_unavailable: true
   - term:
       id: GO:0030163
       label: protein catabolic process
@@ -1535,7 +1532,6 @@ existing_annotations:
         - reference_id: PMID:17389591
           supporting_text: RIP1 synergizes with AIP1 (but not AIP1-S604A) in 
             inducing both JNK/p38 activation and EC apoptosis
-          full_text_unavailable: true
   - term:
       id: GO:0031434
       label: mitogen-activated protein kinase kinase binding
@@ -1548,7 +1544,6 @@ existing_annotations:
         - reference_id: PMID:17389591
           supporting_text: TNF-induced TRAF2-RIP1-AIP1-ASK1 complex formation 
             and for the activation of ASK1-JNK/p38 apoptotic signaling
-          full_text_unavailable: true
   - term:
       id: GO:0043065
       label: positive regulation of apoptotic process
@@ -1561,7 +1556,6 @@ existing_annotations:
         - reference_id: PMID:17389591
           supporting_text: RIP1 synergizes with AIP1 (but not AIP1-S604A) in 
             inducing both JNK/p38 activation and EC apoptosis
-          full_text_unavailable: true
   - term:
       id: GO:0043124
       label: negative regulation of canonical NF-kappaB signal transduction
@@ -1577,7 +1571,6 @@ existing_annotations:
         - reference_id: PMID:17389591
           supporting_text: TNF-induced TRAF2-RIP1-AIP1-ASK1 complex formation 
             and for the activation of ASK1-JNK/p38 apoptotic signaling
-          full_text_unavailable: true
   - term:
       id: GO:0045944
       label: positive regulation of transcription by RNA polymerase II
@@ -1592,7 +1585,6 @@ existing_annotations:
             14-3-3-binding site Ser-604 is essential for TNF-induced 
             TRAF2-RIP1-AIP1-ASK1 complex formation and for the activation of 
             ASK1-JNK/p38 apoptotic signaling
-          full_text_unavailable: true
   - term:
       id: GO:0046330
       label: positive regulation of JNK cascade
@@ -1606,7 +1598,6 @@ existing_annotations:
           supporting_text: RIP1-mediated AIP1 phosphorylation at a 
             14-3-3-binding site is critical for tumor necrosis factor-induced 
             ASK1-JNK/p38 activation
-          full_text_unavailable: true
   - term:
       id: GO:0071356
       label: cellular response to tumor necrosis factor
@@ -1620,7 +1611,6 @@ existing_annotations:
           supporting_text: TNF treatment of EC induces phosphorylation of AIP1 
             at Ser-604 as detected by a phospho-specific antibody, with a 
             similar kinetics to ASK1-JNK/p38 activation
-          full_text_unavailable: true
   - term:
       id: GO:0000122
       label: negative regulation of transcription by RNA polymerase II
@@ -1633,7 +1623,6 @@ existing_annotations:
         - reference_id: PMID:15310755
           supporting_text: the binding of AIP1 to TRAF2 inhibits TNF-induced 
             IKK-NF-kappaB signaling
-          full_text_unavailable: true
   - term:
       id: GO:0000122
       label: negative regulation of transcription by RNA polymerase II
@@ -1660,7 +1649,6 @@ existing_annotations:
           supporting_text: AIP1 is localized on the plasma membrane in resting 
             endothelial cells (EC) in a complex with TNFR1. TNF binding induces 
             release of AIP1 from TNFR1
-          full_text_unavailable: true
   - term:
       id: GO:0005737
       label: cytoplasm
@@ -1673,7 +1661,6 @@ existing_annotations:
         - reference_id: PMID:15310755
           supporting_text: TNF binding induces release of AIP1 from TNFR1, 
             resulting in cytoplasmic translocation
-          full_text_unavailable: true
   - term:
       id: GO:0005886
       label: plasma membrane
@@ -1686,7 +1673,6 @@ existing_annotations:
         - reference_id: PMID:15310755
           supporting_text: AIP1 is localized on the plasma membrane in resting 
             endothelial cells (EC) in a complex with TNFR1
-          full_text_unavailable: true
   - term:
       id: GO:0010633
       label: negative regulation of epithelial cell migration
@@ -1787,7 +1773,6 @@ existing_annotations:
         - reference_id: PMID:15310755
           supporting_text: the binding of AIP1 to TRAF2 inhibits TNF-induced 
             IKK-NF-kappaB signaling
-          full_text_unavailable: true
   - term:
       id: GO:0045944
       label: positive regulation of transcription by RNA polymerase II
@@ -1801,7 +1786,6 @@ existing_annotations:
           supporting_text: AIP1 is a novel transducer in TNF-induced 
             TRAF2-dependent activation of ASK1 that mediates a balance between 
             JNK versus NF-kappaB signaling
-          full_text_unavailable: true
   - term:
       id: GO:0048147
       label: negative regulation of fibroblast proliferation
@@ -1861,7 +1845,6 @@ existing_annotations:
           supporting_text: AIP1 is localized on the plasma membrane in resting 
             endothelial cells (EC) in a complex with TNFR1. TNF binding induces 
             release of AIP1 from TNFR1
-          full_text_unavailable: true
   - term:
       id: GO:0071364
       label: cellular response to epidermal growth factor stimulus
@@ -1888,7 +1871,6 @@ existing_annotations:
           supporting_text: Ser-604, located in the C-terminal domain of AIP1, 
             was identified as a 14-3-3-binding site. TNF treatment of EC induces
             phosphorylation of AIP1 at Ser-604
-          full_text_unavailable: true
   - term:
       id: GO:0090090
       label: negative regulation of canonical Wnt signaling pathway

--- a/genes/human/GADD45B/GADD45B-ai-review.yaml
+++ b/genes/human/GADD45B/GADD45B-ai-review.yaml
@@ -58,7 +58,6 @@ existing_annotations:
       supporting_text: "Using a yeast two-hybrid method, three related proteins, GADD45alpha\
         \ (= GADD45), GADD45, (= MyD118), and GADD45gamma, were identified that bound\
         \ to an N-terminal domain of MTK1"
-      full_text_unavailable: true
 - term:
     id: GO:0005737
     label: cytoplasm
@@ -73,7 +72,6 @@ existing_annotations:
     - reference_id: PMID:9827804
       supporting_text: "These proteins activated MTK1 kinase activity, both in vivo\
         \ and in vitro"
-      full_text_unavailable: true
 - term:
     id: GO:0005634
     label: nucleus
@@ -107,7 +105,6 @@ existing_annotations:
       supporting_text: "Expression of the GADD45-like genes induces p38/JNK activation\
         \ and apoptosis, which can be partially suppressed by coexpression of a dominant\
         \ inhibitory MTK1 mutant protein"
-      full_text_unavailable: true
     - reference_id: PMID:25314077
       supporting_text: "GADD45β promotes the survival of MM cells by inhibiting JNK-mediated\
         \ apoptosis"
@@ -141,7 +138,6 @@ existing_annotations:
     - reference_id: PMID:9827804
       supporting_text: "Expression of the GADD45-like genes induces p38/JNK activation\
         \ and apoptosis"
-      full_text_unavailable: true
 - term:
     id: GO:0051726
     label: regulation of cell cycle
@@ -208,7 +204,6 @@ existing_annotations:
     - reference_id: PMID:16256071
       supporting_text: "CIN85 was also shown to regulate the activation of MEKK4 by\
         \ GADD45 proteins and promote multi-ubiquitination of MEKK4"
-      full_text_unavailable: true
 - term:
     id: GO:0005515
     label: protein binding
@@ -283,7 +278,6 @@ existing_annotations:
       supporting_text: "Using a yeast two-hybrid method, three related proteins, GADD45alpha\
         \ (= GADD45), GADD45, (= MyD118), and GADD45gamma, were identified that bound\
         \ to an N-terminal domain of MTK1"
-      full_text_unavailable: true
 - term:
     id: GO:0005737
     label: cytoplasm
@@ -300,7 +294,6 @@ existing_annotations:
     - reference_id: PMID:9827804
       supporting_text: "These proteins activated MTK1 kinase activity, both in vivo\
         \ and in vitro"
-      full_text_unavailable: true
 - term:
     id: GO:0043065
     label: positive regulation of apoptotic process
@@ -317,7 +310,6 @@ existing_annotations:
       supporting_text: "Expression of the GADD45-like genes induces p38/JNK activation\
         \ and apoptosis, which can be partially suppressed by coexpression of a dominant\
         \ inhibitory MTK1 mutant protein"
-      full_text_unavailable: true
 - term:
     id: GO:0046330
     label: positive regulation of JNK cascade
@@ -332,7 +324,6 @@ existing_annotations:
     - reference_id: PMID:9827804
       supporting_text: "Expression of the GADD45-like genes induces p38/JNK activation\
         \ and apoptosis"
-      full_text_unavailable: true
 - term:
     id: GO:1900745
     label: positive regulation of p38MAPK cascade
@@ -348,7 +339,6 @@ existing_annotations:
       supporting_text: "The stress-responsive p38 and JNK MAPK pathways regulate cell\
         \ cycle and apoptosis. A human MAPKKK, MTK1 (= MEKK4), mediates activation\
         \ of both p38 and JNK in response to environmental stresses"
-      full_text_unavailable: true
 # NEW annotation for anti-apoptotic function via MKK7 inhibition
 - term:
     id: GO:0043066
@@ -479,7 +469,6 @@ core_functions:
   - reference_id: PMID:9827804
     supporting_text: These proteins activated MTK1 kinase activity, both in vivo and
       in vitro
-    full_text_unavailable: true
   - reference_id: PMID:12052864
     supporting_text: GADD45 proteins bind a site in MTK1 near the inhibitory domain
       and relieve autoinhibition.

--- a/genes/human/IFIT2/IFIT2-ai-review.yaml
+++ b/genes/human/IFIT2/IFIT2-ai-review.yaml
@@ -187,7 +187,6 @@ existing_annotations:
           supporting_text: "the antiviral protein IFIT1 (interferon-induced protein
             with tetratricopeptide repeats 1) mediated binding of a larger protein
             complex containing other IFIT family members"
-          full_text_unavailable: true
   - term:
       id: GO:0005515
       label: protein binding

--- a/genes/human/MYC/MYC-ai-review.yaml
+++ b/genes/human/MYC/MYC-ai-review.yaml
@@ -2859,7 +2859,6 @@ core_functions:
   supported_by:
   - reference_id: PMID:12553908
     supporting_text: X-ray structures of Myc-Max and Mad-Max recognizing DNA
-    full_text_unavailable: true
   - reference_id: PMID:21807113
     supporting_text: Sirt1 deacetylates c-Myc and promotes c-Myc/Max association
   molecular_function:

--- a/genes/human/NDUFA4/NDUFA4-ai-review.yaml
+++ b/genes/human/NDUFA4/NDUFA4-ai-review.yaml
@@ -857,7 +857,6 @@ core_functions:
     supporting_text: >-
       Rather, proteomic, genetic, evolutionary, and biochemical analyses reveal that
       NDUFA4 plays a role in CIV function and biogenesis
-    full_text_unavailable: true
   - reference_id: PMID:30030519
     supporting_text: >-
       Intriguingly, NDUFA4 lies exactly at the dimeric interface observed in previously

--- a/genes/human/NPM1/NPM1-ai-review.yaml
+++ b/genes/human/NPM1/NPM1-ai-review.yaml
@@ -3638,7 +3638,6 @@ core_functions:
       Protein B23 also protected liver alcohol dehydrogenase (LADH), carboxypeptidase
       A, citrate synthase, and rhodanese from aggregation during thermal denaturation
       and preserved the enzyme activity of LADH under these conditions
-    full_text_unavailable: true
 - molecular_function:
     id: GO:0019901
     label: protein kinase binding
@@ -3686,7 +3685,6 @@ core_functions:
     supporting_text: >-
       Here, we discover that nucleophosmin (NPM) may be a Ran-Crm1 substrate that
       controls centrosome duplication
-    full_text_unavailable: true
 references:
 - id: GO_REF:0000033
   title: Annotation inferences using phylogenetic trees

--- a/genes/human/PHTF1/PHTF1-ai-review.yaml
+++ b/genes/human/PHTF1/PHTF1-ai-review.yaml
@@ -158,7 +158,6 @@ existing_annotations:
       supporting_text: >-
         we have identified FEM1B, an ortholog of the C. elegans feminization factor 1 (FEM-1),
         as a binding partner for PHTF1
-      full_text_unavailable: true
       reference_section_type: ABSTRACT
     - reference_id: PMID:36803935
       supporting_text: >-
@@ -251,7 +250,6 @@ core_functions:
     supporting_text: >-
       we have identified FEM1B, an ortholog of the C. elegans feminization factor 1 (FEM-1),
       as a binding partner for PHTF1
-    full_text_unavailable: true
     reference_section_type: ABSTRACT
   - reference_id: PMID:36803935
     supporting_text: >-

--- a/genes/human/PLD3/PLD3-ai-review.yaml
+++ b/genes/human/PLD3/PLD3-ai-review.yaml
@@ -433,7 +433,6 @@ existing_annotations:
     reason: PMID:9140189 identified PLD3 as having sequence homology to the PLD superfamily, leading to the assumption of phospholipase activity. However, extensive subsequent biochemical studies have definitively demonstrated that PLD3 lacks significant phospholipase D activity and instead functions as a 5'-3' exonuclease. UniProt now classifies PLD3 as EC 3.1.16.1 (5'-3' exonuclease) rather than as a phospholipase. This annotation should be removed as it is now known to be incorrect.
     supported_by:
     - reference_id: PMID:9140189
-      full_text_unavailable: true
       supporting_text: We have identified a human gene encoding a protein with 48% amino acid identity to the vaccinia virus (VV) K4L gene product. Both contain motifs characteristic of the phospholipase D (PLD) protein superfamily.
 - term:
     id: GO:0016780

--- a/genes/human/POLE4/POLE4-ai-review.yaml
+++ b/genes/human/POLE4/POLE4-ai-review.yaml
@@ -128,7 +128,6 @@ existing_annotations:
       reason: High-throughput screen, not core function.
       supported_by:
         - reference_id: PMID:22190034
-          full_text_unavailable: true
           supporting_text: Global landscape of HIV-human protein complexes.
   - term:
       id: GO:0005515
@@ -291,7 +290,6 @@ existing_annotations:
         - reference_id: PMID:10801849
           supporting_text: We report here the identification and the cloning of two
             additional subunits of HeLa pol epsilon, p17, and p12
-          full_text_unavailable: true
   - term:
       id: GO:0000510
       label: H3-H4 histone complex chaperone activity

--- a/genes/human/SCN9A/SCN9A-ai-review.yaml
+++ b/genes/human/SCN9A/SCN9A-ai-review.yaml
@@ -696,12 +696,10 @@ core_functions:
     supporting_text: The channel exhibited rapid activation and inactivation kinetics,
       and was blocked by tetrodotoxin and cadmium with IC50 values of 24.5 nM and
       1.1 mM, respectively.
-    full_text_unavailable: true
     reference_section_type: ABSTRACT
   - reference_id: PMID:30765606
     supporting_text: Here we report the cryo-electron microscopy structures of the
       human Nav1.7-β1-β2 complex
-    full_text_unavailable: true
     reference_section_type: ABSTRACT
   - reference_id: file:human/SCN9A/SCN9A-deep-research-falcon.md
     supporting_text: NaV1.7 is selective for Na+ and shares the canonical NaV architecture

--- a/genes/human/SCO1/SCO1-ai-review.yaml
+++ b/genes/human/SCO1/SCO1-ai-review.yaml
@@ -39,7 +39,6 @@ existing_annotations:
           supporting_text: >-
             The subsequent maturation of CO II is contingent upon the formation of a complex that includes
             both SCO proteins, each with a functional CxxxC copper-coordinating motif.
-          full_text_unavailable: true
         - reference_id: file:human/SCO1/SCO1-deep-research-falcon.md
           supporting_text: >-
             SCO1 has a thioredoxin-like fold and a copper-binding CxxxC motif characteristic of SCO-family
@@ -134,12 +133,10 @@ existing_annotations:
           supporting_text: >-
             Our results demonstrate that the human SCO proteins have non-overlapping, cooperative
             functions in mitochondrial copper delivery.
-          full_text_unavailable: true
         - reference_id: PMID:19336478
           supporting_text: >-
             Based on these data we present a model in which each SCO protein fulfills distinct,
             stage-specific functions during CO II synthesis and CuA site maturation.
-          full_text_unavailable: true
         - reference_id: file:human/SCO1/SCO1-hypotheses/core-function-1-go-0016531/openscientist.md
           supporting_text: >-
             OpenScientist judged copper chaperone activity (GO:0016531) to be supported as a core
@@ -447,12 +444,10 @@ core_functions:
         supporting_text: >-
           Our results demonstrate that the human SCO proteins have non-overlapping, cooperative functions
           in mitochondrial copper delivery.
-        full_text_unavailable: true
       - reference_id: PMID:19336478
         supporting_text: >-
           Based on these data we present a model in which each SCO protein fulfills distinct,
           stage-specific functions during CO II synthesis and CuA site maturation.
-        full_text_unavailable: true
       - reference_id: file:human/SCO1/SCO1-hypotheses/core-function-1-go-0016531/openscientist.md
         supporting_text: >-
           The focused OpenScientist hypothesis review found the SCO1 copper chaperone core-function

--- a/genes/human/SGCE/SGCE-ai-review.yaml
+++ b/genes/human/SGCE/SGCE-ai-review.yaml
@@ -65,7 +65,6 @@ existing_annotations:
     - reference_id: PMID:9475163
       supporting_text: The sarcoglycans are transmembrane proteins within the DGC,
         and the function of the sarcoglycans is unknown
-      full_text_unavailable: true
     - reference_id: PMID:9405466
       supporting_text: The sarcoglycans are transmembrane components of the dystrophin-glycoprotein
         complex

--- a/genes/human/SLC3A2/SLC3A2-ai-review.yaml
+++ b/genes/human/SLC3A2/SLC3A2-ai-review.yaml
@@ -2184,7 +2184,6 @@ core_functions:
     supporting_text: rboado@mednet.ucla.edu The deleterious effects on the brain of
       phenylketonuria are caused by the saturation of the blood-brain barrier large
       neutral amino acid transporter type 1 (LAT1) by high plasma phenylalanine concentrations
-    full_text_unavailable: true
   - reference_id: PMID:11564694
     supporting_text: Thyroid hormone transport by the heterodimeric human system L
       amino acid transporter

--- a/genes/human/UCK2/UCK2-ai-review.yaml
+++ b/genes/human/UCK2/UCK2-ai-review.yaml
@@ -502,7 +502,6 @@ core_functions:
     supporting_text: The approximately 30-kDa proteins, named UCK1 and UCK2, were
       expressed in Escherichia coli and shown to catalyze the phosphorylation of Urd
       and Cyd
-    full_text_unavailable: true
   - reference_id: PMID:27239701
     supporting_text: Uridine-cytidine kinase (UCK) catalyzes the phosphorylation of
       uridine and cytidine as well as the pharmacological activation of several cytotoxic

--- a/genes/human/XIST/XIST-ai-review.yaml
+++ b/genes/human/XIST/XIST-ai-review.yaml
@@ -274,7 +274,6 @@ proposed_new_terms:
   supported_by:
   - reference_id: PMID:9069284
     supporting_text: Here we show that Xist, introduced onto an autosome, is sufficient by itself for inactivation in cis and that Xist RNA becomes localized close to the autosome into which the gene is integrated
-    full_text_unavailable: true
 suggested_questions:
 - question: What are the specific repeat elements in XIST that are required for chromosome coating versus silencing?
   experts:

--- a/genes/mouse/Cyp1a1/Cyp1a1-ai-review.yaml
+++ b/genes/mouse/Cyp1a1/Cyp1a1-ai-review.yaml
@@ -116,7 +116,6 @@ existing_annotations:
     - reference_id: PMID:17166882
       supporting_text: the major CYP1 enzymes that metabolize DBC are CYP1A1 in beta-naphthoflavone (BNF)-induced liver, CYP1A2 in non-induced liver, CYP1B1 and CYP1A1 in induced lung and none in non-induced lung.
       reference_section_type: ABSTRACT
-      full_text_unavailable: true
     additional_reference_ids:
     - file:mouse/Cyp1a1/Cyp1a1-deep-research-falcon.md
     - PMID:17166882
@@ -139,7 +138,6 @@ existing_annotations:
     - reference_id: PMID:16377763
       supporting_text: inducible CYP1A1, probably in both intestine and liver, is most important in detoxication
       reference_section_type: ABSTRACT
-      full_text_unavailable: true
     additional_reference_ids:
     - file:mouse/Cyp1a1/Cyp1a1-uniprot.txt
     - file:mouse/Cyp1a1/Cyp1a1-deep-research-falcon.md
@@ -389,7 +387,6 @@ existing_annotations:
     - reference_id: PMID:16377763
       supporting_text: inducible CYP1A1, probably in both intestine and liver, is most important in detoxication
       reference_section_type: ABSTRACT
-      full_text_unavailable: true
     additional_reference_ids:
     - file:mouse/Cyp1a1/Cyp1a1-uniprot.txt
     - file:mouse/Cyp1a1/Cyp1a1-deep-research-falcon.md
@@ -992,7 +989,6 @@ existing_annotations:
     - reference_id: PMID:16377763
       supporting_text: inducible CYP1A1, probably in both intestine and liver, is most important in detoxication
       reference_section_type: ABSTRACT
-      full_text_unavailable: true
     additional_reference_ids:
     - file:mouse/Cyp1a1/Cyp1a1-uniprot.txt
     - file:mouse/Cyp1a1/Cyp1a1-deep-research-falcon.md
@@ -1475,7 +1471,6 @@ existing_annotations:
     - reference_id: PMID:16377763
       supporting_text: inducible CYP1A1, probably in both intestine and liver, is most important in detoxication
       reference_section_type: ABSTRACT
-      full_text_unavailable: true
 - term:
     id: GO:0009308
     label: amine metabolic process
@@ -1489,7 +1484,6 @@ existing_annotations:
     - reference_id: PMID:17052995
       supporting_text: These results reveal that mouse lung has basal and inducible PhIP N(2)-hydroxylase activity predominantly catalyzed by CYP1A1.
       reference_section_type: ABSTRACT
-      full_text_unavailable: true
 - term:
     id: GO:0009404
     label: toxin metabolic process
@@ -1506,7 +1500,6 @@ existing_annotations:
     - reference_id: PMID:17166882
       supporting_text: the major CYP1 enzymes that metabolize DBC are CYP1A1 in beta-naphthoflavone (BNF)-induced liver, CYP1A2 in non-induced liver, CYP1B1 and CYP1A1 in induced lung and none in non-induced lung.
       reference_section_type: ABSTRACT
-      full_text_unavailable: true
     additional_reference_ids:
     - file:mouse/Cyp1a1/Cyp1a1-deep-research-falcon.md
 - term:
@@ -1522,7 +1515,6 @@ existing_annotations:
     - reference_id: PMID:17052995
       supporting_text: These results reveal that mouse lung has basal and inducible PhIP N(2)-hydroxylase activity predominantly catalyzed by CYP1A1.
       reference_section_type: ABSTRACT
-      full_text_unavailable: true
 - term:
     id: GO:0016712
     label: oxidoreductase activity, acting on paired donors, with incorporation or reduction of molecular oxygen, reduced flavin or flavoprotein as one donor, and incorporation of one atom of oxygen
@@ -1559,7 +1551,6 @@ existing_annotations:
     - reference_id: PMID:14980704
       supporting_text: Cyp1a1(-/-) microsomes displayed markedly lower levels of H(2)O(2) production in both induced and noninduced microsomes, compared with those in wild-type and Cyp1a2(-/-) microsomes.
       reference_section_type: ABSTRACT
-      full_text_unavailable: true
 - term:
     id: GO:0004497
     label: monooxygenase activity
@@ -1583,7 +1574,6 @@ existing_annotations:
     - reference_id: PMID:14642533
       supporting_text: ethoxyresorufin O-dealkylase activity of CYP1A
       reference_section_type: ABSTRACT
-      full_text_unavailable: true
     additional_reference_ids:
     - file:mouse/Cyp1a1/Cyp1a1-uniprot.txt
     - file:mouse/Cyp1a1/Cyp1a1-deep-research-falcon.md
@@ -1690,15 +1680,12 @@ core_functions:
   - reference_id: PMID:16377763
     supporting_text: inducible CYP1A1, probably in both intestine and liver, is most important in detoxication
     reference_section_type: ABSTRACT
-    full_text_unavailable: true
   - reference_id: PMID:17052995
     supporting_text: These results reveal that mouse lung has basal and inducible PhIP N(2)-hydroxylase activity predominantly catalyzed by CYP1A1.
     reference_section_type: ABSTRACT
-    full_text_unavailable: true
   - reference_id: PMID:17166882
     supporting_text: the major CYP1 enzymes that metabolize DBC are CYP1A1 in beta-naphthoflavone (BNF)-induced liver, CYP1A2 in non-induced liver, CYP1B1 and CYP1A1 in induced lung and none in non-induced lung.
     reference_section_type: ABSTRACT
-    full_text_unavailable: true
 proposed_new_terms: []
 suggested_questions:
 - question: Should mouse Cyp1a1 retain mitochondrial inner membrane and HSP70/HSP90 binding annotations when the cited support is primarily homology to rat CYP1A1 rather than direct mouse localization evidence?

--- a/genes/mouse/Sirt2/Sirt2-ai-review.yaml
+++ b/genes/mouse/Sirt2/Sirt2-ai-review.yaml
@@ -2520,11 +2520,9 @@ core_functions:
   - reference_id: PMID:24334550
     supporting_text: Sirt2 functions in spindle organization and chromosome alignment
       in mouse oocyte meiosis
-    full_text_unavailable: true
   - reference_id: PMID:23126280
     supporting_text: Finally, we show that katanin, a microtubule-severing protein
       with enhanced activity on acetylated α-tubulin, is actively involved in adipogenesis
-    full_text_unavailable: true
 - description: Regulates cell cycle progression through deacetylation of APC/C co-activators
     CDC20 and FZR1, ensuring proper mitotic checkpoint function and genomic stability.
   molecular_function:

--- a/genes/mouse/Surf1/Surf1-ai-review.yaml
+++ b/genes/mouse/Surf1/Surf1-ai-review.yaml
@@ -53,7 +53,6 @@ existing_annotations:
         We report here the creation of a constitutive knockout mouse for SURF1,
         a gene encoding one of the assembly proteins involved in the formation
         of cytochrome c oxidase (COX).
-      full_text_unavailable: true
     - reference_id: file:mouse/Surf1/Surf1-deep-research-falcon.md
       supporting_text: >-
         The requested target corresponds to the mammalian SURF1-family protein
@@ -341,7 +340,6 @@ existing_annotations:
         We performed a proteomic survey of mitochondria from mouse brain, heart,
         kidney, and liver and combined the results with existing gene
         annotations to produce a list of 591 mitochondrial proteins.
-      full_text_unavailable: true
     - reference_id: UniProt:P09925
       supporting_text: >-
         SUBCELLULAR LOCATION: Mitochondrion membrane.
@@ -380,7 +378,6 @@ existing_annotations:
         We report here the creation of a constitutive knockout mouse for SURF1,
         a gene encoding one of the assembly proteins involved in the formation
         of cytochrome c oxidase (COX).
-      full_text_unavailable: true
 - term:
     id: GO:0062011
     label: mitochondrial respiratory chain complex IV pre-assembly complex
@@ -576,7 +573,6 @@ core_functions:
       We report here the creation of a constitutive knockout mouse for SURF1, a
       gene encoding one of the assembly proteins involved in the formation of
       cytochrome c oxidase (COX).
-    full_text_unavailable: true
   - reference_id: PMID:23838831
     supporting_text: >-
       Surf1 participates in the efficient assembly and function of cytochrome C

--- a/genes/mouse/Tuba1a/Tuba1a-ai-review.yaml
+++ b/genes/mouse/Tuba1a/Tuba1a-ai-review.yaml
@@ -1637,7 +1637,6 @@ core_functions:
   - reference_id: PMID:20603323
     supporting_text: Disease-associated mutations in TUBA1A result in a spectrum of
       defects in the tubulin folding and heterodimer assembly pathway
-    full_text_unavailable: true
   - reference_id: file:mouse/Tuba1a/Tuba1a-deep-research-falcon.md
     supporting_text: Microtubules are cytoskeletal polymers built from alpha/beta-tubulin
       heterodimers; TUBA1A is the predominant neuronal alpha-tubulin during brain

--- a/genes/rat/Pfkfb4/Pfkfb4-ai-review.yaml
+++ b/genes/rat/Pfkfb4/Pfkfb4-ai-review.yaml
@@ -182,7 +182,6 @@ existing_annotations:
       supporting_text: Regulation of the regulatory enzyme,
         6-phosphofructo-2-kinase/fructose-2,6-bisphosphatase.
       reference_section_type: TITLE
-      full_text_unavailable: true
     - reference_id: file:rat/Pfkfb4/Pfkfb4-deep-research-falcon.md
       supporting_text: |-
         At **submicromolar concentrations**, it stimulates glycolysis and inhibits gluconeogenesis by:
@@ -203,7 +202,6 @@ existing_annotations:
       supporting_text: Regulation of the regulatory enzyme,
         6-phosphofructo-2-kinase/fructose-2,6-bisphosphatase.
       reference_section_type: TITLE
-      full_text_unavailable: true
     - reference_id: file:rat/Pfkfb4/Pfkfb4-deep-research-falcon.md
       supporting_text: |-
         At the pathway level, PFKFB4 regulates **glycolytic flux** by controlling the concentration of **F-2,6-BP**, which directly tunes PFK1 activity.

--- a/genes/rat/Qdpr/Qdpr-ai-review.yaml
+++ b/genes/rat/Qdpr/Qdpr-ai-review.yaml
@@ -183,7 +183,6 @@ existing_annotations:
     - reference_id: PMID:3477172
       supporting_text: The effect of lead and aluminium on rat dihydropteridine reductase
       reference_section_type: TITLE
-      full_text_unavailable: true
 - term:
     id: GO:0010288
     label: response to lead ion

--- a/genes/worm/bbs-8/bbs-8-ai-review.yaml
+++ b/genes/worm/bbs-8/bbs-8-ai-review.yaml
@@ -358,7 +358,6 @@ existing_annotations:
           supporting_text: requires BBS-8 and DAF-25 (known as Ankmy2 in 
             mammals) for correct localization of guanylyl cyclases needed for 
             thermosensation
-          full_text_unavailable: true
   - term:
       id: GO:0044292
       label: dendrite terminus
@@ -377,7 +376,6 @@ existing_annotations:
           supporting_text: One compartment, a bona fide cilium, is delineated by
             proteins associated with Bardet-Biedl syndrome (BBS), Meckel 
             syndrome and nephronophthisis at its base
-          full_text_unavailable: true
   - term:
       id: GO:0097546
       label: ciliary base

--- a/genes/worm/cebp-2/cebp-2-ai-review.yaml
+++ b/genes/worm/cebp-2/cebp-2-ai-review.yaml
@@ -355,7 +355,6 @@ existing_annotations:
           supporting_text: CEBP-2, the C. elegans ortholog of mammalian 
             CCAAT-enhancer-binding protein gamma, is a key player in 
             surveillance immunity
-          full_text_unavailable: true
   - term:
       id: GO:0006357
       label: regulation of transcription by RNA polymerase II

--- a/genes/worm/csr-1/csr-1-ai-review.yaml
+++ b/genes/worm/csr-1/csr-1-ai-review.yaml
@@ -289,7 +289,6 @@ existing_annotations:
         granule localization.
       supported_by:
         - reference_id: PMID:19804758
-          full_text_unavailable: true
           supporting_text: The Argonaute CSR-1 and its 22G-RNA cofactors are 
             required for holocentric chromosome segregation.
   - term:

--- a/genes/worm/drp-1/drp-1-ai-review.yaml
+++ b/genes/worm/drp-1/drp-1-ai-review.yaml
@@ -366,7 +366,6 @@ existing_annotations:
     - reference_id: PMID:10619028
       supporting_text: mitochondria are disrupted by mutations in a C. elegans dynamin-related
         protein (DRP-1).
-      full_text_unavailable: true
 - term:
     id: GO:0006915
     label: apoptotic process
@@ -418,7 +417,6 @@ existing_annotations:
     supported_by:
     - reference_id: PMID:10619028
       supporting_text: C. elegans dynamin-related protein (DRP-1)
-      full_text_unavailable: true
 - term:
     id: GO:0005739
     label: mitochondrion

--- a/genes/worm/nhr-49/nhr-49-ai-review.yaml
+++ b/genes/worm/nhr-49/nhr-49-ai-review.yaml
@@ -952,7 +952,6 @@ core_functions:
       elegans Mediator complex, as an NHR-49-interacting protein and transcriptional
       coactivator
 
-    full_text_unavailable: true
 - molecular_function:
     id: GO:0004879
     label: nuclear receptor activity

--- a/genes/worm/sta-2/sta-2-ai-review.yaml
+++ b/genes/worm/sta-2/sta-2-ai-review.yaml
@@ -396,7 +396,6 @@ existing_annotations:
       supported_by:
         - reference_id: PMID:21575913
           supporting_text: the STAT transcription factor-like protein STA-2
-          full_text_unavailable: true
   - term:
       id: GO:0030139
       label: endocytic vesicle
@@ -412,7 +411,6 @@ existing_annotations:
         - reference_id: PMID:21575913
           supporting_text: the STAT transcription factor-like protein STA-2 as a
             direct physical interactor of SNF-12
-          full_text_unavailable: true
   - term:
       id: GO:0045177
       label: apical part of cell

--- a/genes/yeast/HDA1/HDA1-ai-review.yaml
+++ b/genes/yeast/HDA1/HDA1-ai-review.yaml
@@ -522,7 +522,6 @@ existing_annotations:
       supporting_text: In cells lacking Gcn5 activity, the H3 acetylation increase
         does not occur and an unexpected increase of histone H4 acetylation is
         observed.
-      full_text_unavailable: true
 - term:
     id: GO:0000122
     label: negative regulation of transcription by RNA polymerase II

--- a/genes/yeast/JEM1/JEM1-ai-review.yaml
+++ b/genes/yeast/JEM1/JEM1-ai-review.yaml
@@ -92,7 +92,6 @@ existing_annotations:
     supported_by:
     - reference_id: PMID:15282802
       supporting_text: localization data for 21 other proteins
-      full_text_unavailable: true
 - term:
     id: GO:0005515
     label: protein binding
@@ -204,7 +203,6 @@ existing_annotations:
     supported_by:
     - reference_id: PMID:15282802
       supporting_text: localization data for 21 other proteins
-      full_text_unavailable: true
     - reference_id: PMID:9148890
       supporting_text: protein was anchored in the endoplasmic reticulum (ER) membrane and its J-domain
 references:

--- a/genes/yeast/LPL1/LPL1-ai-review.yaml
+++ b/genes/yeast/LPL1/LPL1-ai-review.yaml
@@ -73,7 +73,6 @@ existing_annotations:
     supported_by:
     - reference_id: PMID:25014274
       supporting_text: 'The purified Lpl1p showed phospholipase activity with broader substrate specificity, acting on all glycerophospholipids primarily at sn-2 position and later at sn-1 position'
-      full_text_unavailable: true
     - reference_id: file:yeast/LPL1/LPL1-deep-research.md
       supporting_text: Lpl1 and Rog1p have diverged substrate preferences but analogous structural frameworks
 - term:

--- a/genes/yeast/SOD2/SOD2-ai-review.yaml
+++ b/genes/yeast/SOD2/SOD2-ai-review.yaml
@@ -339,7 +339,6 @@ existing_annotations:
     supported_by:
     - reference_id: PMID:11914276
       supporting_text: "By high-throughput immunolocalization of tagged gene products, we have determined the subcellular localization of 2744 yeast proteins."
-      full_text_unavailable: true
 - term:
     id: GO:0005739
     label: mitochondrion


### PR DESCRIPTION
## What

Removes 313 `full_text_unavailable: true` flags across 61 gene-review files where the supporting quote is in fact verifiable against the cached reference.

The `full_text_unavailable` convention lets a curator declare "I can't see the full text, so this quote may be unverifiable" — the reference validator then skips quote-checking for that entry. But these 313 entries were flagged despite the cached publication (abstract or full text) actually containing the quoted text. An LRV audit confirmed each removed flag's quote is present in the cache, so dropping the flag re-enables real quote validation without introducing failures.

This pairs with the cache warm (#1527): with full text now cached, more of these quotes become checkable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)