### PR TITLE
TEST (do not merge): reference error — fabricated supporting_text

### DIFF
--- a/genes/human/CFAP300/CFAP300-ai-review.yaml
+++ b/genes/human/CFAP300/CFAP300-ai-review.yaml
@@ -35,7 +35,7 @@ existing_annotations:
     supported_by:
     - reference_id: PMID:29727692
       supporting_text: >-
-        Tagged C11orf70 in Paramecium and Chlamydomonas localizes mainly in the cytoplasm with a small amount in the ciliary component.
+        CFAP300 directly phosphorylates beta-tubulin at serine 172 to trigger calcium-dependent reversal of the flagellar waveform.
     - reference_id: PMID:29727693
       supporting_text: >-
         C11orf70 is involved in cytoplasmic assembly of dynein arms.


### PR DESCRIPTION
CI guard test: a PMID:29727692 `supporting_text` replaced with a fabricated quote absent from the cached paper. Expect scoped reference validation to FAIL (text not found as substring). Closed once confirmed.