### PR TITLE
Document term-id validation policy + reference auto-checks

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -179,6 +179,24 @@ Therefore:
   **cached abstract explicitly states it** (e.g. "in nontransformed mammalian cells"). Do
   not infer the organism or assay details that the abstract does not state.
 
+### Term-id validation: GOA ids are trusted, your `core_functions` ids are checked
+
+Validation deliberately treats the two sources of GO term ids differently:
+
+- **`existing_annotations[].term.id` is NOT hard-validated.** These ids come from GOA, not
+  from you, so there is no hallucination risk — and GOA legitimately lags or leads the
+  ontology version used for validation. `linkml-term-validator` therefore does **not**
+  reject unresolvable or obsolete ids here (e.g. a non-existent `GO:9999999` passes); label
+  correctness is instead checked against GOA in the best-practices rules. **Do not rewrite
+  an existing-annotation id just to satisfy validation.**
+- **`core_functions` term ids ARE strictly validated.** These you author, so the
+  `molecular_function`, `contributes_to_molecular_function`, `locations`, and `in_complex`
+  slots are bound to dynamic enums (branch-reachability). A wrong-branch term — e.g. a
+  cellular-component term placed in `molecular_function` — is a blocking `❌ ERROR`.
+
+Rule of thumb: machine-sourced ids are trusted (other deterministic steps guarantee they
+are real GOA terms); author-supplied ids are checked hard.
+
 ## Reviewing references
 
 Entries in the top-level `references:` list can carry an optional `reference_review` object recording
@@ -186,6 +204,14 @@ your **manual** assessment of each reference. The `id` and `title` are machine-f
 from the cached `publications/PMID_xxxx.md`); `reference_review` is reviewer-supplied judgment. Use it
 especially to flag citation problems that format validation cannot catch (e.g. a well-formed PMID that
 points to the wrong paper).
+
+The reference validator already catches the *mechanical* citation failures automatically: it
+verifies each cited reference's `title` matches the fetched record (a transposed/wrong PMID whose
+title no longer matches fails) and that every `supporting_text` is a **verbatim substring** of the
+cached publication (a quote from the wrong paper, or a paraphrased/invented quote, fails).
+`reference_review` is for what those checks *cannot* see — chiefly whether an internally-consistent
+citation actually **supports** the claim, or whether a well-formed id+title points to a paper that is
+simply the wrong choice for this gene.
 
 ```yaml
 references:

--- a/src/ai_gene_review/schema/gene_review.yaml
+++ b/src/ai_gene_review/schema/gene_review.yaml
@@ -976,6 +976,12 @@ classes:
     # As a consequence, linkml-term-validator does not check term IDs or
     # labels in existing_annotations.  Label correctness is instead
     # covered by the GOA comparison in check_best_practices_rules().
+    # These IDs are machine-sourced from GOA (not author-supplied), so there is
+    # no hallucination risk in leaving them unbound.  By contrast, the
+    # author-supplied term IDs in core_functions ARE bound to dynamic enums
+    # (GOMolecularActivityEnum / GOCellularLocationEnum /
+    # GOProteinContainingComplexEnum, ...) and a wrong-branch term there is a
+    # blocking validation error.
 
   Review:
     description: A review of an existing annotation.


### PR DESCRIPTION
## Why

While building deliberate-error test PRs, a non-existent GO id (`GO:9999999`) in `existing_annotations` *passed* term validation. That's **intentional**, but undocumented — so it reads like a gap. This documents the policy.

## What

- **CLAUDE.md** — new "Term-id validation" subsection:
  - `existing_annotations[].term.id` is GOA-sourced (not agent-authored), so it is **not** hard-validated: GOA legitimately lags/leads the validation ontology, and there's no hallucination risk for machine-sourced ids. Unresolvable/obsolete ids pass; label correctness is checked against GOA in best-practices rules.
  - `core_functions` term ids **are** strictly validated (dynamic-enum branch-reachability) — a wrong-branch term is a blocking `❌ ERROR`.
  - Plus a note in "Reviewing references" on what reference validation already catches automatically (title mismatch + verbatim-substring `supporting_text`) vs what `reference_review` is for (relevance / wrong-paper-for-claim).
- **gene_review.yaml** — expands the existing comment on the unbound `existing_annotation` `term.id` to state the rationale and contrast it with the strictly-bound `core_functions` ids.

## Backing evidence (adversarial tests, all run against the real validator)

| Vector | Caught? |
|--------|---------|
| Non-existent GO id in `existing_annotations` | No — **by design** (GOA-sourced) |
| Wrong-branch term in `core_functions.molecular_function` | Yes — `❌ ERROR` dynamic enum |
| Misattributed *real* quote (right gene, wrong paper) | Yes — snippet not in cited paper |
| Paraphrased/invented `supporting_text` | Yes — verbatim substring required |
| Wrong PMID via title mismatch | Yes — title compared to cached record |

Docs only (CLAUDE.md + schema comment); no behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)