### PR TITLE
Add module pages and convert index to table layout

### DIFF
--- a/pages/modules/bbsome.html
+++ b/pages/modules/bbsome.html
@@ -1,0 +1,906 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>BBSome ciliary trafficking complex module - AI Gene Review</title>
+    <style>
+        :root {
+            --bg-page: #f7f8fb;
+            --bg-panel: #ffffff;
+            --bg-soft: #f2f6f8;
+            --border: #d9e1e7;
+            --text: #17212b;
+            --muted: #637282;
+            --accent: #0f766e;
+            --accent-soft: #dff4f0;
+            --blue: #2563eb;
+            --amber: #b45309;
+            --green: #15803d;
+            --red: #b91c1c;
+        }
+
+        * {
+            box-sizing: border-box;
+        }
+
+        body {
+            margin: 0;
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+            color: var(--text);
+            background: var(--bg-page);
+            line-height: 1.55;
+        }
+
+        a {
+            color: var(--blue);
+            text-decoration: none;
+        }
+
+        a:hover {
+            text-decoration: underline;
+        }
+
+        .page {
+            max-width: 1440px;
+            margin: 0 auto;
+            padding: 24px;
+        }
+
+        .breadcrumb {
+            margin-bottom: 14px;
+            color: var(--muted);
+            font-size: 0.9rem;
+        }
+
+        .header {
+            background: var(--bg-panel);
+            border: 1px solid var(--border);
+            border-radius: 8px;
+            padding: 22px 24px;
+            margin-bottom: 18px;
+        }
+
+        h1 {
+            margin: 0 0 8px;
+            font-size: 2rem;
+            line-height: 1.2;
+        }
+
+        h2 {
+            margin: 0 0 14px;
+            font-size: 1.3rem;
+        }
+
+        h3 {
+            margin: 0 0 10px;
+            font-size: 1.1rem;
+        }
+
+        h4 {
+            margin: 16px 0 8px;
+            font-size: 0.95rem;
+            color: #344454;
+        }
+
+        .description {
+            max-width: 980px;
+            color: #2f3d4a;
+        }
+
+        .meta-row {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 8px;
+            margin-top: 14px;
+        }
+
+        .pill {
+            display: inline-flex;
+            align-items: center;
+            gap: 6px;
+            padding: 4px 9px;
+            border: 1px solid var(--border);
+            border-radius: 999px;
+            background: var(--bg-soft);
+            color: #304150;
+            font-size: 0.82rem;
+            font-weight: 600;
+            white-space: nowrap;
+        }
+
+        .pill.status {
+            background: #fff7ed;
+            border-color: #fed7aa;
+            color: var(--amber);
+        }
+
+        .pill.type {
+            background: var(--accent-soft);
+            border-color: #b8dfd8;
+            color: var(--accent);
+        }
+
+        .stats {
+            display: grid;
+            grid-template-columns: repeat(6, minmax(90px, 1fr));
+            gap: 10px;
+            margin-bottom: 18px;
+        }
+
+        .stat {
+            background: var(--bg-panel);
+            border: 1px solid var(--border);
+            border-radius: 8px;
+            padding: 10px 12px;
+        }
+
+        .stat-value {
+            display: block;
+            font-size: 1.35rem;
+            font-weight: 700;
+        }
+
+        .stat-label {
+            color: var(--muted);
+            font-size: 0.78rem;
+            text-transform: uppercase;
+        }
+
+        .browser {
+            display: grid;
+            grid-template-columns: minmax(310px, 420px) minmax(0, 1fr);
+            gap: 18px;
+            align-items: start;
+        }
+
+        .panel {
+            background: var(--bg-panel);
+            border: 1px solid var(--border);
+            border-radius: 8px;
+            min-width: 0;
+        }
+
+        .tree-panel {
+            position: sticky;
+            top: 16px;
+            max-height: calc(100vh - 32px);
+            overflow: auto;
+        }
+
+        .panel-header {
+            padding: 14px 16px;
+            border-bottom: 1px solid var(--border);
+            background: #fbfcfd;
+        }
+
+        .panel-body {
+            padding: 16px;
+        }
+
+        .tree-tools {
+            display: grid;
+            grid-template-columns: 1fr auto auto;
+            gap: 8px;
+            margin-top: 10px;
+        }
+
+        .tree-search {
+            width: 100%;
+            min-width: 0;
+            border: 1px solid var(--border);
+            border-radius: 6px;
+            padding: 7px 9px;
+            font: inherit;
+        }
+
+        .tool-button {
+            border: 1px solid var(--border);
+            border-radius: 6px;
+            padding: 7px 9px;
+            background: #ffffff;
+            color: #273747;
+            font: inherit;
+            font-size: 0.85rem;
+            cursor: pointer;
+        }
+
+        .tool-button:hover {
+            border-color: #9eb0bd;
+            background: #f8fafc;
+        }
+
+        .tree-list,
+        .tree-list ol,
+        .tree-list ul {
+            list-style: none;
+            padding-left: 0;
+            margin: 0;
+        }
+
+        .tree-list ol,
+        .tree-list ul {
+            margin-left: 16px;
+            padding-left: 12px;
+            border-left: 1px solid var(--border);
+        }
+
+        .tree-node {
+            margin: 5px 0;
+        }
+
+        .tree-node > summary {
+            cursor: pointer;
+            border-radius: 6px;
+            padding: 6px 8px;
+        }
+
+        .tree-node > summary:hover {
+            background: var(--bg-soft);
+        }
+
+        .tree-row {
+            display: inline-flex;
+            flex-wrap: wrap;
+            align-items: center;
+            gap: 6px;
+            max-width: calc(100% - 16px);
+            vertical-align: top;
+        }
+
+        .tree-row.is-dimmed {
+            opacity: 0.35;
+        }
+
+        .tree-link {
+            font-weight: 650;
+            color: var(--text);
+        }
+
+        .tree-id {
+            color: var(--muted);
+            font-size: 0.78rem;
+        }
+
+        .tree-group-title {
+            margin: 8px 0 4px 20px;
+            color: var(--muted);
+            font-size: 0.78rem;
+            font-weight: 700;
+            text-transform: uppercase;
+        }
+
+        .edge-note {
+            color: var(--muted);
+            font-size: 0.82rem;
+        }
+
+        .annoton-item {
+            margin: 5px 0;
+            font-size: 0.9rem;
+        }
+
+        .detail-panel {
+            overflow: hidden;
+        }
+
+        .node-detail {
+            border: 1px solid var(--border);
+            border-radius: 8px;
+            padding: 16px;
+            margin-bottom: 14px;
+            background: #ffffff;
+        }
+
+        .node-detail.depth-1,
+        .node-detail.depth-2,
+        .node-detail.depth-3 {
+            background: #fbfcfd;
+        }
+
+        .node-heading {
+            display: flex;
+            flex-wrap: wrap;
+            align-items: center;
+            gap: 8px;
+            margin-bottom: 8px;
+        }
+
+        .node-title {
+            font-size: 1.1rem;
+            font-weight: 700;
+        }
+
+        .node-description,
+        .role-description {
+            color: #31404e;
+            margin: 8px 0;
+        }
+
+        .descriptor-list {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 6px;
+            margin: 8px 0;
+        }
+
+        .descriptor {
+            display: inline-flex;
+            flex-wrap: wrap;
+            align-items: center;
+            gap: 5px;
+            padding: 4px 7px;
+            border-radius: 6px;
+            background: #eef7ff;
+            border: 1px solid #cce4ff;
+            font-size: 0.87rem;
+        }
+
+        .descriptor-description {
+            color: var(--muted);
+        }
+
+        .term-id,
+        .source-id {
+            font-family: "SFMono-Regular", Consolas, "Liberation Mono", Menlo, monospace;
+            font-size: 0.78rem;
+        }
+
+        .slot-row {
+            margin-top: 4px;
+            font-size: 0.86rem;
+        }
+
+        .slot-name {
+            color: var(--muted);
+            font-weight: 700;
+        }
+
+        .participant-detail {
+            margin-top: 6px;
+        }
+
+        .annoton-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+            gap: 10px;
+            margin-top: 10px;
+        }
+
+        .annoton-card,
+        .connection-card,
+        .context-card,
+        .evidence-card,
+        .complex-unit {
+            border: 1px solid var(--border);
+            border-radius: 8px;
+            background: #ffffff;
+            padding: 11px;
+        }
+
+        .active-unit-list {
+            display: grid;
+            gap: 8px;
+            margin-top: 6px;
+        }
+
+        .annoton-title {
+            font-weight: 700;
+            margin-bottom: 4px;
+        }
+
+        .muted {
+            color: var(--muted);
+        }
+
+        .small {
+            font-size: 0.85rem;
+        }
+
+        .connection-list,
+        .evidence-list {
+            display: grid;
+            gap: 8px;
+            margin-top: 8px;
+        }
+
+        .connection-arrow {
+            color: var(--green);
+            font-weight: 700;
+        }
+
+        .variant-set {
+            margin-top: 14px;
+            border-left: 3px solid #94a3b8;
+            padding-left: 12px;
+        }
+
+        .part-marker,
+        .variant-marker {
+            color: var(--muted);
+            font-size: 0.85rem;
+            font-weight: 700;
+            margin: 12px 0 8px;
+        }
+
+        .warnings {
+            border: 1px solid #fecaca;
+            background: #fef2f2;
+            color: var(--red);
+            border-radius: 8px;
+            padding: 12px 16px;
+            margin-bottom: 18px;
+        }
+
+        @media (max-width: 960px) {
+            .page {
+                padding: 14px;
+            }
+
+            .stats {
+                grid-template-columns: repeat(2, minmax(120px, 1fr));
+            }
+
+            .browser {
+                grid-template-columns: 1fr;
+            }
+
+            .tree-panel {
+                position: static;
+                max-height: none;
+            }
+        }
+    </style>
+</head>
+<body>
+
+
+
+
+
+
+
+
+
+
+
+
+<main class="page">
+    <nav class="breadcrumb">
+        <a href="index.html">Module KB</a> / BBSome ciliary trafficking complex module
+    </nav>
+
+    <header class="header">
+        <h1>BBSome ciliary trafficking complex module</h1>            <p class="description">The BBSome is a conserved octameric protein complex that acts as a coat-like adaptor for ciliary membrane-protein trafficking. It is built from eight core subunits (BBS1, BBS2, BBS4, BBS5, BBS7, BBS8/TTC8, BBS9, and BBIP1/BBS18), assembled with the help of a dedicated chaperonin-like module (BBS6/MKKS, BBS10, BBS12 acting with the CCT/TRiC chaperonin). Once assembled, the BBSome is recruited to the ciliary membrane by the GTP-bound Arf-like GTPase ARL6/BBS3, where it polymerizes into a coat that recognizes signaling-receptor cargo (ciliary GPCRs and Hedgehog-pathway components) and couples them to the intraflagellar transport (IFT) machinery, mediating ciliary import and, especially, retrieval/export across the transition zone. LZTFL1/BBS17 and the accessory factor CCDC28B regulate BBSome ciliary trafficking. Loss of BBSome function causes Bardet-Biedl syndrome. This module models the BBSome as a cellular component / protein complex grounded in GO:0034464, capturing its composition, assembly, membrane recruitment, cargo trafficking, and regulation.</p>        <div class="meta-row"><span class="pill">MODULE:bbsome</span><span class="pill status">DRAFT</span><span class="pill type">Protein Complex</span><span class="pill">modules/bbsome.yaml</span>
+        </div>
+        <div class="descriptor-list">                <span class="descriptor">
+            <span>BBSome</span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0034464" target="_blank" rel="noopener">GO:0034464</a></span>                <span class="descriptor">
+            <span>intraciliary transport</span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0042073" target="_blank" rel="noopener">GO:0042073</a></span>        </div>
+        <div class="evidence-list">                <div class="evidence-card small"><a class="source-id" href="https://pubmed.ncbi.nlm.nih.gov/17574030/" target="_blank" rel="noopener">PMID:17574030</a><div><strong>A core complex of BBS proteins cooperates with the GTPase Rab8 to promote ciliary membrane biogenesis</strong></div><div>Identifies the BBSome as a stable complex of seven BBS proteins plus BBIP10 that associates with the ciliary membrane and promotes ciliary membrane trafficking.</div></div>                <div class="evidence-card small"><a class="source-id" href="https://pubmed.ncbi.nlm.nih.gov/19081074/" target="_blank" rel="noopener">PMID:19081074</a><div><strong>A BBSome subunit links ciliogenesis, microtubule stability, and acetylation</strong></div><div>Establishes BBIP10 (BBIP1) as an integral eighth BBSome subunit required for complex integrity and links the BBSome to microtubule stability and acetylation.</div></div>                <div class="evidence-card small"><a class="source-id" href="https://pubmed.ncbi.nlm.nih.gov/20603001/" target="_blank" rel="noopener">PMID:20603001</a><div><strong>The conserved Bardet-Biedl syndrome proteins assemble a coat that traffics membrane proteins to cilia</strong></div><div>Shows the BBSome forms a planar coat on membranes whose assembly is nucleated by ARL6/BBS3-GTP, supporting the coat-adaptor model for ciliary cargo trafficking.</div></div>                <div class="evidence-card small"><a class="source-id" href="https://pubmed.ncbi.nlm.nih.gov/25402481/" target="_blank" rel="noopener">PMID:25402481</a><div><strong>Structural basis for membrane targeting of the BBSome by ARL6</strong></div><div>Provides the structural basis for GTP-dependent recruitment of the BBSome to membranes by ARL6/BBS3 via the BBS1 beta-propeller.</div></div>                <div class="evidence-card small"><a class="source-id" href="https://pubmed.ncbi.nlm.nih.gov/20080638/" target="_blank" rel="noopener">PMID:20080638</a><div><strong>BBS6, BBS10, and BBS12 form a complex with CCT/TRiC family chaperonins and mediate BBSome assembly</strong></div><div>Demonstrates that the chaperonin-like BBS proteins (MKKS/BBS6, BBS10, BBS12) act with the CCT/TRiC chaperonin to assemble the BBSome core, supporting a dedicated assembly module distinct from the mature complex.</div></div>                <div class="evidence-card small"><a class="source-id" href="https://pubmed.ncbi.nlm.nih.gov/22072986/" target="_blank" rel="noopener">PMID:22072986</a><div><strong>A novel protein LZTFL1 regulates ciliary trafficking of the BBSome and Smoothened</strong></div><div>Shows LZTFL1/BBS17 regulates ciliary entry and retrieval of the BBSome and of Smoothened, supporting a trafficking-regulation interface to the complex.</div></div>        </div><p class="muted small">This module is intentionally BBSome-centric: it represents the eight-subunit core complex, its dedicated chaperonin-like assembly module, its ARL6/BBS3 membrane recruiter, and its LZTFL1/CCDC28B trafficking regulators. Broader ciliary machinery that the BBSome cooperates with (the IFT-A/IFT-B trains, the transition-zone MKS/NPHP modules, and Rab8/Rab23 membrane-trafficking regulators) is treated as an interface rather than part of the complex. Several proteins carry &#34;BBS&#34; disease-locus numbers but belong primarily to other ciliary modules (e.g. IFT27/BBS19, IFT172/BBS20, MKS1/BBS13, CEP290/BBS14, SDCCAG8/BBS16, WDPCP/BBS15) and are out of scope here. Subunit roles reflect the cryo-EM/biochemical consensus; where a precise GO molecular function is uncertain, only a preferred_term and description are given.</p></header>
+    <section class="stats" aria-label="Module counts">
+        <div class="stat"><span class="stat-value">6</span><span class="stat-label">Nodes</span></div>
+        <div class="stat"><span class="stat-value">5</span><span class="stat-label">Parts</span></div>
+        <div class="stat"><span class="stat-value">0</span><span class="stat-label">Variant Sets</span></div>
+        <div class="stat"><span class="stat-value">0</span><span class="stat-label">Variants</span></div>
+        <div class="stat"><span class="stat-value">6</span><span class="stat-label">Annotons</span></div>
+        <div class="stat"><span class="stat-value">4</span><span class="stat-label">Connections</span></div>
+    </section>
+
+    <section class="browser">
+        <aside class="panel tree-panel">
+            <div class="panel-header">
+                <h2>Tree</h2>
+                <div class="tree-tools">
+                    <input class="tree-search" type="search" placeholder="Filter tree" data-tree-search>
+                    <button class="tool-button" type="button" data-tree-action="expand">Expand</button>
+                    <button class="tool-button" type="button" data-tree-action="collapse">Collapse</button>
+                </div>
+            </div>
+            <div class="panel-body">
+                <ol class="tree-list">
+                    <li class="tree-entry">
+        <details class="tree-node" open>
+            <summary>
+                <span class="tree-row">
+                    <a class="tree-link" href="#node-bbsome">BBSome ciliary trafficking complex</a><span class="pill type">Protein Complex</span><span class="tree-id">bbsome</span>
+                </span>
+            </summary>                <div class="tree-group-title">Parts</div>
+                <ol>                            <li>
+                                <div class="edge-note">1. assembly of the BBSome core by chaperonin-like factors</div>
+                                <li class="tree-entry">
+        <details class="tree-node" open>
+            <summary>
+                <span class="tree-row">
+                    <a class="tree-link" href="#node-bbsome_assembly">Chaperonin-mediated BBSome assembly</a><span class="pill type">Protein Complex</span><span class="tree-id">bbsome_assembly</span>
+                </span>
+            </summary>                <div class="tree-group-title">Annotons</div>
+                <ul>                        <li class="annoton-item tree-entry">
+                            <span class="tree-row">
+                                <a href="#annoton-bbs_chaperonin_assembly_module">BBS chaperonin-like assembly module (BBS6/BBS10/BBS12 + CCT)</a>
+                                <span class="tree-id">Protein Complex: BBS chaperonin-like assembly complex with CCT/TRiC</span>
+                            </span>
+                        </li>                </ul></details>
+    </li>
+                            </li>                            <li>
+                                <div class="edge-note">2. mature BBSome core complex</div>
+                                <li class="tree-entry">
+        <details class="tree-node" open>
+            <summary>
+                <span class="tree-row">
+                    <a class="tree-link" href="#node-bbsome_core_octamer">BBSome core octamer</a><span class="pill type">Protein Complex</span><span class="tree-id">bbsome_core_octamer</span>
+                </span>
+            </summary>                <div class="tree-group-title">Annotons</div>
+                <ul>                        <li class="annoton-item tree-entry">
+                            <span class="tree-row">
+                                <a href="#annoton-bbsome_octamer_units">BBSome octamer subunits</a>
+                                <span class="tree-id">Protein Complex: BBSome octamer</span>
+                            </span>
+                        </li>                </ul></details>
+    </li>
+                            </li>                            <li>
+                                <div class="edge-note">3. GTP-dependent membrane recruitment</div>
+                                <li class="tree-entry">
+        <details class="tree-node" open>
+            <summary>
+                <span class="tree-row">
+                    <a class="tree-link" href="#node-arl6_membrane_recruitment">ARL6/BBS3 membrane recruitment of the BBSome</a><span class="pill type">Regulatory Step</span><span class="tree-id">arl6_membrane_recruitment</span>
+                </span>
+            </summary>                <div class="tree-group-title">Annotons</div>
+                <ul>                        <li class="annoton-item tree-entry">
+                            <span class="tree-row">
+                                <a href="#annoton-arl6_gtpase_recruitment">ARL6/BBS3 GTP-dependent BBSome recruitment</a>
+                                <span class="tree-id">Gene Product: ARL6 (BBS3)</span>
+                            </span>
+                        </li>                </ul></details>
+    </li>
+                            </li>                            <li>
+                                <div class="edge-note">4. cargo recognition and ciliary trafficking</div>
+                                <li class="tree-entry">
+        <details class="tree-node" open>
+            <summary>
+                <span class="tree-row">
+                    <a class="tree-link" href="#node-bbsome_cargo_trafficking">BBSome cargo recognition and ciliary import/retrieval</a><span class="pill type">Transport Step</span><span class="tree-id">bbsome_cargo_trafficking</span>
+                </span>
+            </summary>                <div class="tree-group-title">Annotons</div>
+                <ul>                        <li class="annoton-item tree-entry">
+                            <span class="tree-row">
+                                <a href="#annoton-bbsome_cargo_adaptor">BBSome ciliary cargo adaptor activity</a>
+                                <span class="tree-id">Protein Complex: membrane-bound BBSome coat</span>
+                            </span>
+                        </li>                </ul></details>
+    </li>
+                            </li>                            <li>
+                                <div class="edge-note">5. regulation of BBSome ciliary trafficking optional</div>
+                                <li class="tree-entry">
+        <details class="tree-node" open>
+            <summary>
+                <span class="tree-row">
+                    <a class="tree-link" href="#node-bbsome_trafficking_regulation">Regulation of BBSome ciliary trafficking</a><span class="pill type">Regulatory Step</span><span class="tree-id">bbsome_trafficking_regulation</span>
+                </span>
+            </summary>                <div class="tree-group-title">Annotons</div>
+                <ul>                        <li class="annoton-item tree-entry">
+                            <span class="tree-row">
+                                <a href="#annoton-lztfl1_regulation">LZTFL1/BBS17 regulation of BBSome ciliary trafficking</a>
+                                <span class="tree-id">Gene Product: LZTFL1 (BBS17)</span>
+                            </span>
+                        </li>                        <li class="annoton-item tree-entry">
+                            <span class="tree-row">
+                                <a href="#annoton-ccdc28b_modifier">CCDC28B accessory modifier of BBSome ciliary localization</a>
+                                <span class="tree-id">Gene Product: CCDC28B</span>
+                            </span>
+                        </li>                </ul></details>
+    </li>
+                            </li>                </ol></details>
+    </li>
+                </ol>
+            </div>
+        </aside>
+
+        <section class="panel detail-panel">
+            <div class="panel-header">
+                <h2>Details</h2>
+            </div>
+            <div class="panel-body">
+                <div class="context-card small">
+            <strong>Context</strong>
+            <div class="descriptor-list">                <span class="descriptor">
+            <span>ciliated eukaryotes</span></span>        </div>
+
+
+
+            <div class="descriptor-list">                <span class="descriptor">
+            <span>cilium</span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0005929" target="_blank" rel="noopener">GO:0005929</a></span>                <span class="descriptor">
+            <span>ciliary membrane</span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0060170" target="_blank" rel="noopener">GO:0060170</a></span>                <span class="descriptor">
+            <span>ciliary basal body</span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0036064" target="_blank" rel="noopener">GO:0036064</a></span>                <span class="descriptor">
+            <span>ciliary tip</span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0097542" target="_blank" rel="noopener">GO:0097542</a></span>        </div>
+
+            </div>
+                <section class="node-detail depth-0" id="node-bbsome">
+        <div class="node-heading">
+            <span class="node-title">BBSome ciliary trafficking complex</span><span class="pill type">Protein Complex</span><span class="pill">bbsome</span>
+        </div><div class="descriptor-list">                <span class="descriptor">
+            <span>BBSome</span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0034464" target="_blank" rel="noopener">GO:0034464</a></span>                <span class="descriptor">
+            <span>intraciliary transport</span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0042073" target="_blank" rel="noopener">GO:0042073</a></span>        </div>
+        <div class="context-card small">
+            <strong>Context</strong>
+            <div class="descriptor-list">                <span class="descriptor">
+            <span>ciliated eukaryotes</span></span>        </div>
+
+
+
+            <div class="descriptor-list">                <span class="descriptor">
+            <span>cilium</span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0005929" target="_blank" rel="noopener">GO:0005929</a></span>                <span class="descriptor">
+            <span>ciliary membrane</span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0060170" target="_blank" rel="noopener">GO:0060170</a></span>                <span class="descriptor">
+            <span>ciliary basal body</span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0036064" target="_blank" rel="noopener">GO:0036064</a></span>                <span class="descriptor">
+            <span>ciliary tip</span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0097542" target="_blank" rel="noopener">GO:0097542</a></span>        </div>
+
+            </div>
+                    <h4>Connections</h4>
+            <div class="connection-list">                <div class="connection-card small">
+                    <div>
+                        <a href="#node-bbsome_assembly">bbsome_assembly</a>
+                        <span class="connection-arrow">-&gt;</span>
+                        <a href="#node-bbsome_core_octamer">bbsome_core_octamer</a>                            <span class="pill">Precedes</span></div>                        <div class="muted">Chaperonin-mediated assembly produces the mature BBSome octamer.</div>
+
+                </div>                <div class="connection-card small">
+                    <div>
+                        <a href="#node-bbsome_core_octamer">bbsome_core_octamer</a>
+                        <span class="connection-arrow">-&gt;</span>
+                        <a href="#node-arl6_membrane_recruitment">arl6_membrane_recruitment</a>                            <span class="pill">Provides Input For</span></div>                        <div class="muted">The assembled octamer is the substrate recruited to the ciliary membrane by ARL6/BBS3.</div>
+
+                </div>                <div class="connection-card small">
+                    <div>
+                        <a href="#node-arl6_membrane_recruitment">arl6_membrane_recruitment</a>
+                        <span class="connection-arrow">-&gt;</span>
+                        <a href="#node-bbsome_cargo_trafficking">bbsome_cargo_trafficking</a>                            <span class="pill">Provides Input For</span></div>                        <div class="muted">Membrane recruitment positions the BBSome coat to capture cargo and couple it to IFT.</div>
+
+                </div>                <div class="connection-card small">
+                    <div>
+                        <a href="#node-bbsome_trafficking_regulation">bbsome_trafficking_regulation</a>
+                        <span class="connection-arrow">-&gt;</span>
+                        <a href="#node-bbsome_cargo_trafficking">bbsome_cargo_trafficking</a>                            <span class="pill">Negatively Regulates</span></div>                        <div class="muted">LZTFL1/CCDC28B regulate BBSome ciliary entry and cargo retrieval.</div>
+
+                </div>        </div>                <div class="part-marker">
+                    Part 1: assembly of the BBSome core by chaperonin-like factors</div>
+                <section class="node-detail depth-1" id="node-bbsome_assembly">
+        <div class="node-heading">
+            <span class="node-title">Chaperonin-mediated BBSome assembly</span><span class="pill type">Protein Complex</span><span class="pill">bbsome_assembly</span>
+        </div>            <p class="node-description">The chaperonin-like BBS proteins MKKS/BBS6, BBS10, and BBS12 form a complex with the CCT/TRiC chaperonin that folds BBS7 and nucleates assembly of the eight-subunit BBSome core. These factors are required to build the complex but are not stable subunits of the mature BBSome.</p><div class="descriptor-list">                <span class="descriptor">
+            <span>chaperone-mediated protein complex assembly</span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0051131" target="_blank" rel="noopener">GO:0051131</a></span>        </div>
+
+                    <h4>Annotons</h4>
+            <div class="annoton-grid">                    <article class="annoton-card" id="annoton-bbs_chaperonin_assembly_module">
+        <div class="annoton-title">BBS chaperonin-like assembly module (BBS6/BBS10/BBS12 + CCT)</div>
+        <div class="small muted">bbs_chaperonin_assembly_module</div>            <div class="small"><strong>Participant:</strong> Protein Complex: BBS chaperonin-like assembly complex with CCT/TRiC</div>
+            <div class="participant-detail">                    <div class="slot-row">
+                        <span class="slot-name">Protein Complex:</span>
+                        <div class="descriptor">
+            <span><strong>BBS chaperonin-like assembly complex with CCT/TRiC</strong></span>                <span class="descriptor-description">Chaperonin-like BBS proteins acting with the cytosolic CCT/TRiC chaperonin to assemble the BBSome core.</span>                <div class="slot-row">
+                    <span class="slot-name">Active units:</span>
+                    <div class="active-unit-list">                            <div class="complex-unit">
+        <div>
+            <strong>MKKS/BBS6 chaperonin-like unit</strong></div>            <div class="small"><strong>Participant:</strong> Gene Product: MKKS (BBS6)</div>
+            <div class="participant-detail">                    <div class="slot-row">
+                        <span class="slot-name">Gene Product:</span>
+                        <div class="descriptor">
+            <span><strong>MKKS (BBS6)</strong></span><a class="term-id" href="https://www.uniprot.org/uniprotkb/Q9NPJ1/entry" target="_blank" rel="noopener">UniProtKB:Q9NPJ1</a></div>
+                    </div></div>            <div class="small"><strong>Role:</strong> chaperonin-like assembly factor</div>            <div class="small"><strong>Function:</strong> <div class="descriptor">
+            <span><strong>protein folding chaperone</strong></span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0044183" target="_blank" rel="noopener">GO:0044183</a></div></div></div>                            <div class="complex-unit">
+        <div>
+            <strong>BBS10 chaperonin-like unit</strong></div>            <div class="small"><strong>Participant:</strong> Gene Product: BBS10</div>
+            <div class="participant-detail">                    <div class="slot-row">
+                        <span class="slot-name">Gene Product:</span>
+                        <div class="descriptor">
+            <span><strong>BBS10</strong></span><a class="term-id" href="https://www.uniprot.org/uniprotkb/Q8TAM1/entry" target="_blank" rel="noopener">UniProtKB:Q8TAM1</a></div>
+                    </div></div>            <div class="small"><strong>Role:</strong> chaperonin-like assembly factor</div></div>                            <div class="complex-unit">
+        <div>
+            <strong>BBS12 chaperonin-like unit</strong></div>            <div class="small"><strong>Participant:</strong> Gene Product: BBS12</div>
+            <div class="participant-detail">                    <div class="slot-row">
+                        <span class="slot-name">Gene Product:</span>
+                        <div class="descriptor">
+            <span><strong>BBS12</strong></span><a class="term-id" href="https://www.uniprot.org/uniprotkb/Q6ZW61/entry" target="_blank" rel="noopener">UniProtKB:Q6ZW61</a></div>
+                    </div></div>            <div class="small"><strong>Role:</strong> chaperonin-like assembly factor</div></div>                            <div class="complex-unit">
+        <div>
+            <strong>CCT/TRiC chaperonin</strong></div>            <div class="small"><strong>Participant:</strong> Protein Complex: CCT/TRiC chaperonin</div>
+            <div class="participant-detail">                    <div class="slot-row">
+                        <span class="slot-name">Protein Complex:</span>
+                        <div class="descriptor">
+            <span><strong>CCT/TRiC chaperonin</strong></span>                <span class="descriptor-description">Cytosolic chaperonin containing TCP-1 (TRiC) that cooperates with the BBS chaperonins.</span></div>
+                    </div></div>            <div class="small"><strong>Role:</strong> cytosolic chaperonin that folds BBSome subunits</div></div>                    </div>
+                </div></div>
+                    </div></div>            <h4>Function</h4>
+            <div class="descriptor">
+            <span><strong>chaperone-mediated assembly of the BBSome core</strong></span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0051131" target="_blank" rel="noopener">GO:0051131</a>                    <div class="slot-row">
+                        <span class="slot-name">Targets:</span>                            <span class="descriptor">
+            <span>BBSome core subunits</span></span>                    </div></div><div class="evidence-list">                <div class="evidence-card small"><a class="source-id" href="https://pubmed.ncbi.nlm.nih.gov/20080638/" target="_blank" rel="noopener">PMID:20080638</a><div>BBS6/BBS10/BBS12 form a complex with CCT/TRiC chaperonins and mediate BBSome assembly.</div></div>        </div></article>            </div>    </section>                <div class="part-marker">
+                    Part 2: mature BBSome core complex</div>
+                <section class="node-detail depth-1" id="node-bbsome_core_octamer">
+        <div class="node-heading">
+            <span class="node-title">BBSome core octamer</span><span class="pill type">Protein Complex</span><span class="pill">bbsome_core_octamer</span>
+        </div>            <p class="node-description">The mature eight-subunit BBSome. BBS2, BBS7, and BBS9 form an interlocking beta-propeller/GAE/platform scaffold; BBS1 is the principal cargo- and ARL6/BBS3-interaction subunit; BBS4 and BBS8/TTC8 are TPR-superhelix adaptors; BBS5 contributes phosphoinositide-binding pleckstrin-homology domains for membrane association; and the small BBIP1/BBS18 subunit is required for complex integrity.</p><div class="descriptor-list">                <span class="descriptor">
+            <span>BBSome</span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0034464" target="_blank" rel="noopener">GO:0034464</a></span>        </div>
+
+                    <h4>Annotons</h4>
+            <div class="annoton-grid">                    <article class="annoton-card" id="annoton-bbsome_octamer_units">
+        <div class="annoton-title">BBSome octamer subunits</div>
+        <div class="small muted">bbsome_octamer_units</div>            <div class="small"><strong>Participant:</strong> Protein Complex: BBSome octamer</div>
+            <div class="participant-detail">                    <div class="slot-row">
+                        <span class="slot-name">Protein Complex:</span>
+                        <div class="descriptor">
+            <span><strong>BBSome octamer</strong></span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0034464" target="_blank" rel="noopener">GO:0034464</a>                <div class="slot-row">
+                    <span class="slot-name">Active units:</span>
+                    <div class="active-unit-list">                            <div class="complex-unit">
+        <div>
+            <strong>BBS1 subunit</strong><span class="pill">1</span></div>            <div class="small"><strong>Participant:</strong> Gene Product: BBS1</div>
+            <div class="participant-detail">                    <div class="slot-row">
+                        <span class="slot-name">Gene Product:</span>
+                        <div class="descriptor">
+            <span><strong>BBS1</strong></span><a class="term-id" href="https://www.uniprot.org/uniprotkb/Q8NFJ9/entry" target="_blank" rel="noopener">UniProtKB:Q8NFJ9</a></div>
+                    </div></div>            <div class="small"><strong>Role:</strong> beta-propeller subunit; principal cargo recognition and ARL6/BBS3-GTP binding interface</div></div>                            <div class="complex-unit">
+        <div>
+            <strong>BBS2 subunit</strong><span class="pill">1</span></div>            <div class="small"><strong>Participant:</strong> Gene Product: BBS2</div>
+            <div class="participant-detail">                    <div class="slot-row">
+                        <span class="slot-name">Gene Product:</span>
+                        <div class="descriptor">
+            <span><strong>BBS2</strong></span><a class="term-id" href="https://www.uniprot.org/uniprotkb/Q9BXC9/entry" target="_blank" rel="noopener">UniProtKB:Q9BXC9</a></div>
+                    </div></div>            <div class="small"><strong>Role:</strong> beta-propeller/GAE/platform scaffold subunit</div></div>                            <div class="complex-unit">
+        <div>
+            <strong>BBS4 subunit</strong><span class="pill">1</span></div>            <div class="small"><strong>Participant:</strong> Gene Product: BBS4</div>
+            <div class="participant-detail">                    <div class="slot-row">
+                        <span class="slot-name">Gene Product:</span>
+                        <div class="descriptor">
+            <span><strong>BBS4</strong></span><a class="term-id" href="https://www.uniprot.org/uniprotkb/Q96RK4/entry" target="_blank" rel="noopener">UniProtKB:Q96RK4</a></div>
+                    </div></div>            <div class="small"><strong>Role:</strong> TPR-superhelix adaptor subunit</div></div>                            <div class="complex-unit">
+        <div>
+            <strong>BBS5 subunit</strong><span class="pill">1</span></div>            <div class="small"><strong>Participant:</strong> Gene Product: BBS5</div>
+            <div class="participant-detail">                    <div class="slot-row">
+                        <span class="slot-name">Gene Product:</span>
+                        <div class="descriptor">
+            <span><strong>BBS5</strong></span><a class="term-id" href="https://www.uniprot.org/uniprotkb/Q8N3I7/entry" target="_blank" rel="noopener">UniProtKB:Q8N3I7</a></div>
+                    </div></div>            <div class="small"><strong>Role:</strong> pleckstrin-homology subunit; phosphoinositide-dependent membrane association</div>            <div class="small"><strong>Function:</strong> <div class="descriptor">
+            <span><strong>phosphatidylinositol-3-phosphate binding</strong></span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0032266" target="_blank" rel="noopener">GO:0032266</a></div></div></div>                            <div class="complex-unit">
+        <div>
+            <strong>BBS7 subunit</strong><span class="pill">1</span></div>            <div class="small"><strong>Participant:</strong> Gene Product: BBS7</div>
+            <div class="participant-detail">                    <div class="slot-row">
+                        <span class="slot-name">Gene Product:</span>
+                        <div class="descriptor">
+            <span><strong>BBS7</strong></span><a class="term-id" href="https://www.uniprot.org/uniprotkb/Q8IWZ6/entry" target="_blank" rel="noopener">UniProtKB:Q8IWZ6</a></div>
+                    </div></div>            <div class="small"><strong>Role:</strong> beta-propeller/GAE/platform scaffold subunit; CCT/chaperonin client during assembly</div></div>                            <div class="complex-unit">
+        <div>
+            <strong>BBS8/TTC8 subunit</strong><span class="pill">1</span></div>            <div class="small"><strong>Participant:</strong> Gene Product: TTC8 (BBS8)</div>
+            <div class="participant-detail">                    <div class="slot-row">
+                        <span class="slot-name">Gene Product:</span>
+                        <div class="descriptor">
+            <span><strong>TTC8 (BBS8)</strong></span><a class="term-id" href="https://www.uniprot.org/uniprotkb/Q8TAM2/entry" target="_blank" rel="noopener">UniProtKB:Q8TAM2</a></div>
+                    </div></div>            <div class="small"><strong>Role:</strong> TPR-superhelix adaptor subunit</div></div>                            <div class="complex-unit">
+        <div>
+            <strong>BBS9 subunit</strong><span class="pill">1</span></div>            <div class="small"><strong>Participant:</strong> Gene Product: BBS9</div>
+            <div class="participant-detail">                    <div class="slot-row">
+                        <span class="slot-name">Gene Product:</span>
+                        <div class="descriptor">
+            <span><strong>BBS9</strong></span><a class="term-id" href="https://www.uniprot.org/uniprotkb/Q3SYG4/entry" target="_blank" rel="noopener">UniProtKB:Q3SYG4</a></div>
+                    </div></div>            <div class="small"><strong>Role:</strong> central beta-propeller/GAE/platform/alpha-helical scaffold subunit</div></div>                            <div class="complex-unit">
+        <div>
+            <strong>BBIP1/BBS18 subunit</strong><span class="pill">1</span></div>            <div class="small"><strong>Participant:</strong> Gene Product: BBIP1 (BBIP10, BBS18)</div>
+            <div class="participant-detail">                    <div class="slot-row">
+                        <span class="slot-name">Gene Product:</span>
+                        <div class="descriptor">
+            <span><strong>BBIP1 (BBIP10, BBS18)</strong></span><a class="term-id" href="https://www.uniprot.org/uniprotkb/A8MTZ0/entry" target="_blank" rel="noopener">UniProtKB:A8MTZ0</a></div>
+                    </div></div>            <div class="small"><strong>Role:</strong> small subunit required for BBSome integrity; links to microtubule stability/acetylation</div></div>                    </div>
+                </div></div>
+                    </div></div>            <h4>Function</h4>
+            <div class="descriptor">
+            <span><strong>ciliary membrane-protein cargo adaptor</strong></span>                <span class="descriptor-description">The assembled octamer functions as a coat-like adaptor that selects membrane-protein cargo for intraflagellar transport.</span></div>            <h4>Locations</h4>
+            <div class="descriptor-list">                <span class="descriptor">
+            <span>ciliary membrane</span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0060170" target="_blank" rel="noopener">GO:0060170</a></span>                <span class="descriptor">
+            <span>ciliary basal body</span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0036064" target="_blank" rel="noopener">GO:0036064</a></span>        </div><div class="evidence-list">                <div class="evidence-card small"><a class="source-id" href="https://pubmed.ncbi.nlm.nih.gov/17574030/" target="_blank" rel="noopener">PMID:17574030</a><div>Defines the seven-subunit BBSome plus BBIP10 associated with the ciliary membrane.</div></div>                <div class="evidence-card small"><a class="source-id" href="https://pubmed.ncbi.nlm.nih.gov/19081074/" target="_blank" rel="noopener">PMID:19081074</a><div>Establishes BBIP10/BBIP1 as the integral eighth subunit required for complex integrity.</div></div>        </div></article>            </div>    </section>                <div class="part-marker">
+                    Part 3: GTP-dependent membrane recruitment</div>
+                <section class="node-detail depth-1" id="node-arl6_membrane_recruitment">
+        <div class="node-heading">
+            <span class="node-title">ARL6/BBS3 membrane recruitment of the BBSome</span><span class="pill type">Regulatory Step</span><span class="pill">arl6_membrane_recruitment</span>
+        </div>            <p class="node-description">The Arf-like GTPase ARL6/BBS3, in its GTP-bound state, binds the BBS1 beta-propeller and recruits the BBSome to the ciliary membrane, where BBSome coat polymerization is nucleated. This is the membrane-targeting switch for BBSome function.</p>
+
+                    <h4>Annotons</h4>
+            <div class="annoton-grid">                    <article class="annoton-card" id="annoton-arl6_gtpase_recruitment">
+        <div class="annoton-title">ARL6/BBS3 GTP-dependent BBSome recruitment</div>
+        <div class="small muted">arl6_gtpase_recruitment</div>            <div class="small"><strong>Participant:</strong> Gene Product: ARL6 (BBS3)</div>
+            <div class="participant-detail">                    <div class="slot-row">
+                        <span class="slot-name">Gene Product:</span>
+                        <div class="descriptor">
+            <span><strong>ARL6 (BBS3)</strong></span><a class="term-id" href="https://www.uniprot.org/uniprotkb/Q9H0F7/entry" target="_blank" rel="noopener">UniProtKB:Q9H0F7</a></div>
+                    </div></div>            <h4>Function</h4>
+            <div class="descriptor">
+            <span><strong>GTP-dependent recruitment of the BBSome to the ciliary membrane</strong></span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0005525" target="_blank" rel="noopener">GO:0005525</a>                    <div class="slot-row">
+                        <span class="slot-name">Targets:</span>                            <span class="descriptor">
+            <span>BBSome</span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0034464" target="_blank" rel="noopener">GO:0034464</a></span>                    </div></div>            <h4>Locations</h4>
+            <div class="descriptor-list">                <span class="descriptor">
+            <span>ciliary membrane</span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0060170" target="_blank" rel="noopener">GO:0060170</a></span>        </div><div class="evidence-list">                <div class="evidence-card small"><a class="source-id" href="https://pubmed.ncbi.nlm.nih.gov/20603001/" target="_blank" rel="noopener">PMID:20603001</a><div>ARL6/BBS3-GTP nucleates BBSome coat assembly on membranes.</div></div>                <div class="evidence-card small"><a class="source-id" href="https://pubmed.ncbi.nlm.nih.gov/25402481/" target="_blank" rel="noopener">PMID:25402481</a><div>Structural basis for ARL6-GTP recruitment of the BBSome via the BBS1 beta-propeller.</div></div>        </div></article>            </div>    </section>                <div class="part-marker">
+                    Part 4: cargo recognition and ciliary trafficking</div>
+                <section class="node-detail depth-1" id="node-bbsome_cargo_trafficking">
+        <div class="node-heading">
+            <span class="node-title">BBSome cargo recognition and ciliary import/retrieval</span><span class="pill type">Transport Step</span><span class="pill">bbsome_cargo_trafficking</span>
+        </div>            <p class="node-description">The membrane-bound BBSome recognizes signaling-receptor cargo (ciliary GPCRs such as SSTR3, MCHR1, NPY2R, and Hedgehog-pathway components such as Smoothened and GPR161) and couples them to the IFT trains. The BBSome is especially required for retrieval/export of activated receptors out of the cilium across the transition zone.</p><div class="descriptor-list">                <span class="descriptor">
+            <span>protein localization to cilium</span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0061512" target="_blank" rel="noopener">GO:0061512</a></span>        </div>
+
+                    <h4>Annotons</h4>
+            <div class="annoton-grid">                    <article class="annoton-card" id="annoton-bbsome_cargo_adaptor">
+        <div class="annoton-title">BBSome ciliary cargo adaptor activity</div>
+        <div class="small muted">bbsome_cargo_adaptor</div>            <div class="small"><strong>Participant:</strong> Protein Complex: membrane-bound BBSome coat</div>
+            <div class="participant-detail">                    <div class="slot-row">
+                        <span class="slot-name">Protein Complex:</span>
+                        <div class="descriptor">
+            <span><strong>membrane-bound BBSome coat</strong></span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0034464" target="_blank" rel="noopener">GO:0034464</a></div>
+                    </div></div>            <h4>Function</h4>
+            <div class="descriptor">
+            <span><strong>ciliary membrane-protein cargo adaptor coupling to intraflagellar transport</strong></span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0042073" target="_blank" rel="noopener">GO:0042073</a>                    <div class="slot-row">
+                        <span class="slot-name">Cargo:</span>                            <span class="descriptor">
+            <span>ciliary GPCR cargo (e.g. SSTR3, MCHR1, NPY2R)</span></span>                            <span class="descriptor">
+            <span>Hedgehog signaling components (Smoothened, GPR161)</span></span>                    </div></div>            <h4>Locations</h4>
+            <div class="descriptor-list">                <span class="descriptor">
+            <span>ciliary membrane</span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0060170" target="_blank" rel="noopener">GO:0060170</a></span>                <span class="descriptor">
+            <span>ciliary tip</span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0097542" target="_blank" rel="noopener">GO:0097542</a></span>                <span class="descriptor">
+            <span>ciliary transition zone</span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0035869" target="_blank" rel="noopener">GO:0035869</a></span>        </div><div class="evidence-list">                <div class="evidence-card small"><a class="source-id" href="https://pubmed.ncbi.nlm.nih.gov/20603001/" target="_blank" rel="noopener">PMID:20603001</a><div>The BBSome coat traffics membrane proteins to and within cilia.</div></div>        </div></article>            </div>    </section>                <div class="part-marker">
+                    Part 5: regulation of BBSome ciliary trafficking (optional)</div>
+                <section class="node-detail depth-1" id="node-bbsome_trafficking_regulation">
+        <div class="node-heading">
+            <span class="node-title">Regulation of BBSome ciliary trafficking</span><span class="pill type">Regulatory Step</span><span class="pill">bbsome_trafficking_regulation</span>
+        </div>            <p class="node-description">LZTFL1/BBS17 and the accessory factor CCDC28B regulate BBSome ciliary entry and retrieval. LZTFL1 associates with the BBSome in the cytoplasm and controls ciliary trafficking of the BBSome and Smoothened.</p>
+
+                    <h4>Annotons</h4>
+            <div class="annoton-grid">                    <article class="annoton-card" id="annoton-lztfl1_regulation">
+        <div class="annoton-title">LZTFL1/BBS17 regulation of BBSome ciliary trafficking</div>
+        <div class="small muted">lztfl1_regulation</div>            <div class="small"><strong>Participant:</strong> Gene Product: LZTFL1 (BBS17)</div>
+            <div class="participant-detail">                    <div class="slot-row">
+                        <span class="slot-name">Gene Product:</span>
+                        <div class="descriptor">
+            <span><strong>LZTFL1 (BBS17)</strong></span><a class="term-id" href="https://www.uniprot.org/uniprotkb/Q9NQ48/entry" target="_blank" rel="noopener">UniProtKB:Q9NQ48</a></div>
+                    </div></div>            <h4>Function</h4>
+            <div class="descriptor">
+            <span><strong>regulation of BBSome and Smoothened ciliary localization</strong></span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:1903565" target="_blank" rel="noopener">GO:1903565</a>                    <div class="slot-row">
+                        <span class="slot-name">Targets:</span>                            <span class="descriptor">
+            <span>BBSome</span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0034464" target="_blank" rel="noopener">GO:0034464</a></span>                            <span class="descriptor">
+            <span>Smoothened</span></span>                    </div></div><div class="evidence-list">                <div class="evidence-card small"><a class="source-id" href="https://pubmed.ncbi.nlm.nih.gov/22072986/" target="_blank" rel="noopener">PMID:22072986</a><div>LZTFL1 regulates ciliary trafficking of the BBSome and Smoothened.</div></div>        </div></article>                    <article class="annoton-card" id="annoton-ccdc28b_modifier">
+        <div class="annoton-title">CCDC28B accessory modifier of BBSome ciliary localization</div>
+        <div class="small muted">ccdc28b_modifier</div>            <div class="small"><strong>Participant:</strong> Gene Product: CCDC28B</div>
+            <div class="participant-detail">                    <div class="slot-row">
+                        <span class="slot-name">Gene Product:</span>
+                        <div class="descriptor">
+            <span><strong>CCDC28B</strong></span><a class="term-id" href="https://www.uniprot.org/uniprotkb/Q9BUN5/entry" target="_blank" rel="noopener">UniProtKB:Q9BUN5</a></div>
+                    </div></div>            <h4>Function</h4>
+            <div class="descriptor">
+            <span><strong>modifier of BBSome ciliary localization</strong></span>                <span class="descriptor-description">Accessory factor that influences BBSome ciliary localization; acts as a genetic modifier of Bardet-Biedl syndrome rather than a core subunit. No precise GO molecular function is asserted here.</span></div>            <p class="role-description">Accessory modifier of BBSome ciliary trafficking.</p></article>            </div>    </section>    </section>
+            </div>
+        </section>
+    </section>
+</main>
+
+<script>
+    const searchInput = document.querySelector("[data-tree-search]");
+    if (searchInput) {
+        searchInput.addEventListener("input", () => {
+            const query = searchInput.value.trim().toLowerCase();
+            document.querySelectorAll(".tree-row").forEach((row) => {
+                const matches = !query || row.textContent.toLowerCase().includes(query);
+                row.classList.toggle("is-dimmed", !matches);
+                if (query && matches) {
+                    let detail = row.closest("details");
+                    while (detail) {
+                        detail.open = true;
+                        detail = detail.parentElement ? detail.parentElement.closest("details") : null;
+                    }
+                }
+            });
+        });
+    }
+
+    document.querySelectorAll("[data-tree-action]").forEach((button) => {
+        button.addEventListener("click", () => {
+            const shouldOpen = button.dataset.treeAction === "expand";
+            document.querySelectorAll(".tree-panel details").forEach((detail) => {
+                detail.open = shouldOpen;
+            });
+        });
+    });
+</script>
+</body>
+</html>

--- a/pages/modules/erythromycin_biosynthesis.html
+++ b/pages/modules/erythromycin_biosynthesis.html
@@ -1,0 +1,1084 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Erythromycin A biosynthesis (Saccharopolyspora erythraea) - AI Gene Review</title>
+    <style>
+        :root {
+            --bg-page: #f7f8fb;
+            --bg-panel: #ffffff;
+            --bg-soft: #f2f6f8;
+            --border: #d9e1e7;
+            --text: #17212b;
+            --muted: #637282;
+            --accent: #0f766e;
+            --accent-soft: #dff4f0;
+            --blue: #2563eb;
+            --amber: #b45309;
+            --green: #15803d;
+            --red: #b91c1c;
+        }
+
+        * {
+            box-sizing: border-box;
+        }
+
+        body {
+            margin: 0;
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+            color: var(--text);
+            background: var(--bg-page);
+            line-height: 1.55;
+        }
+
+        a {
+            color: var(--blue);
+            text-decoration: none;
+        }
+
+        a:hover {
+            text-decoration: underline;
+        }
+
+        .page {
+            max-width: 1440px;
+            margin: 0 auto;
+            padding: 24px;
+        }
+
+        .breadcrumb {
+            margin-bottom: 14px;
+            color: var(--muted);
+            font-size: 0.9rem;
+        }
+
+        .header {
+            background: var(--bg-panel);
+            border: 1px solid var(--border);
+            border-radius: 8px;
+            padding: 22px 24px;
+            margin-bottom: 18px;
+        }
+
+        h1 {
+            margin: 0 0 8px;
+            font-size: 2rem;
+            line-height: 1.2;
+        }
+
+        h2 {
+            margin: 0 0 14px;
+            font-size: 1.3rem;
+        }
+
+        h3 {
+            margin: 0 0 10px;
+            font-size: 1.1rem;
+        }
+
+        h4 {
+            margin: 16px 0 8px;
+            font-size: 0.95rem;
+            color: #344454;
+        }
+
+        .description {
+            max-width: 980px;
+            color: #2f3d4a;
+        }
+
+        .meta-row {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 8px;
+            margin-top: 14px;
+        }
+
+        .pill {
+            display: inline-flex;
+            align-items: center;
+            gap: 6px;
+            padding: 4px 9px;
+            border: 1px solid var(--border);
+            border-radius: 999px;
+            background: var(--bg-soft);
+            color: #304150;
+            font-size: 0.82rem;
+            font-weight: 600;
+            white-space: nowrap;
+        }
+
+        .pill.status {
+            background: #fff7ed;
+            border-color: #fed7aa;
+            color: var(--amber);
+        }
+
+        .pill.type {
+            background: var(--accent-soft);
+            border-color: #b8dfd8;
+            color: var(--accent);
+        }
+
+        .stats {
+            display: grid;
+            grid-template-columns: repeat(6, minmax(90px, 1fr));
+            gap: 10px;
+            margin-bottom: 18px;
+        }
+
+        .stat {
+            background: var(--bg-panel);
+            border: 1px solid var(--border);
+            border-radius: 8px;
+            padding: 10px 12px;
+        }
+
+        .stat-value {
+            display: block;
+            font-size: 1.35rem;
+            font-weight: 700;
+        }
+
+        .stat-label {
+            color: var(--muted);
+            font-size: 0.78rem;
+            text-transform: uppercase;
+        }
+
+        .browser {
+            display: grid;
+            grid-template-columns: minmax(310px, 420px) minmax(0, 1fr);
+            gap: 18px;
+            align-items: start;
+        }
+
+        .panel {
+            background: var(--bg-panel);
+            border: 1px solid var(--border);
+            border-radius: 8px;
+            min-width: 0;
+        }
+
+        .tree-panel {
+            position: sticky;
+            top: 16px;
+            max-height: calc(100vh - 32px);
+            overflow: auto;
+        }
+
+        .panel-header {
+            padding: 14px 16px;
+            border-bottom: 1px solid var(--border);
+            background: #fbfcfd;
+        }
+
+        .panel-body {
+            padding: 16px;
+        }
+
+        .tree-tools {
+            display: grid;
+            grid-template-columns: 1fr auto auto;
+            gap: 8px;
+            margin-top: 10px;
+        }
+
+        .tree-search {
+            width: 100%;
+            min-width: 0;
+            border: 1px solid var(--border);
+            border-radius: 6px;
+            padding: 7px 9px;
+            font: inherit;
+        }
+
+        .tool-button {
+            border: 1px solid var(--border);
+            border-radius: 6px;
+            padding: 7px 9px;
+            background: #ffffff;
+            color: #273747;
+            font: inherit;
+            font-size: 0.85rem;
+            cursor: pointer;
+        }
+
+        .tool-button:hover {
+            border-color: #9eb0bd;
+            background: #f8fafc;
+        }
+
+        .tree-list,
+        .tree-list ol,
+        .tree-list ul {
+            list-style: none;
+            padding-left: 0;
+            margin: 0;
+        }
+
+        .tree-list ol,
+        .tree-list ul {
+            margin-left: 16px;
+            padding-left: 12px;
+            border-left: 1px solid var(--border);
+        }
+
+        .tree-node {
+            margin: 5px 0;
+        }
+
+        .tree-node > summary {
+            cursor: pointer;
+            border-radius: 6px;
+            padding: 6px 8px;
+        }
+
+        .tree-node > summary:hover {
+            background: var(--bg-soft);
+        }
+
+        .tree-row {
+            display: inline-flex;
+            flex-wrap: wrap;
+            align-items: center;
+            gap: 6px;
+            max-width: calc(100% - 16px);
+            vertical-align: top;
+        }
+
+        .tree-row.is-dimmed {
+            opacity: 0.35;
+        }
+
+        .tree-link {
+            font-weight: 650;
+            color: var(--text);
+        }
+
+        .tree-id {
+            color: var(--muted);
+            font-size: 0.78rem;
+        }
+
+        .tree-group-title {
+            margin: 8px 0 4px 20px;
+            color: var(--muted);
+            font-size: 0.78rem;
+            font-weight: 700;
+            text-transform: uppercase;
+        }
+
+        .edge-note {
+            color: var(--muted);
+            font-size: 0.82rem;
+        }
+
+        .annoton-item {
+            margin: 5px 0;
+            font-size: 0.9rem;
+        }
+
+        .detail-panel {
+            overflow: hidden;
+        }
+
+        .node-detail {
+            border: 1px solid var(--border);
+            border-radius: 8px;
+            padding: 16px;
+            margin-bottom: 14px;
+            background: #ffffff;
+        }
+
+        .node-detail.depth-1,
+        .node-detail.depth-2,
+        .node-detail.depth-3 {
+            background: #fbfcfd;
+        }
+
+        .node-heading {
+            display: flex;
+            flex-wrap: wrap;
+            align-items: center;
+            gap: 8px;
+            margin-bottom: 8px;
+        }
+
+        .node-title {
+            font-size: 1.1rem;
+            font-weight: 700;
+        }
+
+        .node-description,
+        .role-description {
+            color: #31404e;
+            margin: 8px 0;
+        }
+
+        .descriptor-list {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 6px;
+            margin: 8px 0;
+        }
+
+        .descriptor {
+            display: inline-flex;
+            flex-wrap: wrap;
+            align-items: center;
+            gap: 5px;
+            padding: 4px 7px;
+            border-radius: 6px;
+            background: #eef7ff;
+            border: 1px solid #cce4ff;
+            font-size: 0.87rem;
+        }
+
+        .descriptor-description {
+            color: var(--muted);
+        }
+
+        .term-id,
+        .source-id {
+            font-family: "SFMono-Regular", Consolas, "Liberation Mono", Menlo, monospace;
+            font-size: 0.78rem;
+        }
+
+        .slot-row {
+            margin-top: 4px;
+            font-size: 0.86rem;
+        }
+
+        .slot-name {
+            color: var(--muted);
+            font-weight: 700;
+        }
+
+        .participant-detail {
+            margin-top: 6px;
+        }
+
+        .annoton-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+            gap: 10px;
+            margin-top: 10px;
+        }
+
+        .annoton-card,
+        .connection-card,
+        .context-card,
+        .evidence-card,
+        .complex-unit {
+            border: 1px solid var(--border);
+            border-radius: 8px;
+            background: #ffffff;
+            padding: 11px;
+        }
+
+        .active-unit-list {
+            display: grid;
+            gap: 8px;
+            margin-top: 6px;
+        }
+
+        .annoton-title {
+            font-weight: 700;
+            margin-bottom: 4px;
+        }
+
+        .muted {
+            color: var(--muted);
+        }
+
+        .small {
+            font-size: 0.85rem;
+        }
+
+        .connection-list,
+        .evidence-list {
+            display: grid;
+            gap: 8px;
+            margin-top: 8px;
+        }
+
+        .connection-arrow {
+            color: var(--green);
+            font-weight: 700;
+        }
+
+        .variant-set {
+            margin-top: 14px;
+            border-left: 3px solid #94a3b8;
+            padding-left: 12px;
+        }
+
+        .part-marker,
+        .variant-marker {
+            color: var(--muted);
+            font-size: 0.85rem;
+            font-weight: 700;
+            margin: 12px 0 8px;
+        }
+
+        .warnings {
+            border: 1px solid #fecaca;
+            background: #fef2f2;
+            color: var(--red);
+            border-radius: 8px;
+            padding: 12px 16px;
+            margin-bottom: 18px;
+        }
+
+        @media (max-width: 960px) {
+            .page {
+                padding: 14px;
+            }
+
+            .stats {
+                grid-template-columns: repeat(2, minmax(120px, 1fr));
+            }
+
+            .browser {
+                grid-template-columns: 1fr;
+            }
+
+            .tree-panel {
+                position: static;
+                max-height: none;
+            }
+        }
+    </style>
+</head>
+<body>
+
+
+
+
+
+
+
+
+
+
+
+
+<main class="page">
+    <nav class="breadcrumb">
+        <a href="index.html">Module KB</a> / Erythromycin A biosynthesis (Saccharopolyspora erythraea)
+    </nav>
+
+    <header class="header">
+        <h1>Erythromycin A biosynthesis (Saccharopolyspora erythraea)</h1>            <p class="description">Representative-species module for biosynthesis of the macrolide antibiotic erythromycin A in Saccharopolyspora erythraea, encoded by the ery cluster (MIBiG BGC0000055). It is grounded to the concrete S. erythraea gene set reviewed under genes/SACEN/. The module combines a modular type I polyketide synthase (DEBS) that builds the macrolactone, post-PKS cytochrome-P450 oxidations, two TDP-deoxysugar pathways feeding two glycosyltransferases, final O-methylation, and rRNA-methylation self-resistance. Companion prose/MIBiG-alignment notes are in terms/erythromycin_biosynthesis/.</p>        <div class="meta-row"><span class="pill">MODULE:erythromycin_biosynthesis</span><span class="pill status">DRAFT</span><span class="pill type">Metabolic Pathway</span><span class="pill">modules/erythromycin_biosynthesis.yaml</span>
+        </div>
+        <div class="descriptor-list">                <span class="descriptor">
+            <span>erythromycin biosynthetic process</span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:1901115" target="_blank" rel="noopener">GO:1901115</a></span>        </div>
+        <div class="evidence-list">                <div class="evidence-card small"><span class="source-id">MIBiG:BGC0000055</span><div><strong>Erythromycin biosynthetic gene cluster</strong></div><div>The ery cluster (23 genes) encodes the enzymes of erythromycin A biosynthesis in S. erythraea.</div></div>                <div class="evidence-card small"><a class="source-id" href="https://amigo.geneontology.org/amigo/term/GO:1901115" target="_blank" rel="noopener">GO:1901115</a><div><strong>erythromycin biosynthetic process</strong></div><div>The module is grounded in the GO biological process term for erythromycin biosynthesis.</div></div>        </div></header>
+    <section class="stats" aria-label="Module counts">
+        <div class="stat"><span class="stat-value">9</span><span class="stat-label">Nodes</span></div>
+        <div class="stat"><span class="stat-value">8</span><span class="stat-label">Parts</span></div>
+        <div class="stat"><span class="stat-value">0</span><span class="stat-label">Variant Sets</span></div>
+        <div class="stat"><span class="stat-value">0</span><span class="stat-label">Variants</span></div>
+        <div class="stat"><span class="stat-value">20</span><span class="stat-label">Annotons</span></div>
+        <div class="stat"><span class="stat-value">6</span><span class="stat-label">Connections</span></div>
+    </section>
+
+    <section class="browser">
+        <aside class="panel tree-panel">
+            <div class="panel-header">
+                <h2>Tree</h2>
+                <div class="tree-tools">
+                    <input class="tree-search" type="search" placeholder="Filter tree" data-tree-search>
+                    <button class="tool-button" type="button" data-tree-action="expand">Expand</button>
+                    <button class="tool-button" type="button" data-tree-action="collapse">Collapse</button>
+                </div>
+            </div>
+            <div class="panel-body">
+                <ol class="tree-list">
+                    <li class="tree-entry">
+        <details class="tree-node" open>
+            <summary>
+                <span class="tree-row">
+                    <a class="tree-link" href="#node-erythromycin_biosynthesis">Erythromycin A biosynthesis</a><span class="pill type">Metabolic Pathway</span><span class="tree-id">erythromycin_biosynthesis</span>
+                </span>
+            </summary>                <div class="tree-group-title">Parts</div>
+                <ol>                            <li>
+                                <div class="edge-note">1. macrolactone assembly</div>
+                                <li class="tree-entry">
+        <details class="tree-node" open>
+            <summary>
+                <span class="tree-row">
+                    <a class="tree-link" href="#node-debs_assembly">DEBS modular type I PKS assembles 6-deoxyerythronolide B</a><span class="pill type">Metabolic Pathway</span><span class="tree-id">debs_assembly</span>
+                </span>
+            </summary>                <div class="tree-group-title">Annotons</div>
+                <ul>                        <li class="annoton-item tree-entry">
+                            <span class="tree-row">
+                                <a href="#annoton-eryai_fn">DEBS1 (loading didomain + modules 1-2)</a>
+                                <span class="tree-id">Gene: eryAI</span>
+                            </span>
+                        </li>                        <li class="annoton-item tree-entry">
+                            <span class="tree-row">
+                                <a href="#annoton-eryaii_fn">DEBS2 (modules 3-4)</a>
+                                <span class="tree-id">Gene: eryAII</span>
+                            </span>
+                        </li>                        <li class="annoton-item tree-entry">
+                            <span class="tree-row">
+                                <a href="#annoton-eryaiii_fn">DEBS3 (modules 5-6 + thioesterase)</a>
+                                <span class="tree-id">Gene: eryAIII</span>
+                            </span>
+                        </li>                        <li class="annoton-item tree-entry">
+                            <span class="tree-row">
+                                <a href="#annoton-teii_fn">type II thioesterase (PKS editing/proofreading)</a>
+                                <span class="tree-id">Gene: TEII (locus CAM00070)</span>
+                            </span>
+                        </li>                </ul></details>
+    </li>
+                            </li>                            <li>
+                                <div class="edge-note">2. post-PKS C-6 hydroxylation</div>
+                                <li class="tree-entry">
+        <details class="tree-node" open>
+            <summary>
+                <span class="tree-row">
+                    <a class="tree-link" href="#node-eryf_step">EryF hydroxylates 6-dEB to erythronolide B</a><span class="pill type">Reaction</span><span class="tree-id">eryF_step</span>
+                </span>
+            </summary>                <div class="tree-group-title">Annotons</div>
+                <ul>                        <li class="annoton-item tree-entry">
+                            <span class="tree-row">
+                                <a href="#annoton-eryf_fn">6-deoxyerythronolide B C-6 hydroxylase (P450eryF)</a>
+                                <span class="tree-id">Gene: eryF</span>
+                            </span>
+                        </li>                </ul></details>
+    </li>
+                            </li>                            <li>
+                                <div class="edge-note">3. mycarosylation (first glycosylation)</div>
+                                <li class="tree-entry">
+        <details class="tree-node" open>
+            <summary>
+                <span class="tree-row">
+                    <a class="tree-link" href="#node-erybv_step">EryBV attaches L-mycarose to erythronolide B</a><span class="pill type">Reaction</span><span class="tree-id">eryBV_step</span>
+                </span>
+            </summary>                <div class="tree-group-title">Annotons</div>
+                <ul>                        <li class="annoton-item tree-entry">
+                            <span class="tree-row">
+                                <a href="#annoton-erybv_fn">mycarosyltransferase</a>
+                                <span class="tree-id">Gene: eryBV</span>
+                            </span>
+                        </li>                </ul></details>
+    </li>
+                            </li>                            <li>
+                                <div class="edge-note">4. desosaminylation (second glycosylation, activator-dependent)</div>
+                                <li class="tree-entry">
+        <details class="tree-node" open>
+            <summary>
+                <span class="tree-row">
+                    <a class="tree-link" href="#node-eryciii_step">EryCIII (activated by EryCII) attaches D-desosamine, forming erythromycin D</a><span class="pill type">Reaction</span><span class="tree-id">eryCIII_step</span>
+                </span>
+            </summary>                <div class="tree-group-title">Annotons</div>
+                <ul>                        <li class="annoton-item tree-entry">
+                            <span class="tree-row">
+                                <a href="#annoton-eryciii_fn">desosaminyltransferase</a>
+                                <span class="tree-id">Gene: eryCIII</span>
+                            </span>
+                        </li>                        <li class="annoton-item tree-entry">
+                            <span class="tree-row">
+                                <a href="#annoton-erycii_fn">EryCII - required allosteric activator of EryCIII (heme-less P450 pseudoenzyme)</a>
+                                <span class="tree-id">Gene: eryCII</span>
+                            </span>
+                        </li>                </ul></details>
+    </li>
+                            </li>                            <li>
+                                <div class="edge-note">5. final tailoring to erythromycin A</div>
+                                <li class="tree-entry">
+        <details class="tree-node" open>
+            <summary>
+                <span class="tree-row">
+                    <a class="tree-link" href="#node-tailoring">C-12 hydroxylation (EryK) and 3&#39;&#39;-O-methylation (EryG)</a><span class="pill type">Metabolic Pathway</span><span class="tree-id">tailoring</span>
+                </span>
+            </summary>                <div class="tree-group-title">Annotons</div>
+                <ul>                        <li class="annoton-item tree-entry">
+                            <span class="tree-row">
+                                <a href="#annoton-eryk_fn">erythromycin C-12 hydroxylase (CYP113A1)</a>
+                                <span class="tree-id">Gene: eryK</span>
+                            </span>
+                        </li>                        <li class="annoton-item tree-entry">
+                            <span class="tree-row">
+                                <a href="#annoton-eryg_fn">erythromycin 3&#39;&#39;-O-methyltransferase (mycarose to cladinose)</a>
+                                <span class="tree-id">Gene: eryG</span>
+                            </span>
+                        </li>                </ul></details>
+    </li>
+                            </li>                            <li>
+                                <div class="edge-note">6. TDP-D-desosamine biosynthesis (donor for desosaminylation)</div>
+                                <li class="tree-entry">
+        <details class="tree-node" open>
+            <summary>
+                <span class="tree-row">
+                    <a class="tree-link" href="#node-desosamine_pathway">TDP-D-desosamine biosynthesis (EryC* + EryBVII)</a><span class="pill type">Metabolic Pathway</span><span class="tree-id">desosamine_pathway</span>
+                </span>
+            </summary>                <div class="tree-group-title">Annotons</div>
+                <ul>                        <li class="annoton-item tree-entry">
+                            <span class="tree-row">
+                                <a href="#annoton-eryci_fn">PLP-dependent sugar aminotransferase (DegT/DnrJ/EryC1 family)</a>
+                                <span class="tree-id">Gene: eryCI</span>
+                            </span>
+                        </li>                        <li class="annoton-item tree-entry">
+                            <span class="tree-row">
+                                <a href="#annoton-eryciv_fn">PLP-dependent 3,4-dehydratase (activity unverified)</a>
+                                <span class="tree-id">Gene: eryCIV</span>
+                            </span>
+                        </li>                        <li class="annoton-item tree-entry">
+                            <span class="tree-row">
+                                <a href="#annoton-erycv_fn">radical-SAM (4Fe-4S) enzyme (activity unverified)</a>
+                                <span class="tree-id">Gene: eryCV</span>
+                            </span>
+                        </li>                        <li class="annoton-item tree-entry">
+                            <span class="tree-row">
+                                <a href="#annoton-erycvi_fn">TDP-desosamine N,N-dimethyltransferase</a>
+                                <span class="tree-id">Gene: eryCVI</span>
+                            </span>
+                        </li>                        <li class="annoton-item tree-entry">
+                            <span class="tree-row">
+                                <a href="#annoton-erybvii_desosamine_fn">dTDP-sugar 3,5-epimerase (shared)</a>
+                                <span class="tree-id">Gene: eryBVII</span>
+                            </span>
+                        </li>                </ul></details>
+    </li>
+                            </li>                            <li>
+                                <div class="edge-note">7. TDP-L-mycarose biosynthesis (donor for mycarosylation)</div>
+                                <li class="tree-entry">
+        <details class="tree-node" open>
+            <summary>
+                <span class="tree-row">
+                    <a class="tree-link" href="#node-mycarose_pathway">TDP-L-mycarose biosynthesis (EryB*)</a><span class="pill type">Metabolic Pathway</span><span class="tree-id">mycarose_pathway</span>
+                </span>
+            </summary>                <div class="tree-group-title">Annotons</div>
+                <ul>                        <li class="annoton-item tree-entry">
+                            <span class="tree-row">
+                                <a href="#annoton-erybvi_fn">2,3-dehydratase</a>
+                                <span class="tree-id">Gene: eryBVI</span>
+                            </span>
+                        </li>                        <li class="annoton-item tree-entry">
+                            <span class="tree-row">
+                                <a href="#annoton-erybii_fn">TDP-sugar 2,3-reductase</a>
+                                <span class="tree-id">Gene: eryBII</span>
+                            </span>
+                        </li>                        <li class="annoton-item tree-entry">
+                            <span class="tree-row">
+                                <a href="#annoton-erybiii_fn">3-C-methyltransferase (mycarose C-methyl branch)</a>
+                                <span class="tree-id">Gene: eryBIII</span>
+                            </span>
+                        </li>                        <li class="annoton-item tree-entry">
+                            <span class="tree-row">
+                                <a href="#annoton-erybiv_fn">4-reductase</a>
+                                <span class="tree-id">Gene: eryBIV</span>
+                            </span>
+                        </li>                </ul></details>
+    </li>
+                            </li>                            <li>
+                                <div class="edge-note">8. self-resistance optional</div>
+                                <li class="tree-entry">
+        <details class="tree-node" open>
+            <summary>
+                <span class="tree-row">
+                    <a class="tree-link" href="#node-resistance">ErmE 23S rRNA methylation self-resistance</a><span class="pill type">Reaction</span><span class="tree-id">resistance</span>
+                </span>
+            </summary>                <div class="tree-group-title">Annotons</div>
+                <ul>                        <li class="annoton-item tree-entry">
+                            <span class="tree-row">
+                                <a href="#annoton-erme_fn">23S rRNA A2085 N6,N6-dimethyltransferase</a>
+                                <span class="tree-id">Gene: ermE</span>
+                            </span>
+                        </li>                </ul></details>
+    </li>
+                            </li>                </ol></details>
+    </li>
+                </ol>
+            </div>
+        </aside>
+
+        <section class="panel detail-panel">
+            <div class="panel-header">
+                <h2>Details</h2>
+            </div>
+            <div class="panel-body">
+                <div class="context-card small">
+            <strong>Context</strong>
+            <div class="descriptor-list">                <span class="descriptor">
+            <span>Saccharopolyspora erythraea NRRL 2338</span><a class="term-id" href="https://www.ncbi.nlm.nih.gov/Taxonomy/Browser/wwwtax.cgi?id=405948" target="_blank" rel="noopener">NCBITaxon:405948</a></span>        </div>
+
+
+
+
+
+            </div>
+                <section class="node-detail depth-0" id="node-erythromycin_biosynthesis">
+        <div class="node-heading">
+            <span class="node-title">Erythromycin A biosynthesis</span><span class="pill type">Metabolic Pathway</span><span class="pill">erythromycin_biosynthesis</span>
+        </div><div class="descriptor-list">                <span class="descriptor">
+            <span>erythromycin biosynthetic process</span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:1901115" target="_blank" rel="noopener">GO:1901115</a></span>        </div>
+        <div class="context-card small">
+            <strong>Context</strong>
+            <div class="descriptor-list">                <span class="descriptor">
+            <span>Saccharopolyspora erythraea NRRL 2338</span><a class="term-id" href="https://www.ncbi.nlm.nih.gov/Taxonomy/Browser/wwwtax.cgi?id=405948" target="_blank" rel="noopener">NCBITaxon:405948</a></span>        </div>
+
+
+
+
+
+            </div>
+        <p class="muted small">Status DRAFT. EryCIV/EryCV catalytic specifics and several mycarose-pathway steps are name-/homology-based (TrEMBL) and carried as UNDECIDED in the per-gene reviews. EC 2.4.1.278 (desosaminyltransferase), EC 1.14.15.35 (EryF) and EC 1.14.13.154 (EryK) lack specific GO MF terms; the function descriptors above carry the precise activity names. See genes/SACEN/&lt;gene&gt;/ for per-gene reviews and terms/erythromycin_biosynthesis/ for the MIBiG-aligned prose and discrepancy notes.</p>            <h4>Connections</h4>
+            <div class="connection-list">                <div class="connection-card small">
+                    <div>
+                        <a href="#node-debs_assembly">debs_assembly</a>
+                        <span class="connection-arrow">-&gt;</span>
+                        <a href="#node-eryf_step">eryF_step</a>                            <span class="pill">Provides Input For</span></div>                        <div class="muted">6-deoxyerythronolide B is the substrate of EryF.</div>
+
+                </div>                <div class="connection-card small">
+                    <div>
+                        <a href="#node-eryf_step">eryF_step</a>
+                        <span class="connection-arrow">-&gt;</span>
+                        <a href="#node-erybv_step">eryBV_step</a>                            <span class="pill">Provides Input For</span></div>                        <div class="muted">Erythronolide B is the acceptor for mycarosylation.</div>
+
+                </div>                <div class="connection-card small">
+                    <div>
+                        <a href="#node-erybv_step">eryBV_step</a>
+                        <span class="connection-arrow">-&gt;</span>
+                        <a href="#node-eryciii_step">eryCIII_step</a>                            <span class="pill">Provides Input For</span></div>                        <div class="muted">3-O-mycarosyl-erythronolide B is the acceptor for desosaminylation.</div>
+
+                </div>                <div class="connection-card small">
+                    <div>
+                        <a href="#node-eryciii_step">eryCIII_step</a>
+                        <span class="connection-arrow">-&gt;</span>
+                        <a href="#node-tailoring">tailoring</a>                            <span class="pill">Provides Input For</span></div>                        <div class="muted">Erythromycin D is the substrate for the final EryK/EryG tailoring.</div>
+
+                </div>                <div class="connection-card small">
+                    <div>
+                        <a href="#node-mycarose_pathway">mycarose_pathway</a>
+                        <span class="connection-arrow">-&gt;</span>
+                        <a href="#node-erybv_step">eryBV_step</a>                            <span class="pill">Provides Input For</span></div>                        <div class="muted">Supplies the TDP-L-mycarose glycosyl donor.</div>
+
+                </div>                <div class="connection-card small">
+                    <div>
+                        <a href="#node-desosamine_pathway">desosamine_pathway</a>
+                        <span class="connection-arrow">-&gt;</span>
+                        <a href="#node-eryciii_step">eryCIII_step</a>                            <span class="pill">Provides Input For</span></div>                        <div class="muted">Supplies the TDP-D-desosamine glycosyl donor.</div>
+
+                </div>        </div>                <div class="part-marker">
+                    Part 1: macrolactone assembly</div>
+                <section class="node-detail depth-1" id="node-debs_assembly">
+        <div class="node-heading">
+            <span class="node-title">DEBS modular type I PKS assembles 6-deoxyerythronolide B</span><span class="pill type">Metabolic Pathway</span><span class="pill">debs_assembly</span>
+        </div>            <p class="node-description">Three multimodular polypeptides (EryAI/AII/AIII) condense one propionyl-CoA starter with six (2S)-methylmalonyl-CoA extenders over six modules; the EryAIII C-terminal thioesterase macrolactonizes and releases 6-deoxyerythronolide B (6-dEB).</p>
+
+                    <h4>Annotons</h4>
+            <div class="annoton-grid">                    <article class="annoton-card" id="annoton-eryai_fn">
+        <div class="annoton-title">DEBS1 (loading didomain + modules 1-2)</div>
+        <div class="small muted">eryAI_fn</div>            <div class="small"><strong>Participant:</strong> Gene: eryAI</div>
+            <div class="participant-detail">                    <div class="slot-row">
+                        <span class="slot-name">Gene:</span>
+                        <div class="descriptor">
+            <span><strong>eryAI</strong></span><a class="term-id" href="https://www.uniprot.org/uniprotkb/A4F7N8/entry" target="_blank" rel="noopener">UniProtKB:A4F7N8</a></div>
+                    </div></div>            <h4>Function</h4>
+            <div class="descriptor">
+            <span><strong>erythronolide synthase activity (EC 2.3.1.94)</strong></span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0047879" target="_blank" rel="noopener">GO:0047879</a>                    <div class="slot-row">
+                        <span class="slot-name">Substrates:</span>                            <span class="descriptor">
+            <span>propionyl-CoA</span></span>                            <span class="descriptor">
+            <span>(2S)-methylmalonyl-CoA</span></span>                    </div></div>            <p class="role-description">Loads the propionyl starter and performs the first two chain-extension cycles.</p></article>                    <article class="annoton-card" id="annoton-eryaii_fn">
+        <div class="annoton-title">DEBS2 (modules 3-4)</div>
+        <div class="small muted">eryAII_fn</div>            <div class="small"><strong>Participant:</strong> Gene: eryAII</div>
+            <div class="participant-detail">                    <div class="slot-row">
+                        <span class="slot-name">Gene:</span>
+                        <div class="descriptor">
+            <span><strong>eryAII</strong></span><a class="term-id" href="https://www.uniprot.org/uniprotkb/A4F7P0/entry" target="_blank" rel="noopener">UniProtKB:A4F7P0</a></div>
+                    </div></div>            <h4>Function</h4>
+            <div class="descriptor">
+            <span><strong>erythronolide synthase activity (EC 2.3.1.94)</strong></span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0047879" target="_blank" rel="noopener">GO:0047879</a></div>            <p class="role-description">Chain-extension and beta-keto reduction cycles 3-4 (module 4 fully reducing).</p></article>                    <article class="annoton-card" id="annoton-eryaiii_fn">
+        <div class="annoton-title">DEBS3 (modules 5-6 + thioesterase)</div>
+        <div class="small muted">eryAIII_fn</div>            <div class="small"><strong>Participant:</strong> Gene: eryAIII</div>
+            <div class="participant-detail">                    <div class="slot-row">
+                        <span class="slot-name">Gene:</span>
+                        <div class="descriptor">
+            <span><strong>eryAIII</strong></span><a class="term-id" href="https://www.uniprot.org/uniprotkb/A4F7P1/entry" target="_blank" rel="noopener">UniProtKB:A4F7P1</a></div>
+                    </div></div>            <h4>Function</h4>
+            <div class="descriptor">
+            <span><strong>erythronolide synthase activity (EC 2.3.1.94)</strong></span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0047879" target="_blank" rel="noopener">GO:0047879</a>                    <div class="slot-row">
+                        <span class="slot-name">Products:</span>                            <span class="descriptor">
+            <span>6-deoxyerythronolide B</span></span>                    </div></div>            <p class="role-description">Final extensions; the thioesterase macrolactonizes and releases 6-dEB.</p></article>                    <article class="annoton-card" id="annoton-teii_fn">
+        <div class="annoton-title">type II thioesterase (PKS editing/proofreading)</div>
+        <div class="small muted">teII_fn</div>            <div class="small"><strong>Participant:</strong> Gene: TEII (locus CAM00070)</div>
+            <div class="participant-detail">                    <div class="slot-row">
+                        <span class="slot-name">Gene:</span>
+                        <div class="descriptor">
+            <span><strong>TEII (locus CAM00070)</strong></span><a class="term-id" href="https://www.uniprot.org/uniprotkb/A4F7P6/entry" target="_blank" rel="noopener">UniProtKB:A4F7P6</a></div>
+                    </div></div>            <h4>Function</h4>
+            <div class="descriptor">
+            <span><strong>acyl-[ACP] hydrolase, PKS editing</strong></span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0016297" target="_blank" rel="noopener">GO:0016297</a></div>            <p class="role-description">Hydrolyzes aberrant acyl-ACP species to maintain assembly-line fidelity.</p></article>            </div>    </section>                <div class="part-marker">
+                    Part 2: post-PKS C-6 hydroxylation</div>
+                <section class="node-detail depth-1" id="node-eryf_step">
+        <div class="node-heading">
+            <span class="node-title">EryF hydroxylates 6-dEB to erythronolide B</span><span class="pill type">Reaction</span><span class="pill">eryF_step</span>
+        </div>
+
+                    <h4>Annotons</h4>
+            <div class="annoton-grid">                    <article class="annoton-card" id="annoton-eryf_fn">
+        <div class="annoton-title">6-deoxyerythronolide B C-6 hydroxylase (P450eryF)</div>
+        <div class="small muted">eryF_fn</div>            <div class="small"><strong>Participant:</strong> Gene: eryF</div>
+            <div class="participant-detail">                    <div class="slot-row">
+                        <span class="slot-name">Gene:</span>
+                        <div class="descriptor">
+            <span><strong>eryF</strong></span><a class="term-id" href="https://www.uniprot.org/uniprotkb/Q00441/entry" target="_blank" rel="noopener">UniProtKB:Q00441</a></div>
+                    </div></div>            <h4>Function</h4>
+            <div class="descriptor">
+            <span><strong>6-deoxyerythronolide B 6-hydroxylase activity (EC 1.14.15.35)</strong></span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0004497" target="_blank" rel="noopener">GO:0004497</a>                    <div class="slot-row">
+                        <span class="slot-name">Substrates:</span>                            <span class="descriptor">
+            <span>6-deoxyerythronolide B</span></span>                            <span class="descriptor">
+            <span>dioxygen</span></span>                    </div>                    <div class="slot-row">
+                        <span class="slot-name">Products:</span>                            <span class="descriptor">
+            <span>erythronolide B</span></span>                    </div></div>            <h4>Locations</h4>
+            <div class="descriptor-list">                <span class="descriptor">
+            <span>cytoplasm</span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0005737" target="_blank" rel="noopener">GO:0005737</a></span>        </div></article>            </div>    </section>                <div class="part-marker">
+                    Part 3: mycarosylation (first glycosylation)</div>
+                <section class="node-detail depth-1" id="node-erybv_step">
+        <div class="node-heading">
+            <span class="node-title">EryBV attaches L-mycarose to erythronolide B</span><span class="pill type">Reaction</span><span class="pill">eryBV_step</span>
+        </div>
+
+                    <h4>Annotons</h4>
+            <div class="annoton-grid">                    <article class="annoton-card" id="annoton-erybv_fn">
+        <div class="annoton-title">mycarosyltransferase</div>
+        <div class="small muted">eryBV_fn</div>            <div class="small"><strong>Participant:</strong> Gene: eryBV</div>
+            <div class="participant-detail">                    <div class="slot-row">
+                        <span class="slot-name">Gene:</span>
+                        <div class="descriptor">
+            <span><strong>eryBV</strong></span><a class="term-id" href="https://www.uniprot.org/uniprotkb/A4F7N6/entry" target="_blank" rel="noopener">UniProtKB:A4F7N6</a></div>
+                    </div></div>            <h4>Function</h4>
+            <div class="descriptor">
+            <span><strong>TDP-L-mycarose mycarosyltransferase activity</strong></span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0016758" target="_blank" rel="noopener">GO:0016758</a>                    <div class="slot-row">
+                        <span class="slot-name">Substrates:</span>                            <span class="descriptor">
+            <span>erythronolide B</span></span>                            <span class="descriptor">
+            <span>TDP-L-mycarose</span></span>                    </div>                    <div class="slot-row">
+                        <span class="slot-name">Products:</span>                            <span class="descriptor">
+            <span>3-O-mycarosyl-erythronolide B</span></span>                    </div></div></article>            </div>    </section>                <div class="part-marker">
+                    Part 4: desosaminylation (second glycosylation, activator-dependent)</div>
+                <section class="node-detail depth-1" id="node-eryciii_step">
+        <div class="node-heading">
+            <span class="node-title">EryCIII (activated by EryCII) attaches D-desosamine, forming erythromycin D</span><span class="pill type">Reaction</span><span class="pill">eryCIII_step</span>
+        </div>
+
+                    <h4>Annotons</h4>
+            <div class="annoton-grid">                    <article class="annoton-card" id="annoton-eryciii_fn">
+        <div class="annoton-title">desosaminyltransferase</div>
+        <div class="small muted">eryCIII_fn</div>            <div class="small"><strong>Participant:</strong> Gene: eryCIII</div>
+            <div class="participant-detail">                    <div class="slot-row">
+                        <span class="slot-name">Gene:</span>
+                        <div class="descriptor">
+            <span><strong>eryCIII</strong></span><a class="term-id" href="https://www.uniprot.org/uniprotkb/A4F7P3/entry" target="_blank" rel="noopener">UniProtKB:A4F7P3</a></div>
+                    </div></div>            <h4>Function</h4>
+            <div class="descriptor">
+            <span><strong>3-alpha-mycarosylerythronolide B desosaminyltransferase activity (EC 2.4.1.278)</strong></span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0016758" target="_blank" rel="noopener">GO:0016758</a>                    <div class="slot-row">
+                        <span class="slot-name">Substrates:</span>                            <span class="descriptor">
+            <span>3-O-mycarosyl-erythronolide B</span></span>                            <span class="descriptor">
+            <span>TDP-D-desosamine</span></span>                    </div>                    <div class="slot-row">
+                        <span class="slot-name">Products:</span>                            <span class="descriptor">
+            <span>erythromycin D</span></span>                    </div></div></article>                    <article class="annoton-card" id="annoton-erycii_fn">
+        <div class="annoton-title">EryCII - required allosteric activator of EryCIII (heme-less P450 pseudoenzyme)</div>
+        <div class="small muted">eryCII_fn</div>            <div class="small"><strong>Participant:</strong> Gene: eryCII</div>
+            <div class="participant-detail">                    <div class="slot-row">
+                        <span class="slot-name">Gene:</span>
+                        <div class="descriptor">
+            <span><strong>eryCII</strong></span><a class="term-id" href="https://www.uniprot.org/uniprotkb/A4F7P2/entry" target="_blank" rel="noopener">UniProtKB:A4F7P2</a></div>
+                    </div></div>            <h4>Function</h4>
+            <div class="descriptor">
+            <span><strong>glycosyltransferase (EryCIII) activator activity</strong></span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0008047" target="_blank" rel="noopener">GO:0008047</a></div>            <p class="role-description">Forms an alpha2-beta2 heterotetramer with EryCIII and is required for its activity; a cytochrome-P450 homologue that lacks the heme and is catalytically dead.</p></article>            </div>    </section>                <div class="part-marker">
+                    Part 5: final tailoring to erythromycin A</div>
+                <section class="node-detail depth-1" id="node-tailoring">
+        <div class="node-heading">
+            <span class="node-title">C-12 hydroxylation (EryK) and 3&#39;&#39;-O-methylation (EryG)</span><span class="pill type">Metabolic Pathway</span><span class="pill">tailoring</span>
+        </div>            <p class="node-description">EryK (C-12 hydroxylation) and EryG (mycarose 3&#39;&#39;-O-methylation to cladinose) act in either order on erythromycin D, via erythromycins B and C, converging on erythromycin A.</p>
+
+                    <h4>Annotons</h4>
+            <div class="annoton-grid">                    <article class="annoton-card" id="annoton-eryk_fn">
+        <div class="annoton-title">erythromycin C-12 hydroxylase (CYP113A1)</div>
+        <div class="small muted">eryK_fn</div>            <div class="small"><strong>Participant:</strong> Gene: eryK</div>
+            <div class="participant-detail">                    <div class="slot-row">
+                        <span class="slot-name">Gene:</span>
+                        <div class="descriptor">
+            <span><strong>eryK</strong></span><a class="term-id" href="https://www.uniprot.org/uniprotkb/P48635/entry" target="_blank" rel="noopener">UniProtKB:P48635</a></div>
+                    </div></div>            <h4>Function</h4>
+            <div class="descriptor">
+            <span><strong>erythromycin 12-hydroxylase activity (EC 1.14.13.154)</strong></span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0016709" target="_blank" rel="noopener">GO:0016709</a>                    <div class="slot-row">
+                        <span class="slot-name">Substrates:</span>                            <span class="descriptor">
+            <span>erythromycin D</span></span>                            <span class="descriptor">
+            <span>dioxygen</span></span>                    </div>                    <div class="slot-row">
+                        <span class="slot-name">Products:</span>                            <span class="descriptor">
+            <span>erythromycin C</span></span>                    </div></div></article>                    <article class="annoton-card" id="annoton-eryg_fn">
+        <div class="annoton-title">erythromycin 3&#39;&#39;-O-methyltransferase (mycarose to cladinose)</div>
+        <div class="small muted">eryG_fn</div>            <div class="small"><strong>Participant:</strong> Gene: eryG</div>
+            <div class="participant-detail">                    <div class="slot-row">
+                        <span class="slot-name">Gene:</span>
+                        <div class="descriptor">
+            <span><strong>eryG</strong></span><a class="term-id" href="https://www.uniprot.org/uniprotkb/A4F7P5/entry" target="_blank" rel="noopener">UniProtKB:A4F7P5</a></div>
+                    </div></div>            <h4>Function</h4>
+            <div class="descriptor">
+            <span><strong>erythromycin 3&#39;&#39;-O-methyltransferase activity (EC 2.1.1.254)</strong></span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0102307" target="_blank" rel="noopener">GO:0102307</a>                    <div class="slot-row">
+                        <span class="slot-name">Substrates:</span>                            <span class="descriptor">
+            <span>erythromycin C</span></span>                            <span class="descriptor">
+            <span>S-adenosyl-L-methionine</span></span>                    </div>                    <div class="slot-row">
+                        <span class="slot-name">Products:</span>                            <span class="descriptor">
+            <span>erythromycin A</span></span>                            <span class="descriptor">
+            <span>S-adenosyl-L-homocysteine</span></span>                    </div></div></article>            </div>    </section>                <div class="part-marker">
+                    Part 6: TDP-D-desosamine biosynthesis (donor for desosaminylation)</div>
+                <section class="node-detail depth-1" id="node-desosamine_pathway">
+        <div class="node-heading">
+            <span class="node-title">TDP-D-desosamine biosynthesis (EryC* + EryBVII)</span><span class="pill type">Metabolic Pathway</span><span class="pill">desosamine_pathway</span>
+        </div>            <p class="node-description">Builds the aminodeoxysugar donor TDP-D-desosamine from a TDP-4-keto-6-deoxyglucose precursor. Several enzymes are minimally characterized; the C-3 aminotransferase (EryCI) and the N,N-dimethyltransferase (EryCVI) are the best-defined steps.</p>
+
+                    <h4>Annotons</h4>
+            <div class="annoton-grid">                    <article class="annoton-card" id="annoton-eryci_fn">
+        <div class="annoton-title">PLP-dependent sugar aminotransferase (DegT/DnrJ/EryC1 family)</div>
+        <div class="small muted">eryCI_fn</div>            <div class="small"><strong>Participant:</strong> Gene: eryCI</div>
+            <div class="participant-detail">                    <div class="slot-row">
+                        <span class="slot-name">Gene:</span>
+                        <div class="descriptor">
+            <span><strong>eryCI</strong></span><a class="term-id" href="https://www.uniprot.org/uniprotkb/P14290/entry" target="_blank" rel="noopener">UniProtKB:P14290</a></div>
+                    </div></div>            <h4>Function</h4>
+            <div class="descriptor">
+            <span><strong>sugar (C-3) aminotransferase activity</strong></span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0008483" target="_blank" rel="noopener">GO:0008483</a></div>            <p class="role-description">Installs the C-3 amino group; UniProt P14290 is mis-named a &#34;sensory transduction protein&#34;.</p></article>                    <article class="annoton-card" id="annoton-eryciv_fn">
+        <div class="annoton-title">PLP-dependent 3,4-dehydratase (activity unverified)</div>
+        <div class="small muted">eryCIV_fn</div>            <div class="small"><strong>Participant:</strong> Gene: eryCIV</div>
+            <div class="participant-detail">                    <div class="slot-row">
+                        <span class="slot-name">Gene:</span>
+                        <div class="descriptor">
+            <span><strong>eryCIV</strong></span><a class="term-id" href="https://www.uniprot.org/uniprotkb/A4F7N3/entry" target="_blank" rel="noopener">UniProtKB:A4F7N3</a></div>
+                    </div></div>            <h4>Function</h4>
+            <div class="descriptor">
+            <span><strong>pyridoxal phosphate binding</strong></span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0030170" target="_blank" rel="noopener">GO:0030170</a></div></article>                    <article class="annoton-card" id="annoton-erycv_fn">
+        <div class="annoton-title">radical-SAM (4Fe-4S) enzyme (activity unverified)</div>
+        <div class="small muted">eryCV_fn</div>            <div class="small"><strong>Participant:</strong> Gene: eryCV</div>
+            <div class="participant-detail">                    <div class="slot-row">
+                        <span class="slot-name">Gene:</span>
+                        <div class="descriptor">
+            <span><strong>eryCV</strong></span><a class="term-id" href="https://www.uniprot.org/uniprotkb/A4F7N2/entry" target="_blank" rel="noopener">UniProtKB:A4F7N2</a></div>
+                    </div></div>            <h4>Function</h4>
+            <div class="descriptor">
+            <span><strong>4Fe-4S cluster binding (radical-SAM)</strong></span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0051539" target="_blank" rel="noopener">GO:0051539</a></div></article>                    <article class="annoton-card" id="annoton-erycvi_fn">
+        <div class="annoton-title">TDP-desosamine N,N-dimethyltransferase</div>
+        <div class="small muted">eryCVI_fn</div>            <div class="small"><strong>Participant:</strong> Gene: eryCVI</div>
+            <div class="participant-detail">                    <div class="slot-row">
+                        <span class="slot-name">Gene:</span>
+                        <div class="descriptor">
+            <span><strong>eryCVI</strong></span><a class="term-id" href="https://www.uniprot.org/uniprotkb/A4F7N5/entry" target="_blank" rel="noopener">UniProtKB:A4F7N5</a></div>
+                    </div></div>            <h4>Function</h4>
+            <div class="descriptor">
+            <span><strong>TDP-desosamine N,N-dimethyltransferase activity</strong></span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0008168" target="_blank" rel="noopener">GO:0008168</a>                    <div class="slot-row">
+                        <span class="slot-name">Products:</span>                            <span class="descriptor">
+            <span>TDP-D-desosamine</span></span>                    </div></div></article>                    <article class="annoton-card" id="annoton-erybvii_desosamine_fn">
+        <div class="annoton-title">dTDP-sugar 3,5-epimerase (shared)</div>
+        <div class="small muted">eryBVII_desosamine_fn</div>            <div class="small"><strong>Participant:</strong> Gene: eryBVII</div>
+            <div class="participant-detail">                    <div class="slot-row">
+                        <span class="slot-name">Gene:</span>
+                        <div class="descriptor">
+            <span><strong>eryBVII</strong></span><a class="term-id" href="https://www.uniprot.org/uniprotkb/A4F7N1/entry" target="_blank" rel="noopener">UniProtKB:A4F7N1</a></div>
+                    </div></div>            <h4>Function</h4>
+            <div class="descriptor">
+            <span><strong>dTDP-sugar 3,5-epimerase activity (EC 5.1.3.13)</strong></span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0008830" target="_blank" rel="noopener">GO:0008830</a></div>            <p class="role-description">Shared 3,5-epimerase used by both the desosamine and mycarose branches.</p></article>            </div>    </section>                <div class="part-marker">
+                    Part 7: TDP-L-mycarose biosynthesis (donor for mycarosylation)</div>
+                <section class="node-detail depth-1" id="node-mycarose_pathway">
+        <div class="node-heading">
+            <span class="node-title">TDP-L-mycarose biosynthesis (EryB*)</span><span class="pill type">Metabolic Pathway</span><span class="pill">mycarose_pathway</span>
+        </div>            <p class="node-description">Builds the branched-chain deoxysugar donor TDP-L-mycarose. Enzymes are largely name-/homology-defined (TrEMBL); the C-methyltransferase (EryBIII) installs the C-3 methyl branch.</p>
+
+                    <h4>Annotons</h4>
+            <div class="annoton-grid">                    <article class="annoton-card" id="annoton-erybvi_fn">
+        <div class="annoton-title">2,3-dehydratase</div>
+        <div class="small muted">eryBVI_fn</div>            <div class="small"><strong>Participant:</strong> Gene: eryBVI</div>
+            <div class="participant-detail">                    <div class="slot-row">
+                        <span class="slot-name">Gene:</span>
+                        <div class="descriptor">
+            <span><strong>eryBVI</strong></span><a class="term-id" href="https://www.uniprot.org/uniprotkb/A4F7N4/entry" target="_blank" rel="noopener">UniProtKB:A4F7N4</a></div>
+                    </div></div>            <h4>Function</h4>
+            <div class="descriptor">
+            <span><strong>NDP-4-keto-6-deoxyglucose 2,3-dehydratase activity</strong></span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0016829" target="_blank" rel="noopener">GO:0016829</a></div></article>                    <article class="annoton-card" id="annoton-erybii_fn">
+        <div class="annoton-title">TDP-sugar 2,3-reductase</div>
+        <div class="small muted">eryBII_fn</div>            <div class="small"><strong>Participant:</strong> Gene: eryBII</div>
+            <div class="participant-detail">                    <div class="slot-row">
+                        <span class="slot-name">Gene:</span>
+                        <div class="descriptor">
+            <span><strong>eryBII</strong></span><a class="term-id" href="https://www.uniprot.org/uniprotkb/A4F7P4/entry" target="_blank" rel="noopener">UniProtKB:A4F7P4</a></div>
+                    </div></div>            <h4>Function</h4>
+            <div class="descriptor">
+            <span><strong>TDP-4-keto-6-deoxyhexose 2,3-reductase activity</strong></span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0016491" target="_blank" rel="noopener">GO:0016491</a></div></article>                    <article class="annoton-card" id="annoton-erybiii_fn">
+        <div class="annoton-title">3-C-methyltransferase (mycarose C-methyl branch)</div>
+        <div class="small muted">eryBIII_fn</div>            <div class="small"><strong>Participant:</strong> Gene: eryBIII</div>
+            <div class="participant-detail">                    <div class="slot-row">
+                        <span class="slot-name">Gene:</span>
+                        <div class="descriptor">
+            <span><strong>eryBIII</strong></span><a class="term-id" href="https://www.uniprot.org/uniprotkb/A4F7P8/entry" target="_blank" rel="noopener">UniProtKB:A4F7P8</a></div>
+                    </div></div>            <h4>Function</h4>
+            <div class="descriptor">
+            <span><strong>NDP-4-keto-2,6-dideoxyhexose 3-C-methyltransferase activity</strong></span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0008168" target="_blank" rel="noopener">GO:0008168</a></div></article>                    <article class="annoton-card" id="annoton-erybiv_fn">
+        <div class="annoton-title">4-reductase</div>
+        <div class="small muted">eryBIV_fn</div>            <div class="small"><strong>Participant:</strong> Gene: eryBIV</div>
+            <div class="participant-detail">                    <div class="slot-row">
+                        <span class="slot-name">Gene:</span>
+                        <div class="descriptor">
+            <span><strong>eryBIV</strong></span><a class="term-id" href="https://www.uniprot.org/uniprotkb/A4F7N7/entry" target="_blank" rel="noopener">UniProtKB:A4F7N7</a></div>
+                    </div></div>            <h4>Function</h4>
+            <div class="descriptor">
+            <span><strong>dTDP-4-keto-6-deoxy-L-hexose 4-reductase activity</strong></span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0016491" target="_blank" rel="noopener">GO:0016491</a>                    <div class="slot-row">
+                        <span class="slot-name">Products:</span>                            <span class="descriptor">
+            <span>TDP-L-mycarose</span></span>                    </div></div></article>            </div>    </section>                <div class="part-marker">
+                    Part 8: self-resistance (optional)</div>
+                <section class="node-detail depth-1" id="node-resistance">
+        <div class="node-heading">
+            <span class="node-title">ErmE 23S rRNA methylation self-resistance</span><span class="pill type">Reaction</span><span class="pill">resistance</span>
+        </div>
+
+                    <h4>Annotons</h4>
+            <div class="annoton-grid">                    <article class="annoton-card" id="annoton-erme_fn">
+        <div class="annoton-title">23S rRNA A2085 N6,N6-dimethyltransferase</div>
+        <div class="small muted">ermE_fn</div>            <div class="small"><strong>Participant:</strong> Gene: ermE</div>
+            <div class="participant-detail">                    <div class="slot-row">
+                        <span class="slot-name">Gene:</span>
+                        <div class="descriptor">
+            <span><strong>ermE</strong></span><a class="term-id" href="https://www.uniprot.org/uniprotkb/P07287/entry" target="_blank" rel="noopener">UniProtKB:P07287</a></div>
+                    </div></div>            <h4>Function</h4>
+            <div class="descriptor">
+            <span><strong>23S rRNA (adenine-2085-N6)-dimethyltransferase activity (EC 2.1.1.184)</strong></span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0052910" target="_blank" rel="noopener">GO:0052910</a></div>            <p class="role-description">Dimethylates 23S rRNA A2085 (E. coli A2058), blocking erythromycin binding to the 50S subunit and conferring macrolide self-resistance on the producer.</p></article>            </div>    </section>    </section>
+            </div>
+        </section>
+    </section>
+</main>
+
+<script>
+    const searchInput = document.querySelector("[data-tree-search]");
+    if (searchInput) {
+        searchInput.addEventListener("input", () => {
+            const query = searchInput.value.trim().toLowerCase();
+            document.querySelectorAll(".tree-row").forEach((row) => {
+                const matches = !query || row.textContent.toLowerCase().includes(query);
+                row.classList.toggle("is-dimmed", !matches);
+                if (query && matches) {
+                    let detail = row.closest("details");
+                    while (detail) {
+                        detail.open = true;
+                        detail = detail.parentElement ? detail.parentElement.closest("details") : null;
+                    }
+                }
+            });
+        });
+    }
+
+    document.querySelectorAll("[data-tree-action]").forEach((button) => {
+        button.addEventListener("click", () => {
+            const shouldOpen = button.dataset.treeAction === "expand";
+            document.querySelectorAll(".tree-panel details").forEach((detail) => {
+                detail.open = shouldOpen;
+            });
+        });
+    });
+</script>
+</body>
+</html>

--- a/pages/modules/index.html
+++ b/pages/modules/index.html
@@ -40,7 +40,7 @@
         }
 
         .page {
-            max-width: 1180px;
+            max-width: 1280px;
             margin: 0 auto;
             padding: 24px;
         }
@@ -82,51 +82,96 @@
             font-weight: 600;
         }
 
-        .module-grid {
-            display: grid;
-            grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
-            gap: 14px;
-        }
-
-        .module-card {
+        .table-wrap {
             background: var(--bg-panel);
             border: 1px solid var(--border);
             border-radius: 8px;
-            padding: 16px;
+            overflow-x: auto;
         }
 
-        .module-card.is-hidden {
+        table.modules {
+            width: 100%;
+            border-collapse: collapse;
+            font-size: 0.9rem;
+        }
+
+        table.modules thead th {
+            position: sticky;
+            top: 0;
+            background: var(--bg-soft);
+            text-align: left;
+            font-size: 0.74rem;
+            text-transform: uppercase;
+            letter-spacing: 0.02em;
+            color: var(--muted);
+            padding: 10px 12px;
+            border-bottom: 1px solid var(--border);
+            white-space: nowrap;
+            cursor: pointer;
+            user-select: none;
+        }
+
+        table.modules thead th.num {
+            text-align: right;
+        }
+
+        table.modules thead th .arrow {
+            color: var(--accent);
+            font-size: 0.7rem;
+        }
+
+        table.modules tbody td {
+            padding: 10px 12px;
+            border-bottom: 1px solid var(--border);
+            vertical-align: top;
+        }
+
+        table.modules tbody td.num {
+            text-align: right;
+            font-variant-numeric: tabular-nums;
+        }
+
+        table.modules tbody tr:last-child td {
+            border-bottom: none;
+        }
+
+        table.modules tbody tr.is-hidden {
             display: none;
         }
 
-        .module-title {
-            display: inline-block;
-            font-size: 1.05rem;
+        table.modules tbody tr:hover {
+            background: #fafcfd;
+        }
+
+        .module-name {
             font-weight: 700;
-            margin-bottom: 8px;
         }
 
-        .description {
+        .module-id {
+            display: block;
+            color: var(--muted);
+            font-size: 0.78rem;
+            font-weight: 500;
+        }
+
+        .module-desc {
+            display: block;
             color: #31404e;
-            margin: 0 0 12px;
-        }
-
-        .pill-row {
-            display: flex;
-            flex-wrap: wrap;
-            gap: 6px;
-            margin: 8px 0;
+            font-weight: 400;
+            font-size: 0.82rem;
+            margin-top: 3px;
+            max-width: 520px;
         }
 
         .pill {
             display: inline-flex;
             align-items: center;
-            padding: 4px 8px;
+            padding: 3px 8px;
             border: 1px solid var(--border);
             border-radius: 999px;
             background: var(--bg-soft);
             color: #304150;
-            font-size: 0.8rem;
+            font-size: 0.76rem;
             font-weight: 650;
             white-space: nowrap;
         }
@@ -143,28 +188,21 @@
             color: var(--amber);
         }
 
-        .stats {
-            display: grid;
-            grid-template-columns: repeat(3, 1fr);
-            gap: 6px;
-            margin-top: 12px;
+        .concepts {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 4px;
+            max-width: 260px;
         }
 
-        .stat {
-            background: #fbfcfd;
-            border: 1px solid var(--border);
-            border-radius: 6px;
-            padding: 7px 8px;
+        .concepts .pill {
+            font-weight: 600;
         }
 
-        .stat strong {
-            display: block;
-        }
-
-        .stat span {
+        .source {
             color: var(--muted);
             font-size: 0.76rem;
-            text-transform: uppercase;
+            font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
         }
 
         @media (max-width: 720px) {
@@ -182,42 +220,132 @@
 <main class="page">
     <header class="header">
         <h1>Module KB</h1>
-        <p class="muted">Reusable biological module sketches rendered from YAML.</p>
+        <p class="muted">Reusable biological module sketches rendered from YAML. Columns
+            with numeric counts are derived by recursively walking each module document.
+            Click a column header to sort; counts and concepts come straight from the YAML.</p>
     </header>
 
     <section class="toolbar">
         <input class="search" type="search" placeholder="Filter modules" data-module-search>
-        <div class="count"><span data-visible-count>2</span> / 2 modules</div>
+        <div class="count"><span data-visible-count>6</span> / 6 modules</div>
     </section>
 
-    <section class="module-grid">            <article class="module-card" data-module-card>
-                <a class="module-title" href="gluconeogenesis.html">Generic gluconeogenesis module</a>                    <p class="description">A generic, taxon-neutral decomposition of gluconeogenesis as a module. The module is intentionally phrased as a set of functions and pathway segments rather than as a fixed list of genes, so it can represent bacterial, fungal, plant, and animal implementations.</p>                <div class="pill-row"><span class="pill">MODULE:generic_gluconeogenesis</span><span class="pill status">DRAFT</span><span class="pill type">Metabolic Pathway</span></div>                    <div class="pill-row">                            <span class="pill">gluconeogenesis</span>                    </div>                <div class="stats">
-                    <div class="stat"><strong>11</strong><span>Nodes</span></div>
-                    <div class="stat"><strong>6</strong><span>Annotons</span></div>
-                    <div class="stat"><strong>2</strong><span>Variant Sets</span></div>
-                </div>
-                <p class="muted">modules/gluconeogenesis.yaml</p>
-            </article>            <article class="module-card" data-module-card>
-                <a class="module-title" href="peroxisome-lifecycle.html">Peroxisome lifecycle and matrix protein import module</a>                    <p class="description">Peroxisomes are maintained by coordinated membrane-protein delivery, matrix cargo recognition, receptor docking and translocation at the importomer, ubiquitin-dependent receptor recycling, membrane growth and division, and import of resident metabolic enzymes. This module captures the conserved peroxin roles and the major route variants that support peroxisome assembly, inheritance, and function across eukaryotes.</p>                <div class="pill-row"><span class="pill">MODULE:peroxisome_lifecycle</span><span class="pill status">DRAFT</span><span class="pill type">Organelle Lifecycle</span></div>                    <div class="pill-row">                            <span class="pill">peroxisome organization</span>                            <span class="pill">peroxisome</span>                    </div>                <div class="stats">
-                    <div class="stat"><strong>20</strong><span>Nodes</span></div>
-                    <div class="stat"><strong>14</strong><span>Annotons</span></div>
-                    <div class="stat"><strong>5</strong><span>Variant Sets</span></div>
-                </div>
-                <p class="muted">modules/peroxisome-lifecycle.yaml</p>
-            </article>    </section>
+    <div class="table-wrap">
+        <table class="modules" data-module-table>
+            <thead>
+                <tr>
+                    <th data-sort="text" data-default-dir="asc">Module <span class="arrow"></span></th>
+                    <th data-sort="text">Type <span class="arrow"></span></th>
+                    <th data-sort="text">Status <span class="arrow"></span></th>
+                    <th data-sort="text">Concepts <span class="arrow"></span></th>
+                    <th class="num" data-sort="num">Nodes <span class="arrow"></span></th>
+                    <th class="num" data-sort="num">Annotons <span class="arrow"></span></th>
+                    <th class="num" data-sort="num">Parts <span class="arrow"></span></th>
+                    <th class="num" data-sort="num">Variant&nbsp;sets <span class="arrow"></span></th>
+                    <th class="num" data-sort="num">Variants <span class="arrow"></span></th>
+                    <th class="num" data-sort="num">Connections <span class="arrow"></span></th>
+                    <th data-sort="text">Source <span class="arrow"></span></th>
+                </tr>
+            </thead>
+            <tbody>                <tr data-module-row>
+                    <td>
+                        <a class="module-name" href="bbsome.html">BBSome ciliary trafficking complex module</a><span class="module-id">MODULE:bbsome</span><span class="module-desc">The BBSome is a conserved octameric protein complex that acts as a coat-like adaptor for ciliary membrane-protein trafficking. It is built from eight core subunits (BBS1, BBS2, BBS4, BBS5, BBS7, BBS8/TTC8, BBS9, and BBIP1/BBS18), assembled with the help of a dedicated chaperonin-like module (BBS6/MKKS, BBS10, BBS12 acting with the CCT/TRiC chaperonin). Once assembled, the BBSome is recruited to the ciliary membrane by the GTP-bound Arf-like GTPase ARL6/BBS3, where it polymerizes into a coat that recognizes signaling-receptor cargo (ciliary GPCRs and Hedgehog-pathway components) and couples them to the intraflagellar transport (IFT) machinery, mediating ciliary import and, especially, retrieval/export across the transition zone. LZTFL1/BBS17 and the accessory factor CCDC28B regulate BBSome ciliary trafficking. Loss of BBSome function causes Bardet-Biedl syndrome. This module models the BBSome as a cellular component / protein complex grounded in GO:0034464, capturing its composition, assembly, membrane recruitment, cargo trafficking, and regulation.</span>                    </td>
+                    <td data-sort-value="Protein Complex"><span class="pill type">Protein Complex</span>                    </td>
+                    <td data-sort-value="DRAFT"><span class="pill status">DRAFT</span>                    </td>
+                    <td data-sort-value="2">                        <div class="concepts">                            <span class="pill">BBSome</span>                            <span class="pill">intraciliary transport</span>                        </div>                    </td>
+                    <td class="num">6</td>
+                    <td class="num">6</td>
+                    <td class="num">5</td>
+                    <td class="num">0</td>
+                    <td class="num">0</td>
+                    <td class="num">4</td>
+                    <td><span class="source">modules/bbsome.yaml</span></td>
+                </tr>                <tr data-module-row>
+                    <td>
+                        <a class="module-name" href="erythromycin_biosynthesis.html">Erythromycin A biosynthesis (Saccharopolyspora erythraea)</a><span class="module-id">MODULE:erythromycin_biosynthesis</span><span class="module-desc">Representative-species module for biosynthesis of the macrolide antibiotic erythromycin A in Saccharopolyspora erythraea, encoded by the ery cluster (MIBiG BGC0000055). It is grounded to the concrete S. erythraea gene set reviewed under genes/SACEN/. The module combines a modular type I polyketide synthase (DEBS) that builds the macrolactone, post-PKS cytochrome-P450 oxidations, two TDP-deoxysugar pathways feeding two glycosyltransferases, final O-methylation, and rRNA-methylation self-resistance. Companion prose/MIBiG-alignment notes are in terms/erythromycin_biosynthesis/.</span>                    </td>
+                    <td data-sort-value="Metabolic Pathway"><span class="pill type">Metabolic Pathway</span>                    </td>
+                    <td data-sort-value="DRAFT"><span class="pill status">DRAFT</span>                    </td>
+                    <td data-sort-value="1">                        <div class="concepts">                            <span class="pill">erythromycin biosynthetic process</span>                        </div>                    </td>
+                    <td class="num">9</td>
+                    <td class="num">20</td>
+                    <td class="num">8</td>
+                    <td class="num">0</td>
+                    <td class="num">0</td>
+                    <td class="num">6</td>
+                    <td><span class="source">modules/erythromycin_biosynthesis.yaml</span></td>
+                </tr>                <tr data-module-row>
+                    <td>
+                        <a class="module-name" href="gluconeogenesis.html">Generic gluconeogenesis module</a><span class="module-id">MODULE:generic_gluconeogenesis</span><span class="module-desc">A generic, taxon-neutral decomposition of gluconeogenesis as a module. The module is intentionally phrased as a set of functions and pathway segments rather than as a fixed list of genes, so it can represent bacterial, fungal, plant, and animal implementations.</span>                    </td>
+                    <td data-sort-value="Metabolic Pathway"><span class="pill type">Metabolic Pathway</span>                    </td>
+                    <td data-sort-value="DRAFT"><span class="pill status">DRAFT</span>                    </td>
+                    <td data-sort-value="1">                        <div class="concepts">                            <span class="pill">gluconeogenesis</span>                        </div>                    </td>
+                    <td class="num">11</td>
+                    <td class="num">6</td>
+                    <td class="num">5</td>
+                    <td class="num">2</td>
+                    <td class="num">5</td>
+                    <td class="num">4</td>
+                    <td><span class="source">modules/gluconeogenesis.yaml</span></td>
+                </tr>                <tr data-module-row>
+                    <td>
+                        <a class="module-name" href="methionine_cycle.html">Methionine (S-adenosylmethionine) cycle module</a><span class="module-id">MODULE:methionine_cycle</span><span class="module-desc">A taxon-neutral decomposition of the methionine / S-adenosylmethionine (SAM) cycle, the core methyl-group-cycling pathway that interconverts methionine, S-adenosyl-L-methionine, S-adenosyl-L-homocysteine, and homocysteine, with exits to transsulfuration (via cystathionine beta-synthase) and remethylation inputs from folate (via methionine synthase) and choline/betaine (via BHMT).
+This module is intentionally structured in two layers. The CATALYTIC layer (enzymatic steps) grounds each step to a GO molecular-function term, the same EC &lt;-&gt; GO MF alignment used by the gluconeogenesis module. The REGULATORY layer is captured as connections of type POSITIVELY_REGULATES / NEGATIVELY_REGULATES whose predicate is grounded to a Systems Biology Ontology (SBO) term that distinguishes the MECHANISM (competitive vs allosteric), with the effector represented as a ChEBI-grounded metabolite-pool node. This regulatory wiring (small-molecule effector -&gt; enzyme, with mechanism and sign) is information GO cannot express: GO annotations attach to gene products, the effectors here are metabolites, and GO has no competitive-vs-allosteric distinction.
+The regulatory structure is transcribed from the biosustain Maud kinetic model `data/methionine/methionine_cycle.toml`. A notable showcase is METAT, where two isozyme forms of methionine adenosyltransferase catalyse the SAME reaction but are OPPOSITELY regulated by SAM: MAT-I is competitively product-inhibited by SAM, whereas MAT-III is allosterically activated by SAM. Isozyme-specific regulation of this kind is the central thing GO flattens away.</span>                    </td>
+                    <td data-sort-value="Metabolic Pathway"><span class="pill type">Metabolic Pathway</span>                    </td>
+                    <td data-sort-value="DRAFT"><span class="pill status">DRAFT</span>                    </td>
+                    <td data-sort-value="1">                        <div class="concepts">                            <span class="pill">methionine cycle</span>                        </div>                    </td>
+                    <td class="num">17</td>
+                    <td class="num">9</td>
+                    <td class="num">11</td>
+                    <td class="num">2</td>
+                    <td class="num">5</td>
+                    <td class="num">20</td>
+                    <td><span class="source">modules/methionine_cycle.yaml</span></td>
+                </tr>                <tr data-module-row>
+                    <td>
+                        <a class="module-name" href="photosynthesis.html">Oxygenic photosynthesis module</a><span class="module-id">MODULE:oxygenic_photosynthesis</span><span class="module-desc">A taxon-neutral decomposition of oxygenic photosynthesis as a recursively decomposable module. The module separates the thylakoid light reactions (light harvesting, water oxidation at photosystem II, the cytochrome b6f complex, photosystem I, mobile electron carriers, ferredoxin-NADP+ reductase, and the ATP synthase) from carbon fixation by the Calvin-Benson-Bassham reductive pentose-phosphate cycle, and adds optional photoprotection/electron balancing, the inorganic carbon-concentrating mechanism, and chlorophyll supply. It is phrased as functions, complexes, and pathway segments rather than a fixed gene list so it can represent cyanobacterial, algal, and plant implementations. Anoxygenic photosynthesis (single reaction center, non-water electron donors) is explicitly out of scope.</span>                    </td>
+                    <td data-sort-value="Biological Process"><span class="pill type">Biological Process</span>                    </td>
+                    <td data-sort-value="DRAFT"><span class="pill status">DRAFT</span>                    </td>
+                    <td data-sort-value="1">                        <div class="concepts">                            <span class="pill">oxygenic photosynthesis</span>                        </div>                    </td>
+                    <td class="num">25</td>
+                    <td class="num">22</td>
+                    <td class="num">17</td>
+                    <td class="num">3</td>
+                    <td class="num">7</td>
+                    <td class="num">9</td>
+                    <td><span class="source">modules/photosynthesis.yaml</span></td>
+                </tr>                <tr data-module-row>
+                    <td>
+                        <a class="module-name" href="peroxisome-lifecycle.html">Peroxisome lifecycle and matrix protein import module</a><span class="module-id">MODULE:peroxisome_lifecycle</span><span class="module-desc">Peroxisomes are maintained by coordinated membrane-protein delivery, matrix cargo recognition, receptor docking and translocation at the importomer, ubiquitin-dependent receptor recycling, membrane growth and division, and import of resident metabolic enzymes. This module captures the conserved peroxin roles and the major route variants that support peroxisome assembly, inheritance, and function across eukaryotes.</span>                    </td>
+                    <td data-sort-value="Organelle Lifecycle"><span class="pill type">Organelle Lifecycle</span>                    </td>
+                    <td data-sort-value="DRAFT"><span class="pill status">DRAFT</span>                    </td>
+                    <td data-sort-value="2">                        <div class="concepts">                            <span class="pill">peroxisome organization</span>                            <span class="pill">peroxisome</span>                        </div>                    </td>
+                    <td class="num">20</td>
+                    <td class="num">14</td>
+                    <td class="num">9</td>
+                    <td class="num">5</td>
+                    <td class="num">10</td>
+                    <td class="num">8</td>
+                    <td><span class="source">modules/peroxisome-lifecycle.yaml</span></td>
+                </tr>            </tbody>
+        </table>
+    </div>
 </main>
 
 <script>
     const input = document.querySelector("[data-module-search]");
     const count = document.querySelector("[data-visible-count]");
-    const cards = Array.from(document.querySelectorAll("[data-module-card]"));
+    const table = document.querySelector("[data-module-table]");
+    const tbody = table ? table.querySelector("tbody") : null;
+    const rows = tbody ? Array.from(tbody.querySelectorAll("[data-module-row]")) : [];
+
     if (input) {
         input.addEventListener("input", () => {
             const query = input.value.trim().toLowerCase();
             let visible = 0;
-            cards.forEach((card) => {
-                const matches = !query || card.textContent.toLowerCase().includes(query);
-                card.classList.toggle("is-hidden", !matches);
+            rows.forEach((row) => {
+                const matches = !query || row.textContent.toLowerCase().includes(query);
+                row.classList.toggle("is-hidden", !matches);
                 if (matches) {
                     visible += 1;
                 }
@@ -225,6 +353,50 @@
             if (count) {
                 count.textContent = String(visible);
             }
+        });
+    }
+
+    if (table && tbody) {
+        const headers = Array.from(table.querySelectorAll("thead th"));
+        const cellValue = (row, index, kind) => {
+            const cell = row.children[index];
+            if (!cell) {
+                return kind === "num" ? 0 : "";
+            }
+            const raw = cell.hasAttribute("data-sort-value")
+                ? cell.getAttribute("data-sort-value")
+                : cell.textContent.trim();
+            return kind === "num" ? parseFloat(raw) || 0 : raw.toLowerCase();
+        };
+        headers.forEach((header, index) => {
+            header.addEventListener("click", () => {
+                const kind = header.getAttribute("data-sort") || "text";
+                const ascending = header.dataset.dir !== "asc";
+                headers.forEach((other) => {
+                    delete other.dataset.dir;
+                    const arrow = other.querySelector(".arrow");
+                    if (arrow) {
+                        arrow.textContent = "";
+                    }
+                });
+                header.dataset.dir = ascending ? "asc" : "desc";
+                const arrow = header.querySelector(".arrow");
+                if (arrow) {
+                    arrow.textContent = ascending ? "▲" : "▼";
+                }
+                const sorted = rows.slice().sort((a, b) => {
+                    const va = cellValue(a, index, kind);
+                    const vb = cellValue(b, index, kind);
+                    if (va < vb) {
+                        return ascending ? -1 : 1;
+                    }
+                    if (va > vb) {
+                        return ascending ? 1 : -1;
+                    }
+                    return 0;
+                });
+                sorted.forEach((row) => tbody.appendChild(row));
+            });
         });
     }
 </script>

--- a/pages/modules/methionine_cycle.html
+++ b/pages/modules/methionine_cycle.html
@@ -1,0 +1,1160 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Methionine (S-adenosylmethionine) cycle module - AI Gene Review</title>
+    <style>
+        :root {
+            --bg-page: #f7f8fb;
+            --bg-panel: #ffffff;
+            --bg-soft: #f2f6f8;
+            --border: #d9e1e7;
+            --text: #17212b;
+            --muted: #637282;
+            --accent: #0f766e;
+            --accent-soft: #dff4f0;
+            --blue: #2563eb;
+            --amber: #b45309;
+            --green: #15803d;
+            --red: #b91c1c;
+        }
+
+        * {
+            box-sizing: border-box;
+        }
+
+        body {
+            margin: 0;
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+            color: var(--text);
+            background: var(--bg-page);
+            line-height: 1.55;
+        }
+
+        a {
+            color: var(--blue);
+            text-decoration: none;
+        }
+
+        a:hover {
+            text-decoration: underline;
+        }
+
+        .page {
+            max-width: 1440px;
+            margin: 0 auto;
+            padding: 24px;
+        }
+
+        .breadcrumb {
+            margin-bottom: 14px;
+            color: var(--muted);
+            font-size: 0.9rem;
+        }
+
+        .header {
+            background: var(--bg-panel);
+            border: 1px solid var(--border);
+            border-radius: 8px;
+            padding: 22px 24px;
+            margin-bottom: 18px;
+        }
+
+        h1 {
+            margin: 0 0 8px;
+            font-size: 2rem;
+            line-height: 1.2;
+        }
+
+        h2 {
+            margin: 0 0 14px;
+            font-size: 1.3rem;
+        }
+
+        h3 {
+            margin: 0 0 10px;
+            font-size: 1.1rem;
+        }
+
+        h4 {
+            margin: 16px 0 8px;
+            font-size: 0.95rem;
+            color: #344454;
+        }
+
+        .description {
+            max-width: 980px;
+            color: #2f3d4a;
+        }
+
+        .meta-row {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 8px;
+            margin-top: 14px;
+        }
+
+        .pill {
+            display: inline-flex;
+            align-items: center;
+            gap: 6px;
+            padding: 4px 9px;
+            border: 1px solid var(--border);
+            border-radius: 999px;
+            background: var(--bg-soft);
+            color: #304150;
+            font-size: 0.82rem;
+            font-weight: 600;
+            white-space: nowrap;
+        }
+
+        .pill.status {
+            background: #fff7ed;
+            border-color: #fed7aa;
+            color: var(--amber);
+        }
+
+        .pill.type {
+            background: var(--accent-soft);
+            border-color: #b8dfd8;
+            color: var(--accent);
+        }
+
+        .stats {
+            display: grid;
+            grid-template-columns: repeat(6, minmax(90px, 1fr));
+            gap: 10px;
+            margin-bottom: 18px;
+        }
+
+        .stat {
+            background: var(--bg-panel);
+            border: 1px solid var(--border);
+            border-radius: 8px;
+            padding: 10px 12px;
+        }
+
+        .stat-value {
+            display: block;
+            font-size: 1.35rem;
+            font-weight: 700;
+        }
+
+        .stat-label {
+            color: var(--muted);
+            font-size: 0.78rem;
+            text-transform: uppercase;
+        }
+
+        .browser {
+            display: grid;
+            grid-template-columns: minmax(310px, 420px) minmax(0, 1fr);
+            gap: 18px;
+            align-items: start;
+        }
+
+        .panel {
+            background: var(--bg-panel);
+            border: 1px solid var(--border);
+            border-radius: 8px;
+            min-width: 0;
+        }
+
+        .tree-panel {
+            position: sticky;
+            top: 16px;
+            max-height: calc(100vh - 32px);
+            overflow: auto;
+        }
+
+        .panel-header {
+            padding: 14px 16px;
+            border-bottom: 1px solid var(--border);
+            background: #fbfcfd;
+        }
+
+        .panel-body {
+            padding: 16px;
+        }
+
+        .tree-tools {
+            display: grid;
+            grid-template-columns: 1fr auto auto;
+            gap: 8px;
+            margin-top: 10px;
+        }
+
+        .tree-search {
+            width: 100%;
+            min-width: 0;
+            border: 1px solid var(--border);
+            border-radius: 6px;
+            padding: 7px 9px;
+            font: inherit;
+        }
+
+        .tool-button {
+            border: 1px solid var(--border);
+            border-radius: 6px;
+            padding: 7px 9px;
+            background: #ffffff;
+            color: #273747;
+            font: inherit;
+            font-size: 0.85rem;
+            cursor: pointer;
+        }
+
+        .tool-button:hover {
+            border-color: #9eb0bd;
+            background: #f8fafc;
+        }
+
+        .tree-list,
+        .tree-list ol,
+        .tree-list ul {
+            list-style: none;
+            padding-left: 0;
+            margin: 0;
+        }
+
+        .tree-list ol,
+        .tree-list ul {
+            margin-left: 16px;
+            padding-left: 12px;
+            border-left: 1px solid var(--border);
+        }
+
+        .tree-node {
+            margin: 5px 0;
+        }
+
+        .tree-node > summary {
+            cursor: pointer;
+            border-radius: 6px;
+            padding: 6px 8px;
+        }
+
+        .tree-node > summary:hover {
+            background: var(--bg-soft);
+        }
+
+        .tree-row {
+            display: inline-flex;
+            flex-wrap: wrap;
+            align-items: center;
+            gap: 6px;
+            max-width: calc(100% - 16px);
+            vertical-align: top;
+        }
+
+        .tree-row.is-dimmed {
+            opacity: 0.35;
+        }
+
+        .tree-link {
+            font-weight: 650;
+            color: var(--text);
+        }
+
+        .tree-id {
+            color: var(--muted);
+            font-size: 0.78rem;
+        }
+
+        .tree-group-title {
+            margin: 8px 0 4px 20px;
+            color: var(--muted);
+            font-size: 0.78rem;
+            font-weight: 700;
+            text-transform: uppercase;
+        }
+
+        .edge-note {
+            color: var(--muted);
+            font-size: 0.82rem;
+        }
+
+        .annoton-item {
+            margin: 5px 0;
+            font-size: 0.9rem;
+        }
+
+        .detail-panel {
+            overflow: hidden;
+        }
+
+        .node-detail {
+            border: 1px solid var(--border);
+            border-radius: 8px;
+            padding: 16px;
+            margin-bottom: 14px;
+            background: #ffffff;
+        }
+
+        .node-detail.depth-1,
+        .node-detail.depth-2,
+        .node-detail.depth-3 {
+            background: #fbfcfd;
+        }
+
+        .node-heading {
+            display: flex;
+            flex-wrap: wrap;
+            align-items: center;
+            gap: 8px;
+            margin-bottom: 8px;
+        }
+
+        .node-title {
+            font-size: 1.1rem;
+            font-weight: 700;
+        }
+
+        .node-description,
+        .role-description {
+            color: #31404e;
+            margin: 8px 0;
+        }
+
+        .descriptor-list {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 6px;
+            margin: 8px 0;
+        }
+
+        .descriptor {
+            display: inline-flex;
+            flex-wrap: wrap;
+            align-items: center;
+            gap: 5px;
+            padding: 4px 7px;
+            border-radius: 6px;
+            background: #eef7ff;
+            border: 1px solid #cce4ff;
+            font-size: 0.87rem;
+        }
+
+        .descriptor-description {
+            color: var(--muted);
+        }
+
+        .term-id,
+        .source-id {
+            font-family: "SFMono-Regular", Consolas, "Liberation Mono", Menlo, monospace;
+            font-size: 0.78rem;
+        }
+
+        .slot-row {
+            margin-top: 4px;
+            font-size: 0.86rem;
+        }
+
+        .slot-name {
+            color: var(--muted);
+            font-weight: 700;
+        }
+
+        .participant-detail {
+            margin-top: 6px;
+        }
+
+        .annoton-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+            gap: 10px;
+            margin-top: 10px;
+        }
+
+        .annoton-card,
+        .connection-card,
+        .context-card,
+        .evidence-card,
+        .complex-unit {
+            border: 1px solid var(--border);
+            border-radius: 8px;
+            background: #ffffff;
+            padding: 11px;
+        }
+
+        .active-unit-list {
+            display: grid;
+            gap: 8px;
+            margin-top: 6px;
+        }
+
+        .annoton-title {
+            font-weight: 700;
+            margin-bottom: 4px;
+        }
+
+        .muted {
+            color: var(--muted);
+        }
+
+        .small {
+            font-size: 0.85rem;
+        }
+
+        .connection-list,
+        .evidence-list {
+            display: grid;
+            gap: 8px;
+            margin-top: 8px;
+        }
+
+        .connection-arrow {
+            color: var(--green);
+            font-weight: 700;
+        }
+
+        .variant-set {
+            margin-top: 14px;
+            border-left: 3px solid #94a3b8;
+            padding-left: 12px;
+        }
+
+        .part-marker,
+        .variant-marker {
+            color: var(--muted);
+            font-size: 0.85rem;
+            font-weight: 700;
+            margin: 12px 0 8px;
+        }
+
+        .warnings {
+            border: 1px solid #fecaca;
+            background: #fef2f2;
+            color: var(--red);
+            border-radius: 8px;
+            padding: 12px 16px;
+            margin-bottom: 18px;
+        }
+
+        @media (max-width: 960px) {
+            .page {
+                padding: 14px;
+            }
+
+            .stats {
+                grid-template-columns: repeat(2, minmax(120px, 1fr));
+            }
+
+            .browser {
+                grid-template-columns: 1fr;
+            }
+
+            .tree-panel {
+                position: static;
+                max-height: none;
+            }
+        }
+    </style>
+</head>
+<body>
+
+
+
+
+
+
+
+
+
+
+
+
+<main class="page">
+    <nav class="breadcrumb">
+        <a href="index.html">Module KB</a> / Methionine (S-adenosylmethionine) cycle module
+    </nav>
+
+    <header class="header">
+        <h1>Methionine (S-adenosylmethionine) cycle module</h1>            <p class="description">A taxon-neutral decomposition of the methionine / S-adenosylmethionine (SAM) cycle, the core methyl-group-cycling pathway that interconverts methionine, S-adenosyl-L-methionine, S-adenosyl-L-homocysteine, and homocysteine, with exits to transsulfuration (via cystathionine beta-synthase) and remethylation inputs from folate (via methionine synthase) and choline/betaine (via BHMT).
+This module is intentionally structured in two layers. The CATALYTIC layer (enzymatic steps) grounds each step to a GO molecular-function term, the same EC &lt;-&gt; GO MF alignment used by the gluconeogenesis module. The REGULATORY layer is captured as connections of type POSITIVELY_REGULATES / NEGATIVELY_REGULATES whose predicate is grounded to a Systems Biology Ontology (SBO) term that distinguishes the MECHANISM (competitive vs allosteric), with the effector represented as a ChEBI-grounded metabolite-pool node. This regulatory wiring (small-molecule effector -&gt; enzyme, with mechanism and sign) is information GO cannot express: GO annotations attach to gene products, the effectors here are metabolites, and GO has no competitive-vs-allosteric distinction.
+The regulatory structure is transcribed from the biosustain Maud kinetic model `data/methionine/methionine_cycle.toml`. A notable showcase is METAT, where two isozyme forms of methionine adenosyltransferase catalyse the SAME reaction but are OPPOSITELY regulated by SAM: MAT-I is competitively product-inhibited by SAM, whereas MAT-III is allosterically activated by SAM. Isozyme-specific regulation of this kind is the central thing GO flattens away.</p>        <div class="meta-row"><span class="pill">MODULE:methionine_cycle</span><span class="pill status">DRAFT</span><span class="pill type">Metabolic Pathway</span><span class="pill">modules/methionine_cycle.yaml</span>
+        </div>
+        <div class="descriptor-list">                <span class="descriptor">
+            <span>methionine cycle</span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0033353" target="_blank" rel="noopener">GO:0033353</a></span>        </div>
+        <div class="evidence-list">                <div class="evidence-card small"><a class="source-id" href="https://amigo.geneontology.org/amigo/term/GO:0033353" target="_blank" rel="noopener">GO:0033353</a><div><strong>L-methionine cycle</strong></div><div>The module is grounded in the GO biological-process term for the methionine / S-adenosylmethionine cycle (exact synonym &#34;S-adenosylmethionine cycle&#34;).</div></div>                <div class="evidence-card small"><a class="source-id" href="https://github.com/biosustain/Methionine_model/blob/main/data/methionine/methionine_cycle.toml" target="_blank" rel="noopener">file:models/methionine/methionine_cycle.regulation.toml</a><div><strong>biosustain Methionine_model (Maud kinetic model)</strong></div><div>Reaction set, isozymes, and the allosteric/competitive regulation wiring are transcribed from the Maud model data/methionine/methionine_cycle.toml.</div></div>        </div></header>
+    <section class="stats" aria-label="Module counts">
+        <div class="stat"><span class="stat-value">17</span><span class="stat-label">Nodes</span></div>
+        <div class="stat"><span class="stat-value">11</span><span class="stat-label">Parts</span></div>
+        <div class="stat"><span class="stat-value">2</span><span class="stat-label">Variant Sets</span></div>
+        <div class="stat"><span class="stat-value">5</span><span class="stat-label">Variants</span></div>
+        <div class="stat"><span class="stat-value">9</span><span class="stat-label">Annotons</span></div>
+        <div class="stat"><span class="stat-value">20</span><span class="stat-label">Connections</span></div>
+    </section>
+
+    <section class="browser">
+        <aside class="panel tree-panel">
+            <div class="panel-header">
+                <h2>Tree</h2>
+                <div class="tree-tools">
+                    <input class="tree-search" type="search" placeholder="Filter tree" data-tree-search>
+                    <button class="tool-button" type="button" data-tree-action="expand">Expand</button>
+                    <button class="tool-button" type="button" data-tree-action="collapse">Collapse</button>
+                </div>
+            </div>
+            <div class="panel-body">
+                <ol class="tree-list">
+                    <li class="tree-entry">
+        <details class="tree-node" open>
+            <summary>
+                <span class="tree-row">
+                    <a class="tree-link" href="#node-methionine_cycle">Methionine (SAM) cycle</a><span class="pill type">Metabolic Pathway</span><span class="tree-id">methionine_cycle</span>
+                </span>
+            </summary>                <div class="tree-group-title">Parts</div>
+                <ol>                            <li>
+                                <div class="edge-note">1. SAM-forming step (methionine activation)</div>
+                                <li class="tree-entry">
+        <details class="tree-node" open>
+            <summary>
+                <span class="tree-row">
+                    <a class="tree-link" href="#node-metat_step">Methionine -&gt; S-adenosyl-L-methionine</a><span class="pill type">Reaction</span><span class="tree-id">metat_step</span>
+                </span>
+            </summary>                <div class="tree-group-title">Variants</div>
+                <ol>                        <li>
+                            <div class="edge-note">
+                                Methionine adenosyltransferase isozyme/oligomeric forms by isozyme / oligomeric form (One Or More)</div>
+                            <ol>                                    <li class="tree-entry">
+        <details class="tree-node" >
+            <summary>
+                <span class="tree-row">
+                    <a class="tree-link" href="#node-mat1_form">MAT-I (high-capacity hepatic form)</a><span class="pill type">Reaction</span><span class="tree-id">mat1_form</span>
+                </span>
+            </summary>                <div class="tree-group-title">Annotons</div>
+                <ul>                        <li class="annoton-item tree-entry">
+                            <span class="tree-row">
+                                <a href="#annoton-mat1_activity">MAT-I methionine adenosyltransferase activity</a>
+                                <span class="tree-id">Gene Product: MAT-I (MAT1A-encoded high-K_m hepatic isozyme)</span>
+                            </span>
+                        </li>                </ul></details>
+    </li>                                    <li class="tree-entry">
+        <details class="tree-node" >
+            <summary>
+                <span class="tree-row">
+                    <a class="tree-link" href="#node-mat3_form">MAT-III (low-affinity hepatic form)</a><span class="pill type">Reaction</span><span class="tree-id">mat3_form</span>
+                </span>
+            </summary>                <div class="tree-group-title">Annotons</div>
+                <ul>                        <li class="annoton-item tree-entry">
+                            <span class="tree-row">
+                                <a href="#annoton-mat3_activity">MAT-III methionine adenosyltransferase activity</a>
+                                <span class="tree-id">Gene Product: MAT-III (MAT1A-encoded low-affinity hepatic isozyme)</span>
+                            </span>
+                        </li>                </ul></details>
+    </li>                            </ol>
+                        </li>                </ol></details>
+    </li>
+                            </li>                            <li>
+                                <div class="edge-note">2. bulk transmethylation (SAM-dependent methyltransferases)</div>
+                                <li class="tree-entry">
+        <details class="tree-node" open>
+            <summary>
+                <span class="tree-row">
+                    <a class="tree-link" href="#node-meth_step">SAM-dependent transmethylation (general)</a><span class="pill type">Reaction</span><span class="tree-id">meth_step</span>
+                </span>
+            </summary>                <div class="tree-group-title">Annotons</div>
+                <ul>                        <li class="annoton-item tree-entry">
+                            <span class="tree-row">
+                                <a href="#annoton-meth_activity">SAM-dependent methyltransferase activity (general)</a>
+                                <span class="tree-id">Any With Function: methyltransferase activity</span>
+                            </span>
+                        </li>                </ul></details>
+    </li>
+                            </li>                            <li>
+                                <div class="edge-note">3. SAM disposal / glycine sink</div>
+                                <li class="tree-entry">
+        <details class="tree-node" open>
+            <summary>
+                <span class="tree-row">
+                    <a class="tree-link" href="#node-gnmt_step">Glycine N-methyltransferase (SAM:SAH buffering)</a><span class="pill type">Reaction</span><span class="tree-id">gnmt_step</span>
+                </span>
+            </summary>                <div class="tree-group-title">Annotons</div>
+                <ul>                        <li class="annoton-item tree-entry">
+                            <span class="tree-row">
+                                <a href="#annoton-gnmt_activity">Glycine N-methyltransferase activity</a>
+                                <span class="tree-id">Any With Function: glycine N-methyltransferase activity</span>
+                            </span>
+                        </li>                </ul></details>
+    </li>
+                            </li>                            <li>
+                                <div class="edge-note">4. SAH hydrolysis</div>
+                                <li class="tree-entry">
+        <details class="tree-node" open>
+            <summary>
+                <span class="tree-row">
+                    <a class="tree-link" href="#node-ahc_step">S-adenosyl-L-homocysteine -&gt; L-homocysteine</a><span class="pill type">Reaction</span><span class="tree-id">ahc_step</span>
+                </span>
+            </summary>                <div class="tree-group-title">Annotons</div>
+                <ul>                        <li class="annoton-item tree-entry">
+                            <span class="tree-row">
+                                <a href="#annoton-ahc_activity">Adenosylhomocysteinase activity</a>
+                                <span class="tree-id">Any With Function: adenosylhomocysteinase activity</span>
+                            </span>
+                        </li>                </ul></details>
+    </li>
+                            </li>                            <li>
+                                <div class="edge-note">5. homocysteine fate (remethylation vs transsulfuration)</div>
+                                <li class="tree-entry">
+        <details class="tree-node" open>
+            <summary>
+                <span class="tree-row">
+                    <a class="tree-link" href="#node-homocysteine_fate">Homocysteine fate branch</a><span class="pill type">Reaction</span><span class="tree-id">homocysteine_fate</span>
+                </span>
+            </summary>                <div class="tree-group-title">Variants</div>
+                <ol>                        <li>
+                            <div class="edge-note">
+                                Homocysteine disposal routes by metabolic fate (One Or More)</div>
+                            <ol>                                    <li class="tree-entry">
+        <details class="tree-node" >
+            <summary>
+                <span class="tree-row">
+                    <a class="tree-link" href="#node-ms_route">Folate-dependent remethylation (methionine synthase)</a><span class="pill type">Reaction</span><span class="tree-id">ms_route</span>
+                </span>
+            </summary>                <div class="tree-group-title">Annotons</div>
+                <ul>                        <li class="annoton-item tree-entry">
+                            <span class="tree-row">
+                                <a href="#annoton-ms_activity">Methionine synthase activity</a>
+                                <span class="tree-id">Any With Function: methionine synthase activity</span>
+                            </span>
+                        </li>                </ul></details>
+    </li>                                    <li class="tree-entry">
+        <details class="tree-node" >
+            <summary>
+                <span class="tree-row">
+                    <a class="tree-link" href="#node-bhmt_route">Betaine-dependent remethylation (BHMT)</a><span class="pill type">Reaction</span><span class="tree-id">bhmt_route</span>
+                </span>
+            </summary>                <div class="tree-group-title">Annotons</div>
+                <ul>                        <li class="annoton-item tree-entry">
+                            <span class="tree-row">
+                                <a href="#annoton-bhmt_activity">Betaine-homocysteine S-methyltransferase activity</a>
+                                <span class="tree-id">Any With Function: betaine-homocysteine S-methyltransferase activity</span>
+                            </span>
+                        </li>                </ul></details>
+    </li>                                    <li class="tree-entry">
+        <details class="tree-node" >
+            <summary>
+                <span class="tree-row">
+                    <a class="tree-link" href="#node-cbs_route">Transsulfuration commitment (cystathionine beta-synthase)</a><span class="pill type">Reaction</span><span class="tree-id">cbs_route</span>
+                </span>
+            </summary>                <div class="tree-group-title">Annotons</div>
+                <ul>                        <li class="annoton-item tree-entry">
+                            <span class="tree-row">
+                                <a href="#annoton-cbs_activity">Cystathionine beta-synthase activity</a>
+                                <span class="tree-id">Any With Function: cystathionine beta-synthase activity</span>
+                            </span>
+                        </li>                </ul></details>
+    </li>                            </ol>
+                        </li>                </ol></details>
+    </li>
+                            </li>                            <li>
+                                <div class="edge-note">6. folate methyl input arm</div>
+                                <li class="tree-entry">
+        <details class="tree-node" open>
+            <summary>
+                <span class="tree-row">
+                    <a class="tree-link" href="#node-mthfr_step">Methylenetetrahydrofolate reductase (5-methyl-THF supply)</a><span class="pill type">Reaction</span><span class="tree-id">mthfr_step</span>
+                </span>
+            </summary>                <div class="tree-group-title">Annotons</div>
+                <ul>                        <li class="annoton-item tree-entry">
+                            <span class="tree-row">
+                                <a href="#annoton-mthfr_activity">Methylenetetrahydrofolate reductase activity</a>
+                                <span class="tree-id">Any With Function: methylenetetrahydrofolate reductase [NAD(P)H] activity</span>
+                            </span>
+                        </li>                </ul></details>
+    </li>
+                            </li>                            <li>
+                                <div class="edge-note">7. regulatory effector pools (metabolite endpoints for regulation edges) optional</div>
+                                <li class="tree-entry">
+        <details class="tree-node" open>
+            <summary>
+                <span class="tree-row">
+                    <a class="tree-link" href="#node-regulatory_effectors">Regulatory effector pools</a><span class="pill type">Module</span><span class="tree-id">regulatory_effectors</span>
+                </span>
+            </summary>                <div class="tree-group-title">Parts</div>
+                <ol>                            <li>
+                                <div class="edge-note">methyl-donor effector</div>
+                                <li class="tree-entry">
+        <details class="tree-node" >
+            <summary>
+                <span class="tree-row">
+                    <a class="tree-link" href="#node-amet_pool">S-adenosyl-L-methionine (SAM) pool</a><span class="tree-id">amet_pool</span>
+                </span>
+            </summary></details>
+    </li>
+                            </li>                            <li>
+                                <div class="edge-note">demethylated-donor effector</div>
+                                <li class="tree-entry">
+        <details class="tree-node" >
+            <summary>
+                <span class="tree-row">
+                    <a class="tree-link" href="#node-ahcys_pool">S-adenosyl-L-homocysteine (SAH) pool</a><span class="tree-id">ahcys_pool</span>
+                </span>
+            </summary></details>
+    </li>
+                            </li>                            <li>
+                                <div class="edge-note">folate effector</div>
+                                <li class="tree-entry">
+        <details class="tree-node" >
+            <summary>
+                <span class="tree-row">
+                    <a class="tree-link" href="#node-mlthf_pool">5,10-methylenetetrahydrofolate pool</a><span class="tree-id">mlthf_pool</span>
+                </span>
+            </summary></details>
+    </li>
+                            </li>                            <li>
+                                <div class="edge-note">amino-acid effector</div>
+                                <li class="tree-entry">
+        <details class="tree-node" >
+            <summary>
+                <span class="tree-row">
+                    <a class="tree-link" href="#node-met_pool">L-methionine pool</a><span class="tree-id">met_pool</span>
+                </span>
+            </summary></details>
+    </li>
+                            </li>                </ol></details>
+    </li>
+                            </li>                </ol></details>
+    </li>
+                </ol>
+            </div>
+        </aside>
+
+        <section class="panel detail-panel">
+            <div class="panel-header">
+                <h2>Details</h2>
+            </div>
+            <div class="panel-body">
+
+                <section class="node-detail depth-0" id="node-methionine_cycle">
+        <div class="node-heading">
+            <span class="node-title">Methionine (SAM) cycle</span><span class="pill type">Metabolic Pathway</span><span class="pill">methionine_cycle</span>
+        </div><div class="descriptor-list">                <span class="descriptor">
+            <span>methionine cycle</span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0033353" target="_blank" rel="noopener">GO:0033353</a></span>        </div>
+
+        <p class="muted small">Layering: catalytic steps ground to GO molecular-function terms (GO:0004478, GO:0008168, GO:0017174, GO:0004013, GO:0008705, GO:0047150, GO:0004122, GO:0004489); the pathway grounds to GO:0033353. The regulatory layer is deliberately NOT expressed in GO. Each regulatory edge is a connection typed POSITIVELY/NEGATIVELY_REGULATES whose predicate is grounded to SBO so the competitive-vs-allosteric MECHANISM is explicit (SBO:0000206 competitive inhibitor, SBO:0000636 allosteric activator, SBO:0000639 allosteric inhibitor), with the effector grounded to ChEBI. This is the information that falls outside GO scope: a metabolite cannot bear a GO annotation, and GO has no representation of inhibition mechanism. The MAT-I vs MAT-III split (same GO MF GO:0004478, opposite SAM regulation) is the canonical illustration. Quantitative kinetics (K_m, k_cat, K_i, Hill/MWC parameters) from the Maud model are intentionally out of scope for this module and belong with the model / SABIO-RK-style resources.</p>            <h4>Connections</h4>
+            <div class="connection-list">                <div class="connection-card small">
+                    <div>
+                        <a href="#annoton-mat1_activity">mat1_activity</a>
+                        <span class="connection-arrow">-&gt;</span>
+                        <a href="#node-meth_step">meth_step</a>                            <span class="pill">Provides Input For</span></div>                        <div class="muted">SAM produced by methionine adenosyltransferase is the methyl donor for transmethylation.</div>
+
+                </div>                <div class="connection-card small">
+                    <div>
+                        <a href="#annoton-mat3_activity">mat3_activity</a>
+                        <span class="connection-arrow">-&gt;</span>
+                        <a href="#node-meth_step">meth_step</a>                            <span class="pill">Provides Input For</span></div>                        <div class="muted">SAM produced by methionine adenosyltransferase is the methyl donor for transmethylation.</div>
+
+                </div>                <div class="connection-card small">
+                    <div>
+                        <a href="#annoton-mat1_activity">mat1_activity</a>
+                        <span class="connection-arrow">-&gt;</span>
+                        <a href="#node-gnmt_step">gnmt_step</a>                            <span class="pill">Provides Input For</span></div>                        <div class="muted">SAM is also consumed by glycine N-methyltransferase (overflow disposal).</div>
+
+                </div>                <div class="connection-card small">
+                    <div>
+                        <a href="#annoton-mat3_activity">mat3_activity</a>
+                        <span class="connection-arrow">-&gt;</span>
+                        <a href="#node-gnmt_step">gnmt_step</a>                            <span class="pill">Provides Input For</span></div>                        <div class="muted">SAM is also consumed by glycine N-methyltransferase (overflow disposal).</div>
+
+                </div>                <div class="connection-card small">
+                    <div>
+                        <a href="#node-meth_step">meth_step</a>
+                        <span class="connection-arrow">-&gt;</span>
+                        <a href="#node-ahc_step">ahc_step</a>                            <span class="pill">Provides Input For</span></div>                        <div class="muted">Transmethylation produces SAH, the substrate of adenosylhomocysteinase.</div>
+
+                </div>                <div class="connection-card small">
+                    <div>
+                        <a href="#node-gnmt_step">gnmt_step</a>
+                        <span class="connection-arrow">-&gt;</span>
+                        <a href="#node-ahc_step">ahc_step</a>                            <span class="pill">Provides Input For</span></div>                        <div class="muted">GNMT produces SAH, the substrate of adenosylhomocysteinase.</div>
+
+                </div>                <div class="connection-card small">
+                    <div>
+                        <a href="#node-ahc_step">ahc_step</a>
+                        <span class="connection-arrow">-&gt;</span>
+                        <a href="#node-homocysteine_fate">homocysteine_fate</a>                            <span class="pill">Provides Input For</span></div>                        <div class="muted">SAH hydrolysis yields homocysteine, the branch-point metabolite.</div>
+
+                </div>                <div class="connection-card small">
+                    <div>
+                        <a href="#node-ms_route">ms_route</a>
+                        <span class="connection-arrow">-&gt;</span>
+                        <a href="#node-metat_step">metat_step</a>                            <span class="pill">Provides Input For</span></div>                        <div class="muted">Folate-dependent remethylation regenerates methionine, closing the cycle.</div>
+
+                </div>                <div class="connection-card small">
+                    <div>
+                        <a href="#node-bhmt_route">bhmt_route</a>
+                        <span class="connection-arrow">-&gt;</span>
+                        <a href="#node-metat_step">metat_step</a>                            <span class="pill">Provides Input For</span></div>                        <div class="muted">Betaine-dependent remethylation regenerates methionine, closing the cycle.</div>
+
+                </div>                <div class="connection-card small">
+                    <div>
+                        <a href="#node-mthfr_step">mthfr_step</a>
+                        <span class="connection-arrow">-&gt;</span>
+                        <a href="#node-ms_route">ms_route</a>                            <span class="pill">Provides Input For</span></div>                        <div class="muted">MTHFR supplies 5-methyltetrahydrofolate consumed by methionine synthase.</div>
+
+                </div>                <div class="connection-card small">
+                    <div>
+                        <a href="#node-amet_pool">amet_pool</a>
+                        <span class="connection-arrow">-&gt;</span>
+                        <a href="#annoton-mat3_activity">mat3_activity</a>                            <span class="pill">Positively Regulates</span></div>                        <div><span class="descriptor">
+            <span>allosteric activation</span><span class="term-id">SBO:0000636</span></span></div>                        <div class="muted">SAM allosterically activates MAT-III (feed-forward). Contrast with MAT-I, which SAM competitively inhibits - same reaction, opposite isozyme logic.</div>
+                    <div class="evidence-list">                <div class="evidence-card small"><span class="source-id">file:models/methionine/methionine_cycle.regulation.toml</span><div><strong>Maud methionine_cycle.toml [allosteric]</strong></div><div>MAT3 activated by amet (allosteric).</div></div>        </div>
+                </div>                <div class="connection-card small">
+                    <div>
+                        <a href="#node-met_pool">met_pool</a>
+                        <span class="connection-arrow">-&gt;</span>
+                        <a href="#annoton-mat3_activity">mat3_activity</a>                            <span class="pill">Positively Regulates</span></div>                        <div><span class="descriptor">
+            <span>allosteric activation</span><span class="term-id">SBO:0000636</span></span></div>                        <div class="muted">Methionine feed-forward activates MAT-III.</div>
+                    <div class="evidence-list">                <div class="evidence-card small"><span class="source-id">file:models/methionine/methionine_cycle.regulation.toml</span><div><strong>Maud methionine_cycle.toml [allosteric]</strong></div><div>MAT3 activated by met-L (allosteric).</div></div>        </div>
+                </div>                <div class="connection-card small">
+                    <div>
+                        <a href="#node-amet_pool">amet_pool</a>
+                        <span class="connection-arrow">-&gt;</span>
+                        <a href="#annoton-gnmt_activity">gnmt_activity</a>                            <span class="pill">Positively Regulates</span></div>                        <div><span class="descriptor">
+            <span>allosteric activation</span><span class="term-id">SBO:0000636</span></span></div>                        <div class="muted">SAM allosterically activates GNMT, opening the SAM overflow valve when methyl donor is in excess.</div>
+                    <div class="evidence-list">                <div class="evidence-card small"><span class="source-id">file:models/methionine/methionine_cycle.regulation.toml</span><div><strong>Maud methionine_cycle.toml [allosteric]</strong></div><div>GNMT1 activated by amet (allosteric).</div></div>        </div>
+                </div>                <div class="connection-card small">
+                    <div>
+                        <a href="#node-mlthf_pool">mlthf_pool</a>
+                        <span class="connection-arrow">-&gt;</span>
+                        <a href="#annoton-gnmt_activity">gnmt_activity</a>                            <span class="pill">Negatively Regulates</span></div>                        <div><span class="descriptor">
+            <span>allosteric inhibition</span><span class="term-id">SBO:0000639</span></span></div>                        <div class="muted">5,10-methylenetetrahydrofolate allosterically inhibits GNMT, linking folate status to SAM disposal.</div>
+                    <div class="evidence-list">                <div class="evidence-card small"><span class="source-id">file:models/methionine/methionine_cycle.regulation.toml</span><div><strong>Maud methionine_cycle.toml [allosteric]</strong></div><div>GNMT1 inhibited by mlthf (allosteric).</div></div>        </div>
+                </div>                <div class="connection-card small">
+                    <div>
+                        <a href="#node-amet_pool">amet_pool</a>
+                        <span class="connection-arrow">-&gt;</span>
+                        <a href="#annoton-cbs_activity">cbs_activity</a>                            <span class="pill">Positively Regulates</span></div>                        <div><span class="descriptor">
+            <span>allosteric activation</span><span class="term-id">SBO:0000636</span></span></div>                        <div class="muted">SAM allosterically activates CBS, diverting homocysteine to transsulfuration when methyl donor is abundant.</div>
+                    <div class="evidence-list">                <div class="evidence-card small"><span class="source-id">file:models/methionine/methionine_cycle.regulation.toml</span><div><strong>Maud methionine_cycle.toml [allosteric]</strong></div><div>CBS1 activated by amet (allosteric).</div></div>        </div>
+                </div>                <div class="connection-card small">
+                    <div>
+                        <a href="#node-amet_pool">amet_pool</a>
+                        <span class="connection-arrow">-&gt;</span>
+                        <a href="#annoton-mthfr_activity">mthfr_activity</a>                            <span class="pill">Negatively Regulates</span></div>                        <div><span class="descriptor">
+            <span>allosteric inhibition</span><span class="term-id">SBO:0000639</span></span></div>                        <div class="muted">SAM allosterically inhibits MTHFR, throttling folate-dependent remethylation when SAM is high.</div>
+                    <div class="evidence-list">                <div class="evidence-card small"><span class="source-id">file:models/methionine/methionine_cycle.regulation.toml</span><div><strong>Maud methionine_cycle.toml [allosteric]</strong></div><div>MTHFR1 inhibited by amet (allosteric).</div></div>        </div>
+                </div>                <div class="connection-card small">
+                    <div>
+                        <a href="#node-ahcys_pool">ahcys_pool</a>
+                        <span class="connection-arrow">-&gt;</span>
+                        <a href="#annoton-mthfr_activity">mthfr_activity</a>                            <span class="pill">Positively Regulates</span></div>                        <div><span class="descriptor">
+            <span>allosteric activation</span><span class="term-id">SBO:0000636</span></span></div>                        <div class="muted">SAH allosterically activates MTHFR, restoring remethylation flux when the methylation index falls.</div>
+                    <div class="evidence-list">                <div class="evidence-card small"><span class="source-id">file:models/methionine/methionine_cycle.regulation.toml</span><div><strong>Maud methionine_cycle.toml [allosteric]</strong></div><div>MTHFR1 activated by ahcys (allosteric).</div></div>        </div>
+                </div>                <div class="connection-card small">
+                    <div>
+                        <a href="#node-amet_pool">amet_pool</a>
+                        <span class="connection-arrow">-&gt;</span>
+                        <a href="#annoton-mat1_activity">mat1_activity</a>                            <span class="pill">Negatively Regulates</span></div>                        <div><span class="descriptor">
+            <span>competitive inhibition</span><span class="term-id">SBO:0000206</span></span></div>                        <div class="muted">SAM competitively (product-feedback) inhibits MAT-I - opposite sign to its allosteric activation of MAT-III.</div>
+                    <div class="evidence-list">                <div class="evidence-card small"><span class="source-id">file:models/methionine/methionine_cycle.regulation.toml</span><div><strong>Maud methionine_cycle.toml [competitive_inhibition]</strong></div><div>MAT1 (reaction METAT) competitively inhibited by amet.</div></div>        </div>
+                </div>                <div class="connection-card small">
+                    <div>
+                        <a href="#node-ahcys_pool">ahcys_pool</a>
+                        <span class="connection-arrow">-&gt;</span>
+                        <a href="#annoton-meth_activity">meth_activity</a>                            <span class="pill">Negatively Regulates</span></div>                        <div><span class="descriptor">
+            <span>competitive inhibition</span><span class="term-id">SBO:0000206</span></span></div>                        <div class="muted">SAH competitively inhibits bulk transmethylation (classic product inhibition / methylation index).</div>
+                    <div class="evidence-list">                <div class="evidence-card small"><span class="source-id">file:models/methionine/methionine_cycle.regulation.toml</span><div><strong>Maud methionine_cycle.toml [competitive_inhibition]</strong></div><div>METH-Gen (reaction METH) competitively inhibited by ahcys.</div></div>        </div>
+                </div>                <div class="connection-card small">
+                    <div>
+                        <a href="#node-ahcys_pool">ahcys_pool</a>
+                        <span class="connection-arrow">-&gt;</span>
+                        <a href="#annoton-gnmt_activity">gnmt_activity</a>                            <span class="pill">Negatively Regulates</span></div>                        <div><span class="descriptor">
+            <span>competitive inhibition</span><span class="term-id">SBO:0000206</span></span></div>                        <div class="muted">SAH competitively inhibits GNMT.</div>
+                    <div class="evidence-list">                <div class="evidence-card small"><span class="source-id">file:models/methionine/methionine_cycle.regulation.toml</span><div><strong>Maud methionine_cycle.toml [competitive_inhibition]</strong></div><div>GNMT1 (reaction GNMT) competitively inhibited by ahcys.</div></div>        </div>
+                </div>        </div>                <div class="part-marker">
+                    Part 1: SAM-forming step (methionine activation)</div>
+                <section class="node-detail depth-1" id="node-metat_step">
+        <div class="node-heading">
+            <span class="node-title">Methionine -&gt; S-adenosyl-L-methionine</span><span class="pill type">Reaction</span><span class="pill">metat_step</span>
+        </div>            <p class="node-description">Methionine adenosyltransferase (EC 2.5.1.6) condenses methionine and ATP to S-adenosyl-L-methionine (SAM), the universal methyl donor. The isozyme forms differ in their feedback logic, so they are modelled as variants to carry isozyme-specific regulation.</p><div class="descriptor-list">                <span class="descriptor">
+            <span>methionine adenosyltransferase reaction</span></span>        </div>
+
+                    <div class="variant-set">
+                <div class="variant-marker">
+                    Variant set: Methionine adenosyltransferase isozyme/oligomeric forms by isozyme / oligomeric form (One Or More)</div>
+                                    <section class="node-detail depth-2" id="node-mat1_form">
+        <div class="node-heading">
+            <span class="node-title">MAT-I (high-capacity hepatic form)</span><span class="pill type">Reaction</span><span class="pill">mat1_form</span>
+        </div>
+
+                    <h4>Annotons</h4>
+            <div class="annoton-grid">                    <article class="annoton-card" id="annoton-mat1_activity">
+        <div class="annoton-title">MAT-I methionine adenosyltransferase activity</div>
+        <div class="small muted">mat1_activity</div>            <div class="small"><strong>Participant:</strong> Gene Product: MAT-I (MAT1A-encoded high-K_m hepatic isozyme)</div>
+            <div class="participant-detail">                    <div class="slot-row">
+                        <span class="slot-name">Gene Product:</span>
+                        <div class="descriptor">
+            <span><strong>MAT-I (MAT1A-encoded high-K_m hepatic isozyme)</strong></span>                <span class="descriptor-description">High-K_m hepatic methionine adenosyltransferase form. Subject to competitive product (SAM) inhibition in the kinetic model.</span></div>
+                    </div></div>            <h4>Function</h4>
+            <div class="descriptor">
+            <span><strong>methionine adenosyltransferase activity</strong></span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0004478" target="_blank" rel="noopener">GO:0004478</a>                    <div class="slot-row">
+                        <span class="slot-name">Substrates:</span>                            <span class="descriptor">
+            <span>L-methionine</span></span>                            <span class="descriptor">
+            <span>ATP</span></span>                    </div>                    <div class="slot-row">
+                        <span class="slot-name">Products:</span>                            <span class="descriptor">
+            <span>S-adenosyl-L-methionine</span></span>                            <span class="descriptor">
+            <span>phosphate</span></span>                            <span class="descriptor">
+            <span>diphosphate</span></span>                    </div></div></article>            </div>    </section>                    <section class="node-detail depth-2" id="node-mat3_form">
+        <div class="node-heading">
+            <span class="node-title">MAT-III (low-affinity hepatic form)</span><span class="pill type">Reaction</span><span class="pill">mat3_form</span>
+        </div>
+
+                    <h4>Annotons</h4>
+            <div class="annoton-grid">                    <article class="annoton-card" id="annoton-mat3_activity">
+        <div class="annoton-title">MAT-III methionine adenosyltransferase activity</div>
+        <div class="small muted">mat3_activity</div>            <div class="small"><strong>Participant:</strong> Gene Product: MAT-III (MAT1A-encoded low-affinity hepatic isozyme)</div>
+            <div class="participant-detail">                    <div class="slot-row">
+                        <span class="slot-name">Gene Product:</span>
+                        <div class="descriptor">
+            <span><strong>MAT-III (MAT1A-encoded low-affinity hepatic isozyme)</strong></span>                <span class="descriptor-description">Low-affinity hepatic methionine adenosyltransferase form, allosterically activated by its own product SAM and by methionine (feed-forward), the opposite of MAT-I.</span></div>
+                    </div></div>            <h4>Function</h4>
+            <div class="descriptor">
+            <span><strong>methionine adenosyltransferase activity</strong></span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0004478" target="_blank" rel="noopener">GO:0004478</a>                    <div class="slot-row">
+                        <span class="slot-name">Substrates:</span>                            <span class="descriptor">
+            <span>L-methionine</span></span>                            <span class="descriptor">
+            <span>ATP</span></span>                    </div>                    <div class="slot-row">
+                        <span class="slot-name">Products:</span>                            <span class="descriptor">
+            <span>S-adenosyl-L-methionine</span></span>                            <span class="descriptor">
+            <span>phosphate</span></span>                            <span class="descriptor">
+            <span>diphosphate</span></span>                    </div></div></article>            </div>    </section>            </div>    </section>                <div class="part-marker">
+                    Part 2: bulk transmethylation (SAM-dependent methyltransferases)</div>
+                <section class="node-detail depth-1" id="node-meth_step">
+        <div class="node-heading">
+            <span class="node-title">SAM-dependent transmethylation (general)</span><span class="pill type">Reaction</span><span class="pill">meth_step</span>
+        </div>            <p class="node-description">Lumped node for the many SAM-dependent methyltransferases (EC 2.1.1.-) that transfer SAM&#39;s methyl group to acceptors (DNA, protein, small molecules), yielding S-adenosyl-L-homocysteine (SAH). Competitively product-inhibited by SAH in the kinetic model.</p>
+
+                    <h4>Annotons</h4>
+            <div class="annoton-grid">                    <article class="annoton-card" id="annoton-meth_activity">
+        <div class="annoton-title">SAM-dependent methyltransferase activity (general)</div>
+        <div class="small muted">meth_activity</div>            <div class="small"><strong>Participant:</strong> Any With Function: methyltransferase activity</div>
+            <div class="participant-detail">                    <div class="slot-row">
+                        <span class="slot-name">Required Function:</span>
+                        <div class="descriptor">
+            <span><strong>methyltransferase activity</strong></span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0008168" target="_blank" rel="noopener">GO:0008168</a></div>
+                    </div></div>            <h4>Function</h4>
+            <div class="descriptor">
+            <span><strong>methyltransferase activity</strong></span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0008168" target="_blank" rel="noopener">GO:0008168</a>                    <div class="slot-row">
+                        <span class="slot-name">Substrates:</span>                            <span class="descriptor">
+            <span>S-adenosyl-L-methionine</span></span>                            <span class="descriptor">
+            <span>methyl acceptor</span></span>                    </div>                    <div class="slot-row">
+                        <span class="slot-name">Products:</span>                            <span class="descriptor">
+            <span>S-adenosyl-L-homocysteine</span></span>                            <span class="descriptor">
+            <span>methylated acceptor</span></span>                    </div></div></article>            </div>    </section>                <div class="part-marker">
+                    Part 3: SAM disposal / glycine sink</div>
+                <section class="node-detail depth-1" id="node-gnmt_step">
+        <div class="node-heading">
+            <span class="node-title">Glycine N-methyltransferase (SAM:SAH buffering)</span><span class="pill type">Reaction</span><span class="pill">gnmt_step</span>
+        </div>            <p class="node-description">Glycine N-methyltransferase (EC 2.1.1.20) methylates glycine to sarcosine, acting as the overflow valve that buffers the SAM:SAH ratio. Allosterically inhibited by 5,10-methylenetetrahydrofolate and competitively inhibited by SAH; activated by SAM.</p>
+
+                    <h4>Annotons</h4>
+            <div class="annoton-grid">                    <article class="annoton-card" id="annoton-gnmt_activity">
+        <div class="annoton-title">Glycine N-methyltransferase activity</div>
+        <div class="small muted">gnmt_activity</div>            <div class="small"><strong>Participant:</strong> Any With Function: glycine N-methyltransferase activity</div>
+            <div class="participant-detail">                    <div class="slot-row">
+                        <span class="slot-name">Required Function:</span>
+                        <div class="descriptor">
+            <span><strong>glycine N-methyltransferase activity</strong></span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0017174" target="_blank" rel="noopener">GO:0017174</a></div>
+                    </div></div>            <h4>Function</h4>
+            <div class="descriptor">
+            <span><strong>glycine N-methyltransferase activity</strong></span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0017174" target="_blank" rel="noopener">GO:0017174</a>                    <div class="slot-row">
+                        <span class="slot-name">Substrates:</span>                            <span class="descriptor">
+            <span>S-adenosyl-L-methionine</span></span>                            <span class="descriptor">
+            <span>glycine</span></span>                    </div>                    <div class="slot-row">
+                        <span class="slot-name">Products:</span>                            <span class="descriptor">
+            <span>S-adenosyl-L-homocysteine</span></span>                            <span class="descriptor">
+            <span>sarcosine</span></span>                    </div></div></article>            </div>    </section>                <div class="part-marker">
+                    Part 4: SAH hydrolysis</div>
+                <section class="node-detail depth-1" id="node-ahc_step">
+        <div class="node-heading">
+            <span class="node-title">S-adenosyl-L-homocysteine -&gt; L-homocysteine</span><span class="pill type">Reaction</span><span class="pill">ahc_step</span>
+        </div>            <p class="node-description">Adenosylhomocysteinase (EC 3.3.1.1) hydrolyses SAH to L-homocysteine and adenosine, relieving SAH product inhibition of methyltransferases.</p>
+
+                    <h4>Annotons</h4>
+            <div class="annoton-grid">                    <article class="annoton-card" id="annoton-ahc_activity">
+        <div class="annoton-title">Adenosylhomocysteinase activity</div>
+        <div class="small muted">ahc_activity</div>            <div class="small"><strong>Participant:</strong> Any With Function: adenosylhomocysteinase activity</div>
+            <div class="participant-detail">                    <div class="slot-row">
+                        <span class="slot-name">Required Function:</span>
+                        <div class="descriptor">
+            <span><strong>adenosylhomocysteinase activity</strong></span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0004013" target="_blank" rel="noopener">GO:0004013</a></div>
+                    </div></div>            <h4>Function</h4>
+            <div class="descriptor">
+            <span><strong>adenosylhomocysteinase activity</strong></span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0004013" target="_blank" rel="noopener">GO:0004013</a>                    <div class="slot-row">
+                        <span class="slot-name">Substrates:</span>                            <span class="descriptor">
+            <span>S-adenosyl-L-homocysteine</span></span>                    </div>                    <div class="slot-row">
+                        <span class="slot-name">Products:</span>                            <span class="descriptor">
+            <span>L-homocysteine</span></span>                            <span class="descriptor">
+            <span>adenosine</span></span>                    </div></div></article>            </div>    </section>                <div class="part-marker">
+                    Part 5: homocysteine fate (remethylation vs transsulfuration)</div>
+                <section class="node-detail depth-1" id="node-homocysteine_fate">
+        <div class="node-heading">
+            <span class="node-title">Homocysteine fate branch</span><span class="pill type">Reaction</span><span class="pill">homocysteine_fate</span>
+        </div>            <p class="node-description">Homocysteine is either remethylated back to methionine (folate-dependent via methionine synthase, or betaine-dependent via BHMT) or committed to transsulfuration via cystathionine beta-synthase.</p>
+
+                    <div class="variant-set">
+                <div class="variant-marker">
+                    Variant set: Homocysteine disposal routes by metabolic fate (One Or More)</div>
+                                    <section class="node-detail depth-2" id="node-ms_route">
+        <div class="node-heading">
+            <span class="node-title">Folate-dependent remethylation (methionine synthase)</span><span class="pill type">Reaction</span><span class="pill">ms_route</span>
+        </div>
+
+                    <h4>Annotons</h4>
+            <div class="annoton-grid">                    <article class="annoton-card" id="annoton-ms_activity">
+        <div class="annoton-title">Methionine synthase activity</div>
+        <div class="small muted">ms_activity</div>            <div class="small"><strong>Participant:</strong> Any With Function: methionine synthase activity</div>
+            <div class="participant-detail">                    <div class="slot-row">
+                        <span class="slot-name">Required Function:</span>
+                        <div class="descriptor">
+            <span><strong>methionine synthase activity</strong></span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0008705" target="_blank" rel="noopener">GO:0008705</a></div>
+                    </div></div>            <h4>Function</h4>
+            <div class="descriptor">
+            <span><strong>methionine synthase activity</strong></span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0008705" target="_blank" rel="noopener">GO:0008705</a>                    <div class="slot-row">
+                        <span class="slot-name">Substrates:</span>                            <span class="descriptor">
+            <span>L-homocysteine</span></span>                            <span class="descriptor">
+            <span>5-methyltetrahydrofolate</span></span>                    </div>                    <div class="slot-row">
+                        <span class="slot-name">Products:</span>                            <span class="descriptor">
+            <span>L-methionine</span></span>                            <span class="descriptor">
+            <span>tetrahydrofolate</span></span>                    </div></div></article>            </div>    </section>                    <section class="node-detail depth-2" id="node-bhmt_route">
+        <div class="node-heading">
+            <span class="node-title">Betaine-dependent remethylation (BHMT)</span><span class="pill type">Reaction</span><span class="pill">bhmt_route</span>
+        </div>
+
+                    <h4>Annotons</h4>
+            <div class="annoton-grid">                    <article class="annoton-card" id="annoton-bhmt_activity">
+        <div class="annoton-title">Betaine-homocysteine S-methyltransferase activity</div>
+        <div class="small muted">bhmt_activity</div>            <div class="small"><strong>Participant:</strong> Any With Function: betaine-homocysteine S-methyltransferase activity</div>
+            <div class="participant-detail">                    <div class="slot-row">
+                        <span class="slot-name">Required Function:</span>
+                        <div class="descriptor">
+            <span><strong>betaine-homocysteine S-methyltransferase activity</strong></span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0047150" target="_blank" rel="noopener">GO:0047150</a></div>
+                    </div></div>            <h4>Function</h4>
+            <div class="descriptor">
+            <span><strong>betaine-homocysteine S-methyltransferase activity</strong></span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0047150" target="_blank" rel="noopener">GO:0047150</a>                    <div class="slot-row">
+                        <span class="slot-name">Substrates:</span>                            <span class="descriptor">
+            <span>L-homocysteine</span></span>                            <span class="descriptor">
+            <span>glycine betaine</span></span>                    </div>                    <div class="slot-row">
+                        <span class="slot-name">Products:</span>                            <span class="descriptor">
+            <span>L-methionine</span></span>                            <span class="descriptor">
+            <span>N,N-dimethylglycine</span></span>                    </div></div></article>            </div>    </section>                    <section class="node-detail depth-2" id="node-cbs_route">
+        <div class="node-heading">
+            <span class="node-title">Transsulfuration commitment (cystathionine beta-synthase)</span><span class="pill type">Reaction</span><span class="pill">cbs_route</span>
+        </div>            <p class="node-description">Exit from the cycle toward cysteine biosynthesis; allosterically activated by SAM.</p>
+
+                    <h4>Annotons</h4>
+            <div class="annoton-grid">                    <article class="annoton-card" id="annoton-cbs_activity">
+        <div class="annoton-title">Cystathionine beta-synthase activity</div>
+        <div class="small muted">cbs_activity</div>            <div class="small"><strong>Participant:</strong> Any With Function: cystathionine beta-synthase activity</div>
+            <div class="participant-detail">                    <div class="slot-row">
+                        <span class="slot-name">Required Function:</span>
+                        <div class="descriptor">
+            <span><strong>cystathionine beta-synthase activity</strong></span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0004122" target="_blank" rel="noopener">GO:0004122</a></div>
+                    </div></div>            <h4>Function</h4>
+            <div class="descriptor">
+            <span><strong>cystathionine beta-synthase activity</strong></span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0004122" target="_blank" rel="noopener">GO:0004122</a>                    <div class="slot-row">
+                        <span class="slot-name">Substrates:</span>                            <span class="descriptor">
+            <span>L-homocysteine</span></span>                            <span class="descriptor">
+            <span>L-serine</span></span>                    </div>                    <div class="slot-row">
+                        <span class="slot-name">Products:</span>                            <span class="descriptor">
+            <span>L-cystathionine</span></span>                    </div></div></article>            </div>    </section>            </div>    </section>                <div class="part-marker">
+                    Part 6: folate methyl input arm</div>
+                <section class="node-detail depth-1" id="node-mthfr_step">
+        <div class="node-heading">
+            <span class="node-title">Methylenetetrahydrofolate reductase (5-methyl-THF supply)</span><span class="pill type">Reaction</span><span class="pill">mthfr_step</span>
+        </div>            <p class="node-description">Methylenetetrahydrofolate reductase (EC 1.5.1.20) reduces 5,10-methylenetetrahydrofolate to 5-methyltetrahydrofolate, the methyl donor consumed by methionine synthase. Allosterically inhibited by SAM and activated by SAH, coupling folate flux to methyl-group demand.</p>
+
+                    <h4>Annotons</h4>
+            <div class="annoton-grid">                    <article class="annoton-card" id="annoton-mthfr_activity">
+        <div class="annoton-title">Methylenetetrahydrofolate reductase activity</div>
+        <div class="small muted">mthfr_activity</div>            <div class="small"><strong>Participant:</strong> Any With Function: methylenetetrahydrofolate reductase [NAD(P)H] activity</div>
+            <div class="participant-detail">                    <div class="slot-row">
+                        <span class="slot-name">Required Function:</span>
+                        <div class="descriptor">
+            <span><strong>methylenetetrahydrofolate reductase [NAD(P)H] activity</strong></span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0004489" target="_blank" rel="noopener">GO:0004489</a></div>
+                    </div></div>            <h4>Function</h4>
+            <div class="descriptor">
+            <span><strong>methylenetetrahydrofolate reductase [NAD(P)H] activity</strong></span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0004489" target="_blank" rel="noopener">GO:0004489</a>                    <div class="slot-row">
+                        <span class="slot-name">Substrates:</span>                            <span class="descriptor">
+            <span>5,10-methylenetetrahydrofolate</span></span>                            <span class="descriptor">
+            <span>NAD(P)H</span></span>                    </div>                    <div class="slot-row">
+                        <span class="slot-name">Products:</span>                            <span class="descriptor">
+            <span>5-methyltetrahydrofolate</span></span>                            <span class="descriptor">
+            <span>NAD(P)+</span></span>                    </div></div></article>            </div>    </section>                <div class="part-marker">
+                    Part 7: regulatory effector pools (metabolite endpoints for regulation edges) (optional)</div>
+                <p class="muted small">These nodes are NOT catalytic steps. They represent the small-molecule effector pools that serve as the source endpoints of the regulatory connections below. They are grounded to ChEBI rather than GO, because the regulators are metabolites and cannot bear GO annotations.</p><section class="node-detail depth-1" id="node-regulatory_effectors">
+        <div class="node-heading">
+            <span class="node-title">Regulatory effector pools</span><span class="pill type">Module</span><span class="pill">regulatory_effectors</span>
+        </div>
+
+                        <div class="part-marker">
+                    Part: methyl-donor effector</div>
+                <section class="node-detail depth-2" id="node-amet_pool">
+        <div class="node-heading">
+            <span class="node-title">S-adenosyl-L-methionine (SAM) pool</span><span class="pill">amet_pool</span>
+        </div><div class="descriptor-list">                <span class="descriptor">
+            <span>S-adenosyl-L-methionine</span><a class="term-id" href="https://www.ebi.ac.uk/chebi/searchId.do?chebiId=CHEBI:15414" target="_blank" rel="noopener">CHEBI:15414</a></span>        </div>
+
+            </section>                <div class="part-marker">
+                    Part: demethylated-donor effector</div>
+                <section class="node-detail depth-2" id="node-ahcys_pool">
+        <div class="node-heading">
+            <span class="node-title">S-adenosyl-L-homocysteine (SAH) pool</span><span class="pill">ahcys_pool</span>
+        </div><div class="descriptor-list">                <span class="descriptor">
+            <span>S-adenosyl-L-homocysteine</span><a class="term-id" href="https://www.ebi.ac.uk/chebi/searchId.do?chebiId=CHEBI:16680" target="_blank" rel="noopener">CHEBI:16680</a></span>        </div>
+
+            </section>                <div class="part-marker">
+                    Part: folate effector</div>
+                <section class="node-detail depth-2" id="node-mlthf_pool">
+        <div class="node-heading">
+            <span class="node-title">5,10-methylenetetrahydrofolate pool</span><span class="pill">mlthf_pool</span>
+        </div><div class="descriptor-list">                <span class="descriptor">
+            <span>5,10-methylenetetrahydrofolate</span><a class="term-id" href="https://www.ebi.ac.uk/chebi/searchId.do?chebiId=CHEBI:1989" target="_blank" rel="noopener">CHEBI:1989</a></span>        </div>
+
+            </section>                <div class="part-marker">
+                    Part: amino-acid effector</div>
+                <section class="node-detail depth-2" id="node-met_pool">
+        <div class="node-heading">
+            <span class="node-title">L-methionine pool</span><span class="pill">met_pool</span>
+        </div><div class="descriptor-list">                <span class="descriptor">
+            <span>L-methionine</span><a class="term-id" href="https://www.ebi.ac.uk/chebi/searchId.do?chebiId=CHEBI:16643" target="_blank" rel="noopener">CHEBI:16643</a></span>        </div>
+
+            </section>    </section>    </section>
+            </div>
+        </section>
+    </section>
+</main>
+
+<script>
+    const searchInput = document.querySelector("[data-tree-search]");
+    if (searchInput) {
+        searchInput.addEventListener("input", () => {
+            const query = searchInput.value.trim().toLowerCase();
+            document.querySelectorAll(".tree-row").forEach((row) => {
+                const matches = !query || row.textContent.toLowerCase().includes(query);
+                row.classList.toggle("is-dimmed", !matches);
+                if (query && matches) {
+                    let detail = row.closest("details");
+                    while (detail) {
+                        detail.open = true;
+                        detail = detail.parentElement ? detail.parentElement.closest("details") : null;
+                    }
+                }
+            });
+        });
+    }
+
+    document.querySelectorAll("[data-tree-action]").forEach((button) => {
+        button.addEventListener("click", () => {
+            const shouldOpen = button.dataset.treeAction === "expand";
+            document.querySelectorAll(".tree-panel details").forEach((detail) => {
+                detail.open = shouldOpen;
+            });
+        });
+    });
+</script>
+</body>
+</html>

--- a/pages/modules/photosynthesis.html
+++ b/pages/modules/photosynthesis.html
@@ -1,0 +1,1562 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Oxygenic photosynthesis module - AI Gene Review</title>
+    <style>
+        :root {
+            --bg-page: #f7f8fb;
+            --bg-panel: #ffffff;
+            --bg-soft: #f2f6f8;
+            --border: #d9e1e7;
+            --text: #17212b;
+            --muted: #637282;
+            --accent: #0f766e;
+            --accent-soft: #dff4f0;
+            --blue: #2563eb;
+            --amber: #b45309;
+            --green: #15803d;
+            --red: #b91c1c;
+        }
+
+        * {
+            box-sizing: border-box;
+        }
+
+        body {
+            margin: 0;
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+            color: var(--text);
+            background: var(--bg-page);
+            line-height: 1.55;
+        }
+
+        a {
+            color: var(--blue);
+            text-decoration: none;
+        }
+
+        a:hover {
+            text-decoration: underline;
+        }
+
+        .page {
+            max-width: 1440px;
+            margin: 0 auto;
+            padding: 24px;
+        }
+
+        .breadcrumb {
+            margin-bottom: 14px;
+            color: var(--muted);
+            font-size: 0.9rem;
+        }
+
+        .header {
+            background: var(--bg-panel);
+            border: 1px solid var(--border);
+            border-radius: 8px;
+            padding: 22px 24px;
+            margin-bottom: 18px;
+        }
+
+        h1 {
+            margin: 0 0 8px;
+            font-size: 2rem;
+            line-height: 1.2;
+        }
+
+        h2 {
+            margin: 0 0 14px;
+            font-size: 1.3rem;
+        }
+
+        h3 {
+            margin: 0 0 10px;
+            font-size: 1.1rem;
+        }
+
+        h4 {
+            margin: 16px 0 8px;
+            font-size: 0.95rem;
+            color: #344454;
+        }
+
+        .description {
+            max-width: 980px;
+            color: #2f3d4a;
+        }
+
+        .meta-row {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 8px;
+            margin-top: 14px;
+        }
+
+        .pill {
+            display: inline-flex;
+            align-items: center;
+            gap: 6px;
+            padding: 4px 9px;
+            border: 1px solid var(--border);
+            border-radius: 999px;
+            background: var(--bg-soft);
+            color: #304150;
+            font-size: 0.82rem;
+            font-weight: 600;
+            white-space: nowrap;
+        }
+
+        .pill.status {
+            background: #fff7ed;
+            border-color: #fed7aa;
+            color: var(--amber);
+        }
+
+        .pill.type {
+            background: var(--accent-soft);
+            border-color: #b8dfd8;
+            color: var(--accent);
+        }
+
+        .stats {
+            display: grid;
+            grid-template-columns: repeat(6, minmax(90px, 1fr));
+            gap: 10px;
+            margin-bottom: 18px;
+        }
+
+        .stat {
+            background: var(--bg-panel);
+            border: 1px solid var(--border);
+            border-radius: 8px;
+            padding: 10px 12px;
+        }
+
+        .stat-value {
+            display: block;
+            font-size: 1.35rem;
+            font-weight: 700;
+        }
+
+        .stat-label {
+            color: var(--muted);
+            font-size: 0.78rem;
+            text-transform: uppercase;
+        }
+
+        .browser {
+            display: grid;
+            grid-template-columns: minmax(310px, 420px) minmax(0, 1fr);
+            gap: 18px;
+            align-items: start;
+        }
+
+        .panel {
+            background: var(--bg-panel);
+            border: 1px solid var(--border);
+            border-radius: 8px;
+            min-width: 0;
+        }
+
+        .tree-panel {
+            position: sticky;
+            top: 16px;
+            max-height: calc(100vh - 32px);
+            overflow: auto;
+        }
+
+        .panel-header {
+            padding: 14px 16px;
+            border-bottom: 1px solid var(--border);
+            background: #fbfcfd;
+        }
+
+        .panel-body {
+            padding: 16px;
+        }
+
+        .tree-tools {
+            display: grid;
+            grid-template-columns: 1fr auto auto;
+            gap: 8px;
+            margin-top: 10px;
+        }
+
+        .tree-search {
+            width: 100%;
+            min-width: 0;
+            border: 1px solid var(--border);
+            border-radius: 6px;
+            padding: 7px 9px;
+            font: inherit;
+        }
+
+        .tool-button {
+            border: 1px solid var(--border);
+            border-radius: 6px;
+            padding: 7px 9px;
+            background: #ffffff;
+            color: #273747;
+            font: inherit;
+            font-size: 0.85rem;
+            cursor: pointer;
+        }
+
+        .tool-button:hover {
+            border-color: #9eb0bd;
+            background: #f8fafc;
+        }
+
+        .tree-list,
+        .tree-list ol,
+        .tree-list ul {
+            list-style: none;
+            padding-left: 0;
+            margin: 0;
+        }
+
+        .tree-list ol,
+        .tree-list ul {
+            margin-left: 16px;
+            padding-left: 12px;
+            border-left: 1px solid var(--border);
+        }
+
+        .tree-node {
+            margin: 5px 0;
+        }
+
+        .tree-node > summary {
+            cursor: pointer;
+            border-radius: 6px;
+            padding: 6px 8px;
+        }
+
+        .tree-node > summary:hover {
+            background: var(--bg-soft);
+        }
+
+        .tree-row {
+            display: inline-flex;
+            flex-wrap: wrap;
+            align-items: center;
+            gap: 6px;
+            max-width: calc(100% - 16px);
+            vertical-align: top;
+        }
+
+        .tree-row.is-dimmed {
+            opacity: 0.35;
+        }
+
+        .tree-link {
+            font-weight: 650;
+            color: var(--text);
+        }
+
+        .tree-id {
+            color: var(--muted);
+            font-size: 0.78rem;
+        }
+
+        .tree-group-title {
+            margin: 8px 0 4px 20px;
+            color: var(--muted);
+            font-size: 0.78rem;
+            font-weight: 700;
+            text-transform: uppercase;
+        }
+
+        .edge-note {
+            color: var(--muted);
+            font-size: 0.82rem;
+        }
+
+        .annoton-item {
+            margin: 5px 0;
+            font-size: 0.9rem;
+        }
+
+        .detail-panel {
+            overflow: hidden;
+        }
+
+        .node-detail {
+            border: 1px solid var(--border);
+            border-radius: 8px;
+            padding: 16px;
+            margin-bottom: 14px;
+            background: #ffffff;
+        }
+
+        .node-detail.depth-1,
+        .node-detail.depth-2,
+        .node-detail.depth-3 {
+            background: #fbfcfd;
+        }
+
+        .node-heading {
+            display: flex;
+            flex-wrap: wrap;
+            align-items: center;
+            gap: 8px;
+            margin-bottom: 8px;
+        }
+
+        .node-title {
+            font-size: 1.1rem;
+            font-weight: 700;
+        }
+
+        .node-description,
+        .role-description {
+            color: #31404e;
+            margin: 8px 0;
+        }
+
+        .descriptor-list {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 6px;
+            margin: 8px 0;
+        }
+
+        .descriptor {
+            display: inline-flex;
+            flex-wrap: wrap;
+            align-items: center;
+            gap: 5px;
+            padding: 4px 7px;
+            border-radius: 6px;
+            background: #eef7ff;
+            border: 1px solid #cce4ff;
+            font-size: 0.87rem;
+        }
+
+        .descriptor-description {
+            color: var(--muted);
+        }
+
+        .term-id,
+        .source-id {
+            font-family: "SFMono-Regular", Consolas, "Liberation Mono", Menlo, monospace;
+            font-size: 0.78rem;
+        }
+
+        .slot-row {
+            margin-top: 4px;
+            font-size: 0.86rem;
+        }
+
+        .slot-name {
+            color: var(--muted);
+            font-weight: 700;
+        }
+
+        .participant-detail {
+            margin-top: 6px;
+        }
+
+        .annoton-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+            gap: 10px;
+            margin-top: 10px;
+        }
+
+        .annoton-card,
+        .connection-card,
+        .context-card,
+        .evidence-card,
+        .complex-unit {
+            border: 1px solid var(--border);
+            border-radius: 8px;
+            background: #ffffff;
+            padding: 11px;
+        }
+
+        .active-unit-list {
+            display: grid;
+            gap: 8px;
+            margin-top: 6px;
+        }
+
+        .annoton-title {
+            font-weight: 700;
+            margin-bottom: 4px;
+        }
+
+        .muted {
+            color: var(--muted);
+        }
+
+        .small {
+            font-size: 0.85rem;
+        }
+
+        .connection-list,
+        .evidence-list {
+            display: grid;
+            gap: 8px;
+            margin-top: 8px;
+        }
+
+        .connection-arrow {
+            color: var(--green);
+            font-weight: 700;
+        }
+
+        .variant-set {
+            margin-top: 14px;
+            border-left: 3px solid #94a3b8;
+            padding-left: 12px;
+        }
+
+        .part-marker,
+        .variant-marker {
+            color: var(--muted);
+            font-size: 0.85rem;
+            font-weight: 700;
+            margin: 12px 0 8px;
+        }
+
+        .warnings {
+            border: 1px solid #fecaca;
+            background: #fef2f2;
+            color: var(--red);
+            border-radius: 8px;
+            padding: 12px 16px;
+            margin-bottom: 18px;
+        }
+
+        @media (max-width: 960px) {
+            .page {
+                padding: 14px;
+            }
+
+            .stats {
+                grid-template-columns: repeat(2, minmax(120px, 1fr));
+            }
+
+            .browser {
+                grid-template-columns: 1fr;
+            }
+
+            .tree-panel {
+                position: static;
+                max-height: none;
+            }
+        }
+    </style>
+</head>
+<body>
+
+
+
+
+
+
+
+
+
+
+
+
+<main class="page">
+    <nav class="breadcrumb">
+        <a href="index.html">Module KB</a> / Oxygenic photosynthesis module
+    </nav>
+
+    <header class="header">
+        <h1>Oxygenic photosynthesis module</h1>            <p class="description">A taxon-neutral decomposition of oxygenic photosynthesis as a recursively decomposable module. The module separates the thylakoid light reactions (light harvesting, water oxidation at photosystem II, the cytochrome b6f complex, photosystem I, mobile electron carriers, ferredoxin-NADP+ reductase, and the ATP synthase) from carbon fixation by the Calvin-Benson-Bassham reductive pentose-phosphate cycle, and adds optional photoprotection/electron balancing, the inorganic carbon-concentrating mechanism, and chlorophyll supply. It is phrased as functions, complexes, and pathway segments rather than a fixed gene list so it can represent cyanobacterial, algal, and plant implementations. Anoxygenic photosynthesis (single reaction center, non-water electron donors) is explicitly out of scope.</p>        <div class="meta-row"><span class="pill">MODULE:oxygenic_photosynthesis</span><span class="pill status">DRAFT</span><span class="pill type">Biological Process</span><span class="pill">modules/photosynthesis.yaml</span>
+        </div>
+        <div class="descriptor-list">                <span class="descriptor">
+            <span>oxygenic photosynthesis</span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0015979" target="_blank" rel="noopener">GO:0015979</a></span>        </div>
+        <div class="evidence-list">                <div class="evidence-card small"><span class="source-id">file:modules/photosynthesis-deep-research-falcon.md</span><div><strong>Photosynthesis module deep research (falcon)</strong></div><div>Module-targeted falcon deep research (generated from this module&#39;s outline) used to cross-check component coverage, variants, and failure modes. Machine-generated citations are not yet manually adjudicated.</div></div>                <div class="evidence-card small"><span class="source-id">file:terms/photosynthesis/photosynthesis-deep-research-falcon.md</span><div><strong>Photosynthesis concept deep research (falcon)</strong></div><div>Falcon deep-research synthesis used to set module boundaries and the module-by-module component breakdown across Arabidopsis, Synechocystis, and Chlamydomonas (core vs accessory vs regulatory factors).</div></div>                <div class="evidence-card small"><span class="source-id">file:terms/photosynthesis/photosynthesis-notes.md</span><div><strong>Photosynthesis concept notes</strong></div><div>Manually authored, GO- and PubMed-verified concept notes underpinning this module.</div></div>                <div class="evidence-card small"><a class="source-id" href="https://amigo.geneontology.org/amigo/term/GO:0015979" target="_blank" rel="noopener">GO:0015979</a><div><strong>photosynthesis</strong></div><div>The module is grounded in the GO biological-process term for photosynthesis.</div></div>                <div class="evidence-card small"><a class="source-id" href="https://pubmed.ncbi.nlm.nih.gov/21499260/" target="_blank" rel="noopener">PMID:21499260</a><div><strong>Crystal structure of oxygen-evolving photosystem II at a resolution of 1.9 A</strong></div><div>Defines the PSII D1/D2 reaction center, CP43/CP47 inner antennae, and the Mn4CaO5 water-oxidation cluster stabilized by the extrinsic OEC proteins.</div></div>                <div class="evidence-card small"><a class="source-id" href="https://pubmed.ncbi.nlm.nih.gov/11418848/" target="_blank" rel="noopener">PMID:11418848</a><div><strong>Three-dimensional structure of cyanobacterial photosystem I at 2.5 A resolution</strong></div><div>Defines the PsaA/PsaB reaction-center heterodimer and the terminal Fe-S clusters carried by PsaC.</div></div>                <div class="evidence-card small"><a class="source-id" href="https://pubmed.ncbi.nlm.nih.gov/18294858/" target="_blank" rel="noopener">PMID:18294858</a><div><strong>Structure and function of Rubisco</strong></div><div>Supports Rubisco as the major carboxylating enzyme of the CBB cycle and its competing oxygenase side-reaction.</div></div>                <div class="evidence-card small"><a class="source-id" href="https://pubmed.ncbi.nlm.nih.gov/33761918/" target="_blank" rel="noopener">PMID:33761918</a><div><strong>A new type of flexible CP12 protein in the marine diatom Thalassiosira pseudonana</strong></div><div>Supports CP12 as a redox-controlled scaffold that forms a PRK-GAPDH-CP12 ternary complex regulating the CBB cycle.</div></div>                <div class="evidence-card small"><a class="source-id" href="https://pubmed.ncbi.nlm.nih.gov/37549282/" target="_blank" rel="noopener">PMID:37549282</a><div><strong>NTRC regulates CP12 to activate Calvin-Benson cycle during cold acclimation</strong></div><div>Supports redox (NTRC/thioredoxin)-dependent assembly/disassembly of the PRK-CP12-GAPDH supracomplex gating CBB-cycle activity.</div></div>        </div><p class="muted small">Identifiers are grounded only where verified against the local GO term cache, GOlr, or UniProt; descriptors without a `term` are deliberate (no confident identifier yet) rather than oversights. Representative UniProt members are concrete orienting examples, not exhaustive or species-restricting claims.</p></header>
+    <section class="stats" aria-label="Module counts">
+        <div class="stat"><span class="stat-value">25</span><span class="stat-label">Nodes</span></div>
+        <div class="stat"><span class="stat-value">17</span><span class="stat-label">Parts</span></div>
+        <div class="stat"><span class="stat-value">3</span><span class="stat-label">Variant Sets</span></div>
+        <div class="stat"><span class="stat-value">7</span><span class="stat-label">Variants</span></div>
+        <div class="stat"><span class="stat-value">22</span><span class="stat-label">Annotons</span></div>
+        <div class="stat"><span class="stat-value">9</span><span class="stat-label">Connections</span></div>
+    </section>
+
+    <section class="browser">
+        <aside class="panel tree-panel">
+            <div class="panel-header">
+                <h2>Tree</h2>
+                <div class="tree-tools">
+                    <input class="tree-search" type="search" placeholder="Filter tree" data-tree-search>
+                    <button class="tool-button" type="button" data-tree-action="expand">Expand</button>
+                    <button class="tool-button" type="button" data-tree-action="collapse">Collapse</button>
+                </div>
+            </div>
+            <div class="panel-body">
+                <ol class="tree-list">
+                    <li class="tree-entry">
+        <details class="tree-node" open>
+            <summary>
+                <span class="tree-row">
+                    <a class="tree-link" href="#node-oxygenic_photosynthesis">Oxygenic photosynthesis</a><span class="pill type">Biological Process</span><span class="tree-id">oxygenic_photosynthesis</span>
+                </span>
+            </summary>                <div class="tree-group-title">Parts</div>
+                <ol>                            <li>
+                                <div class="edge-note">1. light reactions (electron transport and photophosphorylation)</div>
+                                <li class="tree-entry">
+        <details class="tree-node" open>
+            <summary>
+                <span class="tree-row">
+                    <a class="tree-link" href="#node-light_reactions">Thylakoid light reactions</a><span class="pill type">Biological Process</span><span class="tree-id">light_reactions</span>
+                </span>
+            </summary>                <div class="tree-group-title">Parts</div>
+                <ol>                            <li>
+                                <div class="edge-note">1. light harvesting / antenna</div>
+                                <li class="tree-entry">
+        <details class="tree-node" >
+            <summary>
+                <span class="tree-row">
+                    <a class="tree-link" href="#node-light_harvesting">Light-harvesting antenna</a><span class="pill type">Molecular Function</span><span class="tree-id">light_harvesting</span>
+                </span>
+            </summary>                <div class="tree-group-title">Annotons</div>
+                <ul>                        <li class="annoton-item tree-entry">
+                            <span class="tree-row">
+                                <a href="#annoton-antenna_chlorophyll_binding">Antenna chlorophyll/carotenoid light capture</a>
+                                <span class="tree-id">Family: light-harvesting chlorophyll a/b binding (LHC) family</span>
+                            </span>
+                        </li>                </ul></details>
+    </li>
+                            </li>                            <li>
+                                <div class="edge-note">2. water oxidation (photosystem II)</div>
+                                <li class="tree-entry">
+        <details class="tree-node" >
+            <summary>
+                <span class="tree-row">
+                    <a class="tree-link" href="#node-photosystem_ii">Photosystem II (water:plastoquinone oxidoreductase)</a><span class="pill type">Protein Complex</span><span class="tree-id">photosystem_II</span>
+                </span>
+            </summary>                <div class="tree-group-title">Annotons</div>
+                <ul>                        <li class="annoton-item tree-entry">
+                            <span class="tree-row">
+                                <a href="#annoton-psii_water_oxidation">Light-driven water oxidation / oxygen evolution</a>
+                                <span class="tree-id">Protein Complex: photosystem II complex</span>
+                            </span>
+                        </li>                </ul></details>
+    </li>
+                            </li>                            <li>
+                                <div class="edge-note">3. plastoquinol oxidation and proton translocation (cytochrome b6f)</div>
+                                <li class="tree-entry">
+        <details class="tree-node" >
+            <summary>
+                <span class="tree-row">
+                    <a class="tree-link" href="#node-cytochrome_b6f">Cytochrome b6f complex</a><span class="pill type">Protein Complex</span><span class="tree-id">cytochrome_b6f</span>
+                </span>
+            </summary>                <div class="tree-group-title">Annotons</div>
+                <ul>                        <li class="annoton-item tree-entry">
+                            <span class="tree-row">
+                                <a href="#annoton-b6f_plastoquinol_plastocyanin_reductase">Plastoquinol--plastocyanin reductase (Q-cycle)</a>
+                                <span class="tree-id">Protein Complex: cytochrome b6f complex</span>
+                            </span>
+                        </li>                </ul></details>
+    </li>
+                            </li>                            <li>
+                                <div class="edge-note">4. inter-photosystem mobile electron carrier</div>
+                                <li class="tree-entry">
+        <details class="tree-node" >
+            <summary>
+                <span class="tree-row">
+                    <a class="tree-link" href="#node-mobile_carrier_b6f_to_psi">Mobile carrier from b6f to PSI</a><span class="pill type">Molecular Function</span><span class="tree-id">mobile_carrier_b6f_to_psi</span>
+                </span>
+            </summary>                <div class="tree-group-title">Variants</div>
+                <ol>                        <li>
+                            <div class="edge-note">
+                                Plastocyanin vs cytochrome c6 by lineage / metal availability (Exactly One)</div>
+                            <ol>                                    <li class="tree-entry">
+        <details class="tree-node" >
+            <summary>
+                <span class="tree-row">
+                    <a class="tree-link" href="#node-plastocyanin_variant">Plastocyanin (copper carrier)</a><span class="pill type">Molecular Function</span><span class="tree-id">plastocyanin_variant</span>
+                </span>
+            </summary>                <div class="tree-group-title">Annotons</div>
+                <ul>                        <li class="annoton-item tree-entry">
+                            <span class="tree-row">
+                                <a href="#annoton-plastocyanin_electron_transfer">Plastocyanin electron transfer</a>
+                                <span class="tree-id">Family: plastocyanin</span>
+                            </span>
+                        </li>                </ul></details>
+    </li>                                    <li class="tree-entry">
+        <details class="tree-node" >
+            <summary>
+                <span class="tree-row">
+                    <a class="tree-link" href="#node-cytochrome_c6_variant">Cytochrome c6 (iron carrier)</a><span class="pill type">Molecular Function</span><span class="tree-id">cytochrome_c6_variant</span>
+                </span>
+            </summary>                <div class="tree-group-title">Annotons</div>
+                <ul>                        <li class="annoton-item tree-entry">
+                            <span class="tree-row">
+                                <a href="#annoton-cytc6_electron_transfer">Cytochrome c6 electron transfer</a>
+                                <span class="tree-id">Family: cytochrome c6</span>
+                            </span>
+                        </li>                </ul></details>
+    </li>                            </ol>
+                        </li>                </ol></details>
+    </li>
+                            </li>                            <li>
+                                <div class="edge-note">5. P700 photo-oxidation and ferredoxin reduction (photosystem I)</div>
+                                <li class="tree-entry">
+        <details class="tree-node" >
+            <summary>
+                <span class="tree-row">
+                    <a class="tree-link" href="#node-photosystem_i">Photosystem I (plastocyanin:ferredoxin oxidoreductase)</a><span class="pill type">Protein Complex</span><span class="tree-id">photosystem_I</span>
+                </span>
+            </summary>                <div class="tree-group-title">Annotons</div>
+                <ul>                        <li class="annoton-item tree-entry">
+                            <span class="tree-row">
+                                <a href="#annoton-psi_ferredoxin_reduction">Light-driven ferredoxin reduction</a>
+                                <span class="tree-id">Protein Complex: photosystem I complex</span>
+                            </span>
+                        </li>                </ul></details>
+    </li>
+                            </li>                            <li>
+                                <div class="edge-note">6. NADPH production</div>
+                                <li class="tree-entry">
+        <details class="tree-node" >
+            <summary>
+                <span class="tree-row">
+                    <a class="tree-link" href="#node-fnr_step">Ferredoxin-NADP+ reductase</a><span class="pill type">Reaction</span><span class="tree-id">fnr_step</span>
+                </span>
+            </summary>                <div class="tree-group-title">Annotons</div>
+                <ul>                        <li class="annoton-item tree-entry">
+                            <span class="tree-row">
+                                <a href="#annoton-fnr_activity">Ferredoxin-NADP+ reductase</a>
+                                <span class="tree-id">Any With Function: ferredoxin-NADP+ reductase activity</span>
+                            </span>
+                        </li>                </ul></details>
+    </li>
+                            </li>                            <li>
+                                <div class="edge-note">7. ATP synthesis from the proton-motive force</div>
+                                <li class="tree-entry">
+        <details class="tree-node" >
+            <summary>
+                <span class="tree-row">
+                    <a class="tree-link" href="#node-atp_synthase">Thylakoid (chloroplast/cyanobacterial) ATP synthase</a><span class="pill type">Protein Complex</span><span class="tree-id">atp_synthase</span>
+                </span>
+            </summary>                <div class="tree-group-title">Annotons</div>
+                <ul>                        <li class="annoton-item tree-entry">
+                            <span class="tree-row">
+                                <a href="#annoton-photophosphorylation">Proton-motive-force-driven ATP synthesis</a>
+                                <span class="tree-id">Protein Complex: thylakoid ATP synthase (CF1FO)</span>
+                            </span>
+                        </li>                </ul></details>
+    </li>
+                            </li>                </ol></details>
+    </li>
+                            </li>                            <li>
+                                <div class="edge-note">2. carbon fixation (Calvin-Benson-Bassham cycle)</div>
+                                <li class="tree-entry">
+        <details class="tree-node" open>
+            <summary>
+                <span class="tree-row">
+                    <a class="tree-link" href="#node-carbon_fixation">Calvin-Benson-Bassham reductive pentose-phosphate cycle</a><span class="pill type">Metabolic Pathway</span><span class="tree-id">carbon_fixation</span>
+                </span>
+            </summary>                <div class="tree-group-title">Parts</div>
+                <ol>                            <li>
+                                <div class="edge-note">1. carboxylation</div>
+                                <li class="tree-entry">
+        <details class="tree-node" >
+            <summary>
+                <span class="tree-row">
+                    <a class="tree-link" href="#node-rubisco_carboxylation">Rubisco carboxylation of RuBP</a><span class="pill type">Reaction</span><span class="tree-id">rubisco_carboxylation</span>
+                </span>
+            </summary>                <div class="tree-group-title">Annotons</div>
+                <ul>                        <li class="annoton-item tree-entry">
+                            <span class="tree-row">
+                                <a href="#annoton-rubisco_activity">Ribulose-bisphosphate carboxylase</a>
+                                <span class="tree-id">Any With Function: ribulose-bisphosphate carboxylase activity</span>
+                            </span>
+                        </li>                </ul></details>
+    </li>
+                            </li>                            <li>
+                                <div class="edge-note">2. reduction phase</div>
+                                <li class="tree-entry">
+        <details class="tree-node" >
+            <summary>
+                <span class="tree-row">
+                    <a class="tree-link" href="#node-cbb_reduction_phase">Reduction of 3-phosphoglycerate to triose phosphate</a><span class="pill type">Metabolic Pathway</span><span class="tree-id">cbb_reduction_phase</span>
+                </span>
+            </summary>                <div class="tree-group-title">Annotons</div>
+                <ul>                        <li class="annoton-item tree-entry">
+                            <span class="tree-row">
+                                <a href="#annoton-cbb_gapdh">NADP-dependent glyceraldehyde-3-phosphate dehydrogenase</a>
+                                <span class="tree-id">Family: chloroplastic GAPDH (GapA/GapB)</span>
+                            </span>
+                        </li>                </ul></details>
+    </li>
+                            </li>                            <li>
+                                <div class="edge-note">3. regeneration phase</div>
+                                <li class="tree-entry">
+        <details class="tree-node" >
+            <summary>
+                <span class="tree-row">
+                    <a class="tree-link" href="#node-cbb_regeneration_phase">Regeneration of ribulose 1,5-bisphosphate</a><span class="pill type">Metabolic Pathway</span><span class="tree-id">cbb_regeneration_phase</span>
+                </span>
+            </summary>                <div class="tree-group-title">Annotons</div>
+                <ul>                        <li class="annoton-item tree-entry">
+                            <span class="tree-row">
+                                <a href="#annoton-cbb_prk">Phosphoribulokinase</a>
+                                <span class="tree-id">Any With Function: phosphoribulokinase activity</span>
+                            </span>
+                        </li>                        <li class="annoton-item tree-entry">
+                            <span class="tree-row">
+                                <a href="#annoton-cbb_sbpase_fbpase">Bisphosphatase regeneration steps (FBPase, SBPase)</a>
+                                <span class="tree-id">Family: chloroplast FBPase / SBPase</span>
+                            </span>
+                        </li>                </ul></details>
+    </li>
+                            </li>                            <li>
+                                <div class="edge-note">4. Rubisco activation and inhibitor repair optional</div>
+                                <li class="tree-entry">
+        <details class="tree-node" >
+            <summary>
+                <span class="tree-row">
+                    <a class="tree-link" href="#node-rubisco_activation">Rubisco activase and inhibitor removal</a><span class="pill type">Regulatory Step</span><span class="tree-id">rubisco_activation</span>
+                </span>
+            </summary>                <div class="tree-group-title">Annotons</div>
+                <ul>                        <li class="annoton-item tree-entry">
+                            <span class="tree-row">
+                                <a href="#annoton-rubisco_activase">Rubisco activase</a>
+                                <span class="tree-id">Family: Rubisco activase (Rca)</span>
+                            </span>
+                        </li>                </ul></details>
+    </li>
+                            </li>                            <li>
+                                <div class="edge-note">5. redox gating of the CBB cycle optional</div>
+                                <li class="tree-entry">
+        <details class="tree-node" >
+            <summary>
+                <span class="tree-row">
+                    <a class="tree-link" href="#node-cbb_redox_regulation">CP12-mediated redox regulation</a><span class="pill type">Regulatory Step</span><span class="tree-id">cbb_redox_regulation</span>
+                </span>
+            </summary>                <div class="tree-group-title">Annotons</div>
+                <ul>                        <li class="annoton-item tree-entry">
+                            <span class="tree-row">
+                                <a href="#annoton-cp12_scaffold">CP12 redox scaffold</a>
+                                <span class="tree-id">Family: CP12</span>
+                            </span>
+                        </li>                </ul></details>
+    </li>
+                            </li>                </ol></details>
+    </li>
+                            </li>                            <li>
+                                <div class="edge-note">3. photoprotection and ATP/NADPH balancing optional</div>
+                                <li class="tree-entry">
+        <details class="tree-node" open>
+            <summary>
+                <span class="tree-row">
+                    <a class="tree-link" href="#node-photoprotection_balancing">Photoprotection and electron/energy balancing</a><span class="pill type">Regulatory Step</span><span class="tree-id">photoprotection_balancing</span>
+                </span>
+            </summary>                <div class="tree-group-title">Variants</div>
+                <ol>                        <li>
+                            <div class="edge-note">
+                                Photoprotection and balancing mechanisms by regulatory mechanism (Zero Or More)</div>
+                            <ol>                                    <li class="tree-entry">
+        <details class="tree-node" >
+            <summary>
+                <span class="tree-row">
+                    <a class="tree-link" href="#node-npq_variant">Non-photochemical quenching (qE)</a><span class="pill type">Regulatory Step</span><span class="tree-id">npq_variant</span>
+                </span>
+            </summary>                <div class="tree-group-title">Annotons</div>
+                <ul>                        <li class="annoton-item tree-entry">
+                            <span class="tree-row">
+                                <a href="#annoton-npq_psbs_xanthophyll">PsbS- and xanthophyll-cycle-dependent quenching</a>
+                                <span class="tree-id">Family: PsbS and xanthophyll-cycle enzymes (VDE/ZEP)</span>
+                            </span>
+                        </li>                </ul></details>
+    </li>                                    <li class="tree-entry">
+        <details class="tree-node" >
+            <summary>
+                <span class="tree-row">
+                    <a class="tree-link" href="#node-state_transitions_variant">State transitions</a><span class="pill type">Regulatory Step</span><span class="tree-id">state_transitions_variant</span>
+                </span>
+            </summary>                <div class="tree-group-title">Annotons</div>
+                <ul>                        <li class="annoton-item tree-entry">
+                            <span class="tree-row">
+                                <a href="#annoton-state_transition_kinase">STN7/Stt7-dependent LHCII redistribution</a>
+                                <span class="tree-id">Family: state-transition kinase (STN7/Stt7) and TAP38/PPH1 phosphatase</span>
+                            </span>
+                        </li>                </ul></details>
+    </li>                                    <li class="tree-entry">
+        <details class="tree-node" >
+            <summary>
+                <span class="tree-row">
+                    <a class="tree-link" href="#node-cyclic_electron_flow_variant">Cyclic electron flow around PSI</a><span class="pill type">Regulatory Step</span><span class="tree-id">cyclic_electron_flow_variant</span>
+                </span>
+            </summary>                <div class="tree-group-title">Annotons</div>
+                <ul>                        <li class="annoton-item tree-entry">
+                            <span class="tree-row">
+                                <a href="#annoton-cef_pgr5_ndh">PGR5/PGRL1- and NDH-dependent cyclic electron flow</a>
+                                <span class="tree-id">Family: PGR5/PGRL1 and NDH(-1) complex</span>
+                            </span>
+                        </li>                </ul></details>
+    </li>                            </ol>
+                        </li>                </ol></details>
+    </li>
+                            </li>                            <li>
+                                <div class="edge-note">4. inorganic carbon-concentrating mechanism (CCM) optional</div>
+                                <li class="tree-entry">
+        <details class="tree-node" open>
+            <summary>
+                <span class="tree-row">
+                    <a class="tree-link" href="#node-carbon_concentrating_mechanism">Carbon-concentrating mechanism</a><span class="pill type">Regulatory Step</span><span class="tree-id">carbon_concentrating_mechanism</span>
+                </span>
+            </summary>                <div class="tree-group-title">Annotons</div>
+                <ul>                        <li class="annoton-item tree-entry">
+                            <span class="tree-row">
+                                <a href="#annoton-ccm_carbonic_anhydrase">Carbonic anhydrase (CO2/HCO3- interconversion)</a>
+                                <span class="tree-id">Any With Function: carbonate dehydratase activity</span>
+                            </span>
+                        </li>                </ul>                <div class="tree-group-title">Variants</div>
+                <ol>                        <li>
+                            <div class="edge-note">
+                                CCM compartmentation strategy by lineage / compartment (Exactly One)</div>
+                            <ol>                                    <li class="tree-entry">
+        <details class="tree-node" >
+            <summary>
+                <span class="tree-row">
+                    <a class="tree-link" href="#node-carboxysome_ccm">Cyanobacterial carboxysome CCM</a><span class="pill type">Cellular Component</span><span class="tree-id">carboxysome_ccm</span>
+                </span>
+            </summary>                <div class="tree-group-title">Annotons</div>
+                <ul>                        <li class="annoton-item tree-entry">
+                            <span class="tree-row">
+                                <a href="#annoton-carboxysome_unit">Carboxysome microcompartment with encapsulated Rubisco/CA</a>
+                                <span class="tree-id">Family: carboxysome shell and cargo (Ccm/Cso)</span>
+                            </span>
+                        </li>                </ul></details>
+    </li>                                    <li class="tree-entry">
+        <details class="tree-node" >
+            <summary>
+                <span class="tree-row">
+                    <a class="tree-link" href="#node-pyrenoid_ccm">Algal pyrenoid CCM</a><span class="pill type">Cellular Component</span><span class="tree-id">pyrenoid_ccm</span>
+                </span>
+            </summary>                <div class="tree-group-title">Annotons</div>
+                <ul>                        <li class="annoton-item tree-entry">
+                            <span class="tree-row">
+                                <a href="#annoton-pyrenoid_unit">Pyrenoid and bicarbonate transporter network</a>
+                                <span class="tree-id">Family: pyrenoid CCM components (HLA3, LCIA, LCI1, LCIB, CAH3, CCM1/CIA5)</span>
+                            </span>
+                        </li>                </ul></details>
+    </li>                            </ol>
+                        </li>                </ol></details>
+    </li>
+                            </li>                            <li>
+                                <div class="edge-note">5. chlorophyll supply (supporting context) optional</div>
+                                <li class="tree-entry">
+        <details class="tree-node" open>
+            <summary>
+                <span class="tree-row">
+                    <a class="tree-link" href="#node-pigment_biosynthesis">Chlorophyll biosynthesis (supporting)</a><span class="pill type">Metabolic Pathway</span><span class="tree-id">pigment_biosynthesis</span>
+                </span>
+            </summary>                <div class="tree-group-title">Annotons</div>
+                <ul>                        <li class="annoton-item tree-entry">
+                            <span class="tree-row">
+                                <a href="#annoton-mg_chelatase">Magnesium chelatase (committed step)</a>
+                                <span class="tree-id">Family: magnesium chelatase (CHLH/CHLD/CHLI)</span>
+                            </span>
+                        </li>                        <li class="annoton-item tree-entry">
+                            <span class="tree-row">
+                                <a href="#annoton-por_reduction">Protochlorophyllide reductase</a>
+                                <span class="tree-id">Any With Function: protochlorophyllide reductase activity</span>
+                            </span>
+                        </li>                </ul></details>
+    </li>
+                            </li>                </ol></details>
+    </li>
+                </ol>
+            </div>
+        </aside>
+
+        <section class="panel detail-panel">
+            <div class="panel-header">
+                <h2>Details</h2>
+            </div>
+            <div class="panel-body">
+                <div class="context-card small">
+            <strong>Context</strong>
+            <div class="descriptor-list">                <span class="descriptor">
+            <span>cyanobacteria</span></span>                <span class="descriptor">
+            <span>eukaryotic algae</span></span>                <span class="descriptor">
+            <span>land plants</span></span>        </div>
+
+
+
+            <div class="descriptor-list">                <span class="descriptor">
+            <span>photosynthetic membrane</span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0034357" target="_blank" rel="noopener">GO:0034357</a></span>        </div>
+
+            </div>
+                <section class="node-detail depth-0" id="node-oxygenic_photosynthesis">
+        <div class="node-heading">
+            <span class="node-title">Oxygenic photosynthesis</span><span class="pill type">Biological Process</span><span class="pill">oxygenic_photosynthesis</span>
+        </div><div class="descriptor-list">                <span class="descriptor">
+            <span>oxygenic photosynthesis</span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0015979" target="_blank" rel="noopener">GO:0015979</a></span>        </div>
+        <div class="context-card small">
+            <strong>Context</strong>
+            <div class="descriptor-list">                <span class="descriptor">
+            <span>cyanobacteria</span></span>                <span class="descriptor">
+            <span>eukaryotic algae</span></span>                <span class="descriptor">
+            <span>land plants</span></span>        </div>
+
+
+
+            <div class="descriptor-list">                <span class="descriptor">
+            <span>photosynthetic membrane</span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0034357" target="_blank" rel="noopener">GO:0034357</a></span>        </div>
+
+            </div>
+        <p class="muted small">Concrete organism modules can specialize abstract participants with specific genes, complexes, compartments, and transporters (e.g. Synechocystis psbA/ psaA, Chlamydomonas pyrenoid CCM, Arabidopsis PsbS/RbcS) without the generic module naming every protein.</p>            <h4>Connections</h4>
+            <div class="connection-list">                <div class="connection-card small">
+                    <div>
+                        <a href="#node-light_reactions">light_reactions</a>
+                        <span class="connection-arrow">-&gt;</span>
+                        <a href="#node-carbon_fixation">carbon_fixation</a>                            <span class="pill">Provides Input For</span></div>                        <div class="muted">The light reactions supply the ATP and NADPH consumed by the Calvin-Benson-Bassham cycle.</div>
+
+                </div>                <div class="connection-card small">
+                    <div>
+                        <a href="#node-carbon_concentrating_mechanism">carbon_concentrating_mechanism</a>
+                        <span class="connection-arrow">-&gt;</span>
+                        <a href="#node-rubisco_carboxylation">rubisco_carboxylation</a>                            <span class="pill">Positively Regulates</span></div>                        <div class="muted">The CCM raises CO2 around Rubisco, favoring carboxylation over oxygenation.</div>
+
+                </div>        </div>                <div class="part-marker">
+                    Part 1: light reactions (electron transport and photophosphorylation)</div>
+                <section class="node-detail depth-1" id="node-light_reactions">
+        <div class="node-heading">
+            <span class="node-title">Thylakoid light reactions</span><span class="pill type">Biological Process</span><span class="pill">light_reactions</span>
+        </div><div class="descriptor-list">                <span class="descriptor">
+            <span>photosynthesis, light reaction</span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0019684" target="_blank" rel="noopener">GO:0019684</a></span>                <span class="descriptor">
+            <span>photosynthetic electron transport chain</span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0009767" target="_blank" rel="noopener">GO:0009767</a></span>        </div>
+
+                    <h4>Connections</h4>
+            <div class="connection-list">                <div class="connection-card small">
+                    <div>
+                        <a href="#node-photosystem_ii">photosystem_II</a>
+                        <span class="connection-arrow">-&gt;</span>
+                        <a href="#node-cytochrome_b6f">cytochrome_b6f</a>                            <span class="pill">Provides Input For</span></div>                        <div class="muted">PSII reduces plastoquinone to plastoquinol, the substrate oxidized by b6f.</div>
+
+                </div>                <div class="connection-card small">
+                    <div>
+                        <a href="#node-cytochrome_b6f">cytochrome_b6f</a>
+                        <span class="connection-arrow">-&gt;</span>
+                        <a href="#node-mobile_carrier_b6f_to_psi">mobile_carrier_b6f_to_psi</a>                            <span class="pill">Provides Input For</span></div>                        <div class="muted">b6f reduces the mobile lumenal carrier (plastocyanin or cyt c6).</div>
+
+                </div>                <div class="connection-card small">
+                    <div>
+                        <a href="#node-mobile_carrier_b6f_to_psi">mobile_carrier_b6f_to_psi</a>
+                        <span class="connection-arrow">-&gt;</span>
+                        <a href="#node-photosystem_i">photosystem_I</a>                            <span class="pill">Provides Input For</span></div>                        <div class="muted">The reduced carrier re-reduces photo-oxidized P700 in PSI.</div>
+
+                </div>                <div class="connection-card small">
+                    <div>
+                        <a href="#node-photosystem_i">photosystem_I</a>
+                        <span class="connection-arrow">-&gt;</span>
+                        <a href="#node-fnr_step">fnr_step</a>                            <span class="pill">Provides Input For</span></div>                        <div class="muted">PSI-reduced ferredoxin is the electron donor for FNR.</div>
+
+                </div>                <div class="connection-card small">
+                    <div>
+                        <a href="#node-fnr_step">fnr_step</a>
+                        <span class="connection-arrow">-&gt;</span>
+                        <a href="#node-atp_synthase">atp_synthase</a>                            <span class="pill">Precedes</span></div>                        <div class="muted">Linear electron flow and water oxidation build the proton-motive force used by the ATP synthase (coupling, not a metabolite hand-off).</div>
+
+                </div>        </div>                <div class="part-marker">
+                    Part 1: light harvesting / antenna</div>
+                <section class="node-detail depth-2" id="node-light_harvesting">
+        <div class="node-heading">
+            <span class="node-title">Light-harvesting antenna</span><span class="pill type">Molecular Function</span><span class="pill">light_harvesting</span>
+        </div>
+
+                    <h4>Annotons</h4>
+            <div class="annoton-grid">                    <article class="annoton-card" id="annoton-antenna_chlorophyll_binding">
+        <div class="annoton-title">Antenna chlorophyll/carotenoid light capture</div>
+        <div class="small muted">antenna_chlorophyll_binding</div>            <div class="small"><strong>Participant:</strong> Family: light-harvesting chlorophyll a/b binding (LHC) family</div>
+            <div class="participant-detail">                    <div class="slot-row">
+                        <span class="slot-name">Family:</span>
+                        <div class="descriptor">
+            <span><strong>light-harvesting chlorophyll a/b binding (LHC) family</strong></span>                <span class="descriptor-description">Membrane antenna proteins (LHCII/LHCI in plants and algae; phycobilisomes substitute in most cyanobacteria).</span></div>
+                    </div></div>            <h4>Function</h4>
+            <div class="descriptor">
+            <span><strong>chlorophyll binding for excitation energy transfer</strong></span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0016168" target="_blank" rel="noopener">GO:0016168</a>                    <div class="slot-row">
+                        <span class="slot-name">Cofactors:</span>                            <span class="descriptor">
+            <span>chlorophyll a</span></span>                            <span class="descriptor">
+            <span>chlorophyll b</span></span>                            <span class="descriptor">
+            <span>carotenoid</span></span>                    </div></div>            <h4>Locations</h4>
+            <div class="descriptor-list">                <span class="descriptor">
+            <span>thylakoid membrane</span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0034357" target="_blank" rel="noopener">GO:0034357</a></span>        </div>            <p class="role-description">Increases absorption cross-section and funnels excitation to the reaction centers; also a site of photoprotective quenching.</p></article>            </div>    </section>                <div class="part-marker">
+                    Part 2: water oxidation (photosystem II)</div>
+                <section class="node-detail depth-2" id="node-photosystem_ii">
+        <div class="node-heading">
+            <span class="node-title">Photosystem II (water:plastoquinone oxidoreductase)</span><span class="pill type">Protein Complex</span><span class="pill">photosystem_II</span>
+        </div><div class="descriptor-list">                <span class="descriptor">
+            <span>photosystem II</span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0009523" target="_blank" rel="noopener">GO:0009523</a></span>        </div>
+
+                    <h4>Annotons</h4>
+            <div class="annoton-grid">                    <article class="annoton-card" id="annoton-psii_water_oxidation">
+        <div class="annoton-title">Light-driven water oxidation / oxygen evolution</div>
+        <div class="small muted">psii_water_oxidation</div>            <div class="small"><strong>Participant:</strong> Protein Complex: photosystem II complex</div>
+            <div class="participant-detail">                    <div class="slot-row">
+                        <span class="slot-name">Protein Complex:</span>
+                        <div class="descriptor">
+            <span><strong>photosystem II complex</strong></span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0009523" target="_blank" rel="noopener">GO:0009523</a>                <div class="slot-row">
+                    <span class="slot-name">Active units:</span>
+                    <div class="active-unit-list">                            <div class="complex-unit">
+        <div>
+            <strong>D1 reaction-center subunit (PsbA)</strong></div>            <div class="small"><strong>Participant:</strong> Family: PsbA / D1</div>
+            <div class="participant-detail">                    <div class="slot-row">
+                        <span class="slot-name">Family:</span>
+                        <div class="descriptor">
+            <span><strong>PsbA / D1</strong></span></div>
+                    </div></div>            <div class="small"><strong>Role:</strong> binds P680 and the Mn4CaO5 cluster; high-turnover repair substrate</div></div>                            <div class="complex-unit">
+        <div>
+            <strong>D2 reaction-center subunit (PsbD)</strong></div>            <div class="small"><strong>Participant:</strong> Family: PsbD / D2</div>
+            <div class="participant-detail">                    <div class="slot-row">
+                        <span class="slot-name">Family:</span>
+                        <div class="descriptor">
+            <span><strong>PsbD / D2</strong></span></div>
+                    </div></div>            <div class="small"><strong>Role:</strong> reaction-center partner of D1</div></div>                            <div class="complex-unit">
+        <div>
+            <strong>Core antennae CP43/CP47 (PsbC/PsbB)</strong></div>            <div class="small"><strong>Participant:</strong> Family: PsbB/PsbC core antenna</div>
+            <div class="participant-detail">                    <div class="slot-row">
+                        <span class="slot-name">Family:</span>
+                        <div class="descriptor">
+            <span><strong>PsbB/PsbC core antenna</strong></span></div>
+                    </div></div>            <div class="small"><strong>Role:</strong> inner chlorophyll antennae feeding excitation to P680</div></div>                            <div class="complex-unit">
+        <div>
+            <strong>Oxygen-evolving complex extrinsic proteins (PsbO/PsbP/PsbQ)</strong></div>            <div class="small"><strong>Participant:</strong> Family: oxygen-evolving complex extrinsic proteins</div>
+            <div class="participant-detail">                    <div class="slot-row">
+                        <span class="slot-name">Family:</span>
+                        <div class="descriptor">
+            <span><strong>oxygen-evolving complex extrinsic proteins</strong></span>                    <div class="slot-row">
+                        <span class="slot-name">Representative Members:</span>                            <span class="descriptor">
+            <span>spinach PsbO (oxygen-evolving enhancer protein 1)</span><a class="term-id" href="https://www.uniprot.org/uniprotkb/P12359/entry" target="_blank" rel="noopener">UniProtKB:P12359</a></span>                    </div></div>
+                    </div></div>            <div class="small"><strong>Role:</strong> stabilize the Mn4CaO5 water-oxidation cluster on the lumenal side</div></div>                    </div>
+                </div></div>
+                    </div></div>            <h4>Function</h4>
+            <div class="descriptor">
+            <span><strong>oxygen evolving activity</strong></span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0010242" target="_blank" rel="noopener">GO:0010242</a>                    <div class="slot-row">
+                        <span class="slot-name">Substrates:</span>                            <span class="descriptor">
+            <span>water</span></span>                            <span class="descriptor">
+            <span>plastoquinone</span></span>                    </div>                    <div class="slot-row">
+                        <span class="slot-name">Products:</span>                            <span class="descriptor">
+            <span>dioxygen</span></span>                            <span class="descriptor">
+            <span>plastoquinol</span></span>                            <span class="descriptor">
+            <span>proton (lumen)</span></span>                    </div></div>            <h4>Locations</h4>
+            <div class="descriptor-list">                <span class="descriptor">
+            <span>thylakoid membrane / oxygen-evolving complex</span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0009654" target="_blank" rel="noopener">GO:0009654</a></span>        </div>            <p class="role-description">Uses light energy to oxidize water at the Mn4CaO5 cluster, reducing plastoquinone and releasing O2 and lumenal protons.</p><div class="evidence-list">                <div class="evidence-card small"><a class="source-id" href="https://pubmed.ncbi.nlm.nih.gov/21499260/" target="_blank" rel="noopener">PMID:21499260</a><div>PSII structure defining the reaction center, antennae, and Mn4CaO5 cluster.</div></div>        </div></article>            </div>    </section>                <div class="part-marker">
+                    Part 3: plastoquinol oxidation and proton translocation (cytochrome b6f)</div>
+                <section class="node-detail depth-2" id="node-cytochrome_b6f">
+        <div class="node-heading">
+            <span class="node-title">Cytochrome b6f complex</span><span class="pill type">Protein Complex</span><span class="pill">cytochrome_b6f</span>
+        </div><div class="descriptor-list">                <span class="descriptor">
+            <span>cytochrome b6f complex</span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0009512" target="_blank" rel="noopener">GO:0009512</a></span>        </div>
+
+                    <h4>Annotons</h4>
+            <div class="annoton-grid">                    <article class="annoton-card" id="annoton-b6f_plastoquinol_plastocyanin_reductase">
+        <div class="annoton-title">Plastoquinol--plastocyanin reductase (Q-cycle)</div>
+        <div class="small muted">b6f_plastoquinol_plastocyanin_reductase</div>            <div class="small"><strong>Participant:</strong> Protein Complex: cytochrome b6f complex</div>
+            <div class="participant-detail">                    <div class="slot-row">
+                        <span class="slot-name">Protein Complex:</span>
+                        <div class="descriptor">
+            <span><strong>cytochrome b6f complex</strong></span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0009512" target="_blank" rel="noopener">GO:0009512</a>                <div class="slot-row">
+                    <span class="slot-name">Active units:</span>
+                    <div class="active-unit-list">                            <div class="complex-unit">
+        <div>
+            <strong>Cytochrome f (PetA)</strong></div>            <div class="small"><strong>Participant:</strong> Family: cytochrome f (PetA)</div>
+            <div class="participant-detail">                    <div class="slot-row">
+                        <span class="slot-name">Family:</span>
+                        <div class="descriptor">
+            <span><strong>cytochrome f (PetA)</strong></span>                    <div class="slot-row">
+                        <span class="slot-name">Representative Members:</span>                            <span class="descriptor">
+            <span>Synechocystis cytochrome f (petA)</span><a class="term-id" href="https://www.uniprot.org/uniprotkb/P26287/entry" target="_blank" rel="noopener">UniProtKB:P26287</a></span>                    </div></div>
+                    </div></div>            <div class="small"><strong>Role:</strong> high-potential heme; reduces plastocyanin/cyt c6</div></div>                            <div class="complex-unit">
+        <div>
+            <strong>Cytochrome b6 (PetB)</strong></div>            <div class="small"><strong>Participant:</strong> Family: cytochrome b6 (PetB)</div>
+            <div class="participant-detail">                    <div class="slot-row">
+                        <span class="slot-name">Family:</span>
+                        <div class="descriptor">
+            <span><strong>cytochrome b6 (PetB)</strong></span></div>
+                    </div></div>            <div class="small"><strong>Role:</strong> low-potential hemes; Q-cycle electron bifurcation</div></div>                            <div class="complex-unit">
+        <div>
+            <strong>Rieske iron-sulfur protein (PetC)</strong></div>            <div class="small"><strong>Participant:</strong> Family: Rieske Fe-S protein (PetC)</div>
+            <div class="participant-detail">                    <div class="slot-row">
+                        <span class="slot-name">Family:</span>
+                        <div class="descriptor">
+            <span><strong>Rieske Fe-S protein (PetC)</strong></span>                    <div class="slot-row">
+                        <span class="slot-name">Representative Members:</span>                            <span class="descriptor">
+            <span>wheat Rieske Fe-S subunit (petC)</span><a class="term-id" href="https://www.uniprot.org/uniprotkb/Q7X9A6/entry" target="_blank" rel="noopener">UniProtKB:Q7X9A6</a></span>                    </div></div>
+                    </div></div>            <div class="small"><strong>Role:</strong> 2Fe-2S cluster; oxidizes plastoquinol</div></div>                    </div>
+                </div></div>
+                    </div></div>            <h4>Function</h4>
+            <div class="descriptor">
+            <span><strong>plastoquinol--plastocyanin reductase activity</strong></span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0009496" target="_blank" rel="noopener">GO:0009496</a>                    <div class="slot-row">
+                        <span class="slot-name">Substrates:</span>                            <span class="descriptor">
+            <span>plastoquinol</span></span>                            <span class="descriptor">
+            <span>plastocyanin (oxidized)</span></span>                    </div>                    <div class="slot-row">
+                        <span class="slot-name">Products:</span>                            <span class="descriptor">
+            <span>plastoquinone</span></span>                            <span class="descriptor">
+            <span>plastocyanin (reduced)</span></span>                            <span class="descriptor">
+            <span>proton (lumen)</span></span>                    </div></div>            <h4>Locations</h4>
+            <div class="descriptor-list">                <span class="descriptor">
+            <span>thylakoid membrane</span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0009535" target="_blank" rel="noopener">GO:0009535</a></span>        </div>            <p class="role-description">Links PSII to PSI, oxidizing plastoquinol and reducing the mobile carrier while translocating protons via the Q-cycle; frequently rate-limiting for linear electron transport.</p></article>            </div>    </section>                <div class="part-marker">
+                    Part 4: inter-photosystem mobile electron carrier</div>
+                <section class="node-detail depth-2" id="node-mobile_carrier_b6f_to_psi">
+        <div class="node-heading">
+            <span class="node-title">Mobile carrier from b6f to PSI</span><span class="pill type">Molecular Function</span><span class="pill">mobile_carrier_b6f_to_psi</span>
+        </div>            <p class="node-description">Soluble lumenal carrier shuttling electrons from cytochrome b6f to photosystem I; the carrier used is lineage- and metal-availability-dependent.</p>
+
+                    <div class="variant-set">
+                <div class="variant-marker">
+                    Variant set: Plastocyanin vs cytochrome c6 by lineage / metal availability (Exactly One)</div>
+                <p class="muted small">Many cyanobacteria and algae switch between plastocyanin and cytochrome c6 depending on copper/iron availability.</p>                    <section class="node-detail depth-3" id="node-plastocyanin_variant">
+        <div class="node-heading">
+            <span class="node-title">Plastocyanin (copper carrier)</span><span class="pill type">Molecular Function</span><span class="pill">plastocyanin_variant</span>
+        </div>
+
+                    <h4>Annotons</h4>
+            <div class="annoton-grid">                    <article class="annoton-card" id="annoton-plastocyanin_electron_transfer">
+        <div class="annoton-title">Plastocyanin electron transfer</div>
+        <div class="small muted">plastocyanin_electron_transfer</div>            <div class="small"><strong>Participant:</strong> Family: plastocyanin</div>
+            <div class="participant-detail">                    <div class="slot-row">
+                        <span class="slot-name">Family:</span>
+                        <div class="descriptor">
+            <span><strong>plastocyanin</strong></span></div>
+                    </div></div>            <h4>Function</h4>
+            <div class="descriptor">
+            <span><strong>electron transfer activity</strong></span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0009055" target="_blank" rel="noopener">GO:0009055</a>                    <div class="slot-row">
+                        <span class="slot-name">Cofactors:</span>                            <span class="descriptor">
+            <span>copper ion</span></span>                    </div></div>            <h4>Locations</h4>
+            <div class="descriptor-list">                <span class="descriptor">
+            <span>thylakoid lumen</span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0009543" target="_blank" rel="noopener">GO:0009543</a></span>        </div></article>            </div>    </section>                    <section class="node-detail depth-3" id="node-cytochrome_c6_variant">
+        <div class="node-heading">
+            <span class="node-title">Cytochrome c6 (iron carrier)</span><span class="pill type">Molecular Function</span><span class="pill">cytochrome_c6_variant</span>
+        </div>
+
+                    <h4>Annotons</h4>
+            <div class="annoton-grid">                    <article class="annoton-card" id="annoton-cytc6_electron_transfer">
+        <div class="annoton-title">Cytochrome c6 electron transfer</div>
+        <div class="small muted">cytc6_electron_transfer</div>            <div class="small"><strong>Participant:</strong> Family: cytochrome c6</div>
+            <div class="participant-detail">                    <div class="slot-row">
+                        <span class="slot-name">Family:</span>
+                        <div class="descriptor">
+            <span><strong>cytochrome c6</strong></span></div>
+                    </div></div>            <h4>Function</h4>
+            <div class="descriptor">
+            <span><strong>electron transfer activity</strong></span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0009055" target="_blank" rel="noopener">GO:0009055</a>                    <div class="slot-row">
+                        <span class="slot-name">Cofactors:</span>                            <span class="descriptor">
+            <span>heme c</span></span>                    </div></div>            <h4>Locations</h4>
+            <div class="descriptor-list">                <span class="descriptor">
+            <span>thylakoid lumen</span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0031977" target="_blank" rel="noopener">GO:0031977</a></span>        </div></article>            </div>    </section>            </div>    </section>                <div class="part-marker">
+                    Part 5: P700 photo-oxidation and ferredoxin reduction (photosystem I)</div>
+                <section class="node-detail depth-2" id="node-photosystem_i">
+        <div class="node-heading">
+            <span class="node-title">Photosystem I (plastocyanin:ferredoxin oxidoreductase)</span><span class="pill type">Protein Complex</span><span class="pill">photosystem_I</span>
+        </div><div class="descriptor-list">                <span class="descriptor">
+            <span>photosystem I</span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0009522" target="_blank" rel="noopener">GO:0009522</a></span>        </div>
+
+                    <h4>Annotons</h4>
+            <div class="annoton-grid">                    <article class="annoton-card" id="annoton-psi_ferredoxin_reduction">
+        <div class="annoton-title">Light-driven ferredoxin reduction</div>
+        <div class="small muted">psi_ferredoxin_reduction</div>            <div class="small"><strong>Participant:</strong> Protein Complex: photosystem I complex</div>
+            <div class="participant-detail">                    <div class="slot-row">
+                        <span class="slot-name">Protein Complex:</span>
+                        <div class="descriptor">
+            <span><strong>photosystem I complex</strong></span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0009522" target="_blank" rel="noopener">GO:0009522</a>                <div class="slot-row">
+                    <span class="slot-name">Active units:</span>
+                    <div class="active-unit-list">                            <div class="complex-unit">
+        <div>
+            <strong>PsaA/PsaB reaction-center heterodimer</strong></div>            <div class="small"><strong>Participant:</strong> Family: PsaA/PsaB reaction-center</div>
+            <div class="participant-detail">                    <div class="slot-row">
+                        <span class="slot-name">Family:</span>
+                        <div class="descriptor">
+            <span><strong>PsaA/PsaB reaction-center</strong></span></div>
+                    </div></div>            <div class="small"><strong>Role:</strong> bind P700 and early electron-transfer cofactors</div></div>                            <div class="complex-unit">
+        <div>
+            <strong>PsaC terminal Fe-S clusters (FA/FB)</strong></div>            <div class="small"><strong>Participant:</strong> Family: PsaC</div>
+            <div class="participant-detail">                    <div class="slot-row">
+                        <span class="slot-name">Family:</span>
+                        <div class="descriptor">
+            <span><strong>PsaC</strong></span>                    <div class="slot-row">
+                        <span class="slot-name">Representative Members:</span>                            <span class="descriptor">
+            <span>Chlamydomonas psaC</span><a class="term-id" href="https://www.uniprot.org/uniprotkb/Q00914/entry" target="_blank" rel="noopener">UniProtKB:Q00914</a></span>                    </div></div>
+                    </div></div>            <div class="small"><strong>Role:</strong> terminal 4Fe-4S clusters that reduce ferredoxin</div></div>                    </div>
+                </div></div>
+                    </div></div>            <h4>Function</h4>
+            <div class="descriptor">
+            <span><strong>light-driven plastocyanin:ferredoxin oxidoreduction</strong></span>                <span class="descriptor-description">Photo-oxidation of P700 drives electron transfer through Fe-S clusters to reduce ferredoxin; no single exact GO MF is asserted for the whole complex here.</span>                    <div class="slot-row">
+                        <span class="slot-name">Substrates:</span>                            <span class="descriptor">
+            <span>plastocyanin (reduced) or cytochrome c6</span></span>                            <span class="descriptor">
+            <span>ferredoxin (oxidized)</span></span>                    </div>                    <div class="slot-row">
+                        <span class="slot-name">Products:</span>                            <span class="descriptor">
+            <span>ferredoxin (reduced)</span></span>                    </div></div>            <h4>Processes</h4>
+            <div class="descriptor-list">                <span class="descriptor">
+            <span>photosynthetic electron transport in photosystem I</span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0009773" target="_blank" rel="noopener">GO:0009773</a></span>        </div>            <h4>Locations</h4>
+            <div class="descriptor-list">                <span class="descriptor">
+            <span>thylakoid membrane</span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0009535" target="_blank" rel="noopener">GO:0009535</a></span>        </div><div class="evidence-list">                <div class="evidence-card small"><a class="source-id" href="https://pubmed.ncbi.nlm.nih.gov/11418848/" target="_blank" rel="noopener">PMID:11418848</a><div>PSI structure defining PsaA/PsaB and terminal Fe-S clusters.</div></div>        </div></article>            </div>    </section>                <div class="part-marker">
+                    Part 6: NADPH production</div>
+                <section class="node-detail depth-2" id="node-fnr_step">
+        <div class="node-heading">
+            <span class="node-title">Ferredoxin-NADP+ reductase</span><span class="pill type">Reaction</span><span class="pill">fnr_step</span>
+        </div>
+
+                    <h4>Annotons</h4>
+            <div class="annoton-grid">                    <article class="annoton-card" id="annoton-fnr_activity">
+        <div class="annoton-title">Ferredoxin-NADP+ reductase</div>
+        <div class="small muted">fnr_activity</div>            <div class="small"><strong>Participant:</strong> Any With Function: ferredoxin-NADP+ reductase activity</div>
+            <div class="participant-detail">                    <div class="slot-row">
+                        <span class="slot-name">Required Function:</span>
+                        <div class="descriptor">
+            <span><strong>ferredoxin-NADP+ reductase activity</strong></span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0004324" target="_blank" rel="noopener">GO:0004324</a></div>
+                    </div></div>            <h4>Function</h4>
+            <div class="descriptor">
+            <span><strong>ferredoxin-NADP+ reductase activity</strong></span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0004324" target="_blank" rel="noopener">GO:0004324</a>                    <div class="slot-row">
+                        <span class="slot-name">Substrates:</span>                            <span class="descriptor">
+            <span>ferredoxin (reduced)</span></span>                            <span class="descriptor">
+            <span>NADP+</span></span>                    </div>                    <div class="slot-row">
+                        <span class="slot-name">Products:</span>                            <span class="descriptor">
+            <span>ferredoxin (oxidized)</span></span>                            <span class="descriptor">
+            <span>NADPH</span></span>                    </div></div></article>            </div>    </section>                <div class="part-marker">
+                    Part 7: ATP synthesis from the proton-motive force</div>
+                <section class="node-detail depth-2" id="node-atp_synthase">
+        <div class="node-heading">
+            <span class="node-title">Thylakoid (chloroplast/cyanobacterial) ATP synthase</span><span class="pill type">Protein Complex</span><span class="pill">atp_synthase</span>
+        </div><div class="descriptor-list">                <span class="descriptor">
+            <span>proton-transporting ATP synthase complex</span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0045259" target="_blank" rel="noopener">GO:0045259</a></span>        </div>
+
+                    <h4>Annotons</h4>
+            <div class="annoton-grid">                    <article class="annoton-card" id="annoton-photophosphorylation">
+        <div class="annoton-title">Proton-motive-force-driven ATP synthesis</div>
+        <div class="small muted">photophosphorylation</div>            <div class="small"><strong>Participant:</strong> Protein Complex: thylakoid ATP synthase (CF1FO)</div>
+            <div class="participant-detail">                    <div class="slot-row">
+                        <span class="slot-name">Protein Complex:</span>
+                        <div class="descriptor">
+            <span><strong>thylakoid ATP synthase (CF1FO)</strong></span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0045259" target="_blank" rel="noopener">GO:0045259</a></div>
+                    </div></div>            <h4>Function</h4>
+            <div class="descriptor">
+            <span><strong>proton-transporting ATP synthase activity, rotational mechanism</strong></span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0046933" target="_blank" rel="noopener">GO:0046933</a>                    <div class="slot-row">
+                        <span class="slot-name">Substrates:</span>                            <span class="descriptor">
+            <span>ADP</span></span>                            <span class="descriptor">
+            <span>phosphate</span></span>                            <span class="descriptor">
+            <span>proton (lumen)</span></span>                    </div>                    <div class="slot-row">
+                        <span class="slot-name">Products:</span>                            <span class="descriptor">
+            <span>ATP</span></span>                    </div></div>            <h4>Locations</h4>
+            <div class="descriptor-list">                <span class="descriptor">
+            <span>thylakoid membrane</span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0009535" target="_blank" rel="noopener">GO:0009535</a></span>        </div></article>            </div>    </section>    </section>                <div class="part-marker">
+                    Part 2: carbon fixation (Calvin-Benson-Bassham cycle)</div>
+                <section class="node-detail depth-1" id="node-carbon_fixation">
+        <div class="node-heading">
+            <span class="node-title">Calvin-Benson-Bassham reductive pentose-phosphate cycle</span><span class="pill type">Metabolic Pathway</span><span class="pill">carbon_fixation</span>
+        </div><div class="descriptor-list">                <span class="descriptor">
+            <span>reductive pentose-phosphate cycle</span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0019253" target="_blank" rel="noopener">GO:0019253</a></span>                <span class="descriptor">
+            <span>carbon fixation</span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0015977" target="_blank" rel="noopener">GO:0015977</a></span>        </div>
+
+                        <div class="part-marker">
+                    Part 1: carboxylation</div>
+                <section class="node-detail depth-2" id="node-rubisco_carboxylation">
+        <div class="node-heading">
+            <span class="node-title">Rubisco carboxylation of RuBP</span><span class="pill type">Reaction</span><span class="pill">rubisco_carboxylation</span>
+        </div>
+
+                    <h4>Annotons</h4>
+            <div class="annoton-grid">                    <article class="annoton-card" id="annoton-rubisco_activity">
+        <div class="annoton-title">Ribulose-bisphosphate carboxylase</div>
+        <div class="small muted">rubisco_activity</div>            <div class="small"><strong>Participant:</strong> Any With Function: ribulose-bisphosphate carboxylase activity</div>
+            <div class="participant-detail">                    <div class="slot-row">
+                        <span class="slot-name">Required Function:</span>
+                        <div class="descriptor">
+            <span><strong>ribulose-bisphosphate carboxylase activity</strong></span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0016984" target="_blank" rel="noopener">GO:0016984</a></div>
+                    </div>                <div class="small muted">Form I Rubisco (L8S8, RbcL+RbcS) in plants, algae, and cyanobacteria; form II (L2) in some bacteria/dinoflagellates.</div></div>            <h4>Function</h4>
+            <div class="descriptor">
+            <span><strong>ribulose-bisphosphate carboxylase activity</strong></span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0016984" target="_blank" rel="noopener">GO:0016984</a>                    <div class="slot-row">
+                        <span class="slot-name">Substrates:</span>                            <span class="descriptor">
+            <span>ribulose 1,5-bisphosphate</span></span>                            <span class="descriptor">
+            <span>CO2</span></span>                    </div>                    <div class="slot-row">
+                        <span class="slot-name">Products:</span>                            <span class="descriptor">
+            <span>3-phosphoglycerate</span></span>                    </div></div>            <h4>Locations</h4>
+            <div class="descriptor-list">                <span class="descriptor">
+            <span>chloroplast stroma / cyanobacterial cytoplasm</span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0009570" target="_blank" rel="noopener">GO:0009570</a></span>        </div>            <p class="role-description">Fixes CO2 onto RuBP. The competing oxygenase reaction with O2 produces 2-phosphoglycolate (the substrate of photorespiration).</p><div class="evidence-list">                <div class="evidence-card small"><a class="source-id" href="https://pubmed.ncbi.nlm.nih.gov/18294858/" target="_blank" rel="noopener">PMID:18294858</a><div>Rubisco as the principal carboxylating enzyme with a competing oxygenase activity.</div></div>        </div></article>            </div>    </section>                <div class="part-marker">
+                    Part 2: reduction phase</div>
+                <section class="node-detail depth-2" id="node-cbb_reduction_phase">
+        <div class="node-heading">
+            <span class="node-title">Reduction of 3-phosphoglycerate to triose phosphate</span><span class="pill type">Metabolic Pathway</span><span class="pill">cbb_reduction_phase</span>
+        </div>            <p class="node-description">ATP- and NADPH-consuming reduction of 3-phosphoglycerate via 1,3-bisphosphoglycerate to glyceraldehyde 3-phosphate (phosphoglycerate kinase + chloroplastic NADP-GAPDH).</p>
+
+                    <h4>Annotons</h4>
+            <div class="annoton-grid">                    <article class="annoton-card" id="annoton-cbb_gapdh">
+        <div class="annoton-title">NADP-dependent glyceraldehyde-3-phosphate dehydrogenase</div>
+        <div class="small muted">cbb_gapdh</div>            <div class="small"><strong>Participant:</strong> Family: chloroplastic GAPDH (GapA/GapB)</div>
+            <div class="participant-detail">                    <div class="slot-row">
+                        <span class="slot-name">Family:</span>
+                        <div class="descriptor">
+            <span><strong>chloroplastic GAPDH (GapA/GapB)</strong></span></div>
+                    </div></div>            <h4>Function</h4>
+            <div class="descriptor">
+            <span><strong>glyceraldehyde-3-phosphate dehydrogenase (NADP+) (phosphorylating) activity</strong></span>                <span class="descriptor-description">NADPH-consuming reduction step; no confident exact GO MF id asserted here.</span>                    <div class="slot-row">
+                        <span class="slot-name">Substrates:</span>                            <span class="descriptor">
+            <span>1,3-bisphosphoglycerate</span></span>                            <span class="descriptor">
+            <span>NADPH</span></span>                    </div>                    <div class="slot-row">
+                        <span class="slot-name">Products:</span>                            <span class="descriptor">
+            <span>glyceraldehyde 3-phosphate</span></span>                            <span class="descriptor">
+            <span>NADP+</span></span>                    </div></div></article>            </div>    </section>                <div class="part-marker">
+                    Part 3: regeneration phase</div>
+                <section class="node-detail depth-2" id="node-cbb_regeneration_phase">
+        <div class="node-heading">
+            <span class="node-title">Regeneration of ribulose 1,5-bisphosphate</span><span class="pill type">Metabolic Pathway</span><span class="pill">cbb_regeneration_phase</span>
+        </div>            <p class="node-description">Rearrangement of triose phosphates through transketolase, aldolase, fructose-1,6-bisphosphatase, and sedoheptulose-1,7- bisphosphatase, ending in phosphoribulokinase regeneration of RuBP.</p>
+
+                    <h4>Annotons</h4>
+            <div class="annoton-grid">                    <article class="annoton-card" id="annoton-cbb_prk">
+        <div class="annoton-title">Phosphoribulokinase</div>
+        <div class="small muted">cbb_prk</div>            <div class="small"><strong>Participant:</strong> Any With Function: phosphoribulokinase activity</div>
+            <div class="participant-detail">                    <div class="slot-row">
+                        <span class="slot-name">Required Function:</span>
+                        <div class="descriptor">
+            <span><strong>phosphoribulokinase activity</strong></span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0008974" target="_blank" rel="noopener">GO:0008974</a></div>
+                    </div></div>            <h4>Function</h4>
+            <div class="descriptor">
+            <span><strong>phosphoribulokinase activity</strong></span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0008974" target="_blank" rel="noopener">GO:0008974</a>                    <div class="slot-row">
+                        <span class="slot-name">Substrates:</span>                            <span class="descriptor">
+            <span>ribulose 5-phosphate</span></span>                            <span class="descriptor">
+            <span>ATP</span></span>                    </div>                    <div class="slot-row">
+                        <span class="slot-name">Products:</span>                            <span class="descriptor">
+            <span>ribulose 1,5-bisphosphate</span></span>                            <span class="descriptor">
+            <span>ADP</span></span>                    </div></div>            <p class="role-description">Regenerates the Rubisco substrate; a major redox-regulated control point.</p></article>                    <article class="annoton-card" id="annoton-cbb_sbpase_fbpase">
+        <div class="annoton-title">Bisphosphatase regeneration steps (FBPase, SBPase)</div>
+        <div class="small muted">cbb_sbpase_fbpase</div>            <div class="small"><strong>Participant:</strong> Family: chloroplast FBPase / SBPase</div>
+            <div class="participant-detail">                    <div class="slot-row">
+                        <span class="slot-name">Family:</span>
+                        <div class="descriptor">
+            <span><strong>chloroplast FBPase / SBPase</strong></span></div>
+                    </div></div>            <h4>Function</h4>
+            <div class="descriptor">
+            <span><strong>bisphosphatase regeneration steps</strong></span>                <span class="descriptor-description">Fructose-1,6-bisphosphatase and sedoheptulose-1,7- bisphosphatase; SBPase is a frequent yield-engineering target.</span></div></article>            </div>    </section>                <div class="part-marker">
+                    Part 4: Rubisco activation and inhibitor repair (optional)</div>
+                <section class="node-detail depth-2" id="node-rubisco_activation">
+        <div class="node-heading">
+            <span class="node-title">Rubisco activase and inhibitor removal</span><span class="pill type">Regulatory Step</span><span class="pill">rubisco_activation</span>
+        </div>
+
+                    <h4>Annotons</h4>
+            <div class="annoton-grid">                    <article class="annoton-card" id="annoton-rubisco_activase">
+        <div class="annoton-title">Rubisco activase</div>
+        <div class="small muted">rubisco_activase</div>            <div class="small"><strong>Participant:</strong> Family: Rubisco activase (Rca)</div>
+            <div class="participant-detail">                    <div class="slot-row">
+                        <span class="slot-name">Family:</span>
+                        <div class="descriptor">
+            <span><strong>Rubisco activase (Rca)</strong></span></div>
+                    </div></div>            <h4>Function</h4>
+            <div class="descriptor">
+            <span><strong>ATP-dependent removal of inhibitory sugar phosphates from Rubisco</strong></span>                <span class="descriptor-description">AAA+ chaperone-like remodeling of Rubisco active sites; thermolabile.</span></div>            <p class="role-description">Restores catalytically competent Rubisco; major thermal-tolerance target.</p></article>            </div>    </section>                <div class="part-marker">
+                    Part 5: redox gating of the CBB cycle (optional)</div>
+                <section class="node-detail depth-2" id="node-cbb_redox_regulation">
+        <div class="node-heading">
+            <span class="node-title">CP12-mediated redox regulation</span><span class="pill type">Regulatory Step</span><span class="pill">cbb_redox_regulation</span>
+        </div>
+
+                    <h4>Annotons</h4>
+            <div class="annoton-grid">                    <article class="annoton-card" id="annoton-cp12_scaffold">
+        <div class="annoton-title">CP12 redox scaffold</div>
+        <div class="small muted">cp12_scaffold</div>            <div class="small"><strong>Participant:</strong> Family: CP12</div>
+            <div class="participant-detail">                    <div class="slot-row">
+                        <span class="slot-name">Family:</span>
+                        <div class="descriptor">
+            <span><strong>CP12</strong></span>                    <div class="slot-row">
+                        <span class="slot-name">Representative Members:</span>                            <span class="descriptor">
+            <span>Chlamydomonas CP12</span><a class="term-id" href="https://www.uniprot.org/uniprotkb/A6Q0K5/entry" target="_blank" rel="noopener">UniProtKB:A6Q0K5</a></span>                    </div></div>
+                    </div></div>            <h4>Function</h4>
+            <div class="descriptor">
+            <span><strong>redox-dependent scaffolding of the PRK-GAPDH-CP12 ternary complex</strong></span>                <span class="descriptor-description">In the dark/oxidizing conditions CP12 assembles an autoinhibitory PRK-GAPDH complex; reduction (thioredoxin/ NTRC) dissociates it to activate the cycle.</span>                    <div class="slot-row">
+                        <span class="slot-name">Targets:</span>                            <span class="descriptor">
+            <span>phosphoribulokinase</span></span>                            <span class="descriptor">
+            <span>glyceraldehyde-3-phosphate dehydrogenase</span></span>                    </div></div>            <p class="role-description">Couples CBB-cycle activity to the light/redox state of the chloroplast.</p><div class="evidence-list">                <div class="evidence-card small"><a class="source-id" href="https://pubmed.ncbi.nlm.nih.gov/33761918/" target="_blank" rel="noopener">PMID:33761918</a><div>CP12 forms a PRK-GAPDH ternary complex regulating the CBB cycle.</div></div>                <div class="evidence-card small"><a class="source-id" href="https://pubmed.ncbi.nlm.nih.gov/37549282/" target="_blank" rel="noopener">PMID:37549282</a><div>NTRC-dependent redox control of the PRK-CP12-GAPDH supracomplex.</div></div>        </div></article>            </div>            <h4>Connections</h4>
+            <div class="connection-list">                <div class="connection-card small">
+                    <div>
+                        <a href="#annoton-cp12_scaffold">cp12_scaffold</a>
+                        <span class="connection-arrow">-&gt;</span>
+                        <a href="#annoton-cbb_prk">cbb_prk</a>                            <span class="pill">Negatively Regulates</span></div>                        <div class="muted">CP12 inhibits PRK in the dark/oxidized state.</div>
+
+                </div>                <div class="connection-card small">
+                    <div>
+                        <a href="#annoton-cp12_scaffold">cp12_scaffold</a>
+                        <span class="connection-arrow">-&gt;</span>
+                        <a href="#annoton-cbb_gapdh">cbb_gapdh</a>                            <span class="pill">Negatively Regulates</span></div>                        <div class="muted">CP12 inhibits GAPDH in the dark/oxidized state.</div>
+
+                </div>        </div>    </section>    </section>                <div class="part-marker">
+                    Part 3: photoprotection and ATP/NADPH balancing (optional)</div>
+                <section class="node-detail depth-1" id="node-photoprotection_balancing">
+        <div class="node-heading">
+            <span class="node-title">Photoprotection and electron/energy balancing</span><span class="pill type">Regulatory Step</span><span class="pill">photoprotection_balancing</span>
+        </div>            <p class="node-description">Mechanisms that dissipate excess excitation, redistribute antennae, and tune the ATP:NADPH ratio under fluctuating light.</p>
+
+                    <div class="variant-set">
+                <div class="variant-marker">
+                    Variant set: Photoprotection and balancing mechanisms by regulatory mechanism (Zero Or More)</div>
+                                    <section class="node-detail depth-2" id="node-npq_variant">
+        <div class="node-heading">
+            <span class="node-title">Non-photochemical quenching (qE)</span><span class="pill type">Regulatory Step</span><span class="pill">npq_variant</span>
+        </div>
+
+                    <h4>Annotons</h4>
+            <div class="annoton-grid">                    <article class="annoton-card" id="annoton-npq_psbs_xanthophyll">
+        <div class="annoton-title">PsbS- and xanthophyll-cycle-dependent quenching</div>
+        <div class="small muted">npq_psbs_xanthophyll</div>            <div class="small"><strong>Participant:</strong> Family: PsbS and xanthophyll-cycle enzymes (VDE/ZEP)</div>
+            <div class="participant-detail">                    <div class="slot-row">
+                        <span class="slot-name">Family:</span>
+                        <div class="descriptor">
+            <span><strong>PsbS and xanthophyll-cycle enzymes (VDE/ZEP)</strong></span></div>
+                    </div></div>            <h4>Function</h4>
+            <div class="descriptor">
+            <span><strong>heat dissipation of excess PSII excitation</strong></span></div>            <p class="role-description">Rapid, reversible thermal dissipation protecting PSII under high light.</p></article>            </div>    </section>                    <section class="node-detail depth-2" id="node-state_transitions_variant">
+        <div class="node-heading">
+            <span class="node-title">State transitions</span><span class="pill type">Regulatory Step</span><span class="pill">state_transitions_variant</span>
+        </div>
+
+                    <h4>Annotons</h4>
+            <div class="annoton-grid">                    <article class="annoton-card" id="annoton-state_transition_kinase">
+        <div class="annoton-title">STN7/Stt7-dependent LHCII redistribution</div>
+        <div class="small muted">state_transition_kinase</div>            <div class="small"><strong>Participant:</strong> Family: state-transition kinase (STN7/Stt7) and TAP38/PPH1 phosphatase</div>
+            <div class="participant-detail">                    <div class="slot-row">
+                        <span class="slot-name">Family:</span>
+                        <div class="descriptor">
+            <span><strong>state-transition kinase (STN7/Stt7) and TAP38/PPH1 phosphatase</strong></span></div>
+                    </div></div>            <h4>Function</h4>
+            <div class="descriptor">
+            <span><strong>redox-controlled LHCII phosphorylation balancing PSII/PSI</strong></span></div>            <p class="role-description">Rebalances excitation between the photosystems via antenna migration.</p></article>            </div>    </section>                    <section class="node-detail depth-2" id="node-cyclic_electron_flow_variant">
+        <div class="node-heading">
+            <span class="node-title">Cyclic electron flow around PSI</span><span class="pill type">Regulatory Step</span><span class="pill">cyclic_electron_flow_variant</span>
+        </div>
+
+                    <h4>Annotons</h4>
+            <div class="annoton-grid">                    <article class="annoton-card" id="annoton-cef_pgr5_ndh">
+        <div class="annoton-title">PGR5/PGRL1- and NDH-dependent cyclic electron flow</div>
+        <div class="small muted">cef_pgr5_ndh</div>            <div class="small"><strong>Participant:</strong> Family: PGR5/PGRL1 and NDH(-1) complex</div>
+            <div class="participant-detail">                    <div class="slot-row">
+                        <span class="slot-name">Family:</span>
+                        <div class="descriptor">
+            <span><strong>PGR5/PGRL1 and NDH(-1) complex</strong></span></div>
+                    </div></div>            <h4>Function</h4>
+            <div class="descriptor">
+            <span><strong>cyclic electron transfer generating extra proton-motive force</strong></span></div>            <p class="role-description">Raises ATP:NADPH and contributes to photoprotection.</p></article>            </div>    </section>            </div>    </section>                <div class="part-marker">
+                    Part 4: inorganic carbon-concentrating mechanism (CCM) (optional)</div>
+                <section class="node-detail depth-1" id="node-carbon_concentrating_mechanism">
+        <div class="node-heading">
+            <span class="node-title">Carbon-concentrating mechanism</span><span class="pill type">Regulatory Step</span><span class="pill">carbon_concentrating_mechanism</span>
+        </div>            <p class="node-description">Active inorganic-carbon uptake and CO2 concentration around Rubisco to suppress the oxygenase reaction; prominent in cyanobacteria and algae.</p>
+
+                    <h4>Annotons</h4>
+            <div class="annoton-grid">                    <article class="annoton-card" id="annoton-ccm_carbonic_anhydrase">
+        <div class="annoton-title">Carbonic anhydrase (CO2/HCO3- interconversion)</div>
+        <div class="small muted">ccm_carbonic_anhydrase</div>            <div class="small"><strong>Participant:</strong> Any With Function: carbonate dehydratase activity</div>
+            <div class="participant-detail">                    <div class="slot-row">
+                        <span class="slot-name">Required Function:</span>
+                        <div class="descriptor">
+            <span><strong>carbonate dehydratase activity</strong></span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0004089" target="_blank" rel="noopener">GO:0004089</a></div>
+                    </div></div>            <h4>Function</h4>
+            <div class="descriptor">
+            <span><strong>carbonate dehydratase activity</strong></span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0004089" target="_blank" rel="noopener">GO:0004089</a>                    <div class="slot-row">
+                        <span class="slot-name">Substrates:</span>                            <span class="descriptor">
+            <span>bicarbonate</span></span>                    </div>                    <div class="slot-row">
+                        <span class="slot-name">Products:</span>                            <span class="descriptor">
+            <span>CO2</span></span>                            <span class="descriptor">
+            <span>water</span></span>                    </div></div></article>            </div>            <div class="variant-set">
+                <div class="variant-marker">
+                    Variant set: CCM compartmentation strategy by lineage / compartment (Exactly One)</div>
+                                    <section class="node-detail depth-2" id="node-carboxysome_ccm">
+        <div class="node-heading">
+            <span class="node-title">Cyanobacterial carboxysome CCM</span><span class="pill type">Cellular Component</span><span class="pill">carboxysome_ccm</span>
+        </div>
+
+                    <h4>Annotons</h4>
+            <div class="annoton-grid">                    <article class="annoton-card" id="annoton-carboxysome_unit">
+        <div class="annoton-title">Carboxysome microcompartment with encapsulated Rubisco/CA</div>
+        <div class="small muted">carboxysome_unit</div>            <div class="small"><strong>Participant:</strong> Family: carboxysome shell and cargo (Ccm/Cso)</div>
+            <div class="participant-detail">                    <div class="slot-row">
+                        <span class="slot-name">Family:</span>
+                        <div class="descriptor">
+            <span><strong>carboxysome shell and cargo (Ccm/Cso)</strong></span></div>
+                    </div></div>            <p class="role-description">Bacterial microcompartment concentrating CO2 around Rubisco.</p></article>            </div>    </section>                    <section class="node-detail depth-2" id="node-pyrenoid_ccm">
+        <div class="node-heading">
+            <span class="node-title">Algal pyrenoid CCM</span><span class="pill type">Cellular Component</span><span class="pill">pyrenoid_ccm</span>
+        </div>
+
+                    <h4>Annotons</h4>
+            <div class="annoton-grid">                    <article class="annoton-card" id="annoton-pyrenoid_unit">
+        <div class="annoton-title">Pyrenoid and bicarbonate transporter network</div>
+        <div class="small muted">pyrenoid_unit</div>            <div class="small"><strong>Participant:</strong> Family: pyrenoid CCM components (HLA3, LCIA, LCI1, LCIB, CAH3, CCM1/CIA5)</div>
+            <div class="participant-detail">                    <div class="slot-row">
+                        <span class="slot-name">Family:</span>
+                        <div class="descriptor">
+            <span><strong>pyrenoid CCM components (HLA3, LCIA, LCI1, LCIB, CAH3, CCM1/CIA5)</strong></span>                    <div class="slot-row">
+                        <span class="slot-name">Representative Members:</span>                            <span class="descriptor">
+            <span>Chlamydomonas LCI5 (low-CO2-inducible protein)</span><a class="term-id" href="https://www.uniprot.org/uniprotkb/Q94ET8/entry" target="_blank" rel="noopener">UniProtKB:Q94ET8</a></span>                    </div></div>
+                    </div></div>            <p class="role-description">Eukaryotic algal biophysical CCM organized around the pyrenoid.</p></article>            </div>    </section>            </div>    </section>                <div class="part-marker">
+                    Part 5: chlorophyll supply (supporting context) (optional)</div>
+                <section class="node-detail depth-1" id="node-pigment_biosynthesis">
+        <div class="node-heading">
+            <span class="node-title">Chlorophyll biosynthesis (supporting)</span><span class="pill type">Metabolic Pathway</span><span class="pill">pigment_biosynthesis</span>
+        </div>            <p class="node-description">Supplies the chlorophyll cofactors required by antennae and reaction centers.</p>
+
+                    <h4>Annotons</h4>
+            <div class="annoton-grid">                    <article class="annoton-card" id="annoton-mg_chelatase">
+        <div class="annoton-title">Magnesium chelatase (committed step)</div>
+        <div class="small muted">mg_chelatase</div>            <div class="small"><strong>Participant:</strong> Family: magnesium chelatase (CHLH/CHLD/CHLI)</div>
+            <div class="participant-detail">                    <div class="slot-row">
+                        <span class="slot-name">Family:</span>
+                        <div class="descriptor">
+            <span><strong>magnesium chelatase (CHLH/CHLD/CHLI)</strong></span></div>
+                    </div></div>            <h4>Function</h4>
+            <div class="descriptor">
+            <span><strong>magnesium chelatase activity</strong></span>                <span class="descriptor-description">Inserts Mg2+ into protoporphyrin IX; committed step toward chlorophyll. No confident GO MF id asserted here.</span></div></article>                    <article class="annoton-card" id="annoton-por_reduction">
+        <div class="annoton-title">Protochlorophyllide reductase</div>
+        <div class="small muted">por_reduction</div>            <div class="small"><strong>Participant:</strong> Any With Function: protochlorophyllide reductase activity</div>
+            <div class="participant-detail">                    <div class="slot-row">
+                        <span class="slot-name">Required Function:</span>
+                        <div class="descriptor">
+            <span><strong>protochlorophyllide reductase activity</strong></span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0016630" target="_blank" rel="noopener">GO:0016630</a></div>
+                    </div></div>            <h4>Function</h4>
+            <div class="descriptor">
+            <span><strong>protochlorophyllide reductase activity</strong></span><a class="term-id" href="https://amigo.geneontology.org/amigo/term/GO:0016630" target="_blank" rel="noopener">GO:0016630</a>                    <div class="slot-row">
+                        <span class="slot-name">Substrates:</span>                            <span class="descriptor">
+            <span>protochlorophyllide</span></span>                    </div>                    <div class="slot-row">
+                        <span class="slot-name">Products:</span>                            <span class="descriptor">
+            <span>chlorophyllide</span></span>                    </div></div></article>            </div>    </section>    </section>
+            </div>
+        </section>
+    </section>
+</main>
+
+<script>
+    const searchInput = document.querySelector("[data-tree-search]");
+    if (searchInput) {
+        searchInput.addEventListener("input", () => {
+            const query = searchInput.value.trim().toLowerCase();
+            document.querySelectorAll(".tree-row").forEach((row) => {
+                const matches = !query || row.textContent.toLowerCase().includes(query);
+                row.classList.toggle("is-dimmed", !matches);
+                if (query && matches) {
+                    let detail = row.closest("details");
+                    while (detail) {
+                        detail.open = true;
+                        detail = detail.parentElement ? detail.parentElement.closest("details") : null;
+                    }
+                }
+            });
+        });
+    }
+
+    document.querySelectorAll("[data-tree-action]").forEach((button) => {
+        button.addEventListener("click", () => {
+            const shouldOpen = button.dataset.treeAction === "expand";
+            document.querySelectorAll(".tree-panel details").forEach((detail) => {
+                detail.open = shouldOpen;
+            });
+        });
+    });
+</script>
+</body>
+</html>

--- a/src/ai_gene_review/templates/module_index.html.j2
+++ b/src/ai_gene_review/templates/module_index.html.j2
@@ -40,7 +40,7 @@
         }
 
         .page {
-            max-width: 1180px;
+            max-width: 1280px;
             margin: 0 auto;
             padding: 24px;
         }
@@ -82,51 +82,96 @@
             font-weight: 600;
         }
 
-        .module-grid {
-            display: grid;
-            grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
-            gap: 14px;
-        }
-
-        .module-card {
+        .table-wrap {
             background: var(--bg-panel);
             border: 1px solid var(--border);
             border-radius: 8px;
-            padding: 16px;
+            overflow-x: auto;
         }
 
-        .module-card.is-hidden {
+        table.modules {
+            width: 100%;
+            border-collapse: collapse;
+            font-size: 0.9rem;
+        }
+
+        table.modules thead th {
+            position: sticky;
+            top: 0;
+            background: var(--bg-soft);
+            text-align: left;
+            font-size: 0.74rem;
+            text-transform: uppercase;
+            letter-spacing: 0.02em;
+            color: var(--muted);
+            padding: 10px 12px;
+            border-bottom: 1px solid var(--border);
+            white-space: nowrap;
+            cursor: pointer;
+            user-select: none;
+        }
+
+        table.modules thead th.num {
+            text-align: right;
+        }
+
+        table.modules thead th .arrow {
+            color: var(--accent);
+            font-size: 0.7rem;
+        }
+
+        table.modules tbody td {
+            padding: 10px 12px;
+            border-bottom: 1px solid var(--border);
+            vertical-align: top;
+        }
+
+        table.modules tbody td.num {
+            text-align: right;
+            font-variant-numeric: tabular-nums;
+        }
+
+        table.modules tbody tr:last-child td {
+            border-bottom: none;
+        }
+
+        table.modules tbody tr.is-hidden {
             display: none;
         }
 
-        .module-title {
-            display: inline-block;
-            font-size: 1.05rem;
+        table.modules tbody tr:hover {
+            background: #fafcfd;
+        }
+
+        .module-name {
             font-weight: 700;
-            margin-bottom: 8px;
         }
 
-        .description {
+        .module-id {
+            display: block;
+            color: var(--muted);
+            font-size: 0.78rem;
+            font-weight: 500;
+        }
+
+        .module-desc {
+            display: block;
             color: #31404e;
-            margin: 0 0 12px;
-        }
-
-        .pill-row {
-            display: flex;
-            flex-wrap: wrap;
-            gap: 6px;
-            margin: 8px 0;
+            font-weight: 400;
+            font-size: 0.82rem;
+            margin-top: 3px;
+            max-width: 520px;
         }
 
         .pill {
             display: inline-flex;
             align-items: center;
-            padding: 4px 8px;
+            padding: 3px 8px;
             border: 1px solid var(--border);
             border-radius: 999px;
             background: var(--bg-soft);
             color: #304150;
-            font-size: 0.8rem;
+            font-size: 0.76rem;
             font-weight: 650;
             white-space: nowrap;
         }
@@ -143,28 +188,21 @@
             color: var(--amber);
         }
 
-        .stats {
-            display: grid;
-            grid-template-columns: repeat(3, 1fr);
-            gap: 6px;
-            margin-top: 12px;
+        .concepts {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 4px;
+            max-width: 260px;
         }
 
-        .stat {
-            background: #fbfcfd;
-            border: 1px solid var(--border);
-            border-radius: 6px;
-            padding: 7px 8px;
+        .concepts .pill {
+            font-weight: 600;
         }
 
-        .stat strong {
-            display: block;
-        }
-
-        .stat span {
+        .source {
             color: var(--muted);
             font-size: 0.76rem;
-            text-transform: uppercase;
+            font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
         }
 
         @media (max-width: 720px) {
@@ -182,7 +220,9 @@
 <main class="page">
     <header class="header">
         <h1>{{ title }}</h1>
-        <p class="muted">Reusable biological module sketches rendered from YAML.</p>
+        <p class="muted">Reusable biological module sketches rendered from YAML. Columns
+            with numeric counts are derived by recursively walking each module document.
+            Click a column header to sort; counts and concepts come straight from the YAML.</p>
     </header>
 
     <section class="toolbar">
@@ -190,47 +230,74 @@
         <div class="count"><span data-visible-count>{{ total_modules }}</span> / {{ total_modules }} modules</div>
     </section>
 
-    <section class="module-grid">
-        {%- for module in modules %}
-            <article class="module-card" data-module-card>
-                <a class="module-title" href="{{ module.href }}">{{ module.title }}</a>
-                {%- if module.description %}
-                    <p class="description">{{ module.description }}</p>
-                {%- endif %}
-                <div class="pill-row">
-                    {%- if module.id %}<span class="pill">{{ module.id }}</span>{% endif -%}
-                    {%- if module.status %}<span class="pill status">{{ module.status }}</span>{% endif -%}
-                    {%- if module.module_type %}<span class="pill type">{{ module.module_type | enum_label }}</span>{% endif -%}
-                </div>
-                {%- if module.concepts %}
-                    <div class="pill-row">
-                        {%- for concept in module.concepts %}
+    <div class="table-wrap">
+        <table class="modules" data-module-table>
+            <thead>
+                <tr>
+                    <th data-sort="text" data-default-dir="asc">Module <span class="arrow"></span></th>
+                    <th data-sort="text">Type <span class="arrow"></span></th>
+                    <th data-sort="text">Status <span class="arrow"></span></th>
+                    <th data-sort="text">Concepts <span class="arrow"></span></th>
+                    <th class="num" data-sort="num">Nodes <span class="arrow"></span></th>
+                    <th class="num" data-sort="num">Annotons <span class="arrow"></span></th>
+                    <th class="num" data-sort="num">Parts <span class="arrow"></span></th>
+                    <th class="num" data-sort="num">Variant&nbsp;sets <span class="arrow"></span></th>
+                    <th class="num" data-sort="num">Variants <span class="arrow"></span></th>
+                    <th class="num" data-sort="num">Connections <span class="arrow"></span></th>
+                    <th data-sort="text">Source <span class="arrow"></span></th>
+                </tr>
+            </thead>
+            <tbody>
+                {%- for module in modules %}
+                <tr data-module-row>
+                    <td>
+                        <a class="module-name" href="{{ module.href }}">{{ module.title }}</a>
+                        {%- if module.id %}<span class="module-id">{{ module.id }}</span>{% endif %}
+                        {%- if module.description %}<span class="module-desc">{{ module.description }}</span>{% endif %}
+                    </td>
+                    <td data-sort-value="{{ module.module_type | enum_label if module.module_type else '' }}">
+                        {%- if module.module_type %}<span class="pill type">{{ module.module_type | enum_label }}</span>{% endif %}
+                    </td>
+                    <td data-sort-value="{{ module.status or '' }}">
+                        {%- if module.status %}<span class="pill status">{{ module.status }}</span>{% endif %}
+                    </td>
+                    <td data-sort-value="{{ module.concepts | length }}">
+                        {%- if module.concepts %}
+                        <div class="concepts">
+                            {%- for concept in module.concepts %}
                             <span class="pill">{{ concept }}</span>
-                        {%- endfor %}
-                    </div>
-                {%- endif %}
-                <div class="stats">
-                    <div class="stat"><strong>{{ module.stats.nodes }}</strong><span>Nodes</span></div>
-                    <div class="stat"><strong>{{ module.stats.annotons }}</strong><span>Annotons</span></div>
-                    <div class="stat"><strong>{{ module.stats.variant_sets }}</strong><span>Variant Sets</span></div>
-                </div>
-                <p class="muted">{{ module.source_path }}</p>
-            </article>
-        {%- endfor %}
-    </section>
+                            {%- endfor %}
+                        </div>
+                        {%- endif %}
+                    </td>
+                    <td class="num">{{ module.stats.nodes }}</td>
+                    <td class="num">{{ module.stats.annotons }}</td>
+                    <td class="num">{{ module.stats.parts }}</td>
+                    <td class="num">{{ module.stats.variant_sets }}</td>
+                    <td class="num">{{ module.stats.variants }}</td>
+                    <td class="num">{{ module.stats.connections }}</td>
+                    <td><span class="source">{{ module.source_path }}</span></td>
+                </tr>
+                {%- endfor %}
+            </tbody>
+        </table>
+    </div>
 </main>
 
 <script>
     const input = document.querySelector("[data-module-search]");
     const count = document.querySelector("[data-visible-count]");
-    const cards = Array.from(document.querySelectorAll("[data-module-card]"));
+    const table = document.querySelector("[data-module-table]");
+    const tbody = table ? table.querySelector("tbody") : null;
+    const rows = tbody ? Array.from(tbody.querySelectorAll("[data-module-row]")) : [];
+
     if (input) {
         input.addEventListener("input", () => {
             const query = input.value.trim().toLowerCase();
             let visible = 0;
-            cards.forEach((card) => {
-                const matches = !query || card.textContent.toLowerCase().includes(query);
-                card.classList.toggle("is-hidden", !matches);
+            rows.forEach((row) => {
+                const matches = !query || row.textContent.toLowerCase().includes(query);
+                row.classList.toggle("is-hidden", !matches);
                 if (matches) {
                     visible += 1;
                 }
@@ -238,6 +305,50 @@
             if (count) {
                 count.textContent = String(visible);
             }
+        });
+    }
+
+    if (table && tbody) {
+        const headers = Array.from(table.querySelectorAll("thead th"));
+        const cellValue = (row, index, kind) => {
+            const cell = row.children[index];
+            if (!cell) {
+                return kind === "num" ? 0 : "";
+            }
+            const raw = cell.hasAttribute("data-sort-value")
+                ? cell.getAttribute("data-sort-value")
+                : cell.textContent.trim();
+            return kind === "num" ? parseFloat(raw) || 0 : raw.toLowerCase();
+        };
+        headers.forEach((header, index) => {
+            header.addEventListener("click", () => {
+                const kind = header.getAttribute("data-sort") || "text";
+                const ascending = header.dataset.dir !== "asc";
+                headers.forEach((other) => {
+                    delete other.dataset.dir;
+                    const arrow = other.querySelector(".arrow");
+                    if (arrow) {
+                        arrow.textContent = "";
+                    }
+                });
+                header.dataset.dir = ascending ? "asc" : "desc";
+                const arrow = header.querySelector(".arrow");
+                if (arrow) {
+                    arrow.textContent = ascending ? "▲" : "▼";
+                }
+                const sorted = rows.slice().sort((a, b) => {
+                    const va = cellValue(a, index, kind);
+                    const vb = cellValue(b, index, kind);
+                    if (va < vb) {
+                        return ascending ? -1 : 1;
+                    }
+                    if (va > vb) {
+                        return ascending ? 1 : -1;
+                    }
+                    return 0;
+                });
+                sorted.forEach((row) => tbody.appendChild(row));
+            });
         });
     }
 </script>

--- a/tests/test_render_modules.py
+++ b/tests/test_render_modules.py
@@ -154,4 +154,46 @@ def test_render_all_modules_with_index(tmp_path):
     assert output_dir / "generic" / "test.html" in output_paths
     assert output_dir / "index.html" in output_paths
     assert (output_dir / "index.html").exists()
-    assert "Test module" in (output_dir / "index.html").read_text()
+
+    index_html = (output_dir / "index.html").read_text()
+    assert "Test module" in index_html
+    # The index renders as a sortable table of modules with derived metadata columns.
+    assert "<table" in index_html
+    assert "data-module-table" in index_html
+    assert "data-module-row" in index_html
+    for column in ("Nodes", "Annotons", "Parts", "Variant", "Variants", "Connections"):
+        assert column in index_html
+    # Derived counts for the single test module should be present in the row.
+    assert "METABOLIC_PATHWAY".replace("_", " ").title() in index_html
+
+
+def test_render_modules_index_table_lists_all_modules(tmp_path):
+    """The index table renders one row per module with its derived stats."""
+    import yaml
+
+    from ai_gene_review.render_modules import make_summary, render_modules_index
+
+    modules_dir = tmp_path / "modules"
+    modules_dir.mkdir()
+    output_dir = tmp_path / "pages" / "modules"
+    output_dir.mkdir(parents=True)
+    index_path = output_dir / "index.html"
+
+    data = yaml.safe_load(MODULE_YAML)
+    summary = make_summary(
+        data,
+        modules_dir / "test.yaml",
+        output_dir / "test.html",
+        index_path,
+    )
+
+    render_modules_index([summary], output_dir=output_dir)
+    html = index_path.read_text()
+
+    # Exactly one data row for the one module summary.
+    assert html.count("<tr data-module-row>") == 1
+    # Derived numeric metadata surfaced in the table.
+    assert str(summary["stats"]["nodes"]) in html
+    assert str(summary["stats"]["connections"]) in html
+    # Concepts derived from the module document appear.
+    assert "test pathway" in html


### PR DESCRIPTION
## Summary

- Added three new module documentation pages: Photosynthesis, Methionine (S-adenosylmethionine) cycle, Erythromycin A biosynthesis, and BBSome ciliary trafficking complex
- Converted the module index from a card grid layout to a sortable table layout for better browsing and organization
- Updated max-width constraint on index page from 1180px to 1280px to accommodate table layout

## Validation

N/A

## Test plan

- [x] Existing tests pass (test_render_modules.py updated to verify index.html generation)

https://claude.ai/code/session_01KtP68PNe1Vs4p1cvRst7Cb