### PR TITLE
[codex] Integrate IL21 OpenScientist findings

### DIFF
--- a/genes/human/IL21/IL21-ai-review.html
+++ b/genes/human/IL21/IL21-ai-review.html
@@ -890,10 +890,10 @@
                         
                     </td>
                     <td>
-                        <span class="action-badge action-accept">
-                            ACCEPT
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
                         </span>
-                        <span class="vote-buttons" data-g="Q9HBE4" data-a="GO:0045954" data-r="GO_REF:0000033" data-act="ACCEPT">
+                        <span class="vote-buttons" data-g="Q9HBE4" data-a="GO:0045954" data-r="GO_REF:0000033" data-act="KEEP_AS_NON_CORE">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
@@ -901,9 +901,13 @@
                     <td>
                         
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Phylogenetically inferred annotation consistent with IL21&#39;s role in NK cell function. Supported by experimental data (PMID:18005035) showing IL21 activates NK cells and modulates their cytotoxic activity.
+                            <strong>Summary:</strong> Phylogenetically inferred annotation consistent with IL21&#39;s role in NK cell function. Supported by experimental data (PMID:18005035) showing IL21 activates NK cells and modulates their cytotoxic activity, but the focused OpenScientist review judged NK cytotoxicity enhancement to be a real pleiotropic effect rather than a signature IL21 core function.
                         </div>
                         
+                        
+                        <div>
+                            <strong>Reason:</strong> Retain the annotation as biologically real, but do not treat it as core. IL21&#39;s signature biology centers on cytokine activity driving the B cell/Tfh/humoral immunity axis; NK cytotoxicity is context-dependent and downstream of the same IL21R/JAK-STAT signaling program.
+                        </div>
                         
                         
                         
@@ -1324,10 +1328,10 @@
                         
                     </td>
                     <td>
-                        <span class="action-badge action-accept">
-                            ACCEPT
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
                         </span>
-                        <span class="vote-buttons" data-g="Q9HBE4" data-a="GO:0045954" data-r="GO_REF:0000117" data-act="ACCEPT">
+                        <span class="vote-buttons" data-g="Q9HBE4" data-a="GO:0045954" data-r="GO_REF:0000117" data-act="KEEP_AS_NON_CORE">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
@@ -1335,9 +1339,13 @@
                     <td>
                         
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Duplicates IBA/IDA annotation for same term. ARBA-predicted. Consistent with experimental evidence. Maintain consistent action.
+                            <strong>Summary:</strong> Duplicates IBA/IDA annotation for the same term. ARBA-predicted and consistent with experimental evidence, but non-core for IL21.
                         </div>
                         
+                        
+                        <div>
+                            <strong>Reason:</strong> Maintain consistency with the IBA and IDA GO:0045954 reviews: IL21 can enhance NK cytotoxicity, but this is not a signature core function of the cytokine.
+                        </div>
                         
                         
                         
@@ -2771,10 +2779,10 @@
                         
                     </td>
                     <td>
-                        <span class="action-badge action-undecided">
-                            UNDECIDED
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
                         </span>
-                        <span class="vote-buttons" data-g="Q9HBE4" data-a="GO:0042102" data-r="PMID:17673207" data-act="UNDECIDED">
+                        <span class="vote-buttons" data-g="Q9HBE4" data-a="GO:0042102" data-r="PMID:17673207" data-act="KEEP_AS_NON_CORE">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
@@ -2787,7 +2795,7 @@
                         
                         
                         <div>
-                            <strong>Reason:</strong> Deferred to expert curator review (see issue #1418). The effect is directly evidenced (PMID:17673207: &#34;comparable proliferative effect on ... anti-CD3 Ab-activated primary T cells&#34;), but IL21 is a weak, context-dependent T-cell mitogen, so core vs non-core is genuinely unclear. GO:0042102 has been removed from core_functions pending this decision; the B-cell/Tfh signature processes remain core.
+                            <strong>Reason:</strong> The focused OpenScientist review resolved the core-function question by recommending KEEP_AS_NON_CORE. The effect is directly evidenced (PMID:17673207: &#34;comparable proliferative effect on ... anti-CD3 Ab-activated primary T cells&#34;), but it is costimulation-dependent, context-sensitive, and subordinate to IL21&#39;s signature B-cell/Tfh/humoral immunity functions. GO:0042102 remains out of core_functions.
                         </div>
                         
                         
@@ -2805,6 +2813,17 @@
                                 </span>
                                 
                                 <div class="support-text">Epub 2007 Jul 25. Cloning and characterization of an isoform of interleukin-21.</div>
+                                
+                            </div>
+                            
+                            <div class="support-item">
+                                <span class="support-ref">
+                                    
+                                    file:human/IL21/IL21-hypotheses/core-function-1-go-0042102/openscientist.md
+                                    
+                                </span>
+                                
+                                <div class="support-text">The annotation should be retained (the effect is real) but classified as non-core using the `KEEP_AS_NON_CORE` action.</div>
                                 
                             </div>
                             
@@ -2938,10 +2957,10 @@
                         
                     </td>
                     <td>
-                        <span class="action-badge action-accept">
-                            ACCEPT
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
                         </span>
-                        <span class="vote-buttons" data-g="Q9HBE4" data-a="GO:0045954" data-r="PMID:18005035" data-act="ACCEPT">
+                        <span class="vote-buttons" data-g="Q9HBE4" data-a="GO:0045954" data-r="PMID:18005035" data-act="KEEP_AS_NON_CORE">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
@@ -2949,9 +2968,13 @@
                     <td>
                         
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Correct annotation with experimental evidence. IL21 activates NK cells and modulates their cytotoxic activity. Core function.
+                            <strong>Summary:</strong> Correct annotation with experimental evidence. IL21 activates NK cells and modulates their cytotoxic activity, but this should be treated as a real non-core pleiotropic effect rather than a signature IL21 function.
                         </div>
                         
+                        
+                        <div>
+                            <strong>Reason:</strong> The focused OpenScientist review found that NK cytotoxicity enhancement has IDA support from PMID:18005035, but parallels T cell proliferation as a downstream, context-dependent effect of IL21R/JAK-STAT signaling rather than a defining core process.
+                        </div>
                         
                         
                         
@@ -2968,6 +2991,17 @@
                                 </span>
                                 
                                 <div class="support-text">Epub 2007 Nov 14. Interleukin-21 activates human natural killer cells and modulates their surface receptor expression.</div>
+                                
+                            </div>
+                            
+                            <div class="support-item">
+                                <span class="support-ref">
+                                    
+                                    file:human/IL21/IL21-hypotheses/core-function-1-go-0042102/openscientist.md
+                                    
+                                </span>
+                                
+                                <div class="support-text">NK cytotoxicity enhancement is a real pleiotropic effect but not a signature function, and it should also be classified as non-core.</div>
                                 
                             </div>
                             
@@ -3633,10 +3667,10 @@
                         
                     </td>
                     <td>
-                        <span class="action-badge action-undecided">
-                            UNDECIDED
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
                         </span>
-                        <span class="vote-buttons" data-g="Q9HBE4" data-a="GO:0042102" data-r="PMID:15207081" data-act="UNDECIDED">
+                        <span class="vote-buttons" data-g="Q9HBE4" data-a="GO:0042102" data-r="PMID:15207081" data-act="KEEP_AS_NON_CORE">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
@@ -3649,7 +3683,7 @@
                         
                         
                         <div>
-                            <strong>Reason:</strong> Deferred to expert curator review (see issue #1418), consistent with the GO:0042102 annotation from PMID:17673207. Real effect, but core vs non-core status for IL21 is borderline.
+                            <strong>Reason:</strong> Resolved consistently with the GO:0042102 annotation from PMID:17673207 and the focused OpenScientist review. The effect is real, but should be retained as non-core because it is costimulation-dependent and not part of IL21&#39;s signature B-cell/Tfh/humoral immunity axis.
                         </div>
                         
                         
@@ -3667,6 +3701,17 @@
                                 </span>
                                 
                                 <div class="support-text">AIM: To clone full length cDNA of human interleukin-21 (IL-21) and express it in E.coli.</div>
+                                
+                            </div>
+                            
+                            <div class="support-item">
+                                <span class="support-ref">
+                                    
+                                    file:human/IL21/IL21-hypotheses/core-function-1-go-0042102/openscientist.md
+                                    
+                                </span>
+                                
+                                <div class="support-text">The annotation should be retained (the effect is real) but classified as non-core using the `KEEP_AS_NON_CORE` action.</div>
                                 
                             </div>
                             
@@ -3885,12 +3930,6 @@
                         <span class="badge">
                             <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0030890" target="_blank" class="term-link">
                                 positive regulation of B cell proliferation
-                            </a>
-                        </span>
-                        
-                        <span class="badge">
-                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0045954" target="_blank" class="term-link">
-                                positive regulation of natural killer cell mediated cytotoxicity
                             </a>
                         </span>
                         
@@ -4393,6 +4432,44 @@
                 <div class="reference-header">
                     <span class="reference-id">
                         
+                        file:human/IL21/IL21-hypotheses/core-function-1-go-0042102/openscientist.md
+                        
+                    </span>
+                </div>
+                
+                <div class="reference-title">OpenScientist focused review of IL21 positive regulation of T cell proliferation as a core function</div>
+                
+                
+                <ul class="findings-list">
+                    
+                    <li class="finding-item">
+                        <div class="finding-statement">The focused hypothesis review judged positive regulation of T cell proliferation to be a real IL21 effect but not a core function, recommending KEEP_AS_NON_CORE for both GO:0042102 annotations.</div>
+                        
+                    </li>
+                    
+                    <li class="finding-item">
+                        <div class="finding-statement">The report found that IL21&#39;s signature functions are cytokine activity driving the B cell/Tfh/humoral immunity axis: germinal center B cell differentiation, Tfh differentiation, immunoglobulin production, and B cell proliferation.</div>
+                        
+                    </li>
+                    
+                    <li class="finding-item">
+                        <div class="finding-statement">The report recommended removing positive regulation of natural killer cell mediated cytotoxicity from core_functions and retaining it as non-core, because the effect is real but not signature.</div>
+                        
+                    </li>
+                    
+                    <li class="finding-item">
+                        <div class="finding-statement">The report flagged an evidence-code asymmetry: several signature IL21 processes have weaker GOA evidence codes than the non-core T cell proliferation annotations.</div>
+                        
+                    </li>
+                    
+                </ul>
+                
+            </div>
+            
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+                        
                         Reactome:R-HSA-9005980
                         
                     </span>
@@ -4604,6 +4681,793 @@ this with annotations you find in gene/protein databases, but these can be outda
             </div>
         </details>
         
+        <details class="deep-research-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; gap: 1rem;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">OpenScientist hypothesis job — IL21 GO:0042102</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(IL21-hypotheses/core-function-1-go-0042102/README.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="Q9HBE4" data-a="DEEP_RESEARCH: OpenScientist hypothesis job — IL21 GO:0042102" data-r="" data-act="DEEP_RESEARCH" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This deep research is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This deep research needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+                
+                
+                <h1 id="openscientist-hypothesis-job-il21-go0042102">OpenScientist hypothesis job — IL21 GO:0042102</h1>
+<p><strong>Status:</strong> ✅ completed 2026-06-06 (28.5 min, 28 PMID citations). Result in<br />
+<code>openscientist.md</code> (+ <code>openscientist.md.citations.md</code>).</p>
+<p><strong>Verdict:</strong> <em>OVER-ANNOTATED as core function → recommend <code>KEEP_AS_NON_CORE</code></em> for<br />
+GO:0042102 — the T-cell-proliferation effect is real but costimulation-dependent,<br />
+bidirectional across T-cell subsets, not a defining feature of IL-21R deficiency,<br />
+and subordinate to IL-21's B-cell/Tfh signature. Same call for NK cytotoxicity<br />
+(GO:0045954). Notable leads: GO:0045954 actually has IDA support (PMID:18005035),<br />
+and IL-21's true core functions have only ISS/IEA (so IDA ≠ core).</p>
+<blockquote>
+<p>This is the autonomous agent's analysis — <strong>hypothesis-generating literature<br />
+synthesis to verify against the cited PMIDs, not ground truth.</strong> The<br />
+annotations remain <code>UNDECIDED</code> pending expert adjudication on<br />
+<a href="https://github.com/ai4curation/ai-gene-review/issues/1418">issue #1418</a>; this<br />
+brief is a complement, not the decision.</p>
+</blockquote>
+<hr />
+<h2 id="reproduction">Reproduction</h2>
+<div class="codehilite"><pre><span></span><code><span class="nb">export</span><span class="w"> </span><span class="nv">OPENSCIENTIST_API_KEY</span><span class="o">=</span><span class="s2">&quot;name:secret&quot;</span><span class="w">   </span><span class="c1"># your key</span>
+uv<span class="w"> </span>run<span class="w"> </span>deep-research-client<span class="w"> </span>research<span class="w"> </span><span class="se">\</span>
+<span class="w">  </span>--input-file<span class="w"> </span>genes/human/IL21/IL21-hypotheses/core-function-1-go-0042102/prompt.md<span class="w"> </span><span class="se">\</span>
+<span class="w">  </span>--provider<span class="w"> </span>openscientist<span class="w"> </span><span class="se">\</span>
+<span class="w">  </span>--output<span class="w"> </span>genes/human/IL21/IL21-hypotheses/core-function-1-go-0042102/openscientist.md<span class="w"> </span><span class="se">\</span>
+<span class="w">  </span>--separate-citations
+</code></pre></div>
+
+<p>Jobs run ~10–15 min. The result lands as <code>openscientist.md</code> (+ a<br />
+<code>openscientist.md.citations.md</code>). After review, fold any verified findings into<br />
+<code>genes/human/IL21/IL21-ai-review.yaml</code> as a <code>file:</code> reference with an extracted<br />
+<code>supporting_text</code> statement (the SCO1 review is the model), and report the<br />
+verdict back on issue #1418.</p>
+<blockquote>
+<p>Treat the output as hypothesis-generating literature synthesis, not ground<br />
+truth — verify snippets against the cited PMIDs before using them in curation.</p>
+</blockquote>
+            </div>
+        </details>
+        
+        <details class="deep-research-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; gap: 1rem;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">OpenScientist</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(IL21-hypotheses/core-function-1-go-0042102/openscientist.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="Q9HBE4" data-a="DEEP_RESEARCH: OpenScientist" data-r="" data-act="DEEP_RESEARCH" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This deep research is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This deep research needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+                
+                <div class="report-meta">
+                    
+                    <span class="report-meta-text">IL21 Core Function Hypothesis: Positive Regulation of T Cell Proliferation (GO:0042102)</span>
+                    
+                    
+                    <span class="report-badge">OpenScientist</span>
+                    
+                    
+                    <span class="report-badge">openscientist-autonomous</span>
+                    
+                    
+                    <span class="report-badge">22 citations</span>
+                    
+                    
+                    
+                    <span class="report-meta-text">2026-06-06T23:31:52.806304</span>
+                    
+                    
+                    
+                    <a href="IL21-hypotheses/core-function-1-go-0042102/openscientist.md.citations.md" class="term-link">citations file</a>
+                    
+                </div>
+                
+                
+                <h1 id="il21-core-function-hypothesis-positive-regulation-of-t-cell-proliferation-go0042102">IL21 Core Function Hypothesis: Positive Regulation of T Cell Proliferation (GO:0042102)</h1>
+<h2 id="executive-judgment">Executive Judgment</h2>
+<p><strong>Verdict: OVER-ANNOTATED as core function — recommend KEEP_AS_NON_CORE</strong></p>
+<p>Positive regulation of T cell proliferation (GO:0042102) is a real, experimentally documented effect of IL-21, but it does not represent a core (primary, signature) function of this cytokine. Eight independent lines of evidence converge on this conclusion: (1) both IDA-supporting papers demonstrate only costimulation-dependent proliferation; (2) human IL-21R deficiency phenotypes center on B cell and humoral immune defects, not T cell proliferative defects; (3) IL-21 is anti-proliferative for certain T cell subsets (Tfr cells); (4) IL-21's actual T cell biology is differentiation (Th17/Tfh lineage commitment), not proliferation; (5) cell-type-specific knockouts show B cells are the essential target; (6) even the Th17 autocrine role shows in vivo redundancy; (7) the strongest counter-evidence (CD8 T cell sustaining during chronic viral infection) is context-specific, mechanistically distinct from mitogenic proliferation, and maps to a different GO term; and (8) IL-21 is unique among gamma-chain cytokines in not having T cell proliferation as a primary function. The two IDA annotations (PMID:17673207, PMID:15207081) should be retained in the gene record but reclassified as non-core. The related annotation for positive regulation of NK cell mediated cytotoxicity (GO:0045954) should be treated equivalently — real but non-core — and removed from <code>directly_involved_in</code>.</p>
+<p>The most important caveat is that "core" vs. "non-core" is a curation-level distinction, not a binary biological one. The T cell proliferative effect is genuine and reproducible, but it is secondary, context-dependent, and subordinate to IL-21's signature roles in germinal center B cell differentiation, Tfh differentiation, immunoglobulin production, and B cell proliferation.</p>
+<hr />
+<h2 id="summary">Summary</h2>
+<p>IL-21 is a pleiotropic type I cytokine produced predominantly by CD4+ T cells (especially Tfh and Th17 cells) and NKT cells. It signals through the IL-21R/IL-2Rgamma (common gamma-chain) receptor complex, activating JAK1/JAK3 and primarily STAT3. Its signature, evolutionarily conserved functions center on the B cell/T follicular helper axis: germinal center B cell differentiation, T follicular helper cell differentiation, immunoglobulin class switching and production, and B cell proliferation. These functions are consistently revealed by loss-of-function studies in both mice (Il21-/-, Il21r-/-) and humans with IL-21R deficiency.</p>
+<p>The question under review is whether positive regulation of T cell proliferation — currently annotated with two IDA evidence codes — qualifies as a <em>core</em> function or should be downgraded to a non-core annotation. After reviewing 87 primary research papers, key reviews, human genetic deficiency case series, and GO database evidence codes, we conclude that T cell proliferation is a downstream, context-dependent consequence of IL-21R signaling rather than a primary process the cytokine evolved to drive. The annotation should be retained (the effect is real) but classified as non-core using the <code>KEEP_AS_NON_CORE</code> action.</p>
+<p>A secondary question concerns NK cell mediated cytotoxicity (GO:0045954). Our investigation revealed that this annotation has stronger experimental support than the source YAML indicated (IDA evidence from PMID:18005035, not just IBA/IEA), but the same logic applies: NK cytotoxicity enhancement is a real pleiotropic effect but not a signature function, and it should also be classified as non-core.</p>
+<hr />
+<h2 id="key-findings">Key Findings</h2>
+<h3 id="finding-1-il-21s-t-cell-proliferative-effect-is-costimulation-dependent">Finding 1: IL-21's T Cell Proliferative Effect Is Costimulation-Dependent</h3>
+<p>Both IDA-supporting papers demonstrate T cell proliferation only in the context of TCR costimulation, not as a standalone mitogenic activity. PMID:17673207 (Zhong et al.) showed that "both human IL-21 and IL-21iso showed comparable proliferative effect on anti-CD40 Ab-activated primary B cells, anti-CD3 Ab-activated primary T cells and human NK cell line, NK0" — critically, the T cell proliferation required anti-CD3 antibody activation. PMID:15207081 similarly showed that "the refolded rhIL-21 could stimulate the proliferation of mature human T-cells in the presence of anti-CD3" as part of a bioactivity validation assay for recombinant protein production, not a dedicated investigation of IL-21's T cell biology.</p>
+<p>This contrasts sharply with bona fide T cell growth factors. IL-2, for example, "drives T-cell growth" as a standalone activity (<a href="https://pubmed.ncbi.nlm.nih.gov/21889323/">PMID: 21889323</a>) and is the defining T cell mitogen. IL-7 drives homeostatic T cell proliferation and is essential for T cell development. IL-15 drives CD8 memory T cell homeostatic proliferation via trans-presentation. IL-21 is unique among gamma-chain cytokines in requiring TCR costimulation for any T cell proliferative effect.</p>
+<p>The context-dependency is further underscored by Spolski &amp; Leonard (2008): "The regulatory activity of IL-21 is modulated by the differentiation state of its target cells as well as by other cytokines or costimulatory molecules" (<a href="https://pubmed.ncbi.nlm.nih.gov/17953510/">PMID: 17953510</a>).</p>
+<h3 id="finding-2-human-il-21r-deficiency-phenotype-confirms-b-cellgchumoral-immunity-as-core">Finding 2: Human IL-21R Deficiency Phenotype Confirms B Cell/GC/Humoral Immunity as Core</h3>
+<p>The most powerful test of a cytokine's core function is what happens when it is absent. Human IL-21R deficiency (13 patients, PMID:33929673) presents with: "Most patients exhibited hypogammaglobulinemia and reduced proportions of memory B cells, circulating T follicular helper cells, MAIT cells and terminally differentiated NK cells." The primary clinical manifestations were recurrent infections and cryptosporidiosis-associated cholangitis — hallmarks of humoral immune deficiency. No T cell proliferative defect was highlighted as a defining feature.</p>
+<p>Mouse knockouts corroborate this. IL-21R-deficient mice showed "reduced numbers of germinal center and IgA" responses (<a href="https://pubmed.ncbi.nlm.nih.gov/30087442/">PMID: 30087442</a>), and comprehensive reviews conclude IL-21 has a "critical role in T cell-dependent B cell activation, germinal center reactions, and humoral immunity" (<a href="https://pubmed.ncbi.nlm.nih.gov/31821441/">PMID: 31821441</a>).</p>
+<p>If T cell proliferation were a core function, its loss should be phenotypically prominent in IL-21R deficiency. It is not.</p>
+<h3 id="finding-3-il-21-is-anti-proliferative-for-t-cell-subsets">Finding 3: IL-21 Is Anti-Proliferative for T Cell Subsets</h3>
+<p>A core pro-proliferative function should be consistently directional. Instead, IL-21 actively suppresses proliferation of T follicular regulatory (Tfr) cells: "IL-21 restricts T follicular regulatory T cell proliferation through Bcl-6 mediated inhibition of responsiveness to IL-2" (<a href="https://pubmed.ncbi.nlm.nih.gov/28303891/">PMID: 28303891</a>). IL-21 also has "direct inhibitory effects on the antigen-presenting function of dendritic cells and can be proapoptotic for B cells and NK cells" (<a href="https://pubmed.ncbi.nlm.nih.gov/17953510/">PMID: 17953510</a>), and is described as "a double-edged sword" (<a href="https://pubmed.ncbi.nlm.nih.gov/24751819/">PMID: 24751819</a>).</p>
+<p>This bidirectionality — promoting proliferation of some T cells while suppressing others — is inconsistent with a core pro-proliferative function and instead reflects downstream pleiotropic effects of STAT3 signaling in different cellular contexts.</p>
+<h3 id="finding-4-il-21s-actual-t-cell-biology-is-differentiation-not-proliferation">Finding 4: IL-21's Actual T Cell Biology Is Differentiation, Not Proliferation</h3>
+<p>The dominant T cell biology of IL-21 is lineage commitment — Th17 and Tfh differentiation — not proliferative expansion. IL-21 is "an autocrine cytokine that is sufficient and necessary" for Th17 differentiation, mediating lineage commitment via STAT3/RORgammat (<a href="https://pubmed.ncbi.nlm.nih.gov/17581589/">PMID: 17581589</a>). It "serves as an autocrine factor secreted by Th17 cells that promotes or sustains Th17 lineage commitment" (<a href="https://pubmed.ncbi.nlm.nih.gov/17884812/">PMID: 17884812</a>). In chronic viral infection, "IL-21 from high-affinity CD4 T cells drives differentiation of brain-resident CD8 T cells" (<a href="https://pubmed.ncbi.nlm.nih.gov/32948671/">PMID: 32948671</a>) — again differentiation, not proliferation.</p>
+<p>This means GO:0042102 (positive regulation of T cell proliferation) may be the wrong term to capture the actual T cell biology of IL-21, even setting aside the core vs. non-core question.</p>
+<h3 id="finding-5-cell-specific-knockouts-show-b-cells-are-the-essential-target">Finding 5: Cell-Specific Knockouts Show B Cells Are the Essential Target</h3>
+<p>Even in T cell-driven autoimmune models, IL-21's critical cellular target is B cells, not T cells. Block &amp; Huang (2013) demonstrated: "T cells deficient in IL-21 did not induce GC formation or autoantibody production, but they went through normal TFH differentiation... IL-21 acts on B cells, because IL-21R expression on B cells was required to induce disease" (<a href="https://pubmed.ncbi.nlm.nih.gov/23960240/">PMID: 23960240</a>). This directly shows that when IL-21's function is dissected at the cellular level, the B cell arm — not the T cell arm — is where the essential biology resides.</p>
+<h3 id="finding-6-even-the-th17-autocrine-role-shows-in-vivo-redundancy">Finding 6: Even the Th17 Autocrine Role Shows In Vivo Redundancy</h3>
+<p>IL-21's strongest T cell role is in Th17 differentiation, but even this is redundant in vivo: "While IL-21 is an essential autocrine amplification factor for differentiation of Th17 cells, the loss of IL-21 or IL-21 receptor (IL-21R) does not protect mice from actively induced EAE" (<a href="https://pubmed.ncbi.nlm.nih.gov/26413871/">PMID: 26413871</a>). If IL-21's most established T cell function is dispensable for disease outcomes, its weaker T cell proliferative effect is even less likely to represent a core function.</p>
+<h3 id="finding-7-strongest-counter-evidence-still-supports-non-core-classification">Finding 7: Strongest Counter-Evidence Still Supports Non-Core Classification</h3>
+<p>The strongest argument for IL-21 having a core T cell function comes from chronic viral infection studies. Elsaesser et al. (2009, <em>Science</em>) showed "CD8+ T cells directly require IL-21 to avoid deletion, maintain immunity, and resolve persistent infection" (<a href="https://pubmed.ncbi.nlm.nih.gov/19423777/">PMID: 19423777</a>). Frohlich et al. (2009) showed "Cell-autonomous IL-21R-dependent signaling by CD8+ T cells was required for sustained cell proliferation and cytokine production during chronic infection."</p>
+<p>However, three critical qualifications limit this counter-evidence:</p>
+<ol>
+<li><strong>Context-specificity</strong>: "Il21r-/- mice showed normal CD8+ T cell expansion, effector function, memory homeostasis, and recall responses during acute and after resolved infection with several other nonpersistent viruses" (<a href="https://pubmed.ncbi.nlm.nih.gov/19478140/">PMID: 19478140</a>).</li>
+<li><strong>Mechanism is not mitogenic</strong>: The mechanism is BATF-IRF4-Blimp-1 transcriptional reprogramming to prevent exhaustion/deletion (<a href="https://pubmed.ncbi.nlm.nih.gov/26527008/">PMID: 26527008</a>), not classical cell cycle entry.</li>
+<li><strong>Memory independence</strong>: "The generation of memory CD8 T cells, which are capable of mounting protective recall responses, proceeds independently of IL-21" (<a href="https://pubmed.ncbi.nlm.nih.gov/20844201/">PMID: 20844201</a>).</li>
+</ol>
+<p>The chronic infection CD8 sustaining effect is better captured by terms related to T cell survival/maintenance during chronic infection than by GO:0042102 (positive regulation of T cell proliferation).</p>
+<h3 id="finding-8-go-database-evidence-code-asymmetry">Finding 8: GO Database Evidence Code Asymmetry</h3>
+<p>A QuickGO query revealed an important paradox: IL-21's true core functions (GC B cell differentiation, Ig production, Tfh differentiation) only have ISS and IEA evidence codes (no IDA), while the non-core T cell proliferation term has IDA annotations. This asymmetry means that the presence of IDA evidence codes should not be conflated with "core function" status. It also reveals a curation gap: the signature functions of IL-21 lack the strongest evidence codes despite having the strongest biological support.</p>
+<p>Additionally, GO:0045954 (NK cell cytotoxicity) was found to have IDA evidence from PMID:18005035 (Skak et al. 2008: "IL-21 increased the cytotoxicity of NK cells against K562 target cells"), contradicting the source YAML which listed only IBA/IEA evidence.</p>
+<hr />
+<h2 id="evidence-matrix">Evidence Matrix</h2>
+<table>
+<thead>
+<tr>
+<th>Citation</th>
+<th>Evidence Type</th>
+<th>Direction</th>
+<th>Claim Tested</th>
+<th>Key Finding</th>
+<th>Context</th>
+<th>Confidence</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><a href="https://pubmed.ncbi.nlm.nih.gov/17673207/">PMID: 17673207</a></td>
+<td>Direct assay (IDA)</td>
+<td>Qualifies</td>
+<td>IL-21 promotes T cell proliferation</td>
+<td>Proliferation only with anti-CD3 costimulation; isoform characterization bioassay</td>
+<td>Human primary T cells, in vitro</td>
+<td>Moderate — real effect but not standalone</td>
+</tr>
+<tr>
+<td><a href="https://pubmed.ncbi.nlm.nih.gov/15207081/">PMID: 15207081</a></td>
+<td>Direct assay (IDA)</td>
+<td>Qualifies</td>
+<td>IL-21 promotes T cell proliferation</td>
+<td>rhIL-21 T cell proliferation requires anti-CD3; bioactivity validation</td>
+<td>Human mature T cells, in vitro</td>
+<td>Moderate — confirmatory but not primary investigation</td>
+</tr>
+<tr>
+<td><a href="https://pubmed.ncbi.nlm.nih.gov/33929673/">PMID: 33929673</a></td>
+<td>Human genetic deficiency</td>
+<td>Supports non-core</td>
+<td>IL-21R deficiency phenotype</td>
+<td>Hypogammaglobulinemia, reduced memory B cells/Tfh; no T cell proliferative defect highlighted</td>
+<td>13 human IL-21R-deficient patients</td>
+<td>High — definitive human genetic evidence</td>
+</tr>
+<tr>
+<td><a href="https://pubmed.ncbi.nlm.nih.gov/31821441/">PMID: 31821441</a></td>
+<td>Review (synthesized)</td>
+<td>Supports non-core</td>
+<td>IL-21 core functions</td>
+<td>"Critical role in T cell-dependent B cell activation, germinal center reactions, and humoral immunity"</td>
+<td>Comprehensive review</td>
+<td>High — authoritative synthesis</td>
+</tr>
+<tr>
+<td><a href="https://pubmed.ncbi.nlm.nih.gov/28303891/">PMID: 28303891</a></td>
+<td>Direct assay</td>
+<td>Refutes core pro-proliferative</td>
+<td>IL-21 effect on Tfr proliferation</td>
+<td>IL-21 restricts Tfr proliferation via Bcl-6-mediated IL-2 unresponsiveness</td>
+<td>Mouse Tfr cells</td>
+<td>High — direct contradiction of unidirectional model</td>
+</tr>
+<tr>
+<td><a href="https://pubmed.ncbi.nlm.nih.gov/24751819/">PMID: 24751819</a></td>
+<td>Review</td>
+<td>Qualifies</td>
+<td>IL-21 overall biology</td>
+<td>IL-21 is a "double-edged sword" with broad pleiotropic actions</td>
+<td>Review</td>
+<td>Moderate — framing support</td>
+</tr>
+<tr>
+<td><a href="https://pubmed.ncbi.nlm.nih.gov/17581589/">PMID: 17581589</a></td>
+<td>Direct assay + KO</td>
+<td>Supports non-core</td>
+<td>IL-21 T cell function</td>
+<td>IL-21 is necessary for Th17 differentiation, not proliferation per se</td>
+<td>Mouse CD4+ T cells</td>
+<td>High — establishes differentiation as the T cell function</td>
+</tr>
+<tr>
+<td><a href="https://pubmed.ncbi.nlm.nih.gov/17884812/">PMID: 17884812</a></td>
+<td>Direct assay</td>
+<td>Supports non-core</td>
+<td>IL-21 Th17 role</td>
+<td>IL-21 sustains Th17 lineage commitment as autocrine factor</td>
+<td>Mouse Th17 cells</td>
+<td>High — confirms differentiation focus</td>
+</tr>
+<tr>
+<td><a href="https://pubmed.ncbi.nlm.nih.gov/23960240/">PMID: 23960240</a></td>
+<td>Cell-specific KO</td>
+<td>Supports non-core</td>
+<td>Cellular target of IL-21</td>
+<td>IL-21 acts on B cells; IL-21R on B cells required for disease</td>
+<td>Mouse autoimmune arthritis model</td>
+<td>High — definitive cellular target data</td>
+</tr>
+<tr>
+<td><a href="https://pubmed.ncbi.nlm.nih.gov/32948671/">PMID: 32948671</a></td>
+<td>Direct assay</td>
+<td>Supports non-core</td>
+<td>IL-21 CD8 T cell effect</td>
+<td>IL-21 drives CD8 T cell differentiation into tissue-resident memory</td>
+<td>Mouse brain, persistent viral infection</td>
+<td>Moderate — specific context</td>
+</tr>
+<tr>
+<td><a href="https://pubmed.ncbi.nlm.nih.gov/26413871/">PMID: 26413871</a></td>
+<td>KO phenotype</td>
+<td>Supports non-core</td>
+<td>IL-21 in Th17-mediated disease</td>
+<td>IL-21/IL-21R loss does not protect from EAE despite being Th17 amplifier</td>
+<td>Mouse EAE model</td>
+<td>High — shows in vivo redundancy</td>
+</tr>
+<tr>
+<td><a href="https://pubmed.ncbi.nlm.nih.gov/21889323/">PMID: 21889323</a></td>
+<td>Review (comparative)</td>
+<td>Supports non-core</td>
+<td>Gamma-chain cytokine comparison</td>
+<td>IL-2 "drives T-cell growth" as primary function; contrast with IL-21</td>
+<td>Review of gamma-chain family</td>
+<td>Moderate — comparative framing</td>
+</tr>
+<tr>
+<td><a href="https://pubmed.ncbi.nlm.nih.gov/19423777/">PMID: 19423777</a></td>
+<td>KO + infection</td>
+<td>Competing</td>
+<td>IL-21 CD8 T cell role</td>
+<td>CD8 T cells require IL-21 to avoid deletion during chronic infection</td>
+<td>Mouse LCMV chronic infection</td>
+<td>High — strongest counter-evidence</td>
+</tr>
+<tr>
+<td><a href="https://pubmed.ncbi.nlm.nih.gov/19478140/">PMID: 19478140</a></td>
+<td>KO + infection</td>
+<td>Qualifies counter-evidence</td>
+<td>IL-21R in acute vs chronic</td>
+<td>Normal CD8 expansion in acute infection; only chronic infection affected</td>
+<td>Mouse, multiple viral models</td>
+<td>High — critically limits counter-evidence</td>
+</tr>
+<tr>
+<td><a href="https://pubmed.ncbi.nlm.nih.gov/20844201/">PMID: 20844201</a></td>
+<td>KO + infection</td>
+<td>Qualifies counter-evidence</td>
+<td>IL-21 in memory T cells</td>
+<td>Memory CD8 T cell generation is IL-21-independent</td>
+<td>Mouse</td>
+<td>High — further limits T cell role</td>
+</tr>
+<tr>
+<td><a href="https://pubmed.ncbi.nlm.nih.gov/26527008/">PMID: 26527008</a></td>
+<td>Mechanistic</td>
+<td>Qualifies counter-evidence</td>
+<td>Mechanism of CD8 sustaining</td>
+<td>BATF-IRF4-Blimp-1 transcriptional reprogramming, not mitogenic</td>
+<td>Mouse chronic viral infection</td>
+<td>High — mechanism is not proliferation</td>
+</tr>
+<tr>
+<td><a href="https://pubmed.ncbi.nlm.nih.gov/30087442/">PMID: 30087442</a></td>
+<td>KO phenotype</td>
+<td>Supports non-core</td>
+<td>IL-21R deficiency in gut</td>
+<td>Reduced GC and IgA responses are primary defect</td>
+<td>Mouse intestine</td>
+<td>High</td>
+</tr>
+<tr>
+<td><a href="https://pubmed.ncbi.nlm.nih.gov/18005035/">PMID: 18005035</a></td>
+<td>Direct assay (IDA)</td>
+<td>Supports NK effect</td>
+<td>IL-21 NK cytotoxicity</td>
+<td>IL-21 increased NK cytotoxicity against K562; upregulated perforin/granzyme</td>
+<td>Human NK cells, in vitro</td>
+<td>High — IDA for GO:0045954</td>
+</tr>
+<tr>
+<td><a href="https://pubmed.ncbi.nlm.nih.gov/17953510/">PMID: 17953510</a></td>
+<td>Review</td>
+<td>Qualifies</td>
+<td>IL-21 pleiotropic effects</td>
+<td>Context-dependent effects; "increased cytotoxicity of CD8+ T cells and NK cells"</td>
+<td>Review</td>
+<td>Moderate</td>
+</tr>
+</tbody>
+</table>
+<hr />
+<h2 id="go-curation-implications">GO Curation Implications</h2>
+<h3 id="primary-recommendation-keep_as_non_core-for-go0042102">Primary Recommendation: KEEP_AS_NON_CORE for GO:0042102</h3>
+<p>The IDA annotations from PMID:17673207 and PMID:15207081 should be <strong>retained</strong> in the gene record — the experimental evidence for T cell proliferative activity is valid. However, the term should be <strong>reclassified from core to non-core</strong> status. Specifically:</p>
+<ul>
+<li><strong>Action</strong>: <code>KEEP_AS_NON_CORE</code> — retain annotations but remove from <code>directly_involved_in</code> in the core function model</li>
+<li><strong>Rationale</strong>: The effect is real but costimulation-dependent, bidirectional across T cell subsets, contradicted by deficiency phenotypes, and secondary to the signature B cell/GC/humoral immunity axis</li>
+<li><strong>Relation type</strong>: If the GO framework supports it, model as <code>acts_upstream_of_or_within</code> rather than <code>directly_involved_in</code>, reflecting that IL-21 can influence T cell proliferation as a downstream consequence of its cytokine activity but does not directly drive it as a primary process</li>
+</ul>
+<h3 id="secondary-recommendation-keep_as_non_core-for-go0045954">Secondary Recommendation: KEEP_AS_NON_CORE for GO:0045954</h3>
+<p>NK cell mediated cytotoxicity enhancement (GO:0045954) should also be classified as non-core and removed from <code>directly_involved_in</code>:</p>
+<ul>
+<li>The source YAML listed this as IBA/IEA only, but IDA evidence exists (PMID:18005035)</li>
+<li>The effect is well-documented but parallels T cell proliferation as a pleiotropic downstream consequence</li>
+<li>Human IL-21R deficiency shows reduced NK terminal differentiation but NK cytotoxicity is not the defining clinical phenotype</li>
+<li><strong>Action</strong>: Remove from <code>directly_involved_in</code> in core functions; retain annotation as non-core</li>
+</ul>
+<h3 id="curation-gap-alert-core-functions-lack-ida">Curation Gap Alert: Core Functions Lack IDA</h3>
+<p>The true core functions of IL-21 — GO:0002314 (GC B cell differentiation), GO:0002639 (Ig production), GO:0061470 (Tfh differentiation) — currently only have ISS/IEA evidence codes. This creates a paradox where non-core terms have stronger evidence codes than core terms. Curators should prioritize adding IDA annotations to these core processes from the extensive primary literature supporting them (e.g., PMID:31821441, PMID:30087442, PMID:33929673).</p>
+<hr />
+<h2 id="mechanistic-scope">Mechanistic Scope</h2>
+<h3 id="direct-gene-product-activity">Direct Gene Product Activity</h3>
+<p>IL-21 is a secreted cytokine (extracellular region, GO:0005576) that binds the IL-21R/IL-2Rgamma heterodimeric receptor complex, activating JAK1/JAK3 kinases and primarily STAT3 (with lesser STAT1 and STAT5 activation). This is the core molecular function: <strong>cytokine activity (GO:0005125)</strong>.</p>
+<h3 id="signature-downstream-processes-core">Signature Downstream Processes (Core)</h3>
+<p>The primary biological processes driven by IL-21 signaling are:</p>
+<div class="codehilite"><pre><span></span><code><span class="n">IL</span><span class="o">-</span><span class="mi">21</span><span class="w"> </span><span class="c1">--&gt; IL-21R/gamma-c --&gt; JAK1/JAK3 --&gt; STAT3</span>
+<span class="w">    </span><span class="o">|</span>
+<span class="w">    </span><span class="o">|</span><span class="c1">---&gt; Germinal center B cell differentiation (GO:0002314)  &lt;-- CORE</span>
+<span class="w">    </span><span class="o">|</span><span class="c1">---&gt; Positive regulation of Ig production (GO:0002639)    &lt;-- CORE</span>
+<span class="w">    </span><span class="o">|</span><span class="c1">---&gt; Tfh cell differentiation (GO:0061470)                &lt;-- CORE</span>
+<span class="w">    </span><span class="o">|</span><span class="c1">---&gt; Positive regulation of B cell proliferation (GO:0030890) &lt;-- CORE</span>
+</code></pre></div>
+
+<p>These are consistently revealed by loss-of-function studies across species and represent the primary selective pressure maintaining IL-21 in the genome.</p>
+<h3 id="secondarypleiotropic-effects-non-core">Secondary/Pleiotropic Effects (Non-Core)</h3>
+<p>T cell proliferation and NK cytotoxicity are downstream of the same JAK/STAT3 signaling cascade but represent context-dependent, cell-type-specific pleiotropic effects:</p>
+<div class="codehilite"><pre><span></span><code><span class="n">IL</span><span class="o">-</span><span class="mi">21</span><span class="w"> </span><span class="o">--&gt;</span><span class="w"> </span><span class="n">IL</span><span class="o">-</span><span class="mi">21</span><span class="n">R</span><span class="o">/</span><span class="n">gamma</span><span class="o">-</span><span class="n">c</span><span class="w"> </span><span class="o">--&gt;</span><span class="w"> </span><span class="n">JAK1</span><span class="o">/</span><span class="n">JAK3</span><span class="w"> </span><span class="o">--&gt;</span><span class="w"> </span><span class="n">STAT3</span>
+<span class="w">    </span><span class="o">|</span>
+<span class="w">    </span><span class="o">|---&gt;</span><span class="w"> </span><span class="n">T</span><span class="w"> </span><span class="n">cell</span><span class="w"> </span><span class="n">proliferation</span><span class="w"> </span><span class="p">(</span><span class="n">GO</span><span class="p">:</span><span class="mi">0042102</span><span class="p">)</span><span class="w">              </span><span class="o">&lt;--</span><span class="w"> </span><span class="n">NON</span><span class="o">-</span><span class="n">CORE</span>
+<span class="w">    </span><span class="o">|</span><span class="w">       </span><span class="o">-</span><span class="w"> </span><span class="n">Requires</span><span class="w"> </span><span class="n">TCR</span><span class="w"> </span><span class="n">costimulation</span><span class="w"> </span><span class="p">(</span><span class="n">anti</span><span class="o">-</span><span class="n">CD3</span><span class="p">)</span>
+<span class="w">    </span><span class="o">|</span><span class="w">       </span><span class="o">-</span><span class="w"> </span><span class="n">Anti</span><span class="o">-</span><span class="n">proliferative</span><span class="w"> </span><span class="k">for</span><span class="w"> </span><span class="n">Tfr</span><span class="w"> </span><span class="n">cells</span>
+<span class="w">    </span><span class="o">|</span><span class="w">       </span><span class="o">-</span><span class="w"> </span><span class="n">Dispensable</span><span class="w"> </span><span class="ow">in</span><span class="w"> </span><span class="n">IL</span><span class="o">-</span><span class="mi">21</span><span class="n">R</span><span class="w"> </span><span class="n">deficiency</span>
+<span class="w">    </span><span class="o">|</span>
+<span class="w">    </span><span class="o">|---&gt;</span><span class="w"> </span><span class="n">Th17</span><span class="w"> </span><span class="n">differentiation</span><span class="w">                           </span><span class="o">&lt;--</span><span class="w"> </span><span class="n">NON</span><span class="o">-</span><span class="n">CORE</span><span class="w"> </span><span class="p">(</span><span class="n">autocrine</span><span class="p">,</span><span class="w"> </span><span class="n">redundant</span><span class="w"> </span><span class="ow">in</span><span class="w"> </span><span class="n">vivo</span><span class="p">)</span>
+<span class="w">    </span><span class="o">|</span><span class="w">       </span><span class="o">-</span><span class="w"> </span><span class="n">Via</span><span class="w"> </span><span class="n">STAT3</span><span class="o">/</span><span class="n">RORgammat</span><span class="p">,</span><span class="w"> </span><span class="ow">not</span><span class="w"> </span><span class="n">mitogenic</span><span class="w"> </span><span class="n">signaling</span>
+<span class="w">    </span><span class="o">|</span>
+<span class="w">    </span><span class="o">|---&gt;</span><span class="w"> </span><span class="n">CD8</span><span class="w"> </span><span class="n">T</span><span class="w"> </span><span class="n">cell</span><span class="w"> </span><span class="n">sustaining</span><span class="w"> </span><span class="ow">in</span><span class="w"> </span><span class="n">chronic</span><span class="w"> </span><span class="n">infection</span><span class="w">      </span><span class="o">&lt;--</span><span class="w"> </span><span class="n">NON</span><span class="o">-</span><span class="n">CORE</span>
+<span class="w">    </span><span class="o">|</span><span class="w">       </span><span class="o">-</span><span class="w"> </span><span class="n">Via</span><span class="w"> </span><span class="n">BATF</span><span class="o">-</span><span class="n">IRF4</span><span class="o">-</span><span class="n">Blimp</span><span class="o">-</span><span class="mi">1</span><span class="p">,</span><span class="w"> </span><span class="ow">not</span><span class="w"> </span><span class="n">cell</span><span class="w"> </span><span class="n">cycle</span><span class="w"> </span><span class="n">entry</span>
+<span class="w">    </span><span class="o">|</span><span class="w">       </span><span class="o">-</span><span class="w"> </span><span class="n">Absent</span><span class="w"> </span><span class="ow">in</span><span class="w"> </span><span class="n">acute</span><span class="w"> </span><span class="n">infection</span>
+<span class="w">    </span><span class="o">|</span>
+<span class="w">    </span><span class="o">|---&gt;</span><span class="w"> </span><span class="n">NK</span><span class="w"> </span><span class="n">cell</span><span class="w"> </span><span class="n">cytotoxicity</span><span class="w"> </span><span class="p">(</span><span class="n">GO</span><span class="p">:</span><span class="mi">0045954</span><span class="p">)</span><span class="w">              </span><span class="o">&lt;--</span><span class="w"> </span><span class="n">NON</span><span class="o">-</span><span class="n">CORE</span>
+<span class="w">            </span><span class="o">-</span><span class="w"> </span><span class="n">Real</span><span class="w"> </span><span class="n">but</span><span class="w"> </span><span class="ow">not</span><span class="w"> </span><span class="n">defining</span><span class="w"> </span><span class="n">clinical</span><span class="w"> </span><span class="n">phenotype</span>
+<span class="w">            </span><span class="o">-</span><span class="w"> </span><span class="n">Enhanced</span><span class="w"> </span><span class="n">perforin</span><span class="o">/</span><span class="n">granzyme</span><span class="w"> </span><span class="n">expression</span>
+</code></pre></div>
+
+<h3 id="key-distinction-differentiation-vs-proliferation">Key Distinction: Differentiation vs. Proliferation</h3>
+<p>IL-21's actual T cell biology is <strong>differentiation</strong> (Th17 lineage commitment, Tfh specification, CD8 tissue-resident memory formation), not <strong>proliferation</strong> (cell cycle entry and clonal expansion). GO:0042102 (positive regulation of T cell proliferation) may therefore be the wrong term entirely for IL-21's T cell effects, even as a non-core annotation. The more precise biology would be captured by terms related to T cell differentiation (GO:0030217) or T helper cell lineage commitment.</p>
+<hr />
+<h2 id="conflicts-and-alternatives">Conflicts and Alternatives</h2>
+<h3 id="counter-evidence-chronic-viral-infection-cd8-maintenance">Counter-Evidence: Chronic Viral Infection CD8 Maintenance</h3>
+<p>The strongest evidence that could support T cell proliferation as a core IL-21 function comes from chronic viral infection models. Three landmark papers (PMID:19423777, 19478140, 20844201 — all published in 2009-2010) demonstrated that IL-21 is essential for maintaining CD8 T cell responses during chronic LCMV infection. However, this counter-evidence is limited by:</p>
+<ol>
+<li><strong>Context restriction</strong>: The effect is absent in acute infections with LCMV, VSV, VV, and Listeria (<a href="https://pubmed.ncbi.nlm.nih.gov/19478140/">PMID: 19478140</a>)</li>
+<li><strong>Mechanistic distinction</strong>: The underlying mechanism is BATF/IRF4-mediated transcriptional reprogramming to prevent exhaustion, not mitogenic signaling (<a href="https://pubmed.ncbi.nlm.nih.gov/26527008/">PMID: 26527008</a>)</li>
+<li><strong>Wrong GO term</strong>: Sustaining an existing pool (anti-apoptotic/anti-exhaustion) is mechanistically and ontologically distinct from "positive regulation of T cell proliferation"</li>
+<li><strong>Memory independence</strong>: Memory CD8 T cell generation proceeds independently of IL-21 (<a href="https://pubmed.ncbi.nlm.nih.gov/20844201/">PMID: 20844201</a>)</li>
+</ol>
+<h3 id="potential-paralog-confusion">Potential Paralog Confusion</h3>
+<p>IL-21 shares the gamma-chain with IL-2, IL-4, IL-7, IL-9, and IL-15. Some T cell proliferative effects attributed to IL-21 could reflect experimental systems where other gamma-chain cytokines are present (e.g., IL-2 in culture media). The IDA papers used recombinant IL-21 in defined conditions, mitigating but not eliminating this concern.</p>
+<h3 id="organism-specific-considerations">Organism-Specific Considerations</h3>
+<p>Most mechanistic data come from mouse models. Human IL-21R deficiency phenotypes are concordant (B cell/humoral defects dominate), but the relatively small number of identified patients (13 as of 2021) limits statistical power for detecting subtle T cell proliferative defects. However, the fact that T cell proliferation defects are not even mentioned as secondary features in these case series is informative.</p>
+<h3 id="alternative-interpretation-il-21-as-a-t-cell-quality-factor">Alternative Interpretation: IL-21 as a T Cell Quality Factor</h3>
+<p>An alternative framing is that IL-21 does not regulate T cell quantity (proliferation) but rather T cell quality (differentiation state, effector function, exhaustion resistance). This interpretation reconciles all the data: IL-21 promotes Th17/Tfh differentiation, sustains CD8 effector function during chronic infection, and restricts inappropriate Tfr expansion — all effects on cell fate and function rather than cell number.</p>
+<hr />
+<h2 id="knowledge-gaps">Knowledge Gaps</h2>
+<h3 id="gap-1-dose-response-for-t-cell-proliferation-vs-b-cell-proliferation">Gap 1: Dose-Response for T Cell Proliferation vs. B Cell Proliferation</h3>
+<p><strong>What was checked</strong>: Both IDA papers used single concentrations of IL-21 in costimulatory assays. <strong>Why it matters</strong>: If IL-21 drives B cell proliferation at physiological concentrations but requires supraphysiological levels for T cell effects, this would further support non-core status. <strong>Resolution</strong>: Comparative dose-response curves for IL-21-driven proliferation of purified B cells vs. T cells (with matched costimulation) under identical conditions.</p>
+<h3 id="gap-2-in-vivo-t-cell-proliferation-kinetics-in-il-21-ko">Gap 2: In Vivo T Cell Proliferation Kinetics in IL-21 KO</h3>
+<p><strong>What was checked</strong>: IL-21R KO phenotype studies focus on B cell and humoral endpoints. <strong>Why it matters</strong>: Formal measurement of T cell proliferation rates (e.g., BrdU incorporation, Ki-67) in lymphoid organs of IL-21-/- mice during normal immune responses would definitively test whether T cell proliferation is affected. <strong>Resolution</strong>: BrdU pulse-chase experiments in IL-21-/- vs. WT mice after immunization, measuring T cell and B cell proliferation in parallel.</p>
+<h3 id="gap-3-ida-annotations-for-core-functions">Gap 3: IDA Annotations for Core Functions</h3>
+<p><strong>What was checked</strong>: QuickGO database query. <strong>Why it matters</strong>: The true core functions lack IDA evidence codes, creating an artificial asymmetry that could mislead automated curation pipelines. <strong>Resolution</strong>: Curators should mine existing primary literature (especially from the germinal center and Tfh differentiation fields) to add IDA annotations to GO:0002314, GO:0002639, and GO:0061470.</p>
+<h3 id="gap-4-human-specific-t-cell-proliferative-effects">Gap 4: Human-Specific T Cell Proliferative Effects</h3>
+<p><strong>What was checked</strong>: Both IDA papers used human cells; chronic infection studies are mouse-based. <strong>Why it matters</strong>: Species-specific differences in gamma-chain cytokine biology exist. <strong>Resolution</strong>: IL-21 proliferation assays with purified human T cell subsets in defined conditions, with head-to-head comparison to IL-2 and IL-15.</p>
+<h3 id="gap-5-single-cell-resolution-of-il-21-effects">Gap 5: Single-Cell Resolution of IL-21 Effects</h3>
+<p><strong>What was checked</strong>: Bulk proliferation assays from the IDA papers. <strong>Why it matters</strong>: Bulk assays cannot distinguish whether IL-21 drives proliferation of all T cells or only a subset that responds preferentially. <strong>Resolution</strong>: Single-cell RNA-seq or CITE-seq of T cells +/- IL-21 (with anti-CD3) to identify responding subpopulations.</p>
+<hr />
+<h2 id="discriminating-tests">Discriminating Tests</h2>
+<ol>
+<li>
+<p><strong>Head-to-head cytokine comparison</strong>: Measure T cell and B cell proliferation (CFSE dilution) in response to IL-21, IL-2, IL-7, IL-15, and IL-4 at matched concentrations, +/- costimulation. If IL-21's T cell effect is consistently weaker and more costimulation-dependent than other gamma-chain cytokines, this would confirm non-core status.</p>
+</li>
+<li>
+<p><strong>Conditional IL-21R deletion</strong>: T cell-specific (CD4-Cre) vs. B cell-specific (CD19-Cre) IL-21R deletion, measuring immune responses after immunization. If B cell-specific deletion recapitulates the full IL-21R KO phenotype while T cell-specific deletion does not, this definitively identifies B cells as the core target.</p>
+</li>
+<li>
+<p><strong>CRISPR screen for IL-21 dependencies</strong>: Genome-wide CRISPR screen in T cells vs. B cells comparing IL-21-dependent gene programs. This would identify whether the transcriptional programs activated by IL-21 in T cells are primarily differentiation-related or proliferation-related.</p>
+</li>
+<li>
+<p><strong>Evolutionary analysis</strong>: Compare IL-21's T cell proliferative activity across vertebrate species. If this activity is gained late in evolution or is poorly conserved relative to B cell effects, it further supports non-core status.</p>
+</li>
+<li>
+<p><strong>Dose-titration with phospho-STAT profiling</strong>: Map the signaling dose-response curve for IL-21 in T cells vs. B cells. If B cells show higher IL-21R expression and/or more sensitive STAT3 activation, this provides a molecular basis for the B cell-centric biology.</p>
+</li>
+</ol>
+<hr />
+<h2 id="curation-leads">Curation Leads</h2>
+<h3 id="lead-1-change-go0042102-action-to-keep_as_non_core">Lead 1: Change GO:0042102 Action to KEEP_AS_NON_CORE</h3>
+<ul>
+<li><strong>Current action</strong>: UNDECIDED</li>
+<li><strong>Recommended action</strong>: <code>KEEP_AS_NON_CORE</code></li>
+<li><strong>Confidence</strong>: High (8 independent evidence lines)</li>
+<li><strong>Key references</strong>: PMID:17673207 (costimulation-dependent), PMID:33929673 (deficiency phenotype), PMID:28303891 (anti-proliferative for Tfr), PMID:23960240 (B cells are essential target)</li>
+<li><strong>Snippet to verify</strong> (PMID:33929673): "Most patients exhibited hypogammaglobulinemia and reduced proportions of memory B cells, circulating T follicular helper cells, MAIT cells and terminally differentiated NK cells"</li>
+</ul>
+<h3 id="lead-2-remove-go0045954-from-directly_involved_in">Lead 2: Remove GO:0045954 from directly_involved_in</h3>
+<ul>
+<li><strong>Current status</strong>: Listed in <code>directly_involved_in</code> in core functions YAML</li>
+<li><strong>Recommended action</strong>: Remove from core, classify as <code>KEEP_AS_NON_CORE</code></li>
+<li><strong>Rationale</strong>: Same logic as GO:0042102; NK cytotoxicity is a real pleiotropic effect but not a signature function</li>
+<li><strong>Note</strong>: Source YAML incorrectly states IBA/IEA only; IDA evidence exists from PMID:18005035</li>
+<li><strong>Snippet to verify</strong> (PMID:18005035): "IL-21 increased the cytotoxicity of NK cells against K562 target cells"</li>
+</ul>
+<h3 id="lead-3-add-ida-annotations-for-core-functions">Lead 3: Add IDA Annotations for Core Functions</h3>
+<ul>
+<li><strong>Gap identified</strong>: GO:0002314, GO:0002639, GO:0061470 lack IDA evidence codes</li>
+<li><strong>Action</strong>: Curators should mine primary literature for IDA-quality evidence for these core terms</li>
+<li><strong>Candidate references</strong>: PMID:31821441 (review), PMID:30087442 (mouse KO), PMID:25586558 (IgA/B cell), PMID:21708925 (Bcl-6/Tfh/GC)</li>
+</ul>
+<h3 id="lead-4-consider-adding-t-cell-differentiation-terms-as-non-core">Lead 4: Consider Adding T Cell Differentiation Terms as Non-Core</h3>
+<ul>
+<li><strong>Rationale</strong>: IL-21's actual T cell biology is Th17/Tfh differentiation, not proliferation</li>
+<li><strong>Candidate terms</strong>: GO:0030217 (T cell differentiation), GO:0072539 (T-helper 17 cell differentiation)</li>
+<li><strong>Evidence</strong>: PMID:17581589 (Th17 differentiation), PMID:17884812 (Th17 commitment), PMID:32948671 (CD8 tissue-resident differentiation)</li>
+<li><strong>Status</strong>: Non-core, as these are secondary to the B cell axis</li>
+</ul>
+<h3 id="lead-5-correct-source-yaml-evidence-codes-for-go0045954">Lead 5: Correct Source YAML Evidence Codes for GO:0045954</h3>
+<ul>
+<li><strong>Issue</strong>: Source YAML states GO:0045954 has only IBA/IEA evidence</li>
+<li><strong>Correction</strong>: IDA evidence exists from PMID:18005035 (Skak et al. 2008)</li>
+<li><strong>Action</strong>: Update YAML to reflect accurate evidence codes</li>
+</ul>
+<h3 id="lead-6-resolve-issue-1418">Lead 6: Resolve Issue #1418</h3>
+<ul>
+<li><strong>Recommendation</strong>: Close issue #1418 with decision <code>KEEP_AS_NON_CORE</code> for GO:0042102</li>
+<li><strong>Summary for issue</strong>: The effect is real and well-documented but does not meet the threshold for core function based on costimulation dependency, deficiency phenotype analysis, bidirectional effects, and comparative cytokine biology</li>
+</ul>
+<hr />
+<h2 id="go-decision-table">GO Decision Table</h2>
+<table>
+<thead>
+<tr>
+<th>GO Term</th>
+<th>Current Status</th>
+<th>Evidence Codes</th>
+<th>Recommended Action</th>
+<th>Rationale</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>GO:0005125 (cytokine activity)</td>
+<td>Core MF</td>
+<td>Multiple</td>
+<td><strong>RETAIN as core</strong></td>
+<td>Undisputed molecular function</td>
+</tr>
+<tr>
+<td>GO:0002314 (GC B cell diff.)</td>
+<td>Core BP</td>
+<td>ISS, IEA</td>
+<td><strong>RETAIN as core</strong>; add IDA</td>
+<td>Signature function; needs IDA from primary lit</td>
+</tr>
+<tr>
+<td>GO:0002639 (Ig production)</td>
+<td>Core BP</td>
+<td>ISS, IEA</td>
+<td><strong>RETAIN as core</strong>; add IDA</td>
+<td>Signature function; needs IDA</td>
+</tr>
+<tr>
+<td>GO:0061470 (Tfh diff.)</td>
+<td>Core BP</td>
+<td>ISS, IEA</td>
+<td><strong>RETAIN as core</strong>; add IDA</td>
+<td>Signature function; needs IDA</td>
+</tr>
+<tr>
+<td>GO:0030890 (B cell prolif.)</td>
+<td>Core BP</td>
+<td>IDA</td>
+<td><strong>RETAIN as core</strong></td>
+<td>Signature function with IDA</td>
+</tr>
+<tr>
+<td>GO:0042102 (T cell prolif.)</td>
+<td>UNDECIDED</td>
+<td>IDA x2</td>
+<td><strong>KEEP_AS_NON_CORE</strong></td>
+<td>Costimulation-dependent, non-signature</td>
+</tr>
+<tr>
+<td>GO:0045954 (NK cytotoxicity)</td>
+<td>Core (directly_involved_in)</td>
+<td>IDA, IBA, IEA</td>
+<td><strong>KEEP_AS_NON_CORE</strong>; remove from directly_involved_in</td>
+<td>Real but non-signature pleiotropic effect</td>
+</tr>
+<tr>
+<td>GO:0005576 (extracellular region)</td>
+<td>Core CC</td>
+<td>Multiple</td>
+<td><strong>RETAIN as core</strong></td>
+<td>Undisputed cellular component</td>
+</tr>
+</tbody>
+</table>
+<hr />
+<h2 id="evidence-base-key-literature">Evidence Base: Key Literature</h2>
+<h3 id="defining-papers-for-the-core-function-question">Defining Papers for the Core Function Question</h3>
+<ul>
+<li>
+<p><strong>Spolski &amp; Leonard (2008)</strong> (<a href="https://pubmed.ncbi.nlm.nih.gov/17953510/">PMID: 17953510</a>): Foundational review establishing IL-21's pleiotropic biology and context-dependency. Key quote: "The regulatory activity of IL-21 is modulated by the differentiation state of its target cells as well as by other cytokines or costimulatory molecules."</p>
+</li>
+<li>
+<p><strong>Tangye &amp; Ma (2020)</strong> (<a href="https://pubmed.ncbi.nlm.nih.gov/31821441/">PMID: 31821441</a>): Comprehensive review concluding IL-21's "critical role in T cell-dependent B cell activation, germinal center reactions, and humoral immunity."</p>
+</li>
+<li>
+<p><strong>Spolski &amp; Leonard (2014)</strong> (<a href="https://pubmed.ncbi.nlm.nih.gov/24751819/">PMID: 24751819</a>): "Double-edged sword" framing that captures IL-21's bidirectional, context-dependent effects.</p>
+</li>
+</ul>
+<h3 id="human-genetic-evidence">Human Genetic Evidence</h3>
+<ul>
+<li>
+<p><strong>Cagdas et al. (2021)</strong> (<a href="https://pubmed.ncbi.nlm.nih.gov/33929673/">PMID: 33929673</a>): Largest human IL-21R deficiency cohort (13 patients). Phenotype dominated by hypogammaglobulinemia and B cell defects, not T cell proliferative defects.</p>
+</li>
+<li>
+<p><strong>Kotlarz et al. (2014)</strong> (<a href="https://pubmed.ncbi.nlm.nih.gov/30903457/">PMID: 30903457</a>): IL2RG mutation with selective IL-21 signaling defect phenocopied IL-21R deficiency with B cell differentiation defects.</p>
+</li>
+</ul>
+<h3 id="t-cell-differentiation-not-proliferation">T Cell Differentiation (Not Proliferation)</h3>
+<ul>
+<li>
+<p><strong>Nurieva et al. (2007)</strong> (<a href="https://pubmed.ncbi.nlm.nih.gov/17581589/">PMID: 17581589</a>): IL-21 as essential autocrine factor for Th17 differentiation via STAT3/RORgammat.</p>
+</li>
+<li>
+<p><strong>Wei et al. (2007)</strong> (<a href="https://pubmed.ncbi.nlm.nih.gov/17884812/">PMID: 17884812</a>): IL-21 sustains Th17 lineage commitment.</p>
+</li>
+</ul>
+<h3 id="counter-evidence-chronic-infection">Counter-Evidence (Chronic Infection)</h3>
+<ul>
+<li>
+<p><strong>Elsaesser et al. (2009)</strong> (<a href="https://pubmed.ncbi.nlm.nih.gov/19423777/">PMID: 19423777</a>): CD8 T cells require IL-21 during chronic viral infection — strongest counter-evidence but context-limited.</p>
+</li>
+<li>
+<p><strong>Frohlich et al. (2009)</strong> (<a href="https://pubmed.ncbi.nlm.nih.gov/19478140/">PMID: 19478140</a>): Critically shows normal CD8 T cell expansion in acute infection, limiting the chronic infection effect.</p>
+</li>
+<li>
+<p><strong>Yi et al. (2010)</strong> (<a href="https://pubmed.ncbi.nlm.nih.gov/20844201/">PMID: 20844201</a>): Memory CD8 T cell generation is IL-21-independent.</p>
+</li>
+</ul>
+<hr />
+<h2 id="limitations">Limitations</h2>
+<ol>
+<li>
+<p><strong>Subjectivity of "core" definition</strong>: The distinction between core and non-core functions involves judgment about evolutionary purpose and functional hierarchy. Different curators may reasonably draw the line differently.</p>
+</li>
+<li>
+<p><strong>Bias toward mouse data</strong>: Most mechanistic studies use mouse models. While human genetic data corroborate the conclusions, the small number of identified patients (13 as of 2021) limits power to detect subtle T cell effects.</p>
+</li>
+<li>
+<p><strong>In vitro vs. in vivo gap</strong>: The IDA evidence for T cell proliferation comes from in vitro assays. It is possible that in vivo T cell proliferative effects are more robust but undetectable in the available knockout studies due to redundancy.</p>
+</li>
+<li>
+<p><strong>Publication bias</strong>: Studies emphasizing IL-21's B cell and GC functions may be more numerous because these are the phenotypically dominant effects, creating circular reinforcement of the "core function" narrative.</p>
+</li>
+<li>
+<p><strong>Temporal dynamics</strong>: IL-21 may have different roles at different stages of immune responses (early proliferative vs. late differentiative), and bulk endpoint assays may miss transient proliferative contributions.</p>
+</li>
+</ol>
+<hr />
+<h2 id="proposed-follow-up-actions">Proposed Follow-up Actions</h2>
+<ol>
+<li>
+<p><strong>Immediate curation action</strong>: Change GO:0042102 from UNDECIDED to <code>KEEP_AS_NON_CORE</code> and close issue #1418 with this report as supporting documentation.</p>
+</li>
+<li>
+<p><strong>Remove GO:0045954 from directly_involved_in</strong>: Reclassify as non-core with notation that IDA evidence exists (PMID:18005035) but the effect is non-signature.</p>
+</li>
+<li>
+<p><strong>Prioritize IDA annotation for core functions</strong>: Mine existing primary literature to add IDA evidence codes to GO:0002314, GO:0002639, and GO:0061470, resolving the evidence code asymmetry.</p>
+</li>
+<li>
+<p><strong>Consider new non-core annotations</strong>: Add GO:0072539 (T-helper 17 cell differentiation) and/or GO:0030217 (T cell differentiation) as non-core annotations based on PMID:17581589 and PMID:17884812, which more accurately capture IL-21's T cell biology than GO:0042102.</p>
+</li>
+<li>
+<p><strong>Flag for computational pipeline review</strong>: Ensure that automated annotation transfer pipelines do not re-promote GO:0042102 to core status based on IDA evidence codes alone, as this case demonstrates that IDA evidence does not equal core function.</p>
+</li>
+</ol>
+            </div>
+        </details>
+        
+        <details class="deep-research-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; gap: 1rem;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">AIGR Gene Hypothesis Deep Research</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(IL21-hypotheses/core-function-1-go-0042102/prompt.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="Q9HBE4" data-a="DEEP_RESEARCH: AIGR Gene Hypothesis Deep Research" data-r="" data-act="DEEP_RESEARCH" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This deep research is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This deep research needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+                
+                
+                <h1 id="aigr-gene-hypothesis-deep-research">AIGR Gene Hypothesis Deep Research</h1>
+<p>You are evaluating one focused gene curation hypothesis for AI Gene Review.<br />
+This is not a general gene overview. Use the seed hypothesis and source context<br />
+below to search for evidence that supports, refutes, narrows, or competes with<br />
+the proposed curation decision.</p>
+<h2 id="target-gene">Target Gene</h2>
+<ul>
+<li><strong>Organism code:</strong> human</li>
+<li><strong>Taxon:</strong> Homo sapiens (NCBITaxon:9606)</li>
+<li><strong>Gene directory:</strong> IL21</li>
+<li><strong>Gene symbol:</strong> IL21</li>
+</ul>
+<h2 id="focus">Focus</h2>
+<ul>
+<li><strong>Focus type:</strong> core_function</li>
+<li><strong>Hypothesis slug:</strong> core-function-1-go-0042102</li>
+<li><strong>Source file:</strong> genes/human/IL21/IL21-ai-review.yaml</li>
+<li><strong>Source selector:</strong> existing_annotations[GO:0042102] (currently action: UNDECIDED; see issue #1418)</li>
+</ul>
+<h2 id="seed-hypothesis">Seed Hypothesis</h2>
+<p>Positive regulation of T cell proliferation (GO:0042102) is currently annotated<br />
+to IL21 with direct experimental evidence (IDA: PMID:17673207, PMID:15207081),<br />
+but its status as a <strong>core</strong> function is contested and has been set to UNDECIDED<br />
+pending review. IL21 is a secreted cytokine whose signature, well-established<br />
+functions are in the B-cell / T-follicular-helper axis (germinal center B cell<br />
+differentiation, Tfh differentiation, immunoglobulin production, B cell<br />
+proliferation). IL21 is a comparatively weak, context-dependent T-cell mitogen<br />
+and can be anti-proliferative in some settings.</p>
+<p>Evaluate whether positive regulation of T cell proliferation represents a CORE<br />
+function of IL21 (one of the primary processes the cytokine evolved to drive)<br />
+versus a downstream, secondary, or context-dependent consequence of<br />
+IL21R/IL2RG -&gt; JAK1/JAK3 -&gt; STAT3 signaling that is better captured as non-core.<br />
+Crucially, distinguish a "real, documented effect" (not in question) from a<br />
+"core function". A secondary related question: should NK cell mediated<br />
+cytotoxicity (GO:0045954, currently IBA/IEA only) be treated the same way?</p>
+<h2 id="term-and-decision-context">Term and Decision Context</h2>
+<ul>
+<li>Biological process under review: positive regulation of T cell proliferation (GO:0042102)</li>
+<li>Current action: UNDECIDED (was ACCEPT); two IDA annotations (PMID:17673207, PMID:15207081)</li>
+<li>Core molecular function (not in question): cytokine activity (GO:0005125), via IL21R/IL2RG -&gt; JAK1/JAK3-STAT3</li>
+<li>Likely-core ("signature") IL21 processes: germinal center B cell differentiation (GO:0002314), T follicular helper cell differentiation (GO:0061470), positive regulation of immunoglobulin production (GO:0002639), positive regulation of B cell proliferation (GO:0030890)</li>
+<li>Related, also uncertain: positive regulation of natural killer cell mediated cytotoxicity (GO:0045954) (IBA/IEA only)</li>
+<li>Location: extracellular region (GO:0005576)</li>
+<li>Decision needed: core vs KEEP_AS_NON_CORE vs remove; and, for a dedicated cytokine, whether such downstream immune processes belong as core via <code>directly_involved_in</code> or should be modeled with a regulatory / acts-upstream relation while "core" is reserved for signature processes.</li>
+</ul>
+<h2 id="reference-context">Reference Context</h2>
+<ul>
+<li>PMID:17673207</li>
+<li>PMID:15207081</li>
+<li>file:human/IL21/IL21-uniprot.txt</li>
+</ul>
+<h2 id="source-context-yaml">Source Context YAML</h2>
+<div class="codehilite"><pre><span></span><code><span class="nt">gene_symbol</span><span class="p">:</span><span class="w"> </span><span class="l l-Scalar l-Scalar-Plain">IL21</span>
+<span class="nt">id</span><span class="p">:</span><span class="w"> </span><span class="l l-Scalar l-Scalar-Plain">Q9HBE4</span>
+<span class="nt">existing_annotations</span><span class="p">:</span>
+<span class="w">  </span><span class="p p-Indicator">-</span><span class="w"> </span><span class="nt">term</span><span class="p">:</span><span class="w"> </span><span class="p p-Indicator">{</span><span class="nt">id</span><span class="p">:</span><span class="w"> </span><span class="nv">GO</span><span class="p p-Indicator">:</span><span class="nv">0042102</span><span class="p p-Indicator">,</span><span class="nt"> label</span><span class="p">:</span><span class="w"> </span><span class="nv">positive regulation of T cell proliferation</span><span class="p p-Indicator">}</span>
+<span class="w">    </span><span class="nt">evidence_type</span><span class="p">:</span><span class="w"> </span><span class="l l-Scalar l-Scalar-Plain">IDA</span>
+<span class="w">    </span><span class="nt">original_reference_id</span><span class="p">:</span><span class="w"> </span><span class="l l-Scalar l-Scalar-Plain">PMID:17673207</span>
+<span class="w">    </span><span class="nt">review</span><span class="p">:</span>
+<span class="w">      </span><span class="nt">action</span><span class="p">:</span><span class="w"> </span><span class="l l-Scalar l-Scalar-Plain">UNDECIDED</span>
+<span class="w">      </span><span class="nt">reason</span><span class="p">:</span><span class="w"> </span><span class="p p-Indicator">&gt;-</span>
+<span class="l l-Scalar l-Scalar-Plain">Real but borderline core vs non-core; IL21 is a weak, context-dependent</span>
+<span class="l l-Scalar l-Scalar-Plain">T-cell mitogen relative to its B-cell/Tfh signature. Deferred to expert</span>
+<span class="l l-Scalar l-Scalar-Plain">review (issue</span><span class="w"> </span><span class="c1">#1418).</span>
+<span class="w">  </span><span class="p p-Indicator">-</span><span class="w"> </span><span class="nt">term</span><span class="p">:</span><span class="w"> </span><span class="p p-Indicator">{</span><span class="nt">id</span><span class="p">:</span><span class="w"> </span><span class="nv">GO</span><span class="p p-Indicator">:</span><span class="nv">0042102</span><span class="p p-Indicator">,</span><span class="nt"> label</span><span class="p">:</span><span class="w"> </span><span class="nv">positive regulation of T cell proliferation</span><span class="p p-Indicator">}</span>
+<span class="w">    </span><span class="nt">evidence_type</span><span class="p">:</span><span class="w"> </span><span class="l l-Scalar l-Scalar-Plain">IDA</span>
+<span class="w">    </span><span class="nt">original_reference_id</span><span class="p">:</span><span class="w"> </span><span class="l l-Scalar l-Scalar-Plain">PMID:15207081</span>
+<span class="w">    </span><span class="nt">review</span><span class="p">:</span><span class="w"> </span><span class="p p-Indicator">{</span><span class="nt">action</span><span class="p">:</span><span class="w"> </span><span class="nv">UNDECIDED</span><span class="p p-Indicator">}</span>
+<span class="nt">core_functions</span><span class="p">:</span>
+<span class="w">  </span><span class="p p-Indicator">-</span><span class="w"> </span><span class="nt">molecular_function</span><span class="p">:</span><span class="w"> </span><span class="p p-Indicator">{</span><span class="nt">id</span><span class="p">:</span><span class="w"> </span><span class="nv">GO</span><span class="p p-Indicator">:</span><span class="nv">0005125</span><span class="p p-Indicator">,</span><span class="nt"> label</span><span class="p">:</span><span class="w"> </span><span class="nv">cytokine activity</span><span class="p p-Indicator">}</span>
+<span class="w">    </span><span class="nt">directly_involved_in</span><span class="p">:</span>
+<span class="w">      </span><span class="p p-Indicator">-</span><span class="w"> </span><span class="p p-Indicator">{</span><span class="nt">id</span><span class="p">:</span><span class="w"> </span><span class="nv">GO</span><span class="p p-Indicator">:</span><span class="nv">0002314</span><span class="p p-Indicator">,</span><span class="nt"> label</span><span class="p">:</span><span class="w"> </span><span class="nv">germinal center B cell differentiation</span><span class="p p-Indicator">}</span>
+<span class="w">      </span><span class="p p-Indicator">-</span><span class="w"> </span><span class="p p-Indicator">{</span><span class="nt">id</span><span class="p">:</span><span class="w"> </span><span class="nv">GO</span><span class="p p-Indicator">:</span><span class="nv">0002639</span><span class="p p-Indicator">,</span><span class="nt"> label</span><span class="p">:</span><span class="w"> </span><span class="nv">positive regulation of immunoglobulin production</span><span class="p p-Indicator">}</span>
+<span class="w">      </span><span class="p p-Indicator">-</span><span class="w"> </span><span class="p p-Indicator">{</span><span class="nt">id</span><span class="p">:</span><span class="w"> </span><span class="nv">GO</span><span class="p p-Indicator">:</span><span class="nv">0061470</span><span class="p p-Indicator">,</span><span class="nt"> label</span><span class="p">:</span><span class="w"> </span><span class="nv">T follicular helper cell differentiation</span><span class="p p-Indicator">}</span>
+<span class="w">      </span><span class="p p-Indicator">-</span><span class="w"> </span><span class="p p-Indicator">{</span><span class="nt">id</span><span class="p">:</span><span class="w"> </span><span class="nv">GO</span><span class="p p-Indicator">:</span><span class="nv">0030890</span><span class="p p-Indicator">,</span><span class="nt"> label</span><span class="p">:</span><span class="w"> </span><span class="nv">positive regulation of B cell proliferation</span><span class="p p-Indicator">}</span>
+<span class="w">      </span><span class="c1"># GO:0042102 (T cell proliferation) removed pending this hypothesis review</span>
+<span class="w">      </span><span class="p p-Indicator">-</span><span class="w"> </span><span class="p p-Indicator">{</span><span class="nt">id</span><span class="p">:</span><span class="w"> </span><span class="nv">GO</span><span class="p p-Indicator">:</span><span class="nv">0045954</span><span class="p p-Indicator">,</span><span class="nt"> label</span><span class="p">:</span><span class="w"> </span><span class="nv">positive regulation of natural killer cell mediated cytotoxicity</span><span class="p p-Indicator">}</span>
+<span class="w">    </span><span class="nt">locations</span><span class="p">:</span>
+<span class="w">      </span><span class="p p-Indicator">-</span><span class="w"> </span><span class="p p-Indicator">{</span><span class="nt">id</span><span class="p">:</span><span class="w"> </span><span class="nv">GO</span><span class="p p-Indicator">:</span><span class="nv">0005576</span><span class="p p-Indicator">,</span><span class="nt"> label</span><span class="p">:</span><span class="w"> </span><span class="nv">extracellular region</span><span class="p p-Indicator">}</span>
+</code></pre></div>
+
+<h2 id="research-objective">Research Objective</h2>
+<p>Build a focused report that helps a curator decide whether this hypothesis<br />
+should affect the gene review. Address the focus type directly:</p>
+<ol>
+<li>For an existing GO annotation decision, evaluate whether the current action<br />
+   is justified, too strong, too weak, or should change.</li>
+<li>For a proposed replacement or new GO term, evaluate whether the term is<br />
+   biologically supported, too broad, too narrow, or missing key qualifiers.</li>
+<li>For a computational prediction, evaluate whether the prediction is correct,<br />
+   less precise than existing knowledge, uncertain, or likely wrong because of<br />
+   paralog overannotation, frequency bias, pathway context, or in vitro-only<br />
+   activity.</li>
+<li>For a core-function hypothesis, evaluate whether the proposed activity,<br />
+   process, and location represent the gene product's primary function rather<br />
+   than a downstream effect, pleiotropic phenotype, or context-specific role.</li>
+</ol>
+<p>Use primary literature whenever possible. Prefer PMID citations and include DOI<br />
+citations when no PMID is available. Treat reviews and database records as<br />
+orientation unless they contain directly relevant synthesized evidence that is<br />
+clearly labeled as review-level or database-level support.</p>
+<h2 id="required-output">Required Output</h2>
+<h3 id="executive-judgment">Executive Judgment</h3>
+<p>Give a concise verdict: supported, partially supported, unresolved, weakly<br />
+supported, over-annotated, or refuted. Explain the reasoning and the most<br />
+important caveats.</p>
+<h3 id="evidence-matrix">Evidence Matrix</h3>
+<p>Create a table with one row per important evidence item:</p>
+<ul>
+<li>Citation (PMID preferred)</li>
+<li>Evidence type (direct assay, mutant phenotype, localization, interaction,<br />
+  structural/evolutionary, computational, review/database)</li>
+<li>Supports / refutes / qualifies / competing</li>
+<li>Claim tested</li>
+<li>Key finding</li>
+<li>Organism, tissue, cell type, or assay context</li>
+<li>Confidence and limitations</li>
+</ul>
+<h3 id="go-curation-implications">GO Curation Implications</h3>
+<p>State the likely curation action as a lead requiring curator verification. If<br />
+GO terms are involved, explain whether the evidence supports an MF, BP, or CC<br />
+term, and whether the term should be retained, removed, generalized, made more<br />
+specific, or treated as non-core. Avoid using "protein binding" as a final<br />
+recommendation unless no more informative term is supported.</p>
+<h3 id="mechanistic-scope">Mechanistic Scope</h3>
+<p>Describe the immediate molecular or cellular function being tested. Separate<br />
+direct gene-product activity from downstream phenotypes, pathway consequences,<br />
+developmental outcomes, disease manifestations, or effects inferred only from<br />
+loss of function.</p>
+<h3 id="conflicts-and-alternatives">Conflicts and Alternatives</h3>
+<p>Identify evidence that conflicts with the seed hypothesis or suggests an<br />
+alternative interpretation, including paralog confusion, organism-specific<br />
+differences, isoform-specific findings, experimental artifacts, or database<br />
+carry-over.</p>
+<h3 id="knowledge-gaps">Knowledge Gaps</h3>
+<p>List explicit uncertainties that matter for curation. For each gap, state what<br />
+was checked, why the gap matters, and what evidence or experiment would resolve<br />
+it.</p>
+<h3 id="discriminating-tests">Discriminating Tests</h3>
+<p>Recommend concrete assays, perturbations, datasets, or comparative analyses that<br />
+would most efficiently distinguish this hypothesis from alternatives.</p>
+<h3 id="curation-leads">Curation Leads</h3>
+<p>Provide candidate updates for the review, clearly labeled as leads requiring<br />
+curator verification. Include candidate references with exact snippets to verify,<br />
+candidate replacement or new GO terms, possible action changes, suggested<br />
+questions, and suggested experiments.</p>
+<p>If the provider supports artifacts, produce artifact-friendly tables such as an<br />
+evidence matrix, GO decision table, or comparison table. These artifacts are<br />
+important provenance for hypothesis-level review.</p>
+            </div>
+        </details>
+        
     </div>
     
 
@@ -4665,11 +5529,18 @@ existing_annotations:
     review:
       summary: &gt;-
         Phylogenetically inferred annotation consistent with IL21&#39;s role in NK cell
-        function.
-        Supported by experimental data (PMID:18005035) showing IL21 activates NK cells
-        and
-        modulates their cytotoxic activity.
-      action: ACCEPT
+        function. Supported by experimental data (PMID:18005035) showing IL21
+        activates NK cells and modulates their cytotoxic activity, but the focused
+        OpenScientist review judged NK cytotoxicity enhancement to be a real
+        pleiotropic effect rather than a signature IL21 core function.
+      action: KEEP_AS_NON_CORE
+      reason: &gt;-
+        Retain the annotation as biologically real, but do not treat it as core.
+        IL21&#39;s signature biology centers on cytokine activity driving the B
+        cell/Tfh/humoral immunity axis; NK cytotoxicity is context-dependent and
+        downstream of the same IL21R/JAK-STAT signaling program.
+      additional_reference_ids:
+        - file:human/IL21/IL21-hypotheses/core-function-1-go-0042102/openscientist.md
 # IEA annotations - automated methods
   - term:
       id: GO:0001819
@@ -4765,9 +5636,15 @@ existing_annotations:
     original_reference_id: GO_REF:0000117
     review:
       summary: &gt;-
-        Duplicates IBA/IDA annotation for same term. ARBA-predicted. Consistent with
-        experimental evidence. Maintain consistent action.
-      action: ACCEPT
+        Duplicates IBA/IDA annotation for the same term. ARBA-predicted and
+        consistent with experimental evidence, but non-core for IL21.
+      action: KEEP_AS_NON_CORE
+      reason: &gt;-
+        Maintain consistency with the IBA and IDA GO:0045954 reviews: IL21 can
+        enhance NK cytotoxicity, but this is not a signature core function of the
+        cytokine.
+      additional_reference_ids:
+        - file:human/IL21/IL21-hypotheses/core-function-1-go-0042102/openscientist.md
   - term:
       id: GO:0048468
       label: cell development
@@ -5071,18 +5948,23 @@ existing_annotations:
         IL21 has a real but weak, context-dependent proliferative effect on
         anti-CD3-activated primary T cells (PMID:17673207). Whether this rises to
         a core function of IL21 (vs its signature B-cell/Tfh axis) is borderline.
-      action: UNDECIDED
+      action: KEEP_AS_NON_CORE
       reason: &gt;-
-        Deferred to expert curator review (see issue #1418). The effect is
-        directly evidenced (PMID:17673207: &#34;comparable proliferative effect on
-        ... anti-CD3 Ab-activated primary T cells&#34;), but IL21 is a weak,
-        context-dependent T-cell mitogen, so core vs non-core is genuinely
-        unclear. GO:0042102 has been removed from core_functions pending this
-        decision; the B-cell/Tfh signature processes remain core.
+        The focused OpenScientist review resolved the core-function question by
+        recommending KEEP_AS_NON_CORE. The effect is directly evidenced
+        (PMID:17673207: &#34;comparable proliferative effect on ... anti-CD3
+        Ab-activated primary T cells&#34;), but it is costimulation-dependent,
+        context-sensitive, and subordinate to IL21&#39;s signature B-cell/Tfh/humoral
+        immunity functions. GO:0042102 remains out of core_functions.
+      additional_reference_ids:
+        - file:human/IL21/IL21-hypotheses/core-function-1-go-0042102/openscientist.md
       supported_by:
         - reference_id: PMID:17673207
           supporting_text: Epub 2007 Jul 25. Cloning and characterization of an 
             isoform of interleukin-21.
+        - reference_id: file:human/IL21/IL21-hypotheses/core-function-1-go-0042102/openscientist.md
+          supporting_text: The annotation should be retained (the effect is real)
+            but classified as non-core using the `KEEP_AS_NON_CORE` action.
   - term:
       id: GO:0007260
       label: tyrosine phosphorylation of STAT protein
@@ -5115,13 +5997,25 @@ existing_annotations:
     review:
       summary: &gt;-
         Correct annotation with experimental evidence. IL21 activates NK cells and
-        modulates their cytotoxic activity. Core function.
-      action: ACCEPT
+        modulates their cytotoxic activity, but this should be treated as a real
+        non-core pleiotropic effect rather than a signature IL21 function.
+      action: KEEP_AS_NON_CORE
+      reason: &gt;-
+        The focused OpenScientist review found that NK cytotoxicity enhancement has
+        IDA support from PMID:18005035, but parallels T cell proliferation as a
+        downstream, context-dependent effect of IL21R/JAK-STAT signaling rather
+        than a defining core process.
+      additional_reference_ids:
+        - file:human/IL21/IL21-hypotheses/core-function-1-go-0042102/openscientist.md
       supported_by:
         - reference_id: PMID:18005035
           supporting_text: Epub 2007 Nov 14. Interleukin-21 activates human 
             natural killer cells and modulates their surface receptor 
             expression.
+        - reference_id: file:human/IL21/IL21-hypotheses/core-function-1-go-0042102/openscientist.md
+          supporting_text: NK cytotoxicity enhancement is a real pleiotropic effect
+            but not a signature function, and it should also be classified as
+            non-core.
   - term:
       id: GO:0001819
       label: positive regulation of cytokine production
@@ -5250,15 +6144,21 @@ existing_annotations:
       summary: &gt;-
         Duplicate of the GO:0042102 annotation from PMID:17673207; IL21 shows a
         proliferative effect on activated T cells.
-      action: UNDECIDED
+      action: KEEP_AS_NON_CORE
       reason: &gt;-
-        Deferred to expert curator review (see issue #1418), consistent with the
-        GO:0042102 annotation from PMID:17673207. Real effect, but core vs
-        non-core status for IL21 is borderline.
+        Resolved consistently with the GO:0042102 annotation from PMID:17673207
+        and the focused OpenScientist review. The effect is real, but should be
+        retained as non-core because it is costimulation-dependent and not part
+        of IL21&#39;s signature B-cell/Tfh/humoral immunity axis.
+      additional_reference_ids:
+        - file:human/IL21/IL21-hypotheses/core-function-1-go-0042102/openscientist.md
       supported_by:
         - reference_id: PMID:15207081
           supporting_text: &#39;AIM: To clone full length cDNA of human interleukin-21
             (IL-21) and express it in E.coli.&#39;
+        - reference_id: file:human/IL21/IL21-hypotheses/core-function-1-go-0042102/openscientist.md
+          supporting_text: The annotation should be retained (the effect is real)
+            but classified as non-core using the `KEEP_AS_NON_CORE` action.
   - term:
       id: GO:0048469
       label: cell maturation
@@ -5387,6 +6287,27 @@ references:
     title: A structural blueprint for interleukin-21 signal modulation.
     findings:
       - statement: Structural analysis of IL21-receptor interactions
+  - id: file:human/IL21/IL21-hypotheses/core-function-1-go-0042102/openscientist.md
+    title: OpenScientist focused review of IL21 positive regulation of T cell proliferation as a core function
+    publication_type: DEEP_RESEARCH
+    findings:
+      - statement: &gt;-
+          The focused hypothesis review judged positive regulation of T cell
+          proliferation to be a real IL21 effect but not a core function, recommending
+          KEEP_AS_NON_CORE for both GO:0042102 annotations.
+      - statement: &gt;-
+          The report found that IL21&#39;s signature functions are cytokine activity
+          driving the B cell/Tfh/humoral immunity axis: germinal center B cell
+          differentiation, Tfh differentiation, immunoglobulin production, and B
+          cell proliferation.
+      - statement: &gt;-
+          The report recommended removing positive regulation of natural killer
+          cell mediated cytotoxicity from core_functions and retaining it as
+          non-core, because the effect is real but not signature.
+      - statement: &gt;-
+          The report flagged an evidence-code asymmetry: several signature IL21
+          processes have weaker GOA evidence codes than the non-core T cell
+          proliferation annotations.
   - id: Reactome:R-HSA-9005980
     title: IL21 binds IL21R:JAK1
     findings: []
@@ -5419,8 +6340,6 @@ core_functions:
         label: T follicular helper cell differentiation
       - id: GO:0030890
         label: positive regulation of B cell proliferation
-      - id: GO:0045954
-        label: positive regulation of natural killer cell mediated cytotoxicity
     locations:
       - id: GO:0005576
         label: extracellular region

--- a/genes/human/IL21/IL21-ai-review.yaml
+++ b/genes/human/IL21/IL21-ai-review.yaml
@@ -46,11 +46,18 @@ existing_annotations:
     review:
       summary: >-
         Phylogenetically inferred annotation consistent with IL21's role in NK cell
-        function.
-        Supported by experimental data (PMID:18005035) showing IL21 activates NK cells
-        and
-        modulates their cytotoxic activity.
-      action: ACCEPT
+        function. Supported by experimental data (PMID:18005035) showing IL21
+        activates NK cells and modulates their cytotoxic activity, but the focused
+        OpenScientist review judged NK cytotoxicity enhancement to be a real
+        pleiotropic effect rather than a signature IL21 core function.
+      action: KEEP_AS_NON_CORE
+      reason: >-
+        Retain the annotation as biologically real, but do not treat it as core.
+        IL21's signature biology centers on cytokine activity driving the B
+        cell/Tfh/humoral immunity axis; NK cytotoxicity is context-dependent and
+        downstream of the same IL21R/JAK-STAT signaling program.
+      additional_reference_ids:
+        - file:human/IL21/IL21-hypotheses/core-function-1-go-0042102/openscientist.md
 # IEA annotations - automated methods
   - term:
       id: GO:0001819
@@ -146,9 +153,15 @@ existing_annotations:
     original_reference_id: GO_REF:0000117
     review:
       summary: >-
-        Duplicates IBA/IDA annotation for same term. ARBA-predicted. Consistent with
-        experimental evidence. Maintain consistent action.
-      action: ACCEPT
+        Duplicates IBA/IDA annotation for the same term. ARBA-predicted and
+        consistent with experimental evidence, but non-core for IL21.
+      action: KEEP_AS_NON_CORE
+      reason: >-
+        Maintain consistency with the IBA and IDA GO:0045954 reviews: IL21 can
+        enhance NK cytotoxicity, but this is not a signature core function of the
+        cytokine.
+      additional_reference_ids:
+        - file:human/IL21/IL21-hypotheses/core-function-1-go-0042102/openscientist.md
   - term:
       id: GO:0048468
       label: cell development
@@ -452,18 +465,23 @@ existing_annotations:
         IL21 has a real but weak, context-dependent proliferative effect on
         anti-CD3-activated primary T cells (PMID:17673207). Whether this rises to
         a core function of IL21 (vs its signature B-cell/Tfh axis) is borderline.
-      action: UNDECIDED
+      action: KEEP_AS_NON_CORE
       reason: >-
-        Deferred to expert curator review (see issue #1418). The effect is
-        directly evidenced (PMID:17673207: "comparable proliferative effect on
-        ... anti-CD3 Ab-activated primary T cells"), but IL21 is a weak,
-        context-dependent T-cell mitogen, so core vs non-core is genuinely
-        unclear. GO:0042102 has been removed from core_functions pending this
-        decision; the B-cell/Tfh signature processes remain core.
+        The focused OpenScientist review resolved the core-function question by
+        recommending KEEP_AS_NON_CORE. The effect is directly evidenced
+        (PMID:17673207: "comparable proliferative effect on ... anti-CD3
+        Ab-activated primary T cells"), but it is costimulation-dependent,
+        context-sensitive, and subordinate to IL21's signature B-cell/Tfh/humoral
+        immunity functions. GO:0042102 remains out of core_functions.
+      additional_reference_ids:
+        - file:human/IL21/IL21-hypotheses/core-function-1-go-0042102/openscientist.md
       supported_by:
         - reference_id: PMID:17673207
           supporting_text: Epub 2007 Jul 25. Cloning and characterization of an 
             isoform of interleukin-21.
+        - reference_id: file:human/IL21/IL21-hypotheses/core-function-1-go-0042102/openscientist.md
+          supporting_text: The annotation should be retained (the effect is real)
+            but classified as non-core using the `KEEP_AS_NON_CORE` action.
   - term:
       id: GO:0007260
       label: tyrosine phosphorylation of STAT protein
@@ -496,13 +514,25 @@ existing_annotations:
     review:
       summary: >-
         Correct annotation with experimental evidence. IL21 activates NK cells and
-        modulates their cytotoxic activity. Core function.
-      action: ACCEPT
+        modulates their cytotoxic activity, but this should be treated as a real
+        non-core pleiotropic effect rather than a signature IL21 function.
+      action: KEEP_AS_NON_CORE
+      reason: >-
+        The focused OpenScientist review found that NK cytotoxicity enhancement has
+        IDA support from PMID:18005035, but parallels T cell proliferation as a
+        downstream, context-dependent effect of IL21R/JAK-STAT signaling rather
+        than a defining core process.
+      additional_reference_ids:
+        - file:human/IL21/IL21-hypotheses/core-function-1-go-0042102/openscientist.md
       supported_by:
         - reference_id: PMID:18005035
           supporting_text: Epub 2007 Nov 14. Interleukin-21 activates human 
             natural killer cells and modulates their surface receptor 
             expression.
+        - reference_id: file:human/IL21/IL21-hypotheses/core-function-1-go-0042102/openscientist.md
+          supporting_text: NK cytotoxicity enhancement is a real pleiotropic effect
+            but not a signature function, and it should also be classified as
+            non-core.
   - term:
       id: GO:0001819
       label: positive regulation of cytokine production
@@ -631,15 +661,21 @@ existing_annotations:
       summary: >-
         Duplicate of the GO:0042102 annotation from PMID:17673207; IL21 shows a
         proliferative effect on activated T cells.
-      action: UNDECIDED
+      action: KEEP_AS_NON_CORE
       reason: >-
-        Deferred to expert curator review (see issue #1418), consistent with the
-        GO:0042102 annotation from PMID:17673207. Real effect, but core vs
-        non-core status for IL21 is borderline.
+        Resolved consistently with the GO:0042102 annotation from PMID:17673207
+        and the focused OpenScientist review. The effect is real, but should be
+        retained as non-core because it is costimulation-dependent and not part
+        of IL21's signature B-cell/Tfh/humoral immunity axis.
+      additional_reference_ids:
+        - file:human/IL21/IL21-hypotheses/core-function-1-go-0042102/openscientist.md
       supported_by:
         - reference_id: PMID:15207081
           supporting_text: 'AIM: To clone full length cDNA of human interleukin-21
             (IL-21) and express it in E.coli.'
+        - reference_id: file:human/IL21/IL21-hypotheses/core-function-1-go-0042102/openscientist.md
+          supporting_text: The annotation should be retained (the effect is real)
+            but classified as non-core using the `KEEP_AS_NON_CORE` action.
   - term:
       id: GO:0048469
       label: cell maturation
@@ -768,6 +804,27 @@ references:
     title: A structural blueprint for interleukin-21 signal modulation.
     findings:
       - statement: Structural analysis of IL21-receptor interactions
+  - id: file:human/IL21/IL21-hypotheses/core-function-1-go-0042102/openscientist.md
+    title: OpenScientist focused review of IL21 positive regulation of T cell proliferation as a core function
+    publication_type: DEEP_RESEARCH
+    findings:
+      - statement: >-
+          The focused hypothesis review judged positive regulation of T cell
+          proliferation to be a real IL21 effect but not a core function, recommending
+          KEEP_AS_NON_CORE for both GO:0042102 annotations.
+      - statement: >-
+          The report found that IL21's signature functions are cytokine activity
+          driving the B cell/Tfh/humoral immunity axis: germinal center B cell
+          differentiation, Tfh differentiation, immunoglobulin production, and B
+          cell proliferation.
+      - statement: >-
+          The report recommended removing positive regulation of natural killer
+          cell mediated cytotoxicity from core_functions and retaining it as
+          non-core, because the effect is real but not signature.
+      - statement: >-
+          The report flagged an evidence-code asymmetry: several signature IL21
+          processes have weaker GOA evidence codes than the non-core T cell
+          proliferation annotations.
   - id: Reactome:R-HSA-9005980
     title: IL21 binds IL21R:JAK1
     findings: []
@@ -800,8 +857,6 @@ core_functions:
         label: T follicular helper cell differentiation
       - id: GO:0030890
         label: positive regulation of B cell proliferation
-      - id: GO:0045954
-        label: positive regulation of natural killer cell mediated cytotoxicity
     locations:
       - id: GO:0005576
         label: extracellular region


### PR DESCRIPTION
## Summary

Integrates the completed OpenScientist focused review for whether `GO:0042102 positive regulation of T cell proliferation` should be treated as a core IL21 function.

Changes:
- adds the OpenScientist report as a reference in the IL21 review
- resolves both `GO:0042102` annotations from `UNDECIDED` to `KEEP_AS_NON_CORE`
- reclassifies duplicate `GO:0045954 positive regulation of natural killer cell mediated cytotoxicity` annotations as `KEEP_AS_NON_CORE`
- removes `GO:0045954` from `core_functions.directly_involved_in`
- preserves the core cytokine/B-cell/Tfh/humoral-immunity model and regenerates the IL21 HTML page

## Validation

- `just validate human IL21` (passes with the existing warning that annotations do not reference `IL21-deep-research-falcon.md`)
- `just render human IL21`