### PR TITLE
Add weekly warm-reference-cache workflow

### DIFF
--- a/.github/workflows/warm-reference-cache.yaml
+++ b/.github/workflows/warm-reference-cache.yaml
@@ -1,0 +1,137 @@
+---
+name: Warm reference cache
+
+# Keeps the committed reference cache (publications/) complete so the full
+# `just validate-all` reference phase stays cache-bound instead of re-fetching
+# references from PubMed/providers on every run. Runs weekly (newly-added
+# references are fetched; an unchanged cache is a no-op) and on demand.
+
+on:  # yamllint disable-line rule:truthy
+  schedule:
+    - cron: '0 4 * * 1'   # Mondays 04:00 UTC, ahead of the weekly validate-all
+  workflow_dispatch:
+
+concurrency:
+  group: warm-reference-cache
+  cancel-in-progress: true
+
+jobs:
+  warm-reference-cache:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: true
+
+      - name: Set up Python
+        uses: actions/setup-python@v6.2.0
+        with:
+          python-version: "3.12"
+
+      - name: Install just
+        run: uv tool install rust-just
+
+      - name: Install project
+        run: uv sync --dev
+
+      - name: Warm the reference cache
+        run: just warm-references
+
+      - name: Check for cache changes
+        id: check-changes
+        run: |
+          if git diff --quiet publications/; then
+            echo "has_changes=false" >> "$GITHUB_OUTPUT"
+            echo "Reference cache already complete; nothing to commit."
+          else
+            echo "has_changes=true" >> "$GITHUB_OUTPUT"
+            git diff --stat publications/ | tail -1
+          fi
+
+      - name: Compute metadata
+        if: steps.check-changes.outputs.has_changes == 'true'
+        id: metadata
+        run: |
+          CHANGED=$(git diff --name-only publications/ | wc -l | tr -d ' ')
+          TOTAL=$(find publications -maxdepth 1 \( -name 'PMID_*.md' -o -name 'DOI_*.md' \) | wc -l | tr -d ' ')
+          {
+            echo "branch=auto/warm-reference-cache"
+            echo "changed=$CHANGED"
+            echo "total=$TOTAL"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Create or update warm-cache PR
+        if: steps.check-changes.outputs.has_changes == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.PAT_FOR_PR != '' && secrets.PAT_FOR_PR || github.token }}
+        shell: bash
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+          BRANCH_NAME="${{ steps.metadata.outputs.branch }}"
+          git fetch origin "$BRANCH_NAME:refs/remotes/origin/$BRANCH_NAME" || true
+          git checkout -B "$BRANCH_NAME"
+
+          git add publications/
+          git commit -m "$(cat <<EOF
+          Warm reference cache (${{ steps.metadata.outputs.changed }} entries updated)
+
+          Automated weekly warm so validate-all reads cached references instead of
+          re-fetching them. ${{ steps.metadata.outputs.total }} references cached total.
+          EOF
+          )"
+
+          git push --force-with-lease origin "$BRANCH_NAME"
+
+          PR_BODY="$(mktemp)"
+          {
+            echo "## Summary"
+            echo
+            echo "Automated weekly warm of the reference cache (\`publications/\`)."
+            echo "Fetches references that are new or lack full text so the full"
+            echo "\`just validate-all\` reference phase stays cache-bound (no re-fetching)."
+            echo
+            echo "- **${{ steps.metadata.outputs.changed }}** cache entries added/updated this run"
+            echo "- **${{ steps.metadata.outputs.total }}** references cached total"
+            echo
+            echo "Cache data only — no functional review needed; merge when convenient."
+            echo "(Raw fetched PDFs in \`publications/files/\` are gitignored.)"
+          } > "$PR_BODY"
+
+          EXISTING_PR_NUMBER="$(gh pr list \
+            --repo "$GITHUB_REPOSITORY" \
+            --head "$BRANCH_NAME" \
+            --state open \
+            --json number \
+            --limit 1 \
+            --jq '.[0].number // empty')"
+
+          if [ -n "$EXISTING_PR_NUMBER" ]; then
+            gh api \
+              --method PATCH \
+              "repos/$GITHUB_REPOSITORY/pulls/$EXISTING_PR_NUMBER" \
+              -f body="$(cat "$PR_BODY")" \
+              >/dev/null
+            echo "Updated existing warm-cache PR #$EXISTING_PR_NUMBER."
+            exit 0
+          fi
+
+          gh pr create \
+            --repo "$GITHUB_REPOSITORY" \
+            --base main \
+            --head "$BRANCH_NAME" \
+            --title "Warm reference cache" \
+            --body-file "$PR_BODY"
+
+          echo "Created warm-cache PR."

--- a/project.justfile
+++ b/project.justfile
@@ -424,6 +424,12 @@ validate-references-all:
         {{ref_validator}} validate data "$f" --schema {{schema_path}} --target-class GeneReview --config {{ref_validator_config}}
     done
 
+# Warm the reference cache (publications/) so validate-all stops re-fetching.
+# Fetches every referenced PMID/DOI (with full text) into the cache; commit the result.
+[group('QC')]
+warm-references:
+    uv run python scripts/warm_reference_cache.py
+
 validate-files files:
     uv run ai-gene-review validate {{files}}
 

--- a/scripts/warm_reference_cache.py
+++ b/scripts/warm_reference_cache.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python
+"""Warm the reference cache (publications/) so `just validate-all` stops
+re-fetching references on every run.
+
+`linkml-reference-validator` fetches each referenced PMID/DOI and caches it under
+publications/ as a side effect of validation. When a cached entry has no full text
+yet, the validator re-fetches it every run, which made the full validate-all
+reference phase network-bound (~59 min). Running the validator once over the whole
+corpus with full-text fetching on (the validator's default) populates the cache so
+subsequent runs are cache-bound.
+
+This processes the corpus in chunks for progress/resumability and ignores
+validation pass/fail — the goal here is only to populate the cache. References are
+read from the structured YAML fields (not a regex over prose), so no malformed
+cache filenames are produced. Raw fetched PDFs land in publications/files/, which
+is gitignored; the extracted text is written into each per-reference .md.
+
+Run from the repo root: `just warm-references` (or `uv run python
+scripts/warm_reference_cache.py`).
+"""
+
+import glob
+import subprocess
+import sys
+import time
+
+SCHEMA = "src/ai_gene_review/schema/gene_review.yaml"
+CONFIG = "conf/reference_validator_config.yaml"
+CHUNK = 100
+
+
+def main() -> int:
+    files = sorted(glob.glob("genes/*/*/*-ai-review.yaml"))
+    if not files:
+        print("no gene-review files found; run from the repo root", file=sys.stderr)
+        return 1
+
+    print(f"warming reference cache for {len(files)} gene files (chunks of {CHUNK})", flush=True)
+    t0 = time.time()
+    for i in range(0, len(files), CHUNK):
+        batch = files[i : i + CHUNK]
+        # check=False: validation failures (snippet mismatches, flaky fetches) are
+        # expected and irrelevant here; we only want the references fetched into the cache.
+        subprocess.run(
+            [
+                "uv", "run", "linkml-reference-validator", "validate", "data", *batch,
+                "--schema", SCHEMA, "--target-class", "GeneReview", "--config", CONFIG,
+            ],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            check=False,
+        )
+        done = i + len(batch)
+        elapsed = time.time() - t0
+        eta = elapsed / done * (len(files) - done)
+        print(f"  warmed {done}/{len(files)}  elapsed={elapsed / 60:.1f}m  eta={eta / 60:.1f}m", flush=True)
+
+    print(f"reference cache warm complete in {(time.time() - t0) / 60:.1f}m", flush=True)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Why

The warmed reference cache (PR #1527) keeps the full `validate-all` reference phase fast only as long as it stays complete. As genes/references are added, new entries go uncached and `validate-all` re-fetches them. This workflow keeps the cache continuously complete.

## What

- **`scripts/warm_reference_cache.py`** — runs `linkml-reference-validator validate data` over the whole corpus in chunks with full-text fetching on (the validator's default). References are read from the structured YAML fields (not a prose regex), so it cannot produce the malformed `PMID_123).md` junk the earlier ad-hoc warm did. Validation pass/fail is ignored — the goal is only to populate `publications/`.
- **`just warm-references`** — recipe wrapping the script.
- **`.github/workflows/warm-reference-cache.yaml`** — runs weekly (Mon 04:00 UTC) + `workflow_dispatch`. Warms, then **skips if the cache is unchanged**; otherwise commits `publications/` and opens/updates a single PR (`auto/warm-reference-cache`), mirroring `generate-pages`'s token/bot/force-push/PR pattern. Raw fetched PDFs (`publications/files/`) are gitignored.

## Behavior

On a complete cache the warm is a **clean no-op** (verified locally: re-running the validator over already-cached genes makes zero tracked changes), so most weeks produce no PR. Only genuinely new/incomplete references trigger a cache-update PR — which needs no real review (cache data) and can be merged at leisure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)