### PR TITLE
TEST (do not merge): schema error — invalid ActionEnum

### DIFF
--- a/genes/human/CFAP300/CFAP300-ai-review.yaml
+++ b/genes/human/CFAP300/CFAP300-ai-review.yaml
@@ -26,7 +26,7 @@ existing_annotations:
       preassembly. This is supported by multiple lines of evidence including immunofluorescence
       studies showing cytoplasmic localization in human airway epithelial cells [PMID:29727692,
       PMID:29727693] and model organism studies in Paramecium and Chlamydomonas [PMID:29727692].
-    action: ACCEPT
+    action: NOT_A_REAL_ACTION
     reason: >-
       Cytoplasmic localization is a core aspect of CFAP300 function, as the protein participates
       in the cytoplasmic preassembly of dynein arm complexes before their IFT-dependent transport


### PR DESCRIPTION
CI guard test: `action: ACCEPT` → `action: NOT_A_REAL_ACTION` in CFAP300. Expect the scoped validation (linkml-validate) to FAIL. Will be closed once confirmed.