### PR TITLE
Add methionine cycle module and regulatory notation tools

### DIFF
--- a/models/methionine/README.md
+++ b/models/methionine/README.md
@@ -1,0 +1,47 @@
+# Methionine cycle — 3rd-party model ingest
+
+Source files and the reviewed bridge for ingesting the **biosustain Maud** methionine
+kinetic model as a regulatory-evidence source for `modules/methionine_cycle.yaml`.
+
+The Maud model is treated as **evidence, not truth**: its `[[allostery]]` and
+`[[competitive_inhibition]]` tables are parsed into canonical regulatory edges,
+mediated by a reviewed id-mapping, and compared against the curated module. Nothing
+is merged automatically.
+
+## Files
+
+- `methionine_cycle.regulation.toml` — the regulation-relevant sections (enzymes,
+  enzyme↔reaction, allostery, competitive inhibition) transcribed from the upstream
+  Maud model `data/methionine/methionine_cycle.toml`
+  (<https://github.com/biosustain/Methionine_model>). Stoichiometry, kinetics, and
+  priors are omitted.
+- `maud_methionine_mapping.yaml` — reviewed mapping from Maud ids to curated module
+  symbols. This is curation knowledge (e.g. MAT1/MAT3 are distinct isozymes, while the
+  trailing `1` in GNMT1/MTHFR1 is just an instance suffix), not something a lexical
+  heuristic can infer.
+
+## Usage
+
+Diff the curated module against the source regulation:
+
+```bash
+ai-gene-review compare-module-regulation \
+  modules/methionine_cycle.yaml \
+  models/methionine/methionine_cycle.regulation.toml \
+  -m models/methionine/maud_methionine_mapping.yaml
+```
+
+Add `--emit-candidates` to print the source edges as candidate module `connections`
+(SBO-grounded, with provenance) for review. The same command works against the full
+upstream TOML if you fetch it:
+
+```bash
+curl -sSL https://raw.githubusercontent.com/biosustain/Methionine_model/main/data/methionine/methionine_cycle.toml \
+  -o /tmp/methionine_cycle.toml
+ai-gene-review compare-module-regulation modules/methionine_cycle.yaml /tmp/methionine_cycle.toml \
+  -m models/methionine/maud_methionine_mapping.yaml
+```
+
+The curated module was transcribed from this source, so the diff currently reports
+**full agreement** (10/10 regulatory edges) — a round-trip validation that the
+curation faithfully captured the model's regulatory wiring.

--- a/models/methionine/maud_methionine_mapping.yaml
+++ b/models/methionine/maud_methionine_mapping.yaml
@@ -1,0 +1,23 @@
+# Reviewed id-bridge from the biosustain Maud methionine model to the curated
+# modules/methionine_cycle.yaml symbols. This mapping is curation knowledge: it is
+# authored/reviewed, not inferred, because purely lexical normalisation cannot tell
+# that MAT1/MAT3 are distinct isozymes (digit is meaningful) while the trailing "1"
+# in GNMT1/MTHFR1/CBS1 is just an instance suffix (single enzyme).
+#
+# Used by: ai-gene-review compare-module-regulation
+source: https://github.com/biosustain/Methionine_model
+enzymes:
+  MAT1: mat1
+  MAT3: mat3
+  METH-Gen: meth
+  GNMT1: gnmt
+  AHC1: ahc
+  MS1: ms
+  BHMT1: bhmt
+  CBS1: cbs
+  MTHFR1: mthfr
+metabolites:
+  amet: amet
+  ahcys: ahcys
+  mlthf: mlthf
+  met-L: met

--- a/models/methionine/methionine_cycle.regulation.toml
+++ b/models/methionine/methionine_cycle.regulation.toml
@@ -1,0 +1,139 @@
+# Methionine cycle regulatory structure — EXCERPT (regulation-relevant sections only).
+#
+# Provenance: the factual regulation wiring transcribed from the biosustain Maud
+# kinetic model  data/methionine/methionine_cycle.toml
+#   https://github.com/biosustain/Methionine_model
+#
+# Only the [[enzyme]], [[enzyme_reaction]], [[allostery]] and
+# [[competitive_inhibition]] sections are reproduced (the regulatory facts), so this
+# file can serve as a parser fixture / ingest source. Reaction stoichiometry, kinetic
+# mechanisms, and Bayesian priors from the full model are intentionally omitted.
+
+[[enzyme]]
+id = "MAT1"
+name = "Methionine adenosyltransferase 1"
+subunits = 1
+
+[[enzyme]]
+id = "MAT3"
+name = "Methionine adenosyltransferase 3"
+subunits = 2
+
+[[enzyme]]
+id = "METH-Gen"
+name = "Generic methylase"
+subunits = 1
+
+[[enzyme]]
+id = "GNMT1"
+name = "Glycine N-methyltransferase"
+subunits = 4
+
+[[enzyme]]
+id = "AHC1"
+name = "S-adenosylhomocysteine hydrolase 1"
+subunits = 1
+
+[[enzyme]]
+id = "MS1"
+name = "Methionine Synthase 1"
+subunits = 1
+
+[[enzyme]]
+id = "BHMT1"
+name = "Betaine-homocysteine methyltransferase"
+subunits = 1
+
+[[enzyme]]
+id = "CBS1"
+name = "Cystathionine beta synthase"
+subunits = 2
+
+[[enzyme]]
+id = "MTHFR1"
+name = "Methylenetetrahydrofolate reductase"
+subunits = 2
+
+[[enzyme_reaction]]
+enzyme_id = "MAT1"
+reaction_id = "METAT"
+
+[[enzyme_reaction]]
+enzyme_id = "MAT3"
+reaction_id = "METAT"
+
+[[enzyme_reaction]]
+enzyme_id = "METH-Gen"
+reaction_id = "METH"
+
+[[enzyme_reaction]]
+enzyme_id = "GNMT1"
+reaction_id = "GNMT"
+
+[[enzyme_reaction]]
+enzyme_id = "CBS1"
+reaction_id = "CBS"
+
+[[enzyme_reaction]]
+enzyme_id = "MTHFR1"
+reaction_id = "MTHFR"
+
+[[allostery]]
+enzyme_id = "MAT3"
+metabolite_id = "amet"
+compartment_id = "c"
+modification_type = "activation"
+
+[[allostery]]
+enzyme_id = "MAT3"
+metabolite_id = "met-L"
+compartment_id = "c"
+modification_type = "activation"
+
+[[allostery]]
+enzyme_id = "GNMT1"
+metabolite_id = "amet"
+compartment_id = "c"
+modification_type = "activation"
+
+[[allostery]]
+enzyme_id = "GNMT1"
+metabolite_id = "mlthf"
+compartment_id = "c"
+modification_type = "inhibition"
+
+[[allostery]]
+enzyme_id = "CBS1"
+metabolite_id = "amet"
+compartment_id = "c"
+modification_type = "activation"
+
+[[allostery]]
+enzyme_id = "MTHFR1"
+metabolite_id = "amet"
+compartment_id = "c"
+modification_type = "inhibition"
+
+[[allostery]]
+enzyme_id = "MTHFR1"
+metabolite_id = "ahcys"
+compartment_id = "c"
+modification_type = "activation"
+
+[[competitive_inhibition]]
+enzyme_id = "MAT1"
+reaction_id = "METAT"
+metabolite_id = "amet"
+compartment_id = "c"
+
+[[competitive_inhibition]]
+enzyme_id = "METH-Gen"
+reaction_id = "METH"
+metabolite_id = "ahcys"
+compartment_id = "c"
+
+[[competitive_inhibition]]
+enzyme_id = "GNMT1"
+reaction_id = "GNMT"
+metabolite_id = "ahcys"
+compartment_id = "c"

--- a/modules/methionine_cycle.yaml
+++ b/modules/methionine_cycle.yaml
@@ -1,0 +1,572 @@
+id: MODULE:methionine_cycle
+title: Methionine (S-adenosylmethionine) cycle module
+description: >-
+  A taxon-neutral decomposition of the methionine / S-adenosylmethionine (SAM)
+  cycle, the core methyl-group-cycling pathway that interconverts methionine,
+  S-adenosyl-L-methionine, S-adenosyl-L-homocysteine, and homocysteine, with
+  exits to transsulfuration (via cystathionine beta-synthase) and remethylation
+  inputs from folate (via methionine synthase) and choline/betaine (via BHMT).
+
+  This module is intentionally structured in two layers. The CATALYTIC layer
+  (enzymatic steps) grounds each step to a GO molecular-function term, the same
+  EC <-> GO MF alignment used by the gluconeogenesis module. The REGULATORY layer
+  is captured as connections of type POSITIVELY_REGULATES / NEGATIVELY_REGULATES
+  whose predicate is grounded to a Systems Biology Ontology (SBO) term that
+  distinguishes the MECHANISM (competitive vs allosteric), with the effector
+  represented as a ChEBI-grounded metabolite-pool node. This regulatory wiring
+  (small-molecule effector -> enzyme, with mechanism and sign) is information GO
+  cannot express: GO annotations attach to gene products, the effectors here are
+  metabolites, and GO has no competitive-vs-allosteric distinction.
+
+  The regulatory structure is transcribed from the biosustain Maud kinetic model
+  `data/methionine/methionine_cycle.toml`. A notable showcase is METAT, where two
+  isozyme forms of methionine adenosyltransferase catalyse the SAME reaction but
+  are OPPOSITELY regulated by SAM: MAT-I is competitively product-inhibited by
+  SAM, whereas MAT-III is allosterically activated by SAM. Isozyme-specific
+  regulation of this kind is the central thing GO flattens away.
+status: DRAFT
+evidence:
+  - source_id: GO:0033353
+    title: L-methionine cycle
+    statement: The module is grounded in the GO biological-process term for the methionine / S-adenosylmethionine cycle (exact synonym "S-adenosylmethionine cycle").
+  - source_id: file:modules/methionine_cycle.yaml
+    title: biosustain Methionine_model (Maud kinetic model)
+    statement: >-
+      Reaction set, isozymes, and the allosteric/competitive regulation wiring are
+      transcribed from the Maud model data/methionine/methionine_cycle.toml.
+    url: https://github.com/biosustain/Methionine_model/blob/main/data/methionine/methionine_cycle.toml
+module:
+  id: methionine_cycle
+  label: Methionine (SAM) cycle
+  module_type: METABOLIC_PATHWAY
+  concepts:
+    - preferred_term: methionine cycle
+      term:
+        id: GO:0033353
+        label: L-methionine cycle
+      description: >-
+        Cyclic interconversion of methionine, S-adenosyl-L-methionine,
+        S-adenosyl-L-homocysteine, and homocysteine, coupling methyl-donor supply
+        to folate one-carbon and transsulfuration metabolism.
+  parts:
+    - order: 1
+      role: SAM-forming step (methionine activation)
+      node:
+        id: metat_step
+        label: Methionine -> S-adenosyl-L-methionine
+        module_type: REACTION
+        description: >-
+          Methionine adenosyltransferase (EC 2.5.1.6) condenses methionine and
+          ATP to S-adenosyl-L-methionine (SAM), the universal methyl donor. The
+          isozyme forms differ in their feedback logic, so they are modelled as
+          variants to carry isozyme-specific regulation.
+        concepts:
+          - preferred_term: methionine adenosyltransferase reaction
+        variant_sets:
+          - id: mat_isozyme_form
+            label: Methionine adenosyltransferase isozyme/oligomeric forms
+            axis: isozyme / oligomeric form
+            selection: ONE_OR_MORE
+            variants:
+              - id: mat1_form
+                label: MAT-I (high-capacity hepatic form)
+                module_type: REACTION
+                annotons:
+                  - id: mat1_activity
+                    label: MAT-I methionine adenosyltransferase activity
+                    participant:
+                      selector_type: GENE_PRODUCT
+                      gene_product:
+                        preferred_term: MAT-I (MAT1A-encoded high-K_m hepatic isozyme)
+                        description: >-
+                          High-K_m hepatic methionine adenosyltransferase form. Subject
+                          to competitive product (SAM) inhibition in the kinetic model.
+                    function:
+                      preferred_term: methionine adenosyltransferase activity
+                      term:
+                        id: GO:0004478
+                        label: methionine adenosyltransferase activity
+                      substrates:
+                        - preferred_term: L-methionine
+                        - preferred_term: ATP
+                      products:
+                        - preferred_term: S-adenosyl-L-methionine
+                        - preferred_term: phosphate
+                        - preferred_term: diphosphate
+              - id: mat3_form
+                label: MAT-III (low-affinity hepatic form)
+                module_type: REACTION
+                annotons:
+                  - id: mat3_activity
+                    label: MAT-III methionine adenosyltransferase activity
+                    participant:
+                      selector_type: GENE_PRODUCT
+                      gene_product:
+                        preferred_term: MAT-III (MAT1A-encoded low-affinity hepatic isozyme)
+                        description: >-
+                          Low-affinity hepatic methionine adenosyltransferase form,
+                          allosterically activated by its own product SAM and by
+                          methionine (feed-forward), the opposite of MAT-I.
+                    function:
+                      preferred_term: methionine adenosyltransferase activity
+                      term:
+                        id: GO:0004478
+                        label: methionine adenosyltransferase activity
+                      substrates:
+                        - preferred_term: L-methionine
+                        - preferred_term: ATP
+                      products:
+                        - preferred_term: S-adenosyl-L-methionine
+                        - preferred_term: phosphate
+                        - preferred_term: diphosphate
+    - order: 2
+      role: bulk transmethylation (SAM-dependent methyltransferases)
+      node:
+        id: meth_step
+        label: SAM-dependent transmethylation (general)
+        module_type: REACTION
+        description: >-
+          Lumped node for the many SAM-dependent methyltransferases (EC 2.1.1.-)
+          that transfer SAM's methyl group to acceptors (DNA, protein, small
+          molecules), yielding S-adenosyl-L-homocysteine (SAH). Competitively
+          product-inhibited by SAH in the kinetic model.
+        annotons:
+          - id: meth_activity
+            label: SAM-dependent methyltransferase activity (general)
+            participant:
+              selector_type: ANY_WITH_FUNCTION
+              required_function:
+                preferred_term: methyltransferase activity
+                term:
+                  id: GO:0008168
+                  label: methyltransferase activity
+            function:
+              preferred_term: methyltransferase activity
+              term:
+                id: GO:0008168
+                label: methyltransferase activity
+              substrates:
+                - preferred_term: S-adenosyl-L-methionine
+                - preferred_term: methyl acceptor
+              products:
+                - preferred_term: S-adenosyl-L-homocysteine
+                - preferred_term: methylated acceptor
+    - order: 3
+      role: SAM disposal / glycine sink
+      node:
+        id: gnmt_step
+        label: Glycine N-methyltransferase (SAM:SAH buffering)
+        module_type: REACTION
+        description: >-
+          Glycine N-methyltransferase (EC 2.1.1.20) methylates glycine to
+          sarcosine, acting as the overflow valve that buffers the SAM:SAH ratio.
+          Allosterically inhibited by 5,10-methylenetetrahydrofolate and
+          competitively inhibited by SAH; activated by SAM.
+        annotons:
+          - id: gnmt_activity
+            label: Glycine N-methyltransferase activity
+            participant:
+              selector_type: ANY_WITH_FUNCTION
+              required_function:
+                preferred_term: glycine N-methyltransferase activity
+                term:
+                  id: GO:0017174
+                  label: glycine N-methyltransferase activity
+            function:
+              preferred_term: glycine N-methyltransferase activity
+              term:
+                id: GO:0017174
+                label: glycine N-methyltransferase activity
+              substrates:
+                - preferred_term: S-adenosyl-L-methionine
+                - preferred_term: glycine
+              products:
+                - preferred_term: S-adenosyl-L-homocysteine
+                - preferred_term: sarcosine
+    - order: 4
+      role: SAH hydrolysis
+      node:
+        id: ahc_step
+        label: S-adenosyl-L-homocysteine -> L-homocysteine
+        module_type: REACTION
+        description: >-
+          Adenosylhomocysteinase (EC 3.3.1.1) hydrolyses SAH to L-homocysteine
+          and adenosine, relieving SAH product inhibition of methyltransferases.
+        annotons:
+          - id: ahc_activity
+            label: Adenosylhomocysteinase activity
+            participant:
+              selector_type: ANY_WITH_FUNCTION
+              required_function:
+                preferred_term: adenosylhomocysteinase activity
+                term:
+                  id: GO:0004013
+                  label: adenosylhomocysteinase activity
+            function:
+              preferred_term: adenosylhomocysteinase activity
+              term:
+                id: GO:0004013
+                label: adenosylhomocysteinase activity
+              substrates:
+                - preferred_term: S-adenosyl-L-homocysteine
+              products:
+                - preferred_term: L-homocysteine
+                - preferred_term: adenosine
+    - order: 5
+      role: homocysteine fate (remethylation vs transsulfuration)
+      node:
+        id: homocysteine_fate
+        label: Homocysteine fate branch
+        module_type: REACTION
+        description: >-
+          Homocysteine is either remethylated back to methionine (folate-dependent
+          via methionine synthase, or betaine-dependent via BHMT) or committed to
+          transsulfuration via cystathionine beta-synthase.
+        variant_sets:
+          - id: homocysteine_fate_axis
+            label: Homocysteine disposal routes
+            axis: metabolic fate
+            selection: ONE_OR_MORE
+            variants:
+              - id: ms_route
+                label: Folate-dependent remethylation (methionine synthase)
+                module_type: REACTION
+                annotons:
+                  - id: ms_activity
+                    label: Methionine synthase activity
+                    participant:
+                      selector_type: ANY_WITH_FUNCTION
+                      required_function:
+                        preferred_term: methionine synthase activity
+                        term:
+                          id: GO:0008705
+                          label: methionine synthase activity
+                    function:
+                      preferred_term: methionine synthase activity
+                      term:
+                        id: GO:0008705
+                        label: methionine synthase activity
+                      substrates:
+                        - preferred_term: L-homocysteine
+                        - preferred_term: 5-methyltetrahydrofolate
+                      products:
+                        - preferred_term: L-methionine
+                        - preferred_term: tetrahydrofolate
+              - id: bhmt_route
+                label: Betaine-dependent remethylation (BHMT)
+                module_type: REACTION
+                annotons:
+                  - id: bhmt_activity
+                    label: Betaine-homocysteine S-methyltransferase activity
+                    participant:
+                      selector_type: ANY_WITH_FUNCTION
+                      required_function:
+                        preferred_term: betaine-homocysteine S-methyltransferase activity
+                        term:
+                          id: GO:0047150
+                          label: betaine-homocysteine S-methyltransferase activity
+                    function:
+                      preferred_term: betaine-homocysteine S-methyltransferase activity
+                      term:
+                        id: GO:0047150
+                        label: betaine-homocysteine S-methyltransferase activity
+                      substrates:
+                        - preferred_term: L-homocysteine
+                        - preferred_term: glycine betaine
+                      products:
+                        - preferred_term: L-methionine
+                        - preferred_term: N,N-dimethylglycine
+              - id: cbs_route
+                label: Transsulfuration commitment (cystathionine beta-synthase)
+                module_type: REACTION
+                description: Exit from the cycle toward cysteine biosynthesis; allosterically activated by SAM.
+                annotons:
+                  - id: cbs_activity
+                    label: Cystathionine beta-synthase activity
+                    participant:
+                      selector_type: ANY_WITH_FUNCTION
+                      required_function:
+                        preferred_term: cystathionine beta-synthase activity
+                        term:
+                          id: GO:0004122
+                          label: cystathionine beta-synthase activity
+                    function:
+                      preferred_term: cystathionine beta-synthase activity
+                      term:
+                        id: GO:0004122
+                        label: cystathionine beta-synthase activity
+                      substrates:
+                        - preferred_term: L-homocysteine
+                        - preferred_term: L-serine
+                      products:
+                        - preferred_term: L-cystathionine
+    - order: 6
+      role: folate methyl input arm
+      node:
+        id: mthfr_step
+        label: Methylenetetrahydrofolate reductase (5-methyl-THF supply)
+        module_type: REACTION
+        description: >-
+          Methylenetetrahydrofolate reductase (EC 1.5.1.20) reduces
+          5,10-methylenetetrahydrofolate to 5-methyltetrahydrofolate, the methyl
+          donor consumed by methionine synthase. Allosterically inhibited by SAM
+          and activated by SAH, coupling folate flux to methyl-group demand.
+        annotons:
+          - id: mthfr_activity
+            label: Methylenetetrahydrofolate reductase activity
+            participant:
+              selector_type: ANY_WITH_FUNCTION
+              required_function:
+                preferred_term: methylenetetrahydrofolate reductase [NAD(P)H] activity
+                term:
+                  id: GO:0004489
+                  label: methylenetetrahydrofolate reductase [NAD(P)H] activity
+            function:
+              preferred_term: methylenetetrahydrofolate reductase [NAD(P)H] activity
+              term:
+                id: GO:0004489
+                label: methylenetetrahydrofolate reductase [NAD(P)H] activity
+              substrates:
+                - preferred_term: 5,10-methylenetetrahydrofolate
+                - preferred_term: NAD(P)H
+              products:
+                - preferred_term: 5-methyltetrahydrofolate
+                - preferred_term: NAD(P)+
+    - order: 7
+      optional: true
+      role: regulatory effector pools (metabolite endpoints for regulation edges)
+      notes: >-
+        These nodes are NOT catalytic steps. They represent the small-molecule
+        effector pools that serve as the source endpoints of the regulatory
+        connections below. They are grounded to ChEBI rather than GO, because the
+        regulators are metabolites and cannot bear GO annotations.
+      node:
+        id: regulatory_effectors
+        label: Regulatory effector pools
+        module_type: MODULE
+        parts:
+          - role: methyl-donor effector
+            node:
+              id: amet_pool
+              label: S-adenosyl-L-methionine (SAM) pool
+              concepts:
+                - preferred_term: S-adenosyl-L-methionine
+                  term:
+                    id: CHEBI:15414
+                    label: S-adenosyl-L-methionine
+                  description: Master regulatory effector of the cycle; signals methyl-donor sufficiency.
+          - role: demethylated-donor effector
+            node:
+              id: ahcys_pool
+              label: S-adenosyl-L-homocysteine (SAH) pool
+              concepts:
+                - preferred_term: S-adenosyl-L-homocysteine
+                  term:
+                    id: CHEBI:16680
+                    label: S-adenosyl-L-homocysteine
+                  description: Pan-methyltransferase product inhibitor; signals methyl-donor depletion.
+          - role: folate effector
+            node:
+              id: mlthf_pool
+              label: 5,10-methylenetetrahydrofolate pool
+              concepts:
+                - preferred_term: 5,10-methylenetetrahydrofolate
+                  term:
+                    id: CHEBI:1989
+                    label: (6R)-5,10-methylenetetrahydrofolic acid
+                  description: Folate one-carbon node; allosteric inhibitor of GNMT in the model.
+          - role: amino-acid effector
+            node:
+              id: met_pool
+              label: L-methionine pool
+              concepts:
+                - preferred_term: L-methionine
+                  description: Substrate that feed-forward activates MAT-III.
+  connections:
+    # ---------------- Metabolic (flux) backbone ----------------
+    - source: mat1_activity
+      target: meth_step
+      connection_type: PROVIDES_INPUT_FOR
+      description: SAM produced by methionine adenosyltransferase is the methyl donor for transmethylation.
+    - source: mat3_activity
+      target: meth_step
+      connection_type: PROVIDES_INPUT_FOR
+      description: SAM produced by methionine adenosyltransferase is the methyl donor for transmethylation.
+    - source: metat_step
+      target: gnmt_step
+      connection_type: PROVIDES_INPUT_FOR
+      description: SAM is also consumed by glycine N-methyltransferase (overflow disposal).
+    - source: meth_step
+      target: ahc_step
+      connection_type: PROVIDES_INPUT_FOR
+      description: Transmethylation produces SAH, the substrate of adenosylhomocysteinase.
+    - source: gnmt_step
+      target: ahc_step
+      connection_type: PROVIDES_INPUT_FOR
+      description: GNMT produces SAH, the substrate of adenosylhomocysteinase.
+    - source: ahc_step
+      target: homocysteine_fate
+      connection_type: PROVIDES_INPUT_FOR
+      description: SAH hydrolysis yields homocysteine, the branch-point metabolite.
+    - source: ms_route
+      target: metat_step
+      connection_type: PROVIDES_INPUT_FOR
+      description: Folate-dependent remethylation regenerates methionine, closing the cycle.
+    - source: bhmt_route
+      target: metat_step
+      connection_type: PROVIDES_INPUT_FOR
+      description: Betaine-dependent remethylation regenerates methionine, closing the cycle.
+    - source: mthfr_step
+      target: ms_route
+      connection_type: PROVIDES_INPUT_FOR
+      description: MTHFR supplies 5-methyltetrahydrofolate consumed by methionine synthase.
+    # ---------------- Regulatory layer (the part GO cannot express) ----------------
+    # Allosteric regulation (SBO:0000636 activator / SBO:0000639 inhibitor)
+    - source: amet_pool
+      target: mat3_activity
+      connection_type: POSITIVELY_REGULATES
+      predicate:
+        preferred_term: allosteric activation
+        term:
+          id: SBO:0000636
+          label: allosteric activator
+      description: >-
+        SAM allosterically activates MAT-III (feed-forward). Contrast with MAT-I,
+        which SAM competitively inhibits - same reaction, opposite isozyme logic.
+      evidence:
+        - source_id: file:modules/methionine_cycle.yaml
+          title: Maud methionine_cycle.toml [allosteric]
+          statement: "MAT3 activated by amet (allosteric)."
+    - source: met_pool
+      target: mat3_activity
+      connection_type: POSITIVELY_REGULATES
+      predicate:
+        preferred_term: allosteric activation
+        term:
+          id: SBO:0000636
+          label: allosteric activator
+      description: Methionine feed-forward activates MAT-III.
+      evidence:
+        - source_id: file:modules/methionine_cycle.yaml
+          title: Maud methionine_cycle.toml [allosteric]
+          statement: "MAT3 activated by met-L (allosteric)."
+    - source: amet_pool
+      target: gnmt_activity
+      connection_type: POSITIVELY_REGULATES
+      predicate:
+        preferred_term: allosteric activation
+        term:
+          id: SBO:0000636
+          label: allosteric activator
+      description: SAM allosterically activates GNMT, opening the SAM overflow valve when methyl donor is in excess.
+      evidence:
+        - source_id: file:modules/methionine_cycle.yaml
+          title: Maud methionine_cycle.toml [allosteric]
+          statement: "GNMT1 activated by amet (allosteric)."
+    - source: mlthf_pool
+      target: gnmt_activity
+      connection_type: NEGATIVELY_REGULATES
+      predicate:
+        preferred_term: allosteric inhibition
+        term:
+          id: SBO:0000639
+          label: allosteric inhibitor
+      description: 5,10-methylenetetrahydrofolate allosterically inhibits GNMT, linking folate status to SAM disposal.
+      evidence:
+        - source_id: file:modules/methionine_cycle.yaml
+          title: Maud methionine_cycle.toml [allosteric]
+          statement: "GNMT1 inhibited by mlthf (allosteric)."
+    - source: amet_pool
+      target: cbs_activity
+      connection_type: POSITIVELY_REGULATES
+      predicate:
+        preferred_term: allosteric activation
+        term:
+          id: SBO:0000636
+          label: allosteric activator
+      description: SAM allosterically activates CBS, diverting homocysteine to transsulfuration when methyl donor is abundant.
+      evidence:
+        - source_id: file:modules/methionine_cycle.yaml
+          title: Maud methionine_cycle.toml [allosteric]
+          statement: "CBS1 activated by amet (allosteric)."
+    - source: amet_pool
+      target: mthfr_activity
+      connection_type: NEGATIVELY_REGULATES
+      predicate:
+        preferred_term: allosteric inhibition
+        term:
+          id: SBO:0000639
+          label: allosteric inhibitor
+      description: SAM allosterically inhibits MTHFR, throttling folate-dependent remethylation when SAM is high.
+      evidence:
+        - source_id: file:modules/methionine_cycle.yaml
+          title: Maud methionine_cycle.toml [allosteric]
+          statement: "MTHFR1 inhibited by amet (allosteric)."
+    - source: ahcys_pool
+      target: mthfr_activity
+      connection_type: POSITIVELY_REGULATES
+      predicate:
+        preferred_term: allosteric activation
+        term:
+          id: SBO:0000636
+          label: allosteric activator
+      description: SAH allosterically activates MTHFR, restoring remethylation flux when the methylation index falls.
+      evidence:
+        - source_id: file:modules/methionine_cycle.yaml
+          title: Maud methionine_cycle.toml [allosteric]
+          statement: "MTHFR1 activated by ahcys (allosteric)."
+    # Competitive inhibition (SBO:0000206)
+    - source: amet_pool
+      target: mat1_activity
+      connection_type: NEGATIVELY_REGULATES
+      predicate:
+        preferred_term: competitive inhibition
+        term:
+          id: SBO:0000206
+          label: competitive inhibitor
+      description: SAM competitively (product-feedback) inhibits MAT-I - opposite sign to its allosteric activation of MAT-III.
+      evidence:
+        - source_id: file:modules/methionine_cycle.yaml
+          title: Maud methionine_cycle.toml [competitive_inhibition]
+          statement: "MAT1 (reaction METAT) competitively inhibited by amet."
+    - source: ahcys_pool
+      target: meth_activity
+      connection_type: NEGATIVELY_REGULATES
+      predicate:
+        preferred_term: competitive inhibition
+        term:
+          id: SBO:0000206
+          label: competitive inhibitor
+      description: SAH competitively inhibits bulk transmethylation (classic product inhibition / methylation index).
+      evidence:
+        - source_id: file:modules/methionine_cycle.yaml
+          title: Maud methionine_cycle.toml [competitive_inhibition]
+          statement: "METH-Gen (reaction METH) competitively inhibited by ahcys."
+    - source: ahcys_pool
+      target: gnmt_activity
+      connection_type: NEGATIVELY_REGULATES
+      predicate:
+        preferred_term: competitive inhibition
+        term:
+          id: SBO:0000206
+          label: competitive inhibitor
+      description: SAH competitively inhibits GNMT.
+      evidence:
+        - source_id: file:modules/methionine_cycle.yaml
+          title: Maud methionine_cycle.toml [competitive_inhibition]
+          statement: "GNMT1 (reaction GNMT) competitively inhibited by ahcys."
+  notes: >-
+    Layering: catalytic steps ground to GO molecular-function terms (GO:0004478,
+    GO:0008168, GO:0017174, GO:0004013, GO:0008705, GO:0047150, GO:0004122,
+    GO:0004489); the pathway grounds to GO:0033353. The regulatory layer is
+    deliberately NOT expressed in GO. Each regulatory edge is a connection typed
+    POSITIVELY/NEGATIVELY_REGULATES whose predicate is grounded to SBO so the
+    competitive-vs-allosteric MECHANISM is explicit (SBO:0000206 competitive
+    inhibitor, SBO:0000636 allosteric activator, SBO:0000639 allosteric
+    inhibitor), with the effector grounded to ChEBI. This is the information that
+    falls outside GO scope: a metabolite cannot bear a GO annotation, and GO has
+    no representation of inhibition mechanism. The MAT-I vs MAT-III split (same
+    GO MF GO:0004478, opposite SAM regulation) is the canonical illustration.
+    Quantitative kinetics (K_m, k_cat, K_i, Hill/MWC parameters) from the Maud
+    model are intentionally out of scope for this module and belong with the
+    model / SABIO-RK-style resources.

--- a/modules/methionine_cycle.yaml
+++ b/modules/methionine_cycle.yaml
@@ -29,7 +29,7 @@ evidence:
   - source_id: GO:0033353
     title: L-methionine cycle
     statement: The module is grounded in the GO biological-process term for the methionine / S-adenosylmethionine cycle (exact synonym "S-adenosylmethionine cycle").
-  - source_id: file:modules/methionine_cycle.yaml
+  - source_id: file:models/methionine/methionine_cycle.regulation.toml
     title: biosustain Methionine_model (Maud kinetic model)
     statement: >-
       Reaction set, isozymes, and the allosteric/competitive regulation wiring are
@@ -381,6 +381,9 @@ module:
               label: L-methionine pool
               concepts:
                 - preferred_term: L-methionine
+                  term:
+                    id: CHEBI:16643
+                    label: L-methionine
                   description: Substrate that feed-forward activates MAT-III.
   connections:
     # ---------------- Metabolic (flux) backbone ----------------
@@ -392,7 +395,11 @@ module:
       target: meth_step
       connection_type: PROVIDES_INPUT_FOR
       description: SAM produced by methionine adenosyltransferase is the methyl donor for transmethylation.
-    - source: metat_step
+    - source: mat1_activity
+      target: gnmt_step
+      connection_type: PROVIDES_INPUT_FOR
+      description: SAM is also consumed by glycine N-methyltransferase (overflow disposal).
+    - source: mat3_activity
       target: gnmt_step
       connection_type: PROVIDES_INPUT_FOR
       description: SAM is also consumed by glycine N-methyltransferase (overflow disposal).
@@ -434,7 +441,7 @@ module:
         SAM allosterically activates MAT-III (feed-forward). Contrast with MAT-I,
         which SAM competitively inhibits - same reaction, opposite isozyme logic.
       evidence:
-        - source_id: file:modules/methionine_cycle.yaml
+        - source_id: file:models/methionine/methionine_cycle.regulation.toml
           title: Maud methionine_cycle.toml [allosteric]
           statement: "MAT3 activated by amet (allosteric)."
     - source: met_pool
@@ -447,7 +454,7 @@ module:
           label: allosteric activator
       description: Methionine feed-forward activates MAT-III.
       evidence:
-        - source_id: file:modules/methionine_cycle.yaml
+        - source_id: file:models/methionine/methionine_cycle.regulation.toml
           title: Maud methionine_cycle.toml [allosteric]
           statement: "MAT3 activated by met-L (allosteric)."
     - source: amet_pool
@@ -460,7 +467,7 @@ module:
           label: allosteric activator
       description: SAM allosterically activates GNMT, opening the SAM overflow valve when methyl donor is in excess.
       evidence:
-        - source_id: file:modules/methionine_cycle.yaml
+        - source_id: file:models/methionine/methionine_cycle.regulation.toml
           title: Maud methionine_cycle.toml [allosteric]
           statement: "GNMT1 activated by amet (allosteric)."
     - source: mlthf_pool
@@ -473,7 +480,7 @@ module:
           label: allosteric inhibitor
       description: 5,10-methylenetetrahydrofolate allosterically inhibits GNMT, linking folate status to SAM disposal.
       evidence:
-        - source_id: file:modules/methionine_cycle.yaml
+        - source_id: file:models/methionine/methionine_cycle.regulation.toml
           title: Maud methionine_cycle.toml [allosteric]
           statement: "GNMT1 inhibited by mlthf (allosteric)."
     - source: amet_pool
@@ -486,7 +493,7 @@ module:
           label: allosteric activator
       description: SAM allosterically activates CBS, diverting homocysteine to transsulfuration when methyl donor is abundant.
       evidence:
-        - source_id: file:modules/methionine_cycle.yaml
+        - source_id: file:models/methionine/methionine_cycle.regulation.toml
           title: Maud methionine_cycle.toml [allosteric]
           statement: "CBS1 activated by amet (allosteric)."
     - source: amet_pool
@@ -499,7 +506,7 @@ module:
           label: allosteric inhibitor
       description: SAM allosterically inhibits MTHFR, throttling folate-dependent remethylation when SAM is high.
       evidence:
-        - source_id: file:modules/methionine_cycle.yaml
+        - source_id: file:models/methionine/methionine_cycle.regulation.toml
           title: Maud methionine_cycle.toml [allosteric]
           statement: "MTHFR1 inhibited by amet (allosteric)."
     - source: ahcys_pool
@@ -512,7 +519,7 @@ module:
           label: allosteric activator
       description: SAH allosterically activates MTHFR, restoring remethylation flux when the methylation index falls.
       evidence:
-        - source_id: file:modules/methionine_cycle.yaml
+        - source_id: file:models/methionine/methionine_cycle.regulation.toml
           title: Maud methionine_cycle.toml [allosteric]
           statement: "MTHFR1 activated by ahcys (allosteric)."
     # Competitive inhibition (SBO:0000206)
@@ -526,7 +533,7 @@ module:
           label: competitive inhibitor
       description: SAM competitively (product-feedback) inhibits MAT-I - opposite sign to its allosteric activation of MAT-III.
       evidence:
-        - source_id: file:modules/methionine_cycle.yaml
+        - source_id: file:models/methionine/methionine_cycle.regulation.toml
           title: Maud methionine_cycle.toml [competitive_inhibition]
           statement: "MAT1 (reaction METAT) competitively inhibited by amet."
     - source: ahcys_pool
@@ -539,7 +546,7 @@ module:
           label: competitive inhibitor
       description: SAH competitively inhibits bulk transmethylation (classic product inhibition / methylation index).
       evidence:
-        - source_id: file:modules/methionine_cycle.yaml
+        - source_id: file:models/methionine/methionine_cycle.regulation.toml
           title: Maud methionine_cycle.toml [competitive_inhibition]
           statement: "METH-Gen (reaction METH) competitively inhibited by ahcys."
     - source: ahcys_pool
@@ -552,7 +559,7 @@ module:
           label: competitive inhibitor
       description: SAH competitively inhibits GNMT.
       evidence:
-        - source_id: file:modules/methionine_cycle.yaml
+        - source_id: file:models/methionine/methionine_cycle.regulation.toml
           title: Maud methionine_cycle.toml [competitive_inhibition]
           statement: "GNMT1 (reaction GNMT) competitively inhibited by ahcys."
   notes: >-

--- a/src/ai_gene_review/cli.py
+++ b/src/ai_gene_review/cli.py
@@ -3012,6 +3012,68 @@ def render_modules(
 
 
 @app.command()
+def render_module_notation(
+    files: Annotated[
+        Optional[List[Path]],
+        typer.Argument(help="Module YAML file(s) to project into compact notation"),
+    ] = None,
+    output_dir: Annotated[
+        Optional[Path],
+        typer.Option(
+            "--output-dir",
+            "-o",
+            help="Write <stem>-notation.txt per module here; if omitted, print to stdout",
+        ),
+    ] = None,
+    modules_dir: Annotated[
+        Path,
+        typer.Option("--modules-dir", "-m", help="Directory containing module YAML files"),
+    ] = Path("modules"),
+    all_modules: Annotated[
+        bool,
+        typer.Option("--all", "-a", help="Project all module YAML files in modules/"),
+    ] = False,
+):
+    """Project module YAML into a compact, human-readable symbol notation.
+
+    This is a read-only view of the canonical YAML: a legend mapping short symbols
+    to grounded entities (GO/ChEBI), a reactions block, and a regulation block in
+    which the arrow encodes sign (-o activation, -| inhibition) and the bracketed
+    tag encodes the SBO-grounded mechanism (competitive vs allosteric).
+
+    Examples:
+        # Print one module's notation to stdout
+        ai-gene-review render-module-notation modules/methionine_cycle.yaml
+
+        # Write notation files for every module
+        ai-gene-review render-module-notation --all -o pages/modules
+    """
+    from ai_gene_review.module_notation import render_module_notation_file
+    from ai_gene_review.render_modules import iter_module_files
+
+    if all_modules:
+        targets = iter_module_files(modules_dir)
+    elif files:
+        targets = list(files)
+    else:
+        typer.echo("Please specify file(s) or use --all", err=True)
+        raise typer.Exit(code=1)
+
+    for module_file in targets:
+        if not module_file.exists():
+            typer.echo(f"Error: File not found: {module_file}", err=True)
+            continue
+        notation = render_module_notation_file(module_file)
+        if output_dir is None:
+            typer.echo(notation)
+        else:
+            output_dir.mkdir(parents=True, exist_ok=True)
+            out_path = output_dir / f"{module_file.stem}-notation.txt"
+            out_path.write_text(notation)
+            typer.echo(f"Wrote {module_file} -> {out_path}")
+
+
+@app.command()
 def fetch_descriptions(
     organism: Annotated[
         str, typer.Argument(help="Organism name (e.g., human, yeast)")

--- a/src/ai_gene_review/cli.py
+++ b/src/ai_gene_review/cli.py
@@ -3074,6 +3074,65 @@ def render_module_notation(
 
 
 @app.command()
+def compare_module_regulation(
+    module_file: Annotated[
+        Path, typer.Argument(help="Curated module YAML (e.g. modules/methionine_cycle.yaml)")
+    ],
+    maud_toml: Annotated[
+        Path, typer.Argument(help="Maud model TOML to ingest as a regulatory source")
+    ],
+    mapping: Annotated[
+        Optional[Path],
+        typer.Option("--mapping", "-m", help="Reviewed id-mapping (source ids -> module symbols)"),
+    ] = None,
+    emit_candidates: Annotated[
+        bool,
+        typer.Option(
+            "--emit-candidates",
+            help="Also print source edges as candidate module connections (YAML)",
+        ),
+    ] = False,
+):
+    """Diff a curated module's regulation against a Maud model's regulatory tables.
+
+    Reduces both sides to canonical (effector, enzyme, sign, mechanism) edges and
+    reports agreements, missing/extra edges, and sign/mechanism conflicts. The Maud
+    source is treated as evidence (mediated by the reviewed --mapping), not merged.
+
+    Example:
+        ai-gene-review compare-module-regulation \\
+            modules/methionine_cycle.yaml \\
+            models/methionine/methionine_cycle.regulation.toml \\
+            -m models/methionine/maud_methionine_mapping.yaml
+    """
+    import yaml as _yaml
+
+    from ai_gene_review.maud_ingest import candidate_connections, maud_edges_from_files
+    from ai_gene_review.regulation_compare import (
+        diff_edges,
+        format_edge_diff,
+        module_regulatory_edges,
+    )
+
+    if not module_file.exists():
+        typer.echo(f"Error: module file not found: {module_file}", err=True)
+        raise typer.Exit(code=1)
+    if not maud_toml.exists():
+        typer.echo(f"Error: TOML file not found: {maud_toml}", err=True)
+        raise typer.Exit(code=1)
+
+    curated = module_regulatory_edges(_yaml.safe_load(module_file.read_text()))
+    source = maud_edges_from_files(maud_toml, mapping)
+    diff = diff_edges(curated, source)
+    typer.echo(format_edge_diff(diff, module_file.name, maud_toml.name))
+
+    if emit_candidates:
+        candidates = candidate_connections(source, source_id=f"file:{maud_toml}")
+        typer.echo("# candidate connections (review before adding to a module):")
+        typer.echo(_yaml.safe_dump(candidates, sort_keys=False))
+
+
+@app.command()
 def fetch_descriptions(
     organism: Annotated[
         str, typer.Argument(help="Organism name (e.g., human, yeast)")

--- a/src/ai_gene_review/maud_ingest.py
+++ b/src/ai_gene_review/maud_ingest.py
@@ -1,0 +1,153 @@
+#!/usr/bin/env python
+"""Ingest a Maud kinetic-model TOML as candidate regulatory facts.
+
+Maud (https://github.com/biosustain/Maud) describes a metabolic model in TOML,
+including ``[[allostery]]`` and ``[[competitive_inhibition]]`` tables that encode
+regulation with an explicit mechanism — exactly the layer GO cannot represent.
+
+This module treats such a source as **evidence, not truth**: it parses the
+regulatory tables into canonical :class:`~ai_gene_review.regulation_compare.RegEdge`
+objects (mediated by a reviewed id-mapping), and can emit them as candidate module
+``connections`` with provenance for a curator to adjudicate. It does not mutate any
+curated module.
+"""
+
+from __future__ import annotations
+
+import tomllib  # type: ignore[import-not-found]  # stdlib on py>=3.11; missing from this mypy's typeshed
+from pathlib import Path
+from typing import Any, Optional
+
+import yaml
+
+from ai_gene_review.regulation_compare import RegEdge
+
+
+# (sign, mechanism) -> (connection_type, SBO id, predicate label, SBO label)
+_SBO_FOR: dict[tuple[str, str], tuple[str, str, str, str]] = {
+    ("+", "allosteric"): (
+        "POSITIVELY_REGULATES",
+        "SBO:0000636",
+        "allosteric activation",
+        "allosteric activator",
+    ),
+    ("-", "allosteric"): (
+        "NEGATIVELY_REGULATES",
+        "SBO:0000639",
+        "allosteric inhibition",
+        "allosteric inhibitor",
+    ),
+    ("-", "competitive"): (
+        "NEGATIVELY_REGULATES",
+        "SBO:0000206",
+        "competitive inhibition",
+        "competitive inhibitor",
+    ),
+}
+
+
+def parse_maud_toml(path: Path | str) -> dict[str, Any]:
+    """Parse a Maud TOML file into a raw dict."""
+    return tomllib.loads(Path(path).read_text())
+
+
+def load_mapping(path: Path | str) -> dict[str, dict[str, str]]:
+    """Load a reviewed id-mapping (``enzymes:`` / ``metabolites:`` keys)."""
+    data = yaml.safe_load(Path(path).read_text()) or {}
+    return {
+        "enzymes": data.get("enzymes") or {},
+        "metabolites": data.get("metabolites") or {},
+    }
+
+
+def maud_regulatory_edges(
+    model: dict[str, Any],
+    enzyme_map: Optional[dict[str, str]] = None,
+    metabolite_map: Optional[dict[str, str]] = None,
+) -> set[RegEdge]:
+    """Extract canonical regulatory edges from a parsed Maud model.
+
+    ``enzyme_map`` / ``metabolite_map`` translate Maud ids to curated module
+    symbols. Unmapped ids fall back to a lower-cased id so the result is still
+    usable (and the mismatch is visible) without a mapping.
+    """
+    enzyme_map = enzyme_map or {}
+    metabolite_map = metabolite_map or {}
+
+    def enzyme(raw: Any) -> str:
+        return enzyme_map.get(str(raw), str(raw).lower())
+
+    def effector(raw: Any) -> str:
+        return metabolite_map.get(str(raw), str(raw).lower())
+
+    edges: set[RegEdge] = set()
+    for entry in model.get("allostery", []):
+        sign = "+" if entry.get("modification_type") == "activation" else "-"
+        edges.add(
+            RegEdge(
+                effector(entry.get("metabolite_id")),
+                enzyme(entry.get("enzyme_id")),
+                sign,
+                "allosteric",
+            )
+        )
+    for entry in model.get("competitive_inhibition", []):
+        edges.add(
+            RegEdge(
+                effector(entry.get("metabolite_id")),
+                enzyme(entry.get("enzyme_id")),
+                "-",
+                "competitive",
+            )
+        )
+    return edges
+
+
+def candidate_connections(
+    edges: set[RegEdge],
+    source_id: str,
+    url: Optional[str] = None,
+) -> list[dict[str, Any]]:
+    """Emit ingested edges as candidate module ``connections`` with provenance.
+
+    Each connection grounds the mechanism to SBO and references the effector/enzyme
+    using the module ``*_pool`` / ``*_activity`` id convention, so a curator can
+    review and paste them into a module. Edges with no SBO mapping (e.g. an
+    activation tagged competitive) are skipped.
+    """
+    connections: list[dict[str, Any]] = []
+    for edge in sorted(edges, key=lambda e: (e.enzyme, e.effector)):
+        spec = _SBO_FOR.get((edge.sign, edge.mechanism))
+        if spec is None:
+            continue
+        connection_type, sbo_id, predicate_label, sbo_label = spec
+        evidence: dict[str, Any] = {"source_id": source_id, "statement": f"{edge}"}
+        if url:
+            evidence["url"] = url
+        connections.append(
+            {
+                "source": f"{edge.effector}_pool",
+                "target": f"{edge.enzyme}_activity",
+                "connection_type": connection_type,
+                "predicate": {
+                    "preferred_term": predicate_label,
+                    "term": {"id": sbo_id, "label": sbo_label},
+                },
+                "evidence": [evidence],
+            }
+        )
+    return connections
+
+
+def maud_edges_from_files(
+    toml_path: Path | str,
+    mapping_path: Optional[Path | str] = None,
+) -> set[RegEdge]:
+    """Convenience: parse a Maud TOML and (optionally) a mapping into edges."""
+    model = parse_maud_toml(toml_path)
+    mapping = (
+        load_mapping(mapping_path)
+        if mapping_path
+        else {"enzymes": {}, "metabolites": {}}
+    )
+    return maud_regulatory_edges(model, mapping["enzymes"], mapping["metabolites"])

--- a/src/ai_gene_review/module_notation.py
+++ b/src/ai_gene_review/module_notation.py
@@ -1,0 +1,386 @@
+#!/usr/bin/env python
+"""Project a module YAML document into a compact, human-readable notation.
+
+This is a *read-only* projection (a view), not a second source of truth: the
+module YAML (and GO-CAM YAML) remains canonical and machine-checkable, while this
+notation gives a scannable ``symbol -> symbol`` rendering plus a legend mapping
+each symbol to its grounded entity.
+
+The notation has three blocks, mirroring the layers we care about:
+
+* **Legend** - ``symbol := GROUNDING  label`` for enzymes (GO MF), grounded
+  metabolite effector pools (ChEBI), and the pathway (GO BP).
+* **Reactions** - ``enzyme: substrates -> products    # GO id``.
+* **Regulation** - ``effector -o|-| enzyme   [mechanism]   # SBO id`` where the
+  arrow encodes sign (``-o`` activation, ``-|`` inhibition, borrowed from
+  Antimony) and the bracketed tag encodes the *mechanism* (competitive vs
+  allosteric) grounded to SBO - the distinction GO cannot express.
+
+Symbols are derived from the document-scoped element ids (a known suffix such as
+``_activity``/``_pool``/``_step`` is stripped), so the projection stays faithful
+to - and loosely reversible against - the YAML.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Iterator, Optional
+
+import yaml
+
+from ai_gene_review.render_modules import as_list
+
+
+# Connection types that represent regulation (the layer GO cannot express).
+_REGULATORY = {"POSITIVELY_REGULATES": "-o", "NEGATIVELY_REGULATES": "-|"}
+
+# Suffixes stripped from element ids to make short, readable symbols.
+_SUFFIXES = ("_activity", "_pool", "_step", "_route", "_form", "_node", "_pathway")
+
+
+@dataclass
+class _Symbol:
+    """A resolved symbol for one document-scoped module element."""
+
+    element_id: str
+    symbol: str
+    kind: str  # "activity" | "metabolite" | "pathway" | "step"
+    term_id: Optional[str] = None
+    term_label: Optional[str] = None
+    preferred_label: Optional[str] = None
+    function: Optional[dict[str, Any]] = None
+
+
+@dataclass
+class _Registry:
+    """Lookup tables built from one module document."""
+
+    by_id: dict[str, _Symbol] = field(default_factory=dict)
+    metabolite_alias: dict[str, str] = field(default_factory=dict)
+
+    def symbol_for(self, element_id: Any) -> str:
+        """Return the short symbol for an id, falling back to the raw id."""
+        if element_id is None:
+            return "?"
+        entry = self.by_id.get(str(element_id))
+        return entry.symbol if entry else str(element_id)
+
+
+def _base_symbol(element_id: str) -> str:
+    """Strip a known trailing role suffix to make a short symbol.
+
+    >>> _base_symbol("mat1_activity")
+    'mat1'
+    >>> _base_symbol("amet_pool")
+    'amet'
+    >>> _base_symbol("plain")
+    'plain'
+    """
+    for suffix in _SUFFIXES:
+        if element_id.endswith(suffix) and len(element_id) > len(suffix):
+            return element_id[: -len(suffix)]
+    return element_id
+
+
+def _term(holder: Any) -> dict[str, Any]:
+    """Return the ``term`` mapping of a descriptor-like holder, or empty."""
+    if isinstance(holder, dict) and isinstance(holder.get("term"), dict):
+        return holder["term"]
+    return {}
+
+
+def iter_nodes(node: dict[str, Any]) -> Iterator[dict[str, Any]]:
+    """Yield a node and all descendant nodes (parts and variants)."""
+    yield node
+    for part in as_list(node.get("parts")):
+        child = part.get("node") if isinstance(part, dict) else None
+        if isinstance(child, dict):
+            yield from iter_nodes(child)
+    for variant_set in as_list(node.get("variant_sets")):
+        if not isinstance(variant_set, dict):
+            continue
+        for variant in as_list(variant_set.get("variants")):
+            if isinstance(variant, dict):
+                yield from iter_nodes(variant)
+
+
+def _node_concept(node: dict[str, Any]) -> dict[str, Any]:
+    """Return the first concept descriptor of a node, or empty."""
+    for concept in as_list(node.get("concepts")):
+        if isinstance(concept, dict):
+            return concept
+    return {}
+
+
+def _is_metabolite_pool(node: dict[str, Any]) -> bool:
+    """A node that is an effector/metabolite pool.
+
+    True if it grounds to ChEBI, or its id is a ``*_pool`` leaf carrying a concept
+    but no catalytic annotons/children (so ungrounded effectors still appear in
+    the legend and alias map).
+    """
+    concept = _node_concept(node)
+    if str(_term(concept).get("id", "")).startswith("CHEBI:"):
+        return True
+    is_leaf = (
+        not as_list(node.get("annotons"))
+        and not as_list(node.get("parts"))
+        and not as_list(node.get("variant_sets"))
+    )
+    return bool(str(node.get("id", "")).endswith("_pool") and concept and is_leaf)
+
+
+def build_registry(data: dict[str, Any]) -> _Registry:
+    """Build symbol lookup tables for a module document.
+
+    Symbols are assigned with priority so that the *interesting* lines (reactions
+    and regulation) get clean short symbols: enzymes (annotons) and metabolite
+    pools are assigned first; container/step nodes take what is left, reusing a
+    single contained annoton's symbol where possible.
+    """
+    module = data.get("module")
+    if not isinstance(module, dict):
+        return _Registry()
+
+    registry = _Registry()
+    used: set[str] = set()
+
+    def claim(preferred: str, element_id: str) -> str:
+        symbol = preferred
+        n = 2
+        while symbol in used:
+            symbol = f"{preferred}{n}"
+            n += 1
+        used.add(symbol)
+        return symbol
+
+    # Pass 1: enzymes (annotons with a function) and metabolite pools.
+    for node in iter_nodes(module):
+        for annoton in as_list(node.get("annotons")):
+            if not isinstance(annoton, dict) or not annoton.get("id"):
+                continue
+            function = (
+                annoton.get("function")
+                if isinstance(annoton.get("function"), dict)
+                else None
+            )
+            term = _term(function)
+            element_id = str(annoton["id"])
+            symbol = claim(_base_symbol(element_id), element_id)
+            registry.by_id[element_id] = _Symbol(
+                element_id=element_id,
+                symbol=symbol,
+                kind="activity",
+                term_id=term.get("id"),
+                term_label=term.get("label"),
+                preferred_label=(function or {}).get("preferred_term"),
+                function=function,
+            )
+
+    for node in iter_nodes(module):
+        if not node.get("id") or not _is_metabolite_pool(node):
+            continue
+        concept = _node_concept(node)
+        term = _term(concept)
+        element_id = str(node["id"])
+        symbol = claim(_base_symbol(element_id), element_id)
+        registry.by_id[element_id] = _Symbol(
+            element_id=element_id,
+            symbol=symbol,
+            kind="metabolite",
+            term_id=term.get("id"),
+            term_label=term.get("label"),
+            preferred_label=concept.get("preferred_term"),
+        )
+        # Alias map so reaction substrates/products render with the same symbol.
+        for key in (term.get("id"), concept.get("preferred_term"), term.get("label")):
+            if key:
+                registry.metabolite_alias.setdefault(_norm(str(key)), symbol)
+
+    # Pass 2: remaining nodes (pathway + container/step nodes).
+    module_id = str(module.get("id"))
+    for node in iter_nodes(module):
+        raw_id = node.get("id")
+        if not raw_id or str(raw_id) in registry.by_id:
+            continue
+        element_id = str(raw_id)
+        annotons = [
+            a
+            for a in as_list(node.get("annotons"))
+            if isinstance(a, dict) and a.get("id")
+        ]
+        no_children = not as_list(node.get("parts")) and not as_list(
+            node.get("variant_sets")
+        )
+        if len(annotons) == 1 and no_children:
+            # A thin wrapper around a single activity: reuse the activity symbol.
+            inner = registry.by_id.get(str(annotons[0]["id"]))
+            if inner:
+                registry.by_id[element_id] = _Symbol(
+                    element_id=element_id, symbol=inner.symbol, kind="step"
+                )
+                continue
+        kind = "pathway" if element_id == module_id else "step"
+        concept = _node_concept(node)
+        term = _term(concept)
+        symbol = claim(_base_symbol(element_id), element_id)
+        registry.by_id[element_id] = _Symbol(
+            element_id=element_id,
+            symbol=symbol,
+            kind=kind,
+            term_id=term.get("id"),
+            term_label=term.get("label"),
+            preferred_label=concept.get("preferred_term"),
+        )
+
+    return registry
+
+
+def _norm(text: str) -> str:
+    """Normalise a metabolite name for alias matching."""
+    return " ".join(text.lower().split())
+
+
+def _render_descriptor_list(descriptors: Any, registry: _Registry) -> str:
+    """Render substrates/products, substituting pool symbols where grounded."""
+    parts: list[str] = []
+    for descriptor in as_list(descriptors):
+        if not isinstance(descriptor, dict):
+            continue
+        term = _term(descriptor)
+        alias = None
+        for key in (
+            term.get("id"),
+            descriptor.get("preferred_term"),
+            term.get("label"),
+        ):
+            if key and _norm(str(key)) in registry.metabolite_alias:
+                alias = registry.metabolite_alias[_norm(str(key))]
+                break
+        parts.append(
+            alias or descriptor.get("preferred_term") or term.get("label") or "?"
+        )
+    return " + ".join(parts)
+
+
+def _mechanism_tag(predicate: Any) -> Optional[str]:
+    """Extract a short mechanism tag (e.g. ``competitive``) from a predicate."""
+    if not isinstance(predicate, dict):
+        return None
+    text = _norm(
+        str(predicate.get("preferred_term") or _term(predicate).get("label") or "")
+    )
+    for tag in (
+        "competitive",
+        "allosteric",
+        "non-competitive",
+        "uncompetitive",
+        "mixed",
+    ):
+        if tag in text:
+            return tag
+    return text or None
+
+
+def iter_connections(module: dict[str, Any]) -> Iterator[dict[str, Any]]:
+    """Yield every connection declared anywhere in the module tree."""
+    for node in iter_nodes(module):
+        for connection in as_list(node.get("connections")):
+            if isinstance(connection, dict):
+                yield connection
+
+
+def render_module_notation(data: dict[str, Any]) -> str:
+    """Render a module YAML document (as a dict) into the compact notation.
+
+    Returns the notation as a single string. This is a faithful projection of the
+    canonical YAML; it does not validate and is not parsed back.
+    """
+    module = data.get("module")
+    if not isinstance(module, dict):
+        raise ValueError("module document is missing a top-level 'module' mapping")
+
+    registry = build_registry(data)
+    title = data.get("title") or module.get("label") or module.get("id") or "module"
+
+    lines: list[str] = [f"# {title}", ""]
+
+    # ---- Legend -------------------------------------------------------------
+    lines.append("# ── Legend (symbol := grounding) ──")
+
+    def legend_line(symbol: str, term_id: Optional[str], label: str) -> str:
+        grounding = f"{term_id}  " if term_id else ""
+        return f"{symbol} := {grounding}{label}".rstrip()
+
+    pathway = registry.by_id.get(str(module.get("id")))
+    if pathway and (pathway.term_id or pathway.preferred_label):
+        lines.append(
+            legend_line(
+                "pathway",
+                pathway.term_id,
+                pathway.preferred_label or pathway.term_label or "",
+            )
+        )
+
+    enzymes = [s for s in registry.by_id.values() if s.kind == "activity"]
+    metabolites = [s for s in registry.by_id.values() if s.kind == "metabolite"]
+    for sym in sorted(enzymes, key=lambda s: s.symbol):
+        lines.append(
+            legend_line(
+                sym.symbol, sym.term_id, sym.preferred_label or sym.term_label or ""
+            )
+        )
+    for sym in sorted(metabolites, key=lambda s: s.symbol):
+        lines.append(
+            legend_line(
+                sym.symbol, sym.term_id, sym.preferred_label or sym.term_label or ""
+            )
+        )
+
+    # ---- Reactions ----------------------------------------------------------
+    reaction_lines: list[str] = []
+    for sym in enzymes:
+        function = sym.function or {}
+        substrates = _render_descriptor_list(function.get("substrates"), registry)
+        products = _render_descriptor_list(function.get("products"), registry)
+        if not substrates and not products:
+            continue
+        comment = f"   # {sym.term_id}" if sym.term_id else ""
+        reaction_lines.append(f"{sym.symbol}: {substrates} -> {products}{comment}")
+    if reaction_lines:
+        lines.extend(["", "# ── Reactions (enzyme: substrates -> products) ──"])
+        lines.extend(reaction_lines)
+
+    # ---- Regulation ---------------------------------------------------------
+    regulation_lines: list[str] = []
+    flow_lines: list[str] = []
+    for connection in iter_connections(module):
+        ctype = connection.get("connection_type")
+        source = registry.symbol_for(connection.get("source"))
+        target = registry.symbol_for(connection.get("target"))
+        if ctype in _REGULATORY:
+            arrow = _REGULATORY[ctype]
+            mechanism = _mechanism_tag(connection.get("predicate"))
+            sbo = _term(connection.get("predicate")).get("id")
+            tag = f"   [{mechanism}]" if mechanism else ""
+            comment = f"   # {sbo}" if sbo else ""
+            regulation_lines.append(f"{source} {arrow} {target}{tag}{comment}")
+        else:
+            flow_lines.append(f"{source} -> {target}   # {ctype}")
+    if regulation_lines:
+        lines.extend(["", "# ── Regulation (effector -o|-| enzyme [mechanism]) ──"])
+        lines.extend(regulation_lines)
+    if flow_lines:
+        lines.extend(["", "# ── Flow (topology) ──"])
+        lines.extend(flow_lines)
+
+    return "\n".join(lines) + "\n"
+
+
+def render_module_notation_file(yaml_path: Path) -> str:
+    """Load a module YAML file and render its notation."""
+    data = yaml.safe_load(Path(yaml_path).read_text())
+    if not isinstance(data, dict):
+        raise ValueError(f"Module YAML must contain a mapping: {yaml_path}")
+    return render_module_notation(data)

--- a/src/ai_gene_review/module_notation.py
+++ b/src/ai_gene_review/module_notation.py
@@ -33,7 +33,7 @@ from ai_gene_review.render_modules import as_list
 
 
 # Connection types that represent regulation (the layer GO cannot express).
-_REGULATORY = {"POSITIVELY_REGULATES": "-o", "NEGATIVELY_REGULATES": "-|"}
+REGULATORY = {"POSITIVELY_REGULATES": "-o", "NEGATIVELY_REGULATES": "-|"}
 
 # Suffixes stripped from element ids to make short, readable symbols.
 _SUFFIXES = ("_activity", "_pool", "_step", "_route", "_form", "_node", "_pathway")
@@ -264,7 +264,7 @@ def _render_descriptor_list(descriptors: Any, registry: _Registry) -> str:
     return " + ".join(parts)
 
 
-def _mechanism_tag(predicate: Any) -> Optional[str]:
+def mechanism_tag(predicate: Any) -> Optional[str]:
     """Extract a short mechanism tag (e.g. ``competitive``) from a predicate."""
     if not isinstance(predicate, dict):
         return None
@@ -359,9 +359,9 @@ def render_module_notation(data: dict[str, Any]) -> str:
         ctype = connection.get("connection_type")
         source = registry.symbol_for(connection.get("source"))
         target = registry.symbol_for(connection.get("target"))
-        if ctype in _REGULATORY:
-            arrow = _REGULATORY[ctype]
-            mechanism = _mechanism_tag(connection.get("predicate"))
+        if ctype in REGULATORY:
+            arrow = REGULATORY[ctype]
+            mechanism = mechanism_tag(connection.get("predicate"))
             sbo = _term(connection.get("predicate")).get("id")
             tag = f"   [{mechanism}]" if mechanism else ""
             comment = f"   # {sbo}" if sbo else ""

--- a/src/ai_gene_review/regulation_compare.py
+++ b/src/ai_gene_review/regulation_compare.py
@@ -15,8 +15,8 @@ from dataclasses import dataclass, field
 from typing import Any
 
 from ai_gene_review.module_notation import (
-    _REGULATORY,
-    _mechanism_tag,
+    REGULATORY,
+    mechanism_tag,
     build_registry,
     iter_connections,
 )
@@ -63,14 +63,14 @@ def module_regulatory_edges(data: dict[str, Any]) -> set[RegEdge]:
     edges: set[RegEdge] = set()
     for connection in iter_connections(module):
         ctype = connection.get("connection_type")
-        if ctype not in _REGULATORY:
+        if ctype not in REGULATORY:
             continue
         edges.add(
             RegEdge(
                 effector=registry.symbol_for(connection.get("source")),
                 enzyme=registry.symbol_for(connection.get("target")),
                 sign=_SIGN[ctype],
-                mechanism=_mechanism_tag(connection.get("predicate")) or "unspecified",
+                mechanism=mechanism_tag(connection.get("predicate")) or "unspecified",
             )
         )
     return edges

--- a/src/ai_gene_review/regulation_compare.py
+++ b/src/ai_gene_review/regulation_compare.py
@@ -1,0 +1,148 @@
+#!/usr/bin/env python
+"""Compare regulatory wiring across a curated module and a 3rd-party source.
+
+A :class:`RegEdge` is the canonical, source-agnostic unit of regulation:
+``(effector, enzyme, sign, mechanism)``. Curated modules and ingested models are
+each reduced to a set of these, then diffed. This is the regulation-layer analogue
+of the EC-discrepancy mining in the METABOLIC_MODEL_ANALYSIS project: instead of
+comparing GO MF / EC, it compares *who regulates whom, with what sign and
+mechanism* — the layer GO cannot express.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+from ai_gene_review.module_notation import (
+    _REGULATORY,
+    _mechanism_tag,
+    build_registry,
+    iter_connections,
+)
+
+
+_SIGN = {"POSITIVELY_REGULATES": "+", "NEGATIVELY_REGULATES": "-"}
+
+
+@dataclass(frozen=True)
+class RegEdge:
+    """A single regulatory relationship, normalised across sources.
+
+    >>> str(RegEdge("amet", "mat1", "-", "competitive"))
+    'amet -| mat1 [competitive]'
+    >>> str(RegEdge("amet", "mat3", "+", "allosteric"))
+    'amet -o mat3 [allosteric]'
+    """
+
+    effector: str
+    enzyme: str
+    sign: str  # "+" (activates) or "-" (inhibits)
+    mechanism: str  # "allosteric" | "competitive" | "unspecified" | ...
+
+    @property
+    def key(self) -> tuple[str, str]:
+        """The (effector, enzyme) pair the edge is keyed on for diffing."""
+        return (self.effector, self.enzyme)
+
+    def __str__(self) -> str:
+        arrow = "-o" if self.sign == "+" else "-|"
+        return f"{self.effector} {arrow} {self.enzyme} [{self.mechanism}]"
+
+
+def module_regulatory_edges(data: dict[str, Any]) -> set[RegEdge]:
+    """Extract regulatory edges from a curated module YAML document.
+
+    Symbols match the module-notation projection (so the edges are human-readable
+    and align with an ingested source mapped to the same symbols).
+    """
+    module = data.get("module")
+    if not isinstance(module, dict):
+        return set()
+    registry = build_registry(data)
+    edges: set[RegEdge] = set()
+    for connection in iter_connections(module):
+        ctype = connection.get("connection_type")
+        if ctype not in _REGULATORY:
+            continue
+        edges.add(
+            RegEdge(
+                effector=registry.symbol_for(connection.get("source")),
+                enzyme=registry.symbol_for(connection.get("target")),
+                sign=_SIGN[ctype],
+                mechanism=_mechanism_tag(connection.get("predicate")) or "unspecified",
+            )
+        )
+    return edges
+
+
+@dataclass
+class EdgeDiff:
+    """The result of comparing a ``left`` (curated) and ``right`` (source) edge set."""
+
+    agreements: list[RegEdge] = field(default_factory=list)
+    only_in_left: list[RegEdge] = field(default_factory=list)
+    only_in_right: list[RegEdge] = field(default_factory=list)
+    sign_conflicts: list[tuple[RegEdge, RegEdge]] = field(default_factory=list)
+    mechanism_conflicts: list[tuple[RegEdge, RegEdge]] = field(default_factory=list)
+
+    @property
+    def is_clean(self) -> bool:
+        """True when the two sources fully agree on the regulatory wiring."""
+        return not (
+            self.only_in_left
+            or self.only_in_right
+            or self.sign_conflicts
+            or self.mechanism_conflicts
+        )
+
+
+def diff_edges(left: set[RegEdge], right: set[RegEdge]) -> EdgeDiff:
+    """Diff two regulatory-edge sets, keyed on (effector, enzyme).
+
+    ``left`` is treated as the curated reference and ``right`` as the ingested
+    source. Same key with differing sign is a ``sign_conflict``; same key and sign
+    with differing mechanism is a ``mechanism_conflict``.
+    """
+    left_by_key = {edge.key: edge for edge in left}
+    right_by_key = {edge.key: edge for edge in right}
+    diff = EdgeDiff()
+    for key, left_edge in sorted(left_by_key.items()):
+        right_edge = right_by_key.get(key)
+        if right_edge is None:
+            diff.only_in_left.append(left_edge)
+        elif left_edge.sign != right_edge.sign:
+            diff.sign_conflicts.append((left_edge, right_edge))
+        elif left_edge.mechanism != right_edge.mechanism:
+            diff.mechanism_conflicts.append((left_edge, right_edge))
+        else:
+            diff.agreements.append(left_edge)
+    for key, right_edge in sorted(right_by_key.items()):
+        if key not in left_by_key:
+            diff.only_in_right.append(right_edge)
+    return diff
+
+
+def format_edge_diff(diff: EdgeDiff, left_label: str, right_label: str) -> str:
+    """Render an :class:`EdgeDiff` as a readable report."""
+    lines = [f"# Regulation diff: {left_label} (curated) vs {right_label} (source)", ""]
+    lines.append(
+        f"agree={len(diff.agreements)}  "
+        f"curated_only={len(diff.only_in_left)}  "
+        f"source_only={len(diff.only_in_right)}  "
+        f"sign_conflicts={len(diff.sign_conflicts)}  "
+        f"mechanism_conflicts={len(diff.mechanism_conflicts)}"
+    )
+    if diff.is_clean:
+        lines.append(
+            "\n✓ full agreement — curated module matches the source regulatory wiring."
+        )
+    for left_edge, right_edge in diff.sign_conflicts:
+        lines.append(f"\n✗ SIGN  {left_edge}   (curated)  vs   {right_edge}   (source)")
+    for left_edge, right_edge in diff.mechanism_conflicts:
+        lines.append(f"\n~ MECH  {left_edge}   (curated)  vs   {right_edge}   (source)")
+    for edge in diff.only_in_left:
+        lines.append(f"\n- curated-only   {edge}")
+    for edge in diff.only_in_right:
+        lines.append(f"\n+ source-only    {edge}")
+    return "\n".join(lines) + "\n"

--- a/tests/test_maud_ingest.py
+++ b/tests/test_maud_ingest.py
@@ -1,0 +1,115 @@
+"""Tests for Maud TOML ingest and regulation diffing.
+
+The methionine_cycle module was transcribed from the Maud source, so a correct
+ingest + diff must report FULL AGREEMENT — and must detect a deliberately
+perturbed edge. The source is treated as evidence (mediated by a reviewed mapping),
+never silently merged.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+import pytest
+
+from ai_gene_review.maud_ingest import (
+    candidate_connections,
+    load_mapping,
+    maud_edges_from_files,
+    maud_regulatory_edges,
+    parse_maud_toml,
+)
+from ai_gene_review.regulation_compare import (
+    RegEdge,
+    diff_edges,
+    module_regulatory_edges,
+)
+
+
+TOML = Path("models/methionine/methionine_cycle.regulation.toml")
+MAPPING = Path("models/methionine/maud_methionine_mapping.yaml")
+MODULE = Path("modules/methionine_cycle.yaml")
+
+pytestmark = pytest.mark.skipif(
+    not (TOML.exists() and MAPPING.exists() and MODULE.exists()),
+    reason="methionine source/module fixtures not present",
+)
+
+
+def test_parse_counts_all_regulatory_entries():
+    model = parse_maud_toml(TOML)
+    assert len(model["allostery"]) == 7
+    assert len(model["competitive_inhibition"]) == 3
+
+
+def test_edges_use_mapped_symbols_and_mechanisms():
+    edges = maud_edges_from_files(TOML, MAPPING)
+    assert len(edges) == 10
+    # MAT-I competitively inhibited by SAM; MAT-III allosterically activated by SAM.
+    assert RegEdge("amet", "mat1", "-", "competitive") in edges
+    assert RegEdge("amet", "mat3", "+", "allosteric") in edges
+    # methionine activates MAT-III (met-L -> met via the mapping)
+    assert RegEdge("met", "mat3", "+", "allosteric") in edges
+
+
+def test_unmapped_ids_fall_back_to_lowercase():
+    model = parse_maud_toml(TOML)
+    edges = maud_regulatory_edges(model)  # no mapping
+    # GNMT1 stays 'gnmt1' without a mapping, surfacing the misalignment rather than guessing.
+    assert any(e.enzyme == "gnmt1" for e in edges)
+
+
+def test_curated_module_fully_agrees_with_source():
+    curated = module_regulatory_edges(yaml.safe_load(MODULE.read_text()))
+    source = maud_edges_from_files(TOML, MAPPING)
+    diff = diff_edges(curated, source)
+    assert diff.is_clean, (
+        f"unexpected differences: only_left={diff.only_in_left} "
+        f"only_right={diff.only_in_right} sign={diff.sign_conflicts} mech={diff.mechanism_conflicts}"
+    )
+    assert len(diff.agreements) == 10
+
+
+def test_diff_detects_sign_flip():
+    curated = module_regulatory_edges(yaml.safe_load(MODULE.read_text()))
+    source = maud_edges_from_files(TOML, MAPPING)
+    # Flip MAT-I inhibition to activation in the source.
+    perturbed = {
+        RegEdge("amet", "mat1", "+", "competitive")
+        if e == RegEdge("amet", "mat1", "-", "competitive")
+        else e
+        for e in source
+    }
+    diff = diff_edges(curated, perturbed)
+    assert not diff.is_clean
+    assert len(diff.sign_conflicts) == 1
+    left, right = diff.sign_conflicts[0]
+    assert left.key == ("amet", "mat1") and left.sign == "-" and right.sign == "+"
+
+
+def test_diff_detects_missing_and_extra():
+    curated = module_regulatory_edges(yaml.safe_load(MODULE.read_text()))
+    source = maud_edges_from_files(TOML, MAPPING)
+    dropped = {e for e in source if e != RegEdge("amet", "cbs", "+", "allosteric")}
+    extra = dropped | {RegEdge("sah", "fake", "-", "competitive")}
+    diff = diff_edges(curated, extra)
+    assert any(e.key == ("amet", "cbs") for e in diff.only_in_left)
+    assert any(e.key == ("sah", "fake") for e in diff.only_in_right)
+
+
+def test_candidate_connections_ground_to_sbo_with_evidence():
+    edges = {RegEdge("amet", "mat1", "-", "competitive")}
+    conns = candidate_connections(edges, source_id="GitHub:biosustain/Methionine_model")
+    assert len(conns) == 1
+    conn = conns[0]
+    assert conn["connection_type"] == "NEGATIVELY_REGULATES"
+    assert conn["predicate"]["term"]["id"] == "SBO:0000206"
+    assert conn["source"] == "amet_pool" and conn["target"] == "mat1_activity"
+    assert conn["evidence"][0]["source_id"] == "GitHub:biosustain/Methionine_model"
+
+
+def test_mapping_loads_enzyme_and_metabolite_tables():
+    mapping = load_mapping(MAPPING)
+    assert mapping["enzymes"]["MAT3"] == "mat3"
+    assert mapping["metabolites"]["met-L"] == "met"

--- a/tests/test_module_notation.py
+++ b/tests/test_module_notation.py
@@ -7,6 +7,7 @@ regulation block. It is generated from the canonical YAML (no parse-back).
 
 from __future__ import annotations
 
+import re
 from pathlib import Path
 
 import yaml
@@ -157,10 +158,9 @@ def test_methionine_isozyme_opposite_regulation_is_visible():
     """The showcase: MAT-I competitively inhibited vs MAT-III allosterically activated by SAM."""
     data = yaml.safe_load(MET_CYCLE.read_text())
     out = render_module_notation(data)
-    assert "amet -| mat1   [competitive]" in out.replace("  ", " ").replace(
-        "  ", " "
-    ) or ("amet -| mat1" in out and "[competitive]" in out)
-    assert "amet -o mat3" in out and "[allosteric]" in out
+    normalized = re.sub(r" {2,}", " ", out)
+    assert "amet -| mat1 [competitive]" in normalized
+    assert "amet -o mat3 [allosteric]" in normalized
     # grounding present
     assert "GO:0004478" in out
     assert "CHEBI:15414" in out

--- a/tests/test_module_notation.py
+++ b/tests/test_module_notation.py
@@ -1,0 +1,179 @@
+"""Tests for the compact human-readable module notation projection.
+
+The notation is a *read-only* projection of a module YAML document: a legend
+block mapping short symbols to grounded entities, a reactions block, and a
+regulation block. It is generated from the canonical YAML (no parse-back).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+import pytest
+
+from ai_gene_review.module_notation import render_module_notation
+
+
+MET_CYCLE = Path("modules/methionine_cycle.yaml")
+
+
+def _small_module() -> dict:
+    """A minimal module exercising legend, a reaction, and both regulation types."""
+    return {
+        "id": "MODULE:toy",
+        "title": "Toy",
+        "module": {
+            "id": "toy",
+            "label": "Toy",
+            "module_type": "METABOLIC_PATHWAY",
+            "concepts": [
+                {
+                    "preferred_term": "toy pathway",
+                    "term": {"id": "GO:0000001", "label": "toy"},
+                }
+            ],
+            "parts": [
+                {
+                    "order": 1,
+                    "node": {
+                        "id": "rxn_step",
+                        "label": "step",
+                        "module_type": "REACTION",
+                        "annotons": [
+                            {
+                                "id": "enz_activity",
+                                "function": {
+                                    "preferred_term": "widgetase activity",
+                                    "term": {
+                                        "id": "GO:0004478",
+                                        "label": "widgetase activity",
+                                    },
+                                    "substrates": [
+                                        {"preferred_term": "A"},
+                                        {"preferred_term": "ATP"},
+                                    ],
+                                    "products": [{"preferred_term": "B"}],
+                                },
+                            }
+                        ],
+                    },
+                },
+                {
+                    "order": 2,
+                    "node": {
+                        "id": "effectors",
+                        "label": "effectors",
+                        "module_type": "MODULE",
+                        "parts": [
+                            {
+                                "node": {
+                                    "id": "x_pool",
+                                    "label": "X pool",
+                                    "concepts": [
+                                        {
+                                            "preferred_term": "X",
+                                            "term": {
+                                                "id": "CHEBI:15414",
+                                                "label": "X-mol",
+                                            },
+                                        }
+                                    ],
+                                }
+                            }
+                        ],
+                    },
+                },
+            ],
+            "connections": [
+                {
+                    "source": "x_pool",
+                    "target": "enz_activity",
+                    "connection_type": "NEGATIVELY_REGULATES",
+                    "predicate": {
+                        "preferred_term": "competitive inhibition",
+                        "term": {"id": "SBO:0000206", "label": "competitive inhibitor"},
+                    },
+                },
+                {
+                    "source": "x_pool",
+                    "target": "enz_activity",
+                    "connection_type": "POSITIVELY_REGULATES",
+                    "predicate": {
+                        "preferred_term": "allosteric activation",
+                        "term": {"id": "SBO:0000636", "label": "allosteric activator"},
+                    },
+                },
+            ],
+        },
+    }
+
+
+def test_legend_lists_enzyme_with_go():
+    out = render_module_notation(_small_module())
+    assert "enz" in out
+    assert "GO:0004478" in out
+
+
+def test_legend_lists_metabolite_with_chebi():
+    out = render_module_notation(_small_module())
+    # the _pool suffix is stripped to a short symbol
+    assert "x " in out or "x\t" in out or "x:=" in out.replace(" ", "")
+    assert "CHEBI:15414" in out
+
+
+def test_reaction_line_uses_arrow_and_symbols():
+    out = render_module_notation(_small_module())
+    # enzyme symbol from the annoton id (suffix stripped), reaction arrow, substrates/products
+    assert "enz:" in out
+    assert "->" in out
+    assert "ATP" in out
+
+
+def test_regulation_competitive_uses_inhibition_arrow_and_mechanism():
+    out = render_module_notation(_small_module())
+    assert "x -| enz" in out
+    assert "[competitive]" in out
+    assert "SBO:0000206" in out
+
+
+def test_regulation_allosteric_uses_activation_arrow():
+    out = render_module_notation(_small_module())
+    assert "x -o enz" in out
+    assert "[allosteric]" in out
+
+
+def test_no_yaml_braces_leak_into_output():
+    out = render_module_notation(_small_module())
+    # The projection should be plain notation, not echoed python/yaml structures.
+    assert "{'" not in out
+    assert "preferred_term:" not in out
+
+
+@pytest.mark.skipif(
+    not MET_CYCLE.exists(), reason="methionine_cycle module not present"
+)
+def test_methionine_isozyme_opposite_regulation_is_visible():
+    """The showcase: MAT-I competitively inhibited vs MAT-III allosterically activated by SAM."""
+    data = yaml.safe_load(MET_CYCLE.read_text())
+    out = render_module_notation(data)
+    assert "amet -| mat1   [competitive]" in out.replace("  ", " ").replace(
+        "  ", " "
+    ) or ("amet -| mat1" in out and "[competitive]" in out)
+    assert "amet -o mat3" in out and "[allosteric]" in out
+    # grounding present
+    assert "GO:0004478" in out
+    assert "CHEBI:15414" in out
+    assert "SBO:0000206" in out
+
+
+@pytest.mark.skipif(
+    not MET_CYCLE.exists(), reason="methionine_cycle module not present"
+)
+def test_methionine_all_ten_regulatory_edges_rendered():
+    data = yaml.safe_load(MET_CYCLE.read_text())
+    out = render_module_notation(data)
+    reg_lines = [
+        ln for ln in out.splitlines() if (" -| " in ln or " -o " in ln) and "[" in ln
+    ]
+    assert len(reg_lines) == 10


### PR DESCRIPTION
## Summary

This PR introduces a complete methionine (S-adenosylmethionine) cycle metabolic pathway module with a novel two-layer structure separating catalytic reactions (grounded to GO molecular functions) from regulatory wiring (grounded to SBO terms). It also adds tooling to project modules into a compact human-readable notation and to ingest regulatory facts from 3rd-party kinetic models (Maud) for comparison against curated modules.

Key additions:
- **`modules/methionine_cycle.yaml`** — A comprehensive 572-line module decomposing the methionine/SAM cycle with explicit isozyme-specific regulation (MAT-I vs MAT-III) that GO cannot express
- **`src/ai_gene_review/module_notation.py`** — A read-only projection of module YAML into compact notation (legend + reactions + regulation blocks with SBO-grounded mechanisms)
- **`src/ai_gene_review/maud_ingest.py`** — Parser for Maud kinetic-model TOML to extract regulatory edges as evidence (not truth) for comparison
- **`src/ai_gene_review/regulation_compare.py`** — Canonical `RegEdge` representation and diffing logic to compare curated modules against ingested sources
- **CLI commands** `render-module-notation` and `compare-module-regulation` in `src/ai_gene_review/cli.py`
- **Test fixtures and tests** — Methionine cycle regulation TOML excerpt, reviewed id-mapping, and comprehensive test coverage for notation, ingest, and diffing

The regulatory structure is transcribed from the biosustain Maud kinetic model and showcases isozyme-specific feedback: MAT-I is competitively product-inhibited by SAM, while MAT-III is allosterically activated by SAM — a distinction that GO flattens away but is central to understanding methyl-group cycling.

## Validation

- Added unit tests in `tests/test_module_notation.py`, `tests/test_maud_ingest.py` covering notation projection, Maud parsing, and regulatory diffing
- Methionine cycle module fully agrees with ingested Maud source (10 regulatory edges, all verified)
- CLI commands tested with real fixtures

## Test plan

- [ ] Run `pytest tests/test_module_notation.py tests/test_maud_ingest.py` to verify notation projection and ingest logic
- [ ] Run `ai-gene-review render-module-notation modules/methionine_cycle.yaml` to inspect notation output
- [ ] Run `ai-gene-review compare-module-regulation modules/methionine_cycle.yaml models/methionine/methionine_cycle.regulation.toml --mapping models/methionine/maud_methionine_mapping.yaml` to verify full agreement with source

https://claude.ai/code/session_013PXZ3sRQBZXvgPTB451tS3