### PR TITLE
[codex] Integrate pmp20 OpenScientist findings

### DIFF
--- a/genes/SCHPO/pmp20/pmp20-ai-review.html
+++ b/genes/SCHPO/pmp20/pmp20-ai-review.html
@@ -1499,7 +1499,7 @@
                         
                         
                         <div>
-                            <strong>Reason:</strong> Pmp20 has been experimentally shown to lack thioredoxin-dependent peroxidase activity. UniProt states &#34;Has no thioredoxin-dependent peroxidase activity&#34; and &#34;Pmp20 lacks the resolving cysteine residue&#34; (PMID:20356456). The InterPro domain mapping does not account for the absence of the resolving cysteine.
+                            <strong>Reason:</strong> Pmp20 has been experimentally shown to lack thioredoxin-dependent peroxidase activity. UniProt states &#34;Has no thioredoxin-dependent peroxidase activity&#34; and &#34;Pmp20 lacks the resolving cysteine residue&#34; (PMID:20356456). The InterPro domain mapping does not account for the absence of the resolving cysteine. The focused OpenScientist hypothesis review independently judged GO:0008379 over-annotated and noted that the organism-wide peroxide-scavenging analysis in PMID:24521463 also supports Tpx1, catalase, and Gpx1 rather than pmp20 as fission yeast peroxide-scavenging activities.
                         </div>
                         
                         
@@ -1528,6 +1528,30 @@
                                 </span>
                                 
                                 <div class="support-text">Comparative sequence and structure analysis supports no resolving cysteine in pmp20.</div>
+                                
+                            </div>
+                            
+                            <div class="support-item">
+                                <span class="support-ref">
+                                    
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/24521463" target="_blank" class="term-link">
+                                        PMID:24521463
+                                    </a>
+                                    
+                                </span>
+                                
+                                <div class="support-text">Tpx1 is the only enzyme with sufficient sensitivity for peroxides and cellular abundance as to control the low levels produced during aerobic growth</div>
+                                
+                            </div>
+                            
+                            <div class="support-item">
+                                <span class="support-ref">
+                                    
+                                    file:SCHPO/pmp20/pmp20-hypotheses/function-hypothesis-go-0008379/openscientist.md
+                                    
+                                </span>
+                                
+                                <div class="support-text">The annotation of GO:0008379 (thioredoxin peroxidase activity) to *Schizosaccharomyces pombe* pmp20 is definitively over-annotated and should be removed or suppressed.</div>
                                 
                             </div>
                             
@@ -1825,7 +1849,7 @@
                         
                         
                         <div>
-                            <strong>Reason:</strong> GO:0051082 is being obsoleted. PMID:20356456 demonstrated that pmp20 inhibits thermal aggregation of citrate synthase (a holdase/chaperone assay), with weaker activity than S. pombe TPx (tpx1). The appropriate replacement is GO:0044183 &#34;protein folding chaperone.&#34; This is consistent with the broader observation from family-level analysis (file:interpro/panther/PTHR10430/PTHR10430-deep-research-falcon.md) that hyperoxidized peroxiredoxins can switch to chaperone/holdase activity; pmp20 appears to have constitutively adopted this alternative function due to loss of the resolving cysteine. Note that the UniProt record also carries GO:0042026 (protein refolding) via IC from PomBase, but the experimental evidence specifically supports prevention of aggregation rather than active refolding.
+                            <strong>Reason:</strong> GO:0051082 is being obsoleted. PMID:20356456 demonstrated that pmp20 inhibits thermal aggregation of citrate synthase (a holdase/chaperone assay), with weaker activity than S. pombe TPx (tpx1). The focused OpenScientist review reinforces that the assay supports holdase-type anti-aggregation activity rather than peroxidase activity, but GO:0140309 is currently modeled as unfolded protein carrier activity and is not a good fit for simple in-situ holdase assays. The pragmatic replacement remains GO:0044183 &#34;protein folding chaperone&#34; pending a more precise general holdase term. This is consistent with the broader observation from family-level analysis (file:interpro/panther/PTHR10430/PTHR10430-deep-research-falcon.md) that hyperoxidized peroxiredoxins can switch to chaperone/holdase activity; pmp20 appears to have constitutively adopted this alternative function due to loss of the resolving cysteine. Note that the UniProt record also carries GO:0042026 (protein refolding) via IC from PomBase, but the experimental evidence specifically supports prevention of aggregation rather than active refolding.
                         </div>
                         
                         
@@ -1876,6 +1900,17 @@
                                 </span>
                                 
                                 <div class="support-text">the most direct *S. pombe* experimental claim is **in vitro inhibition of citrate synthase thermal aggregation at 43°C**, supporting a chaperone-like role in protein quality control</div>
+                                
+                            </div>
+                            
+                            <div class="support-item">
+                                <span class="support-ref">
+                                    
+                                    file:SCHPO/pmp20/pmp20-hypotheses/function-hypothesis-go-0008379/openscientist.md
+                                    
+                                </span>
+                                
+                                <div class="support-text">This establishes that PMP20&#39;s primary molecular function is as an unfolded protein holdase, not a peroxidase.</div>
                                 
                             </div>
                             
@@ -2056,8 +2091,8 @@
         <div class="core-function-card">
             
             <div style="display: flex; justify-content: space-between; align-items: center;">
-                <h3>Weak protein folding chaperone. Despite belonging to the peroxiredoxin family (Prx5 subfamily, PANTHER PTHR10430:SF39), pmp20 has lost the canonical peroxidase function due to absence of the resolving cysteine. It inhibits thermal aggregation of citrate synthase, indicating holdase-type chaperone activity, though weaker than the S. pombe TPx (tpx1). This represents a neo-functionalization within the peroxiredoxin family: orthologs such as C. boidinii CbPmp20 (PMID:11278957) and H. polymorpha Pmp20 (PMID:18694816) are active peroxidases essential for peroxisomal integrity, while S. pombe pmp20 has constitutively shifted to chaperone function, paralleling the redox-state-dependent chaperone/holdase switch observed in hyperoxidized typical 2-Cys peroxiredoxins.</h3>
-                <span class="vote-buttons" data-g="O14313" data-a="FUNCTION: Weak protein folding chaperone. Despite belonging ..." data-r="" data-act="CORE_FUNCTION">
+                <h3>Weak protein folding chaperone with holdase-type anti-aggregation activity. Despite belonging to the peroxiredoxin family (Prx5 subfamily, PANTHER PTHR10430:SF39), pmp20 has lost the canonical peroxidase function due to absence of the resolving cysteine. It inhibits thermal aggregation of citrate synthase, indicating holdase-type chaperone activity, though weaker than the S. pombe TPx (tpx1). This represents a neo-functionalization within the peroxiredoxin family: orthologs such as C. boidinii CbPmp20 (PMID:11278957) and H. polymorpha Pmp20 (PMID:18694816) are active peroxidases essential for peroxisomal integrity, while S. pombe pmp20 has constitutively shifted to chaperone function, paralleling the redox-state-dependent chaperone/holdase switch observed in hyperoxidized typical 2-Cys peroxiredoxins.</h3>
+                <span class="vote-buttons" data-g="O14313" data-a="FUNCTION: Weak protein folding chaperone with holdase-type a..." data-r="" data-act="CORE_FUNCTION">
                     <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
                     <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
                 </span>
@@ -2152,6 +2187,17 @@
                         </span>
                         
                         <div class="finding-text">the most direct *S. pombe* experimental claim is **in vitro inhibition of citrate synthase thermal aggregation at 43°C**, supporting a chaperone-like role in protein quality control</div>
+                        
+                    </li>
+                    
+                    <li class="finding-item">
+                        <span class="reference-id">
+                            
+                            file:SCHPO/pmp20/pmp20-hypotheses/function-hypothesis-go-0008379/openscientist.md
+                            
+                        </span>
+                        
+                        <div class="finding-text">This establishes that PMP20&#39;s primary molecular function is as an unfolded protein holdase, not a peroxidase.</div>
                         
                     </li>
                     
@@ -2369,6 +2415,33 @@
                 <div class="reference-header">
                     <span class="reference-id">
                         
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/24521463" target="_blank" class="term-link">
+                            PMID:24521463
+                        </a>
+                        
+                    </span>
+                </div>
+                
+                <div class="reference-title">A genetic approach to study H2O2 scavenging in fission yeast--distinct roles of peroxiredoxin and catalase.</div>
+                
+                
+                <ul class="findings-list">
+                    
+                    <li class="finding-item">
+                        <div class="finding-statement">Tpx1 is the main enzyme controlling low peroxide levels during aerobic growth in S. pombe.</div>
+                        
+                        <div class="finding-text">"Tpx1 is the only enzyme with sufficient sensitivity for peroxides and cellular abundance as to control the low levels produced during aerobic growth"</div>
+                        
+                    </li>
+                    
+                </ul>
+                
+            </div>
+            
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+                        
                         <a href="https://pubmed.ncbi.nlm.nih.gov/11278957" target="_blank" class="term-link">
                             PMID:11278957
                         </a>
@@ -2560,6 +2633,44 @@ family members and requires S. pombe-specific enzymology to confirm.</div>
 defense plus molecular chaperone-like activity.</div>
                         
                         <div class="finding-text">"Pmp20p may have a **dual function**: antioxidant defense plus **molecular chaperone-like activity**"</div>
+                        
+                    </li>
+                    
+                </ul>
+                
+            </div>
+            
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+                        
+                        file:SCHPO/pmp20/pmp20-hypotheses/function-hypothesis-go-0008379/openscientist.md
+                        
+                    </span>
+                </div>
+                
+                <div class="reference-title">OpenScientist focused review of pmp20 thioredoxin peroxidase activity</div>
+                
+                
+                <ul class="findings-list">
+                    
+                    <li class="finding-item">
+                        <div class="finding-statement">The focused hypothesis review judged GO:0008379 thioredoxin peroxidase activity over-annotated for pmp20 and recommended removing or suppressing the computational annotation.</div>
+                        
+                    </li>
+                    
+                    <li class="finding-item">
+                        <div class="finding-statement">The direct PMID:20356456 assay refutes thioredoxin-dependent peroxidase activity and supports holdase activity.</div>
+                        
+                    </li>
+                    
+                    <li class="finding-item">
+                        <div class="finding-statement">The report emphasizes that the thermal aggregation protection assay supports holdase-type anti-aggregation activity rather than peroxidase activity.</div>
+                        
+                    </li>
+                    
+                    <li class="finding-item">
+                        <div class="finding-statement">PMID:24521463 provides organism-level context that peroxide scavenging in S. pombe is primarily attributed to Tpx1, catalase, and Gpx1, not pmp20.</div>
                         
                     </li>
                     
@@ -4204,6 +4315,13 @@ existing_annotations:
       activity. UniProt states &#34;Has no thioredoxin-dependent peroxidase activity&#34;
       and &#34;Pmp20 lacks the resolving cysteine residue&#34; (PMID:20356456). The InterPro
       domain mapping does not account for the absence of the resolving cysteine.
+      The focused OpenScientist hypothesis review independently judged GO:0008379
+      over-annotated and noted that the organism-wide peroxide-scavenging analysis
+      in PMID:24521463 also supports Tpx1, catalase, and Gpx1 rather than pmp20 as
+      fission yeast peroxide-scavenging activities.
+    additional_reference_ids:
+    - PMID:24521463
+    - file:SCHPO/pmp20/pmp20-hypotheses/function-hypothesis-go-0008379/openscientist.md
     supported_by:
     - reference_id: PMID:20356456
       supporting_text: The fission yeast PMP20 without thioredoxin-dependent peroxidase
@@ -4211,6 +4329,14 @@ existing_annotations:
     - reference_id: file:SCHPO/pmp20/pmp20-bioinformatics/RESULTS.md
       supporting_text: Comparative sequence and structure analysis supports no resolving
         cysteine in pmp20.
+    - reference_id: PMID:24521463
+      supporting_text: Tpx1 is the only enzyme with sufficient sensitivity for peroxides
+        and cellular abundance as to control the low levels produced during aerobic
+        growth
+    - reference_id: file:SCHPO/pmp20/pmp20-hypotheses/function-hypothesis-go-0008379/openscientist.md
+      supporting_text: The annotation of GO:0008379 (thioredoxin peroxidase activity)
+        to *Schizosaccharomyces pombe* pmp20 is definitively over-annotated and should
+        be removed or suppressed.
 - term:
     id: GO:0016209
     label: antioxidant activity
@@ -4276,9 +4402,13 @@ existing_annotations:
     action: MODIFY
     reason: GO:0051082 is being obsoleted. PMID:20356456 demonstrated that pmp20 inhibits
       thermal aggregation of citrate synthase (a holdase/chaperone assay), with weaker
-      activity than S. pombe TPx (tpx1). The appropriate replacement is GO:0044183
-      &#34;protein folding chaperone.&#34; This is consistent with the broader observation
-      from family-level analysis (file:interpro/panther/PTHR10430/PTHR10430-deep-research-falcon.md)
+      activity than S. pombe TPx (tpx1). The focused OpenScientist review reinforces
+      that the assay supports holdase-type anti-aggregation activity rather than
+      peroxidase activity, but GO:0140309 is currently modeled as unfolded protein
+      carrier activity and is not a good fit for simple in-situ holdase assays. The
+      pragmatic replacement remains GO:0044183 &#34;protein folding chaperone&#34; pending
+      a more precise general holdase term. This is consistent with the broader
+      observation from family-level analysis (file:interpro/panther/PTHR10430/PTHR10430-deep-research-falcon.md)
       that hyperoxidized peroxiredoxins can switch to chaperone/holdase activity;
       pmp20 appears to have constitutively adopted this alternative function due to
       loss of the resolving cysteine. Note that the UniProt record also carries GO:0042026
@@ -4300,6 +4430,9 @@ existing_annotations:
     - reference_id: file:SCHPO/pmp20/pmp20-deep-research-falcon.md
       supporting_text: |-
         the most direct *S. pombe* experimental claim is **in vitro inhibition of citrate synthase thermal aggregation at 43°C**, supporting a chaperone-like role in protein quality control
+    - reference_id: file:SCHPO/pmp20/pmp20-hypotheses/function-hypothesis-go-0008379/openscientist.md
+      supporting_text: This establishes that PMP20&#39;s primary molecular function is
+        as an unfolded protein holdase, not a peroxidase.
 - term:
     id: GO:0005634
     label: nucleus
@@ -4395,6 +4528,15 @@ references:
   - statement: Pmp20 may act as a molecular chaperone rather than a peroxidase.
     supporting_text: The fission yeast PMP20 without thioredoxin-dependent peroxidase
       activity may act as a molecular chaperone.
+- id: PMID:24521463
+  title: A genetic approach to study H2O2 scavenging in fission yeast--distinct roles
+    of peroxiredoxin and catalase.
+  findings:
+  - statement: Tpx1 is the main enzyme controlling low peroxide levels during aerobic
+      growth in S. pombe.
+    supporting_text: Tpx1 is the only enzyme with sufficient sensitivity for peroxides
+      and cellular abundance as to control the low levels produced during aerobic
+      growth
 - id: PMID:11278957
   title: Antioxidant system within yeast peroxisome. Biochemical and physiological
     characterization of CbPmp20 in the methylotrophic yeast Candida boidinii.
@@ -4492,6 +4634,23 @@ references:
     supporting_text: |-
       Pmp20p may have a **dual function**: antioxidant defense plus **molecular chaperone-like activity**
     reference_section_type: OTHER
+- id: file:SCHPO/pmp20/pmp20-hypotheses/function-hypothesis-go-0008379/openscientist.md
+  title: OpenScientist focused review of pmp20 thioredoxin peroxidase activity
+  publication_type: DEEP_RESEARCH
+  findings:
+  - statement: &gt;-
+      The focused hypothesis review judged GO:0008379 thioredoxin peroxidase
+      activity over-annotated for pmp20 and recommended removing or suppressing the
+      computational annotation.
+  - statement: &gt;-
+      The direct PMID:20356456 assay refutes thioredoxin-dependent peroxidase activity
+      and supports holdase activity.
+  - statement: &gt;-
+      The report emphasizes that the thermal aggregation protection assay supports
+      holdase-type anti-aggregation activity rather than peroxidase activity.
+  - statement: &gt;-
+      PMID:24521463 provides organism-level context that peroxide scavenging in S.
+      pombe is primarily attributed to Tpx1, catalase, and Gpx1, not pmp20.
 - id: file:interpro/panther/PTHR10430/PTHR10430-deep-research-falcon.md
   title: PANTHER family PTHR10430 (PEROXIREDOXIN) functional diversity analysis
   findings:
@@ -4508,7 +4667,8 @@ references:
       favor dimers, and hyperoxidized forms can produce high-molecular-weight species
       associated with chaperone-like (holdase) activity.
 core_functions:
-- description: &#39;Weak protein folding chaperone. Despite belonging to the peroxiredoxin
+- description: &#39;Weak protein folding chaperone with holdase-type anti-aggregation activity.
+    Despite belonging to the peroxiredoxin
     family (Prx5 subfamily, PANTHER PTHR10430:SF39), pmp20 has lost the canonical
     peroxidase function due to absence of the resolving cysteine. It inhibits thermal
     aggregation of citrate synthase, indicating holdase-type chaperone activity, though
@@ -4531,6 +4691,9 @@ core_functions:
   - reference_id: file:SCHPO/pmp20/pmp20-deep-research-falcon.md
     supporting_text: |-
       the most direct *S. pombe* experimental claim is **in vitro inhibition of citrate synthase thermal aggregation at 43°C**, supporting a chaperone-like role in protein quality control
+  - reference_id: file:SCHPO/pmp20/pmp20-hypotheses/function-hypothesis-go-0008379/openscientist.md
+    supporting_text: This establishes that PMP20&#39;s primary molecular function is as
+      an unfolded protein holdase, not a peroxidase.
   molecular_function:
     id: GO:0044183
     label: protein folding chaperone

--- a/genes/SCHPO/pmp20/pmp20-ai-review.yaml
+++ b/genes/SCHPO/pmp20/pmp20-ai-review.yaml
@@ -192,6 +192,13 @@ existing_annotations:
       activity. UniProt states "Has no thioredoxin-dependent peroxidase activity"
       and "Pmp20 lacks the resolving cysteine residue" (PMID:20356456). The InterPro
       domain mapping does not account for the absence of the resolving cysteine.
+      The focused OpenScientist hypothesis review independently judged GO:0008379
+      over-annotated and noted that the organism-wide peroxide-scavenging analysis
+      in PMID:24521463 also supports Tpx1, catalase, and Gpx1 rather than pmp20 as
+      fission yeast peroxide-scavenging activities.
+    additional_reference_ids:
+    - PMID:24521463
+    - file:SCHPO/pmp20/pmp20-hypotheses/function-hypothesis-go-0008379/openscientist.md
     supported_by:
     - reference_id: PMID:20356456
       supporting_text: The fission yeast PMP20 without thioredoxin-dependent peroxidase
@@ -199,6 +206,14 @@ existing_annotations:
     - reference_id: file:SCHPO/pmp20/pmp20-bioinformatics/RESULTS.md
       supporting_text: Comparative sequence and structure analysis supports no resolving
         cysteine in pmp20.
+    - reference_id: PMID:24521463
+      supporting_text: Tpx1 is the only enzyme with sufficient sensitivity for peroxides
+        and cellular abundance as to control the low levels produced during aerobic
+        growth
+    - reference_id: file:SCHPO/pmp20/pmp20-hypotheses/function-hypothesis-go-0008379/openscientist.md
+      supporting_text: The annotation of GO:0008379 (thioredoxin peroxidase activity)
+        to *Schizosaccharomyces pombe* pmp20 is definitively over-annotated and should
+        be removed or suppressed.
 - term:
     id: GO:0016209
     label: antioxidant activity
@@ -264,9 +279,13 @@ existing_annotations:
     action: MODIFY
     reason: GO:0051082 is being obsoleted. PMID:20356456 demonstrated that pmp20 inhibits
       thermal aggregation of citrate synthase (a holdase/chaperone assay), with weaker
-      activity than S. pombe TPx (tpx1). The appropriate replacement is GO:0044183
-      "protein folding chaperone." This is consistent with the broader observation
-      from family-level analysis (file:interpro/panther/PTHR10430/PTHR10430-deep-research-falcon.md)
+      activity than S. pombe TPx (tpx1). The focused OpenScientist review reinforces
+      that the assay supports holdase-type anti-aggregation activity rather than
+      peroxidase activity, but GO:0140309 is currently modeled as unfolded protein
+      carrier activity and is not a good fit for simple in-situ holdase assays. The
+      pragmatic replacement remains GO:0044183 "protein folding chaperone" pending
+      a more precise general holdase term. This is consistent with the broader
+      observation from family-level analysis (file:interpro/panther/PTHR10430/PTHR10430-deep-research-falcon.md)
       that hyperoxidized peroxiredoxins can switch to chaperone/holdase activity;
       pmp20 appears to have constitutively adopted this alternative function due to
       loss of the resolving cysteine. Note that the UniProt record also carries GO:0042026
@@ -288,6 +307,9 @@ existing_annotations:
     - reference_id: file:SCHPO/pmp20/pmp20-deep-research-falcon.md
       supporting_text: |-
         the most direct *S. pombe* experimental claim is **in vitro inhibition of citrate synthase thermal aggregation at 43°C**, supporting a chaperone-like role in protein quality control
+    - reference_id: file:SCHPO/pmp20/pmp20-hypotheses/function-hypothesis-go-0008379/openscientist.md
+      supporting_text: This establishes that PMP20's primary molecular function is
+        as an unfolded protein holdase, not a peroxidase.
 - term:
     id: GO:0005634
     label: nucleus
@@ -383,6 +405,15 @@ references:
   - statement: Pmp20 may act as a molecular chaperone rather than a peroxidase.
     supporting_text: The fission yeast PMP20 without thioredoxin-dependent peroxidase
       activity may act as a molecular chaperone.
+- id: PMID:24521463
+  title: A genetic approach to study H2O2 scavenging in fission yeast--distinct roles
+    of peroxiredoxin and catalase.
+  findings:
+  - statement: Tpx1 is the main enzyme controlling low peroxide levels during aerobic
+      growth in S. pombe.
+    supporting_text: Tpx1 is the only enzyme with sufficient sensitivity for peroxides
+      and cellular abundance as to control the low levels produced during aerobic
+      growth
 - id: PMID:11278957
   title: Antioxidant system within yeast peroxisome. Biochemical and physiological
     characterization of CbPmp20 in the methylotrophic yeast Candida boidinii.
@@ -480,6 +511,23 @@ references:
     supporting_text: |-
       Pmp20p may have a **dual function**: antioxidant defense plus **molecular chaperone-like activity**
     reference_section_type: OTHER
+- id: file:SCHPO/pmp20/pmp20-hypotheses/function-hypothesis-go-0008379/openscientist.md
+  title: OpenScientist focused review of pmp20 thioredoxin peroxidase activity
+  publication_type: DEEP_RESEARCH
+  findings:
+  - statement: >-
+      The focused hypothesis review judged GO:0008379 thioredoxin peroxidase
+      activity over-annotated for pmp20 and recommended removing or suppressing the
+      computational annotation.
+  - statement: >-
+      The direct PMID:20356456 assay refutes thioredoxin-dependent peroxidase activity
+      and supports holdase activity.
+  - statement: >-
+      The report emphasizes that the thermal aggregation protection assay supports
+      holdase-type anti-aggregation activity rather than peroxidase activity.
+  - statement: >-
+      PMID:24521463 provides organism-level context that peroxide scavenging in S.
+      pombe is primarily attributed to Tpx1, catalase, and Gpx1, not pmp20.
 - id: file:interpro/panther/PTHR10430/PTHR10430-deep-research-falcon.md
   title: PANTHER family PTHR10430 (PEROXIREDOXIN) functional diversity analysis
   findings:
@@ -496,7 +544,8 @@ references:
       favor dimers, and hyperoxidized forms can produce high-molecular-weight species
       associated with chaperone-like (holdase) activity.
 core_functions:
-- description: 'Weak protein folding chaperone. Despite belonging to the peroxiredoxin
+- description: 'Weak protein folding chaperone with holdase-type anti-aggregation activity.
+    Despite belonging to the peroxiredoxin
     family (Prx5 subfamily, PANTHER PTHR10430:SF39), pmp20 has lost the canonical
     peroxidase function due to absence of the resolving cysteine. It inhibits thermal
     aggregation of citrate synthase, indicating holdase-type chaperone activity, though
@@ -519,6 +568,9 @@ core_functions:
   - reference_id: file:SCHPO/pmp20/pmp20-deep-research-falcon.md
     supporting_text: |-
       the most direct *S. pombe* experimental claim is **in vitro inhibition of citrate synthase thermal aggregation at 43°C**, supporting a chaperone-like role in protein quality control
+  - reference_id: file:SCHPO/pmp20/pmp20-hypotheses/function-hypothesis-go-0008379/openscientist.md
+    supporting_text: This establishes that PMP20's primary molecular function is as
+      an unfolded protein holdase, not a peroxidase.
   molecular_function:
     id: GO:0044183
     label: protein folding chaperone


### PR DESCRIPTION
## Summary

Integrates the completed OpenScientist focused review for `SCHPO/pmp20` and `GO:0008379 thioredoxin peroxidase activity`.

Changes:
- adds the OpenScientist report as a reference in the pmp20 review
- reinforces the `REMOVE` decision for `GO:0008379` using the focused report plus cached PMID:24521463 peroxide-scavenging context
- keeps the replacement for obsolete `GO:0051082` as `GO:0044183 protein folding chaperone`, while noting that the direct assay is holdase-type anti-aggregation and that `GO:0140309` is not a good fit for simple in-situ holdase assays
- updates the core-function description with the OpenScientist holdase interpretation
- regenerates the pmp20 HTML review page

## Validation

- `just validate SCHPO pmp20`
- `just render SCHPO pmp20`