### PR TITLE
TEST (do not merge): strict-YAML error — duplicate key

### DIFF
--- a/genes/human/CFAP300/CFAP300-ai-review.yaml
+++ b/genes/human/CFAP300/CFAP300-ai-review.yaml
@@ -1,5 +1,6 @@
 id: Q9BRQ4
 gene_symbol: CFAP300
+gene_symbol: CFAP300
 product_type: PROTEIN
 taxon:
   id: NCBITaxon:9606


### PR DESCRIPTION
CI guard test: duplicated top-level `gene_symbol` key in CFAP300. PyYAML (the scoped validators) silently keeps the last value, but the `Run test suite` step's `test_gene_yaml_strict` uses ruamel and should FAIL with DuplicateKeyError. Closed once confirmed.