### PR TITLE
TEST (do not merge): term error — wrong dynamic-enum branch

### DIFF
--- a/genes/human/CFAP300/CFAP300-ai-review.yaml
+++ b/genes/human/CFAP300/CFAP300-ai-review.yaml
@@ -312,8 +312,8 @@ references:
 
 core_functions:
 - molecular_function:
-    id: GO:0070840
-    label: dynein complex binding
+    id: GO:0005737
+    label: cytoplasm
   description: >-
     CFAP300 is a dynein axonemal assembly factor (DNAAF) required for the cytoplasmic
     preassembly and intraflagellar transport (IFT)-dependent trafficking of both outer


### PR DESCRIPTION
CI guard test: core_functions `molecular_function` set to GO:0005737 (cytoplasm, a cellular_component → not in GOMolecularActivityEnum). Expect scoped term validation to FAIL with ❌ ERROR. Closed once confirmed.