### PR TITLE
[codex] Encourage public bioinformatics in OpenScientist hypothesis prompt

### DIFF
--- a/templates/gene_hypothesis_deep_research.md
+++ b/templates/gene_hypothesis_deep_research.md
@@ -65,7 +65,10 @@ clearly labeled as review-level or database-level support.
 Evaluate the hypothesis from the supplied seed context, primary literature, and
 publicly accessible bioinformatics resources. Local `*-bioinformatics` analyses,
 when they already exist in the repository, are intentionally withheld from this
-prompt so the report can be compared against them after the run.
+prompt so the report can be compared against them after the run. Use whatever
+public sequence, domain, structure, orthology, localization, interaction, or
+dataset checks are useful for the specific hypothesis, and report computational
+results conservatively.
 
 ## Required Output
 


### PR DESCRIPTION
## Summary

Adds a concise sentence to the gene hypothesis OpenScientist prompt encouraging use of public sequence, domain, structure, orthology, localization, interaction, and dataset checks when useful for a focused hypothesis.

## Rationale

The previous wording correctly withheld local `*-bioinformatics` analyses for post-run comparison, but did not clearly nudge OpenScientist toward public bioinformatics resources. This keeps the prompt compact while making the intended evidence scope explicit.

## Validation

- `uv run pytest tests/test_gene_hypothesis_deep_research.py`
- `just gene-hypothesis-research openscientist SCHPO pmp20 --annotation-term-id GO:0008379 --as-function-hypothesis --dry-run`