### PR TITLE
Add generic taxon-neutral OXPHOS module (modules/oxphos.yaml)

### DIFF
--- a/modules/oxphos.yaml
+++ b/modules/oxphos.yaml
@@ -1,0 +1,1129 @@
+id: MODULE:oxidative_phosphorylation
+title: Oxidative phosphorylation (OXPHOS) module
+description: >-
+  A taxon-neutral decomposition of oxidative phosphorylation: the coupled
+  process by which a respiratory electron transport chain (ETC) oxidizes
+  reduced cofactors and uses the released free energy to pump protons across a
+  coupling membrane, and an F1Fo-ATP synthase uses the resulting proton-motive
+  force to phosphorylate ADP. The module is deliberately phrased in terms of
+  functional modules, protein complexes, and pathway segments rather than a
+  fixed gene list, so it can represent the mitochondrial inner-membrane chain of
+  eukaryotes and the plasma-membrane respiratory chains of aerobic bacteria.
+
+  Design intent for complexes (the central modelling question): each respiratory
+  complex is represented as a single PROTEIN_COMPLEX node whose emergent,
+  complex-level catalytic activity is carried by ONE complex-level annoton (the
+  redox half-reaction it performs), with its functionally important subunits
+  exposed as `active_units` on the complex descriptor rather than as separate
+  per-subunit annotons. This mirrors the GO `contributes_to` philosophy: an
+  individual subunit contributes to but does not independently enable the
+  complex activity. Large, internally modular complexes (Complex I; the
+  F1Fo-ATP synthase) are additionally decomposed with `parts` into their
+  functional sub-modules (the N/Q/proton-pumping arms of Complex I; the F1
+  catalytic head and Fo proton turbine of ATP synthase) — this recursive
+  decomposition is the payoff of the module representation over a flat subunit
+  list. Lineage- and chemistry-specific alternatives that bypass the
+  proton-pumping complexes (type-II NADH dehydrogenase, the alternative oxidase,
+  bacterial bd-type oxidases) are captured as `variant_sets` along explicit
+  axes, so OXPHOS reads as one conserved energy-conservation plan with multiple
+  implementations. Complex assembly/biogenesis is treated as a distinct process
+  from chain operation and kept as an optional sub-module.
+status: DRAFT
+evidence:
+  - source_id: GO:0006119
+    title: oxidative phosphorylation
+    statement: The module is grounded in the GO biological-process term for oxidative phosphorylation.
+  - source_id: GO:0022904
+    title: respiratory electron transport chain
+    statement: Grounds the electron-transport-chain sub-process that builds the proton-motive force.
+  - source_id: GO:0042776
+    title: proton motive force-driven mitochondrial ATP synthesis
+    statement: Grounds the chemiosmotic ATP-synthesis sub-process coupled to the ETC.
+  - source_id: PMID:31911585
+    title: "Mitochondrial TCA Cycle and OXPHOS metabolism"
+    statement: >-
+      Review establishing the coordination of the TCA cycle and OXPHOS and the
+      role of Complex II (succinate dehydrogenase) as the shared node feeding
+      electrons from the TCA cycle into the respiratory chain.
+  - source_id: file:projects/OXPHOS.md
+    title: OXPHOS project page
+    statement: >-
+      The sibling gene-by-gene OXPHOS curation project, which this module
+      generalizes from concrete human subunits and assembly factors to a
+      taxon-neutral, recursively decomposable plan.
+notes: >-
+  Identifiers are grounded only where verified against the local validated
+  OXPHOS gene reviews, the OXPHOS project page, or the sibling photosynthesis
+  module; descriptors without a `term` are deliberate (no confident identifier
+  yet, or no exact GO term exists for the abstraction) rather than oversights.
+  Subunit `active_units` are named by their conserved subunit/homolog families
+  (human gene-symbol families given as orienting names) to keep the module
+  taxon-neutral; a concrete organism module can later specialize these with
+  specific UniProt gene products, stoichiometries, and compartments without the
+  generic module enumerating every protein. Complex II is intentionally modelled
+  here as a respiratory-chain electron-entry complex; its succinate->fumarate
+  half-reaction simultaneously belongs to the TCA cycle and is the canonical
+  dual-pathway node. The plasma membrane substitutes for the mitochondrial inner
+  membrane as the coupling membrane in respiring bacteria.
+module:
+  id: oxidative_phosphorylation
+  label: Oxidative phosphorylation
+  module_type: BIOLOGICAL_PROCESS
+  concepts:
+    - preferred_term: oxidative phosphorylation
+      term:
+        id: GO:0006119
+        label: oxidative phosphorylation
+      description: >-
+        Synthesis of ATP driven by the transfer of electrons through a
+        membrane-embedded respiratory chain to a terminal acceptor (usually O2),
+        coupled chemiosmotically via a transmembrane proton-motive force.
+    - preferred_term: aerobic respiration
+      term:
+        id: GO:0009060
+        label: aerobic respiration
+      description: >-
+        The encompassing energy-yielding process when O2 is the terminal
+        electron acceptor; OXPHOS is its membrane-bound, ATP-generating stage.
+    - preferred_term: generation of precursor metabolites and energy
+      term:
+        id: GO:0006091
+        label: generation of precursor metabolites and energy
+  context:
+    taxa:
+      - preferred_term: aerobic (and facultative) bacteria
+        description: Respiratory chain assembled in the plasma membrane.
+      - preferred_term: mitochondriate eukaryotes
+        description: Respiratory chain assembled in the mitochondrial inner membrane.
+    cellular_components:
+      - preferred_term: mitochondrial inner membrane (eukaryotes)
+        term:
+          id: GO:0005743
+          label: mitochondrial inner membrane
+      - preferred_term: plasma membrane (respiring bacteria)
+        description: The bacterial coupling membrane, equivalent to the mitochondrial inner membrane.
+  parts:
+    - order: 1
+      role: respiratory electron transport and proton pumping
+      node:
+        id: respiratory_etc
+        label: Respiratory electron transport chain
+        module_type: BIOLOGICAL_PROCESS
+        description: >-
+          Sequential, exergonic electron transfer from reduced cofactors to a
+          terminal acceptor through membrane redox complexes and two mobile
+          carriers (a quinone pool and a soluble cytochrome/copper carrier),
+          with three of the canonical complexes (I, III, IV) coupling electron
+          flow to vectorial proton translocation that charges the membrane.
+        concepts:
+          - preferred_term: respiratory electron transport chain
+            term:
+              id: GO:0022904
+              label: respiratory electron transport chain
+          - preferred_term: electron transport chain
+            term:
+              id: GO:0022900
+              label: electron transport chain
+        parts:
+          - order: 1
+            role: NADH:quinone oxidoreduction (canonical, proton-pumping)
+            node:
+              id: complex_I
+              label: Complex I (NADH:ubiquinone oxidoreductase)
+              module_type: PROTEIN_COMPLEX
+              description: >-
+                The largest respiratory complex (~1 MDa; ~14 conserved core
+                subunits plus many accessory subunits in eukaryotes). An
+                L-shaped enzyme whose hydrophilic arm oxidizes NADH and relays
+                electrons through a chain of iron-sulfur clusters to reduce
+                ubiquinone at the arm/membrane junction, and whose membrane arm
+                uses the redox free energy to pump four protons per NADH via
+                antiporter-like subunits. Functionally and evolutionarily
+                tripartite: the N (NADH-oxidizing), Q (quinone-reducing) and
+                P (proton-pumping) modules.
+              concepts:
+                - preferred_term: respiratory chain complex I
+                  term:
+                    id: GO:0045271
+                    label: respiratory chain complex I
+              annotons:
+                - id: complex_I_activity
+                  label: NADH:ubiquinone oxidoreductase (proton-pumping)
+                  participant:
+                    selector_type: PROTEIN_COMPLEX
+                    protein_complex:
+                      preferred_term: NADH:ubiquinone oxidoreductase complex
+                      term:
+                        id: GO:0045271
+                        label: respiratory chain complex I
+                      active_units:
+                        - id: ci_flavoprotein
+                          label: FMN/NADH-binding catalytic subunit (NDUFV1/NuoF/Nqo1 family)
+                          role: Primary electron acceptor; oxidizes NADH at the FMN, the entry point of the N-module.
+                          participant:
+                            selector_type: FAMILY
+                            family:
+                              preferred_term: NDUFV1 / NuoF / Nqo1 flavoprotein family
+                          function:
+                            preferred_term: NADH dehydrogenase activity (FMN-dependent)
+                            term:
+                              id: GO:0003954
+                              label: NADH dehydrogenase activity
+                        - id: ci_fes_relay
+                          label: Iron-sulfur relay subunits (NDUFS1/NDUFV2/NDUFS7/NDUFS8 families)
+                          role: Chain of [2Fe-2S]/[4Fe-4S] clusters conducting electrons from FMN to the quinone site.
+                          participant:
+                            selector_type: FAMILY
+                            family:
+                              preferred_term: Complex I iron-sulfur subunits (NDUFS1/NuoG, NDUFV2/NuoE, NDUFS7/NuoB, NDUFS8/NuoI)
+                          function:
+                            preferred_term: electron transfer via iron-sulfur clusters
+                            term:
+                              id: GO:0009055
+                              label: electron transfer activity
+                        - id: ci_quinone_subunit
+                          label: Quinone-binding core subunit (NDUFS2/NuoD/Nqo4 family)
+                          role: Forms the ubiquinone-reduction site at the junction of the hydrophilic and membrane arms.
+                          participant:
+                            selector_type: FAMILY
+                            family:
+                              preferred_term: NDUFS2 / NuoD / Nqo4 family
+                        - id: ci_membrane_pumps
+                          label: Antiporter-like proton-pumping membrane subunits (ND2/ND4/ND5; NuoL/M/N)
+                          role: Mitochondrially (or operon)-encoded membrane subunits that translocate protons driven by quinone-coupled conformational changes.
+                          participant:
+                            selector_type: FAMILY
+                            family:
+                              preferred_term: ND2/ND4/ND5 (NuoL/NuoM/NuoN) antiporter-like family
+                  function:
+                    preferred_term: NADH:ubiquinone oxidoreductase activity
+                    term:
+                      id: GO:0008137
+                      label: NADH dehydrogenase (ubiquinone) activity
+                    substrates:
+                      - preferred_term: NADH
+                      - preferred_term: ubiquinone
+                      - preferred_term: proton (matrix/cytoplasmic side)
+                    products:
+                      - preferred_term: NAD+
+                      - preferred_term: ubiquinol
+                      - preferred_term: proton (intermembrane/periplasmic side)
+                    cofactors:
+                      - preferred_term: FMN
+                      - preferred_term: iron-sulfur clusters
+                  processes:
+                    - preferred_term: mitochondrial electron transport, NADH to ubiquinone
+                      term:
+                        id: GO:0006120
+                        label: mitochondrial electron transport, NADH to ubiquinone
+                  locations:
+                    - preferred_term: mitochondrial inner / bacterial plasma membrane
+                      term:
+                        id: GO:0005743
+                        label: mitochondrial inner membrane
+                  role_description: >-
+                    Couples NADH oxidation and ubiquinone reduction to the
+                    translocation of ~4 H+ per NADH; the major entry point of
+                    electrons into the chain and a principal site of the
+                    proton-motive force and of superoxide production.
+              parts:
+                - order: 1
+                  role: NADH oxidation (N-module)
+                  node:
+                    id: complex_I_N_module
+                    label: Complex I N-module (NADH dehydrogenase)
+                    module_type: MOLECULAR_FUNCTION
+                    description: >-
+                      Distal tip of the hydrophilic arm bearing the FMN and the
+                      first iron-sulfur clusters; oxidizes NADH and injects
+                      electrons into the relay.
+                    annotons:
+                      - id: ci_n_module_nadh_oxidation
+                        label: FMN-dependent NADH oxidation
+                        participant:
+                          selector_type: FAMILY
+                          family:
+                            preferred_term: N-module subunits (NDUFV1/NDUFV2/NDUFS1)
+                        function:
+                          preferred_term: NADH dehydrogenase activity
+                          term:
+                            id: GO:0003954
+                            label: NADH dehydrogenase activity
+                          substrates:
+                            - preferred_term: NADH
+                          products:
+                            - preferred_term: NAD+
+                          cofactors:
+                            - preferred_term: FMN
+                - order: 2
+                  role: ubiquinone reduction (Q-module)
+                  node:
+                    id: complex_I_Q_module
+                    label: Complex I Q-module (quinone reduction)
+                    module_type: MOLECULAR_FUNCTION
+                    description: >-
+                      Proximal hydrophilic-arm/membrane junction carrying the
+                      terminal iron-sulfur cluster (N2) and the ubiquinone-binding
+                      cavity where electrons reduce ubiquinone to ubiquinol.
+                    annotons:
+                      - id: ci_q_module_quinone_reduction
+                        label: Ubiquinone reduction at the Q-site
+                        participant:
+                          selector_type: FAMILY
+                          family:
+                            preferred_term: Q-module subunits (NDUFS2/NDUFS3/NDUFS7/NDUFS8)
+                        function:
+                          preferred_term: ubiquinone reduction
+                          description: >-
+                            Two-electron reduction of ubiquinone to ubiquinol;
+                            modelled as a sub-function of the complex-level
+                            NADH:ubiquinone oxidoreductase activity, so no
+                            separate exact GO MF id is asserted here.
+                          substrates:
+                            - preferred_term: ubiquinone
+                          products:
+                            - preferred_term: ubiquinol
+                - order: 3
+                  role: proton translocation (P-module / membrane arm)
+                  node:
+                    id: complex_I_P_module
+                    label: Complex I P-module (membrane proton-pumping arm)
+                    module_type: TRANSPORT_STEP
+                    description: >-
+                      Membrane arm of antiporter-like subunits that translocate
+                      protons; conformational energy from quinone chemistry is
+                      transmitted along the arm to drive pumping remote from the
+                      redox centres.
+                    annotons:
+                      - id: ci_p_module_proton_pumping
+                        label: Redox-coupled proton translocation
+                        participant:
+                          selector_type: FAMILY
+                          family:
+                            preferred_term: Membrane-arm antiporter-like subunits (ND1-ND6, ND4L; NuoH/J/K/L/M/N/A)
+                        function:
+                          preferred_term: proton transmembrane transport
+                          term:
+                            id: GO:1902600
+                            label: proton transmembrane transport
+                          substrates:
+                            - preferred_term: proton (matrix/cytoplasmic side)
+                          products:
+                            - preferred_term: proton (intermembrane/periplasmic side)
+          - order: 2
+            role: succinate:quinone oxidoreduction (TCA-cycle-linked, non-pumping)
+            node:
+              id: complex_II
+              label: Complex II (succinate dehydrogenase / succinate:quinone oxidoreductase)
+              module_type: PROTEIN_COMPLEX
+              description: >-
+                The only membrane respiratory complex shared with the TCA cycle
+                and the only canonical complex that does not pump protons. Its
+                FAD-bearing flavoprotein oxidizes succinate to fumarate (TCA
+                step 6) and relays electrons through three iron-sulfur clusters
+                and a membrane b-heme to reduce ubiquinone, feeding the quinone
+                pool without contributing to the proton-motive force.
+              concepts:
+                - preferred_term: respiratory chain complex II (succinate dehydrogenase)
+                  term:
+                    id: GO:0045273
+                    label: respiratory chain complex II (succinate dehydrogenase)
+              annotons:
+                - id: complex_II_activity
+                  label: Succinate:ubiquinone oxidoreductase
+                  participant:
+                    selector_type: PROTEIN_COMPLEX
+                    protein_complex:
+                      preferred_term: succinate dehydrogenase (ubiquinone) complex
+                      term:
+                        id: GO:0045273
+                        label: respiratory chain complex II (succinate dehydrogenase)
+                      active_units:
+                        - id: cii_flavoprotein
+                          label: Flavoprotein subunit (SDHA/SdhA family)
+                          role: Covalent-FAD subunit; oxidizes succinate to fumarate (the TCA-cycle half-reaction).
+                          participant:
+                            selector_type: FAMILY
+                            family:
+                              preferred_term: SDHA / SdhA flavoprotein family
+                          function:
+                            preferred_term: succinate dehydrogenase activity
+                            term:
+                              id: GO:0000104
+                              label: succinate dehydrogenase activity
+                        - id: cii_fes
+                          label: Iron-sulfur subunit (SDHB/SdhB family)
+                          role: Three Fe-S clusters relaying electrons from FAD toward the quinone site; tumour-suppressor subunit in humans.
+                          participant:
+                            selector_type: FAMILY
+                            family:
+                              preferred_term: SDHB / SdhB iron-sulfur family
+                          function:
+                            preferred_term: electron transfer activity
+                            term:
+                              id: GO:0009055
+                              label: electron transfer activity
+                        - id: cii_membrane_anchor
+                          label: Membrane-anchor / quinone-binding subunits (SDHC+SDHD / SdhC+SdhD)
+                          role: Bind heme b and form the ubiquinone-reduction site that delivers electrons to the quinone pool.
+                          participant:
+                            selector_type: FAMILY
+                            family:
+                              preferred_term: SDHC/SDHD (SdhC/SdhD) membrane-anchor family
+                  function:
+                    preferred_term: succinate dehydrogenase (quinone) activity
+                    term:
+                      id: GO:0008177
+                      label: succinate dehydrogenase (quinone) activity
+                    substrates:
+                      - preferred_term: succinate
+                      - preferred_term: ubiquinone
+                    products:
+                      - preferred_term: fumarate
+                      - preferred_term: ubiquinol
+                    cofactors:
+                      - preferred_term: FAD
+                      - preferred_term: iron-sulfur clusters
+                      - preferred_term: heme b
+                  processes:
+                    - preferred_term: mitochondrial electron transport, succinate to ubiquinone
+                      term:
+                        id: GO:0006121
+                        label: mitochondrial electron transport, succinate to ubiquinone
+                  locations:
+                    - preferred_term: mitochondrial inner / bacterial plasma membrane
+                      term:
+                        id: GO:0005743
+                        label: mitochondrial inner membrane
+                  role_description: >-
+                    Bridges the TCA cycle and the respiratory chain; does not
+                    pump protons, so its electrons enter the quinone pool at no
+                    direct energetic gain to the proton-motive force.
+                  evidence:
+                    - source_id: PMID:31911585
+                      statement: >-
+                        Succinate dehydrogenase is the shared node coupling the
+                        TCA cycle to the respiratory chain.
+          - order: 3
+            role: auxiliary quinone-reducing dehydrogenases (additional electron entry)
+            optional: true
+            node:
+              id: auxiliary_quinone_dehydrogenases
+              label: Auxiliary dehydrogenases feeding the quinone pool
+              module_type: BIOLOGICAL_PROCESS
+              description: >-
+                Membrane-associated dehydrogenases that reduce the quinone pool
+                outside of Complexes I/II, coupling other metabolic pathways to
+                respiration. None pump protons. Present to varying degrees across
+                taxa and tissues.
+              annotons:
+                - id: etf_quinone_oxidoreductase
+                  label: Electron-transfer-flavoprotein:ubiquinone oxidoreductase (ETF-QO)
+                  participant:
+                    selector_type: ANY_WITH_FUNCTION
+                    required_function:
+                      preferred_term: electron-transferring-flavoprotein dehydrogenase activity
+                      term:
+                        id: GO:0004174
+                        label: electron-transferring-flavoprotein dehydrogenase activity
+                  function:
+                    preferred_term: electron-transferring-flavoprotein dehydrogenase activity
+                    term:
+                      id: GO:0004174
+                      label: electron-transferring-flavoprotein dehydrogenase activity
+                    substrates:
+                      - preferred_term: reduced electron-transfer flavoprotein
+                      - preferred_term: ubiquinone
+                    products:
+                      - preferred_term: oxidized electron-transfer flavoprotein
+                      - preferred_term: ubiquinol
+                  role_description: Channels electrons from mitochondrial fatty-acid beta-oxidation and amino-acid catabolism into the quinone pool.
+                - id: glycerol_3_phosphate_dehydrogenase
+                  label: Mitochondrial glycerol-3-phosphate dehydrogenase (FAD)
+                  participant:
+                    selector_type: FAMILY
+                    family:
+                      preferred_term: FAD-dependent glycerol-3-phosphate dehydrogenase (GPD2 family)
+                  function:
+                    preferred_term: glycerol-3-phosphate:quinone oxidoreductase activity
+                    description: >-
+                      FAD-linked, outer-face inner-membrane enzyme of the
+                      glycerophosphate shuttle that oxidizes glycerol-3-phosphate
+                      and reduces ubiquinone; no confident exact GO MF id asserted here.
+                    substrates:
+                      - preferred_term: sn-glycerol 3-phosphate
+                      - preferred_term: ubiquinone
+                    products:
+                      - preferred_term: dihydroxyacetone phosphate
+                      - preferred_term: ubiquinol
+                - id: dihydroorotate_dehydrogenase
+                  label: Dihydroorotate dehydrogenase (quinone)
+                  participant:
+                    selector_type: ANY_WITH_FUNCTION
+                    required_function:
+                      preferred_term: dihydroorotate dehydrogenase activity
+                      term:
+                        id: GO:0004152
+                        label: dihydroorotate dehydrogenase activity
+                  function:
+                    preferred_term: dihydroorotate dehydrogenase (quinone) activity
+                    term:
+                      id: GO:0004152
+                      label: dihydroorotate dehydrogenase activity
+                    substrates:
+                      - preferred_term: dihydroorotate
+                      - preferred_term: ubiquinone
+                    products:
+                      - preferred_term: orotate
+                      - preferred_term: ubiquinol
+                  role_description: Couples de novo pyrimidine biosynthesis to the quinone pool; a major reason respiration is required for nucleotide synthesis.
+          - order: 4
+            role: mobile electron carrier (quinone pool)
+            node:
+              id: quinone_pool
+              label: Quinone pool (ubiquinone/menaquinone)
+              module_type: MOLECULAR_FUNCTION
+              description: >-
+                Lipid-soluble two-electron/two-proton carrier diffusing within
+                the membrane that collects electrons from all upstream
+                dehydrogenases and delivers them to Complex III (or to a quinol
+                oxidase). The quinone used is lineage-dependent.
+              annotons:
+                - id: quinone_electron_carrier
+                  label: Membrane quinone electron/proton carrier
+                  participant:
+                    selector_type: ANY_PARTICIPANT
+                    description: A diffusible membrane quinone (not a protein); represented as a functional carrier node.
+                  function:
+                    preferred_term: quinone-mediated electron and proton transfer
+                    term:
+                      id: GO:0009055
+                      label: electron transfer activity
+                    cofactors:
+                      - preferred_term: ubiquinone (CoQ10) — most eukaryotes and many proteobacteria
+                      - preferred_term: menaquinone / demethylmenaquinone — many bacteria
+                  locations:
+                    - preferred_term: mitochondrial inner / bacterial plasma membrane (lipid bilayer)
+                      term:
+                        id: GO:0005743
+                        label: mitochondrial inner membrane
+          - order: 5
+            role: quinol:cytochrome-c oxidoreduction (canonical, proton-pumping)
+            node:
+              id: complex_III
+              label: Complex III (cytochrome bc1 / quinol:cytochrome-c reductase)
+              module_type: PROTEIN_COMPLEX
+              description: >-
+                An obligate homodimer that oxidizes ubiquinol and reduces the
+                soluble carrier (cytochrome c / c2) via the protonmotive Q-cycle,
+                in which bifurcated electron transfer recycles one electron
+                through two b-hemes to a second quinone, doubling the protons
+                translocated per electron reaching cytochrome c.
+              concepts:
+                - preferred_term: respiratory chain complex III
+                  term:
+                    id: GO:0045275
+                    label: respiratory chain complex III
+              annotons:
+                - id: complex_III_activity
+                  label: Quinol:cytochrome-c reductase (Q-cycle)
+                  participant:
+                    selector_type: PROTEIN_COMPLEX
+                    protein_complex:
+                      preferred_term: cytochrome bc1 complex (dimeric)
+                      term:
+                        id: GO:0045275
+                        label: respiratory chain complex III
+                      active_units:
+                        - id: ciii_cytb
+                          label: Cytochrome b (MT-CYB / PetB family)
+                          role: Bears the low- and high-potential b-hemes (bL/bH) that carry out Q-cycle electron bifurcation; the only mtDNA-encoded subunit in animals.
+                          participant:
+                            selector_type: FAMILY
+                            family:
+                              preferred_term: cytochrome b (MT-CYB / QcrB) family
+                          function:
+                            preferred_term: electron transfer via b-type hemes
+                            term:
+                              id: GO:0009055
+                              label: electron transfer activity
+                        - id: ciii_cyt_c1
+                          label: Cytochrome c1 (CYC1 family)
+                          role: High-potential c1 heme that reduces the soluble cytochrome c carrier.
+                          participant:
+                            selector_type: FAMILY
+                            family:
+                              preferred_term: cytochrome c1 (CYC1 / QcrC) family
+                          function:
+                            preferred_term: electron transfer to cytochrome c
+                            term:
+                              id: GO:0009055
+                              label: electron transfer activity
+                        - id: ciii_rieske
+                          label: Rieske iron-sulfur protein (UQCRFS1 / PetA family)
+                          role: Mobile [2Fe-2S] head that oxidizes ubiquinol at the Qo site and initiates Q-cycle bifurcation.
+                          participant:
+                            selector_type: FAMILY
+                            family:
+                              preferred_term: Rieske Fe-S protein (UQCRFS1 / QcrA / PetA) family
+                          function:
+                            preferred_term: ubiquinol oxidation via [2Fe-2S] cluster
+                            term:
+                              id: GO:0009055
+                              label: electron transfer activity
+                  function:
+                    preferred_term: quinol-cytochrome-c reductase activity
+                    term:
+                      id: GO:0008121
+                      label: quinol-cytochrome-c reductase activity
+                    substrates:
+                      - preferred_term: ubiquinol
+                      - preferred_term: cytochrome c (oxidized)
+                      - preferred_term: proton (matrix/cytoplasmic side)
+                    products:
+                      - preferred_term: ubiquinone
+                      - preferred_term: cytochrome c (reduced)
+                      - preferred_term: proton (intermembrane/periplasmic side)
+                  processes:
+                    - preferred_term: mitochondrial electron transport, ubiquinol to cytochrome c
+                      term:
+                        id: GO:0006122
+                        label: mitochondrial electron transport, ubiquinol to cytochrome c
+                  locations:
+                    - preferred_term: mitochondrial inner / bacterial plasma membrane
+                      term:
+                        id: GO:0005743
+                        label: mitochondrial inner membrane
+                  role_description: >-
+                    Oxidizes ubiquinol and reduces cytochrome c while
+                    translocating protons via the Q-cycle; frequently a
+                    rate-controlling step and a site of superoxide generation.
+          - order: 6
+            role: mobile electron carrier (soluble cytochrome)
+            node:
+              id: cytochrome_c
+              label: Cytochrome c (soluble carrier)
+              module_type: MOLECULAR_FUNCTION
+              description: >-
+                Small soluble c-type cytochrome on the positive (intermembrane
+                space / periplasmic) face that shuttles single electrons from
+                Complex III to Complex IV. In eukaryotes the same protein is a
+                pro-apoptotic signal when released to the cytosol.
+              annotons:
+                - id: cytochrome_c_electron_transfer
+                  label: Cytochrome c electron shuttling
+                  participant:
+                    selector_type: FAMILY
+                    family:
+                      preferred_term: cytochrome c / cytochrome c2 family
+                  function:
+                    preferred_term: electron transfer activity
+                    term:
+                      id: GO:0009055
+                      label: electron transfer activity
+                    cofactors:
+                      - preferred_term: heme c
+                  locations:
+                    - preferred_term: intermembrane space / periplasm (positive membrane face)
+                      term:
+                        id: GO:0005758
+                        label: mitochondrial intermembrane space
+          - order: 7
+            role: terminal electron transfer to dioxygen (canonical, proton-pumping)
+            node:
+              id: complex_IV
+              label: Complex IV (cytochrome c oxidase)
+              module_type: PROTEIN_COMPLEX
+              description: >-
+                The terminal oxidase of the canonical chain; an aa3-type
+                heme-copper oxidase that accepts electrons from cytochrome c and
+                reduces O2 to water at a binuclear heme a3/CuB centre, both
+                consuming matrix protons for chemistry and pumping additional
+                protons across the membrane.
+              concepts:
+                - preferred_term: respiratory chain complex IV
+                  term:
+                    id: GO:0045277
+                    label: respiratory chain complex IV
+              annotons:
+                - id: complex_IV_activity
+                  label: Cytochrome c oxidase (O2 reduction)
+                  participant:
+                    selector_type: PROTEIN_COMPLEX
+                    protein_complex:
+                      preferred_term: cytochrome c oxidase (aa3-type)
+                      term:
+                        id: GO:0045277
+                        label: respiratory chain complex IV
+                      active_units:
+                        - id: civ_cox1
+                          label: Catalytic subunit I (MT-CO1 / CoxA family)
+                          role: Bears heme a, and the heme a3/CuB binuclear centre where O2 is reduced to water; contains the proton channels.
+                          participant:
+                            selector_type: FAMILY
+                            family:
+                              preferred_term: cytochrome c oxidase subunit I (MT-CO1 / CoxA) family
+                          function:
+                            preferred_term: dioxygen reduction at the heme-copper centre
+                            term:
+                              id: GO:0004129
+                              label: cytochrome-c oxidase activity
+                        - id: civ_cox2
+                          label: Subunit II (MT-CO2 / CoxB family)
+                          role: Bears the binuclear CuA centre that receives electrons from cytochrome c.
+                          participant:
+                            selector_type: FAMILY
+                            family:
+                              preferred_term: cytochrome c oxidase subunit II (MT-CO2 / CoxB) family
+                          function:
+                            preferred_term: electron acceptance from cytochrome c (CuA centre)
+                            term:
+                              id: GO:0009055
+                              label: electron transfer activity
+                        - id: civ_cox3
+                          label: Subunit III (MT-CO3 / CoxC family)
+                          role: Core membrane subunit important for assembly and proton-pathway integrity; no redox cofactor.
+                          participant:
+                            selector_type: FAMILY
+                            family:
+                              preferred_term: cytochrome c oxidase subunit III (MT-CO3 / CoxC) family
+                  function:
+                    preferred_term: cytochrome-c oxidase activity
+                    term:
+                      id: GO:0004129
+                      label: cytochrome-c oxidase activity
+                    substrates:
+                      - preferred_term: cytochrome c (reduced)
+                      - preferred_term: dioxygen
+                      - preferred_term: proton (matrix/cytoplasmic side)
+                    products:
+                      - preferred_term: cytochrome c (oxidized)
+                      - preferred_term: water
+                      - preferred_term: proton (intermembrane/periplasmic side)
+                    cofactors:
+                      - preferred_term: heme a
+                      - preferred_term: heme a3
+                      - preferred_term: CuA
+                      - preferred_term: CuB
+                  processes:
+                    - preferred_term: mitochondrial electron transport, cytochrome c to oxygen
+                      term:
+                        id: GO:0006123
+                        label: mitochondrial electron transport, cytochrome c to oxygen
+                  locations:
+                    - preferred_term: mitochondrial inner / bacterial plasma membrane
+                      term:
+                        id: GO:0005743
+                        label: mitochondrial inner membrane
+                  role_description: >-
+                    Terminal, essentially irreversible step that reduces O2 to
+                    water and pumps protons; sets the directionality of the chain
+                    and is a key regulatory and tissue-specific (isoform) node.
+          - order: 8
+            role: lineage-specific respiratory-chain variants (bypass branches)
+            optional: true
+            node:
+              id: respiratory_chain_variants
+              label: Lineage-specific entry and terminal-oxidase variants
+              module_type: BIOLOGICAL_PROCESS
+              description: >-
+                Alternative implementations of the chain that exist alongside or
+                in place of the canonical proton-pumping complexes. These bypass
+                branches conserve less (or no) free energy as proton-motive force
+                but provide metabolic flexibility, stress tolerance, and redox
+                balancing.
+              variant_sets:
+                - id: nadh_to_quinone_route
+                  label: NADH:quinone oxidoreduction route
+                  axis: enzyme family / energy conservation
+                  selection: ONE_OR_MORE
+                  variants:
+                    - id: canonical_complex_I_variant
+                      label: Proton-pumping Complex I
+                      module_type: PROTEIN_COMPLEX
+                      description: The canonical, energy-conserving NADH:ubiquinone oxidoreductase (see complex_I node).
+                      annotons:
+                        - id: canonical_ci_ref
+                          label: Complex I (energy-conserving)
+                          participant:
+                            selector_type: PROTEIN_COMPLEX
+                            protein_complex:
+                              preferred_term: respiratory chain complex I
+                              term:
+                                id: GO:0045271
+                                label: respiratory chain complex I
+                          role_description: Pumps ~4 H+ per NADH; present in most mitochondria and many bacteria.
+                    - id: type_II_ndh_variant
+                      label: Type-II NADH dehydrogenase (NDH-2, non-pumping)
+                      module_type: MOLECULAR_FUNCTION
+                      description: >-
+                        Single-subunit, FAD-dependent, rotenone-insensitive
+                        alternative NADH:quinone oxidoreductase found in plants,
+                        fungi, protists, and many bacteria (and absent in
+                        mammals). It reduces the quinone pool without pumping
+                        protons, providing a non-energy-conserving NADH bypass.
+                      annotons:
+                        - id: ndh2_activity
+                          label: NDH-2 NADH:quinone oxidoreductase (non-pumping)
+                          participant:
+                            selector_type: FAMILY
+                            family:
+                              preferred_term: type-II NADH dehydrogenase (NDH-2 / NDI1 / Ndh) family
+                          function:
+                            preferred_term: NADH dehydrogenase activity (non-proton-pumping)
+                            term:
+                              id: GO:0003954
+                              label: NADH dehydrogenase activity
+                            substrates:
+                              - preferred_term: NADH
+                              - preferred_term: quinone
+                            products:
+                              - preferred_term: NAD+
+                              - preferred_term: quinol
+                          role_description: Re-oxidizes NADH and reduces the quinone pool with no charge separation.
+                - id: terminal_oxidase_route
+                  label: Route from the quinone pool / cytochrome c to O2
+                  axis: terminal oxidase family / energy conservation
+                  selection: ONE_OR_MORE
+                  variants:
+                    - id: cytochrome_pathway_variant
+                      label: Cytochrome pathway (Complex III -> cytochrome c -> Complex IV)
+                      module_type: BIOLOGICAL_PROCESS
+                      description: The canonical, proton-pumping bc1 -> cytochrome c -> aa3 oxidase route (see complex_III, cytochrome_c, complex_IV nodes).
+                      annotons:
+                        - id: cytochrome_pathway_ref
+                          label: bc1 / cytochrome c / aa3 oxidase route
+                          participant:
+                            selector_type: PROTEIN_COMPLEX
+                            protein_complex:
+                              preferred_term: cytochrome pathway terminal segment
+                              description: The canonical CIII + cytochrome c + CIV segment of the chain.
+                          role_description: Energy-conserving; both CIII and CIV pump protons.
+                    - id: alternative_oxidase_variant
+                      label: Alternative oxidase (AOX) ubiquinol:O2 bypass
+                      module_type: MOLECULAR_FUNCTION
+                      description: >-
+                        Cyanide-insensitive, non-proton-pumping di-iron ubiquinol
+                        oxidase of plants, fungi, and many protists (and some
+                        animals) that oxidizes ubiquinol and reduces O2 to water
+                        directly, bypassing both Complex III and Complex IV and
+                        dissipating the redox energy as heat.
+                      annotons:
+                        - id: aox_activity
+                          label: Alternative oxidase (ubiquinol:O2 oxidoreductase)
+                          participant:
+                            selector_type: FAMILY
+                            family:
+                              preferred_term: alternative oxidase (AOX) family
+                          function:
+                            preferred_term: ubiquinol:oxygen oxidoreductase activity (non-pumping)
+                            description: >-
+                              Reduces O2 to water using ubiquinol at a non-heme
+                              di-iron centre; no proton pumping. No confident
+                              exact GO MF id is asserted here for the generic module.
+                            substrates:
+                              - preferred_term: ubiquinol
+                              - preferred_term: dioxygen
+                            products:
+                              - preferred_term: ubiquinone
+                              - preferred_term: water
+                          role_description: Provides an overflow/antioxidant electron sink; thermogenic in some plants.
+                    - id: bd_oxidase_variant
+                      label: Bacterial bd-type quinol oxidase
+                      module_type: MOLECULAR_FUNCTION
+                      description: >-
+                        High-O2-affinity cytochrome bd quinol oxidase used by many
+                        bacteria under microaerobic or stress conditions; oxidizes
+                        quinol and reduces O2 to water with a lower (or no) proton
+                        pumping stoichiometry than heme-copper oxidases.
+                      annotons:
+                        - id: bd_oxidase_activity
+                          label: Cytochrome bd quinol oxidase
+                          participant:
+                            selector_type: FAMILY
+                            family:
+                              preferred_term: cytochrome bd ubiquinol oxidase (CydAB) family
+                          function:
+                            preferred_term: quinol:oxygen oxidoreductase activity
+                            description: Reduces O2 to water from quinol; no confident exact GO MF id asserted here for the generic module.
+                            substrates:
+                              - preferred_term: quinol
+                              - preferred_term: dioxygen
+                            products:
+                              - preferred_term: quinone
+                              - preferred_term: water
+                          role_description: Confers tolerance to low O2, nitrosative and oxidative stress in bacteria.
+        connections:
+          - source: complex_I
+            target: quinone_pool
+            connection_type: PROVIDES_INPUT_FOR
+            description: Complex I reduces ubiquinone to ubiquinol, charging the quinone pool.
+          - source: complex_II
+            target: quinone_pool
+            connection_type: PROVIDES_INPUT_FOR
+            description: Complex II reduces the quinone pool from succinate (TCA cycle).
+          - source: auxiliary_quinone_dehydrogenases
+            target: quinone_pool
+            connection_type: PROVIDES_INPUT_FOR
+            description: ETF-QO, glycerol-3-phosphate dehydrogenase, and DHODH reduce the quinone pool from other pathways.
+          - source: quinone_pool
+            target: complex_III
+            connection_type: PROVIDES_INPUT_FOR
+            description: Ubiquinol from the pool is the substrate oxidized by Complex III at the Qo site.
+          - source: complex_III
+            target: cytochrome_c
+            connection_type: PROVIDES_INPUT_FOR
+            description: Complex III reduces the soluble cytochrome c carrier.
+          - source: cytochrome_c
+            target: complex_IV
+            connection_type: PROVIDES_INPUT_FOR
+            description: Reduced cytochrome c donates electrons to Complex IV.
+          - source: quinone_pool
+            target: respiratory_chain_variants
+            connection_type: PROVIDES_INPUT_FOR
+            description: The alternative oxidase and bacterial quinol oxidases draw electrons directly from the quinone pool, bypassing CIII/CIV.
+    - order: 2
+      role: chemiosmotic ATP synthesis from the proton-motive force
+      node:
+        id: atp_synthesis
+        label: ATP synthesis (F1Fo-ATP synthase, Complex V)
+        module_type: PROTEIN_COMPLEX
+        description: >-
+          A rotary molecular motor that couples proton flow down the
+          electrochemical gradient (through the membrane Fo sector) to mechanical
+          rotation that drives ADP phosphorylation at the catalytic F1 head. It
+          is the terminal energy-conserving step of OXPHOS and runs reversibly:
+          under collapse of the proton-motive force it can hydrolyze ATP, a mode
+          restrained by a dedicated inhibitor.
+        concepts:
+          - preferred_term: proton-transporting ATP synthase complex
+            term:
+              id: GO:0045259
+              label: proton-transporting ATP synthase complex
+          - preferred_term: proton-transporting two-sector ATPase complex
+            term:
+              id: GO:0016469
+              label: proton-transporting two-sector ATPase complex
+        annotons:
+          - id: complex_V_activity
+            label: Proton-motive-force-driven ATP synthesis (rotational)
+            participant:
+              selector_type: PROTEIN_COMPLEX
+              protein_complex:
+                preferred_term: F1Fo-ATP synthase
+                term:
+                  id: GO:0045259
+                  label: proton-transporting ATP synthase complex
+                active_units:
+                  - id: cv_f1_catalytic
+                    label: F1 catalytic subunits (alpha3/beta3 + central stalk)
+                    role: alpha3beta3 hexamer with catalytic sites on the beta subunits; the gamma/delta/epsilon central stalk converts c-ring rotation into catalytic conformational cycling.
+                    participant:
+                      selector_type: FAMILY
+                      family:
+                        preferred_term: F1 ATP synthase subunits (ATP5F1A/ATP5F1B/ATP5F1C; AtpA/AtpD/AtpG)
+                    function:
+                      preferred_term: ATP synthesis at the catalytic beta subunit
+                      term:
+                        id: GO:0046933
+                        label: "proton-transporting ATP synthase activity, rotational mechanism"
+                  - id: cv_fo_rotor
+                    label: Fo proton-translocating sector (c-ring + a-subunit)
+                    role: The membrane c-ring rotor and stator a-subunit form the two half-channels through which protons cross, driving rotation.
+                    participant:
+                      selector_type: FAMILY
+                      family:
+                        preferred_term: Fo c-ring and a-subunit (ATP5MC1-3 / ATP5MK; AtpE/AtpB)
+                    function:
+                      preferred_term: proton transmembrane transport coupled to rotation
+                      term:
+                        id: GO:1902600
+                        label: proton transmembrane transport
+                  - id: cv_peripheral_stalk
+                    label: Peripheral stalk / stator (OSCP, b, d, F6)
+                    role: Holds the alpha3beta3 head against the torque of rotation (the stator), coupling proton flow to catalysis.
+                    participant:
+                      selector_type: FAMILY
+                      family:
+                        preferred_term: ATP synthase peripheral stalk (ATP5PO/OSCP, ATP5PB, ATP5PD, ATP5PF; AtpF/AtpH)
+            function:
+              preferred_term: "proton-transporting ATP synthase activity, rotational mechanism"
+              term:
+                id: GO:0046933
+                label: "proton-transporting ATP synthase activity, rotational mechanism"
+              substrates:
+                - preferred_term: ADP
+                - preferred_term: phosphate
+                - preferred_term: proton (intermembrane/periplasmic side)
+              products:
+                - preferred_term: ATP
+                - preferred_term: proton (matrix/cytoplasmic side)
+            processes:
+              - preferred_term: proton motive force-driven mitochondrial ATP synthesis
+                term:
+                  id: GO:0042776
+                  label: proton motive force-driven mitochondrial ATP synthesis
+            locations:
+              - preferred_term: mitochondrial inner / bacterial plasma membrane
+                term:
+                  id: GO:0005743
+                  label: mitochondrial inner membrane
+            role_description: >-
+              Converts the proton-motive force into the bulk of cellular ATP;
+              also shapes inner-membrane cristae through dimer rows.
+        parts:
+          - order: 1
+            role: catalytic head (F1)
+            node:
+              id: atp_synthase_F1
+              label: F1 catalytic head
+              module_type: MOLECULAR_FUNCTION
+              description: >-
+                Soluble alpha3beta3 hexamer with three catalytic sites cycling
+                through open/loose/tight states (binding-change mechanism) as the
+                central stalk rotates; synthesizes ATP from ADP and phosphate.
+              annotons:
+                - id: f1_atp_synthesis
+                  label: Rotational ATP synthesis at F1
+                  participant:
+                    selector_type: FAMILY
+                    family:
+                      preferred_term: F1 alpha/beta/gamma subunits
+                  function:
+                    preferred_term: "proton-transporting ATP synthase activity, rotational mechanism"
+                    term:
+                      id: GO:0046933
+                      label: "proton-transporting ATP synthase activity, rotational mechanism"
+                    substrates:
+                      - preferred_term: ADP
+                      - preferred_term: phosphate
+                    products:
+                      - preferred_term: ATP
+          - order: 2
+            role: proton turbine (Fo)
+            node:
+              id: atp_synthase_Fo
+              label: Fo proton-translocating sector
+              module_type: TRANSPORT_STEP
+              description: >-
+                Membrane sector where protons crossing between the a-subunit
+                half-channels protonate/deprotonate c-ring carboxylates, driving
+                rotation of the c-ring and central stalk.
+              annotons:
+                - id: fo_proton_transport
+                  label: Proton-driven c-ring rotation
+                  participant:
+                    selector_type: FAMILY
+                    family:
+                      preferred_term: Fo c-ring and a-subunit
+                  function:
+                    preferred_term: proton transmembrane transport
+                    term:
+                      id: GO:1902600
+                      label: proton transmembrane transport
+                    substrates:
+                      - preferred_term: proton (intermembrane/periplasmic side)
+                    products:
+                      - preferred_term: proton (matrix/cytoplasmic side)
+          - order: 3
+            role: inhibition of reverse (ATP-hydrolysis) mode
+            optional: true
+            node:
+              id: atp_synthase_inhibition
+              label: IF1-mediated inhibition of ATP hydrolysis
+              module_type: REGULATORY_STEP
+              description: >-
+                A pH-sensitive inhibitor (IF1 / ATPIF1 in animals; equivalents
+                elsewhere) binds the F1 catalytic interface when the membrane
+                potential collapses, blocking wasteful ATP hydrolysis without
+                impeding synthesis.
+              annotons:
+                - id: if1_inhibitor
+                  label: ATP synthase inhibitory factor
+                  participant:
+                    selector_type: FAMILY
+                    family:
+                      preferred_term: ATPase inhibitory factor 1 (ATP5IF1 / IF1) family
+                  function:
+                    preferred_term: ATPase inhibitor activity
+                    description: pH-dependent inhibition of the F1 ATP-hydrolysis (reverse) reaction. No exact GO MF id asserted in the generic module.
+                  role_description: Prevents the synthase from running backwards and dissipating ATP under ischemia/uncoupling.
+              connections:
+                - source: if1_inhibitor
+                  target: complex_V_activity
+                  connection_type: NEGATIVELY_REGULATES
+                  description: IF1 inhibits the hydrolytic (reverse) mode of the ATP synthase.
+    - order: 3
+      role: supercomplex (respirasome) organization
+      optional: true
+      node:
+        id: respirasome_organization
+        label: Respiratory supercomplex (respirasome) organization
+        module_type: CELLULAR_COMPONENT
+        description: >-
+          In many eukaryotes (and some bacteria) Complexes I, III2, and IV
+          associate into supercomplexes/respirasomes, and the ATP synthase forms
+          cristae-shaping dimer rows. Supercomplex assembly is promoted by
+          dedicated factors and is thought to aid stability, assembly, and
+          possibly substrate channeling; it is a distinct higher-order
+          organization layered on top of the individual complexes.
+        annotons:
+          - id: respirasome_assembly
+            label: Respirasome (I+III2+IV) and ATP synthase dimer organization
+            participant:
+              selector_type: PROTEIN_COMPLEX
+              protein_complex:
+                preferred_term: respiratory chain supercomplex / respirasome
+                description: >-
+                  Higher-order assembly of Complex I, the Complex III dimer, and
+                  Complex IV (with assembly factors such as COX7A2L/SCAF1); no
+                  single generic GO complex id is asserted here.
+            role_description: >-
+              Organizes the individual respiratory complexes into supercomplexes
+              and the ATP synthase into cristae-shaping rows; an organizational,
+              not catalytic, module.
+    - order: 4
+      role: biogenesis of the respiratory complexes (supporting context)
+      optional: true
+      node:
+        id: oxphos_biogenesis
+        label: OXPHOS complex biogenesis (assembly factors and cofactor delivery)
+        module_type: BIOLOGICAL_PROCESS
+        description: >-
+          Each respiratory complex is built by dedicated assembly factors and
+          cofactor-maturation enzymes that are NOT stable subunits and do NOT
+          themselves carry out electron transport — they should be annotated to
+          assembly/cofactor-insertion processes, not to the chain's catalytic
+          activities. This sub-module captures that distinction generically
+          rather than enumerating the (dozens of) factors per complex.
+        annotons:
+          - id: complex_assembly_factors
+            label: Respiratory-complex assembly factors
+            participant:
+              selector_type: ANY_PARTICIPANT
+              description: >-
+                Examples by complex (human): Complex I — NDUFAF1-8, ACAD9,
+                TMEM126B, NUBPL (Fe-S); Complex II — SDHAF1-4 (Fe-S/FAD);
+                Complex III — BCS1L, LYRM7, TTC19; Complex IV — SURF1, SCO1/2,
+                COX10/COX15 (heme A), COA factors; Complex V — TMEM70, ATPAF1/2.
+            function:
+              preferred_term: respiratory-complex assembly and cofactor maturation
+              description: >-
+                Chaperone-, scaffold-, and cofactor-insertion activities that
+                build and mature the complexes (Fe-S cluster transfer, heme A/heme
+                O biosynthesis, copper delivery, FAD insertion). Modelled as a
+                process distinct from chain operation.
+            role_description: >-
+              Distinguishes complex biogenesis from complex function; loss of an
+              assembly factor causes a complex deficiency without the factor
+              being part of the mature electron-transport machinery.
+  connections:
+    - source: respiratory_etc
+      target: atp_synthesis
+      connection_type: PRECEDES
+      description: >-
+        The electron transport chain pumps protons to build the proton-motive
+        force that the ATP synthase consumes. This is energetic (chemiosmotic)
+        coupling across the membrane, not a direct metabolite hand-off; the two
+        are obligately coupled but can be uncoupled (e.g. by uncoupling proteins
+        or protonophores).

--- a/modules/oxphos.yaml
+++ b/modules/oxphos.yaml
@@ -64,7 +64,16 @@ notes: >-
   here as a respiratory-chain electron-entry complex; its succinate->fumarate
   half-reaction simultaneously belongs to the TCA cycle and is the canonical
   dual-pathway node. The plasma membrane substitutes for the mitochondrial inner
-  membrane as the coupling membrane in respiring bacteria.
+  membrane as the coupling membrane in respiring bacteria. Scope boundaries: the
+  biosynthesis of the quinone pool (e.g. the ubiquinone/CoQ COQ pathway) and of
+  the redox cofactors (heme a/b/c, Fe-S clusters, FAD/FMN, copper centres), as
+  well as the pro-apoptotic role of cytochrome c once released to the cytosol,
+  are upstream or downstream of OXPHOS operation and are intentionally out of
+  scope here; they belong to their own pathways/gene reviews, and this module
+  treats the carriers and cofactors as supplied inputs. Per-complex assembly
+  factors are given by example in the biogenesis sub-module rather than broken
+  out as structured per-complex annotons; a concrete organism-specific
+  specialization can add that detail.
 module:
   id: oxidative_phosphorylation
   label: Oxidative phosphorylation

--- a/projects/OXPHOS.md
+++ b/projects/OXPHOS.md
@@ -25,6 +25,26 @@ The TCA cycle and OXPHOS are tightly coordinated. Complex II (SDH) uniquely brid
 pathways: the succinate → fumarate reaction (TCA step 6) simultaneously feeds electrons
 into the ETC via FAD → FADH₂ → Fe-S → ubiquinone.*
 
+## Generic OXPHOS module
+
+This project began as a gene-by-gene annotation review (below), which predates
+the Module KB. A taxon-neutral, recursively decomposable module for the whole
+pathway now lives at [`modules/oxphos.yaml`](../modules/oxphos.yaml). It models
+OXPHOS as a coupled ETC + ATP-synthesis process, represents each respiratory
+complex as a `PROTEIN_COMPLEX` node carrying its complex-level catalytic
+activity (subunits as `active_units`, not separate annotons), recursively
+decomposes the modular complexes (Complex I N/Q/P arms; ATP synthase F1/Fo), and
+captures lineage variants (type-II NADH dehydrogenase, alternative oxidase,
+bacterial bd-oxidase) as `variant_sets`. The gene-by-gene reviews remain the
+source of concrete subunit grounding that a future organism-specific module can
+specialize from.
+
+Validate with:
+
+```bash
+uv run linkml-validate -s src/ai_gene_review/schema/gene_review.yaml -C ModuleReview modules/oxphos.yaml
+```
+
 ## Model Species
 
 **Primary: Homo sapiens (human)**
@@ -274,6 +294,21 @@ mtDNA-encoded genes have limited GO annotations and are lower priority.
 - [ ] HCCS
 
 # NOTES
+
+## 2026-06-20
+
+Added a generic, taxon-neutral OXPHOS module at `modules/oxphos.yaml`
+(`ModuleReview`, validates cleanly). Key modelling decision ("how we put in
+complexes"): each respiratory complex is one `PROTEIN_COMPLEX` node whose
+emergent catalytic activity is a single complex-level annoton, with subunits as
+`active_units` (mirroring GO `contributes_to`) rather than per-subunit annotons;
+Complex I and the ATP synthase are additionally decomposed into functional
+sub-modules (N/Q/P arms; F1 head + Fo turbine). Mobile carriers (quinone pool,
+cytochrome c) are `MOLECULAR_FUNCTION` carrier nodes; auxiliary quinone-reducing
+dehydrogenases (ETF-QO, mGPDH, DHODH) feed the pool. Lineage alternatives
+(NDH-2, AOX, bd-oxidase) are `variant_sets`; supercomplex/respirasome
+organization and complex biogenesis are optional sub-modules. ETC -> ATP
+synthase is a chemiosmotic `PRECEDES` coupling, not a metabolite hand-off.
 
 ## 2026-05-18
 


### PR DESCRIPTION
Curate oxidative phosphorylation as a recursively decomposable ModuleReview,
generalizing the gene-by-gene OXPHOS project (which predates the Module KB).

Modelling decision for complexes: each respiratory complex is a single
PROTEIN_COMPLEX node carrying its complex-level catalytic activity as one
annoton, with subunits exposed as active_units (mirroring GO contributes_to)
rather than per-subunit annotons. Complex I and the F1Fo-ATP synthase are
further decomposed into functional sub-modules (N/Q/P arms; F1 head + Fo
proton turbine). Mobile carriers (quinone pool, cytochrome c) are carrier
nodes; auxiliary quinone-reducing dehydrogenases (ETF-QO, mGPDH, DHODH) feed
the pool. Lineage alternatives (type-II NADH dehydrogenase, alternative
oxidase, bacterial bd-oxidase) are variant_sets. Supercomplex/respirasome
organization and complex biogenesis are optional sub-modules. ETC -> ATP
synthase is modelled as chemiosmotic PRECEDES coupling, not a metabolite
hand-off. GO term ids grounded against the validated OXPHOS gene reviews.

Validates cleanly against ModuleReview. Cross-linked from projects/OXPHOS.md.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01HBqCrbNjsYqxMyLgjutmWL