### PR TITLE
Add generic Wnt signaling pathway module

### DIFF
--- a/modules/wnt_signaling.yaml
+++ b/modules/wnt_signaling.yaml
@@ -1,0 +1,727 @@
+id: MODULE:generic_wnt_signaling
+title: Generic Wnt signaling pathway module
+description: >-
+  A generic, taxon-neutral decomposition of Wnt signaling as a module. Wnt
+  signaling is an ancient metazoan cell-cell communication system in which
+  secreted, lipid-modified Wnt glycoproteins act on neighboring cells to control
+  proliferation, cell-fate specification, polarity, and stem-cell maintenance.
+  The module is phrased as a set of conserved functions and pathway segments
+  rather than a fixed gene list, so it can represent invertebrate and vertebrate
+  implementations and the multiple paralogous family members at each step. It
+  captures the shared upstream events (Wnt acylation, secretion, and
+  receptor engagement) and then branches into the canonical
+  beta-catenin-dependent pathway and the beta-catenin-independent
+  (planar-cell-polarity and calcium) pathways. The canonical branch is modeled
+  with both its ligand-off state (the beta-catenin destruction complex driving
+  beta-catenin turnover) and its ligand-on state (signalosome assembly,
+  destruction-complex inhibition, beta-catenin stabilization, nuclear entry, and
+  TCF/LEF-dependent transcription).
+status: DRAFT
+evidence:
+  - source_id: GO:0016055
+    title: Wnt signaling pathway
+    statement: The module is grounded in the GO biological-process term for the Wnt signaling pathway.
+  - source_id: GO:0060070
+    title: canonical Wnt signaling pathway
+    statement: The canonical branch is grounded in the GO term for the canonical (beta-catenin-dependent) Wnt signaling pathway.
+  - source_id: GO:0035567
+    title: non-canonical Wnt signaling pathway
+    statement: The beta-catenin-independent branches are grounded in the GO term for non-canonical Wnt signaling.
+  - source_id: Reactome:R-HSA-195721
+    title: Signaling by WNT
+    statement: Reactome represents Wnt signaling as a set of conserved subpathways spanning ligand biogenesis, receptor activation, and downstream transcriptional and non-canonical responses.
+  - source_id: Reactome:R-HSA-201681
+    title: TCF dependent signaling in response to WNT
+    statement: Reactome models the canonical output as TCF/LEF-dependent transcription driven by stabilized beta-catenin.
+notes: >-
+  This is intentionally a generic family-level sketch. Each step is realized in
+  concrete organisms by specific paralogs (e.g. ~19 WNT ligands, ~10 Frizzled
+  receptors, three Dishevelled and three Axin/two GSK3 paralogs in mammals);
+  the abstract FAMILY and ANY_WITH_FUNCTION selectors below carry a few
+  representative UniProt members only to orient the family, not to limit it.
+  Extracellular tuning of the pathway (R-spondin/LGR potentiation,
+  RNF43/ZNRF3 receptor turnover, and the secreted antagonists DKK, SFRP, and
+  WIF) is represented as a regulatory interface rather than as core transduction
+  steps. A species-specific module can specialize each abstract participant with
+  concrete genes, tissues, compartments, and the relevant paralog complement.
+module:
+  id: wnt_signaling
+  label: Generic Wnt signaling pathway
+  module_type: SIGNALING_PATHWAY
+  concepts:
+    - preferred_term: Wnt signaling pathway
+      term:
+        id: GO:0016055
+        label: Wnt signaling pathway
+      description: >-
+        Cell-cell signaling initiated by binding of a secreted Wnt protein to a
+        Frizzled-family receptor and one or more co-receptors on a target cell.
+  context:
+    taxa:
+      - preferred_term: metazoa
+        description: >-
+          Wnt signaling is conserved across metazoans; Wnt ligands, Frizzled
+          receptors, Dishevelled, and beta-catenin/Armadillo are present from
+          cnidarians to vertebrates.
+    cellular_components:
+      - preferred_term: plasma membrane
+        term:
+          id: GO:0005886
+          label: plasma membrane
+      - preferred_term: cytosol
+        term:
+          id: GO:0005829
+          label: cytosol
+      - preferred_term: nucleus
+        term:
+          id: GO:0005634
+          label: nucleus
+  parts:
+    - order: 1
+      role: Wnt ligand biogenesis and secretion (signal-sending cell)
+      node:
+        id: wnt_ligand_biogenesis
+        label: Wnt ligand acylation and secretion
+        module_type: BIOLOGICAL_PROCESS
+        description: >-
+          In the signal-sending cell, nascent Wnt is lipid-modified in the ER by
+          the membrane-bound O-acyltransferase Porcupine, which attaches
+          palmitoleate to a conserved serine. This acylation is required both for
+          Wnt secretion and for receptor binding. The acylated Wnt is then bound
+          by the dedicated cargo receptor Wntless/WLS and trafficked to the cell
+          surface for release.
+        annotons:
+          - id: porcn_wnt_acylation
+            label: Porcupine-mediated Wnt palmitoleoylation
+            participant:
+              selector_type: FAMILY
+              family:
+                preferred_term: Porcupine O-acyltransferase family (MBOAT)
+                description: ER membrane-bound O-acyltransferase that acylates Wnt ligands.
+                representative_members:
+                  - preferred_term: PORCN (human)
+                    term:
+                      id: UniProtKB:Q9H237
+                      label: Protein-serine O-palmitoleoyltransferase porcupine
+            function:
+              preferred_term: protein-serine O-palmitoleoyltransferase activity (Wnt acylation)
+              term:
+                id: GO:0008374
+                label: O-acyltransferase activity
+              substrates:
+                - preferred_term: nascent Wnt protein
+                - preferred_term: palmitoleoyl-CoA
+              products:
+                - preferred_term: palmitoleoylated Wnt protein
+            locations:
+              - preferred_term: endoplasmic reticulum membrane
+            role_description: >-
+              Committed, rate-limiting modification that licenses Wnt for
+              secretion and high-affinity receptor binding; the principal target
+              of porcupine-inhibitor Wnt-pathway drugs.
+          - id: wls_wnt_secretion
+            label: Wntless/WLS-mediated Wnt secretion
+            participant:
+              selector_type: FAMILY
+              family:
+                preferred_term: Wntless/WLS cargo-receptor family
+                description: Multipass membrane protein that escorts acylated Wnt from the Golgi to the cell surface.
+                representative_members:
+                  - preferred_term: WLS (human)
+                    term:
+                      id: UniProtKB:Q5T9L3
+                      label: Protein wntless homolog
+            function:
+              preferred_term: Wnt cargo receptor / secretion transporter
+              cargo:
+                - preferred_term: palmitoleoylated Wnt protein
+            role_description: >-
+              Binds lipidated Wnt and traffics it through the secretory pathway;
+              recycled via retromer back to the Golgi.
+          - id: wnt_ligand
+            label: Secreted Wnt ligand
+            participant:
+              selector_type: FAMILY
+              family:
+                preferred_term: Wnt ligand family
+                description: >-
+                  Secreted, palmitoleoylated, cysteine-rich glycoprotein
+                  morphogens (e.g. ~19 WNT paralogs in mammals).
+                representative_members:
+                  - preferred_term: WNT3A (human)
+                    term:
+                      id: UniProtKB:P56704
+                      label: Protein Wnt-3a
+            function:
+              preferred_term: Wnt receptor ligand / frizzled binding
+              term:
+                id: GO:0005109
+                label: frizzled binding
+              targets:
+                - preferred_term: Frizzled receptor
+                - preferred_term: Wnt co-receptor (LRP5/6 or ROR/RYK)
+            role_description: >-
+              The diffusible signal; different Wnt paralogs preferentially engage
+              canonical or non-canonical branches depending on receptor context.
+    - order: 2
+      role: Wnt reception at the target-cell surface
+      node:
+        id: wnt_receptor_engagement
+        label: Wnt-Frizzled-co-receptor engagement
+        module_type: BIOLOGICAL_PROCESS
+        description: >-
+          On the signal-receiving cell, Wnt binds the cysteine-rich domain of a
+          Frizzled seven-transmembrane receptor. A co-receptor determines branch
+          identity: the single-pass LRP5/6 co-receptor commits to the canonical
+          branch, whereas ROR1/2 and RYK route to non-canonical branches.
+        concepts:
+          - preferred_term: Wnt receptor activity
+            term:
+              id: GO:0042813
+              label: Wnt receptor activity
+        annotons:
+          - id: fzd_receptor
+            label: Frizzled receptor
+            participant:
+              selector_type: FAMILY
+              family:
+                preferred_term: Frizzled receptor family
+                description: Seven-transmembrane Wnt receptors with an extracellular cysteine-rich domain (CRD).
+                representative_members:
+                  - preferred_term: FZD1 (human)
+                    term:
+                      id: UniProtKB:Q9UP38
+                      label: Frizzled-1
+            function:
+              preferred_term: Wnt-activated receptor activity
+              term:
+                id: GO:0042813
+                label: Wnt receptor activity
+              targets:
+                - preferred_term: Dishevelled
+            locations:
+              - preferred_term: plasma membrane
+                term:
+                  id: GO:0005886
+                  label: plasma membrane
+            role_description: Primary Wnt-binding receptor; CRD engages the palmitoleoyl group and core of Wnt.
+        variant_sets:
+          - id: wnt_coreceptor_axis
+            label: Wnt co-receptor variants
+            axis: co-receptor / branch identity
+            selection: EXACTLY_ONE
+            variants:
+              - id: lrp_coreceptor_variant
+                label: LRP5/6 co-receptor (canonical)
+                module_type: REGULATORY_STEP
+                annotons:
+                  - id: lrp_coreceptor
+                    label: LRP5/6 single-pass co-receptor
+                    participant:
+                      selector_type: FAMILY
+                      family:
+                        preferred_term: LRP5/LRP6 Wnt co-receptor family
+                        description: Single-pass LDL-receptor-related co-receptors required for canonical signaling.
+                        representative_members:
+                          - preferred_term: LRP6 (human)
+                            term:
+                              id: UniProtKB:O75581
+                              label: Low-density lipoprotein receptor-related protein 6
+                    function:
+                      preferred_term: Wnt co-receptor activity
+                      term:
+                        id: GO:0017147
+                        label: Wnt-protein binding
+                    role_description: >-
+                      Forms the ternary Wnt-Frizzled-LRP6 complex; its
+                      phosphorylated cytoplasmic tail recruits Axin, committing to
+                      the canonical branch.
+              - id: ror_ryk_coreceptor_variant
+                label: ROR/RYK co-receptor (non-canonical)
+                module_type: REGULATORY_STEP
+                annotons:
+                  - id: ror_ryk_coreceptor
+                    label: ROR1/2 or RYK co-receptor
+                    participant:
+                      selector_type: ANY_WITH_FUNCTION
+                      required_function:
+                        preferred_term: Wnt co-receptor activity (non-canonical)
+                        term:
+                          id: GO:0017147
+                          label: Wnt-protein binding
+                      description: Receptor tyrosine kinase / pseudokinase co-receptors routing to PCP or Ca2+ branches.
+                    function:
+                      preferred_term: non-canonical Wnt co-receptor activity
+                      term:
+                        id: GO:0017147
+                        label: Wnt-protein binding
+                    role_description: Directs Wnt input toward beta-catenin-independent outputs.
+    - order: 3
+      role: branch-specific signal transduction
+      node:
+        id: wnt_branch_transduction
+        label: Branch-specific Wnt transduction
+        module_type: SIGNALING_PATHWAY
+        description: >-
+          Downstream of receptor engagement, Dishevelled is recruited to
+          Frizzled and the pathway diverges. The branch realized depends on
+          ligand, receptor, and cellular context; more than one branch may be
+          active in a tissue.
+        annotons:
+          - id: dvl_recruitment
+            label: Dishevelled recruitment to Frizzled
+            participant:
+              selector_type: FAMILY
+              family:
+                preferred_term: Dishevelled (DVL) scaffold family
+                description: Cytoplasmic scaffold (DIX, PDZ, DEP domains) recruited to activated Frizzled; shared hub for all branches.
+                representative_members:
+                  - preferred_term: DVL1 (human)
+                    term:
+                      id: UniProtKB:O14640
+                      label: Segment polarity protein dishevelled homolog DVL-1
+            function:
+              preferred_term: frizzled binding / signal-transducing scaffold
+              term:
+                id: GO:0005109
+                label: frizzled binding
+            locations:
+              - preferred_term: plasma membrane
+                term:
+                  id: GO:0005886
+                  label: plasma membrane
+            role_description: >-
+              Common transducer: nucleates Wnt signalosome assembly in the
+              canonical branch and organizes Rho/Rac and Ca2+ effectors in the
+              non-canonical branches.
+        variant_sets:
+          - id: wnt_branch_axis
+            label: Wnt signaling branch variants
+            axis: signaling branch
+            selection: ONE_OR_MORE
+            variants:
+              - id: canonical_branch
+                label: Canonical (beta-catenin-dependent) branch
+                module_type: SIGNALING_PATHWAY
+                description: >-
+                  The beta-catenin-dependent branch. In the absence of Wnt, a
+                  cytoplasmic destruction complex keeps beta-catenin low; Wnt
+                  engagement inactivates this complex, allowing beta-catenin to
+                  accumulate, enter the nucleus, and convert TCF/LEF factors into
+                  transcriptional activators.
+                concepts:
+                  - preferred_term: canonical Wnt signaling pathway
+                    term:
+                      id: GO:0060070
+                      label: canonical Wnt signaling pathway
+                parts:
+                  - order: 1
+                    role: ligand-off state - beta-catenin destruction
+                    node:
+                      id: destruction_complex_off_state
+                      label: Beta-catenin destruction complex (Wnt-off)
+                      module_type: REGULATORY_STEP
+                      description: >-
+                        Without Wnt, the Axin-scaffolded destruction complex
+                        (Axin, APC, CK1, GSK3) sequentially phosphorylates
+                        beta-catenin, marking it for SCF(beta-TrCP)-mediated
+                        ubiquitination and proteasomal degradation, so cytoplasmic
+                        beta-catenin stays low and TCF/LEF targets are repressed.
+                      concepts:
+                        - preferred_term: beta-catenin destruction complex
+                          term:
+                            id: GO:0030877
+                            label: beta-catenin destruction complex
+                      annotons:
+                        - id: destruction_complex
+                          label: Axin/APC/CK1/GSK3 destruction complex
+                          participant:
+                            selector_type: PROTEIN_COMPLEX
+                            protein_complex:
+                              preferred_term: beta-catenin destruction complex
+                              term:
+                                id: GO:0030877
+                                label: beta-catenin destruction complex
+                              active_units:
+                                - id: axin_scaffold_unit
+                                  label: Axin scaffold
+                                  participant:
+                                    selector_type: FAMILY
+                                    family:
+                                      preferred_term: Axin scaffold family
+                                      description: Concentration-limiting scaffold that assembles the destruction complex.
+                                      representative_members:
+                                        - preferred_term: AXIN1 (human)
+                                          term:
+                                            id: UniProtKB:O15169
+                                            label: Axin-1
+                                  role: rate-limiting scaffold of the destruction complex
+                                - id: apc_unit
+                                  label: APC
+                                  participant:
+                                    selector_type: FAMILY
+                                    family:
+                                      preferred_term: APC tumor-suppressor family
+                                      description: Large scaffold that binds beta-catenin and Axin; mutated in most colorectal cancers.
+                                      representative_members:
+                                        - preferred_term: APC (human)
+                                          term:
+                                            id: UniProtKB:P25054
+                                            label: Adenomatous polyposis coli protein
+                                  role: co-scaffold; promotes beta-catenin capture and turnover
+                                - id: ck1_unit
+                                  label: Casein kinase 1 (priming kinase)
+                                  participant:
+                                    selector_type: FAMILY
+                                    family:
+                                      preferred_term: Casein kinase 1 family
+                                      description: Priming Ser/Thr kinase that phosphorylates beta-catenin at Ser45.
+                                      representative_members:
+                                        - preferred_term: CSNK1A1 (human)
+                                          term:
+                                            id: UniProtKB:P48729
+                                            label: Casein kinase I isoform alpha
+                                  role: priming kinase
+                                  function:
+                                    preferred_term: protein serine/threonine kinase activity
+                                    term:
+                                      id: GO:0004674
+                                      label: protein serine/threonine kinase activity
+                                - id: gsk3_unit
+                                  label: GSK3 (processive kinase)
+                                  participant:
+                                    selector_type: FAMILY
+                                    family:
+                                      preferred_term: GSK3 family
+                                      description: Ser/Thr kinase that phosphorylates the beta-catenin degron after CK1 priming.
+                                      representative_members:
+                                        - preferred_term: GSK3B (human)
+                                          term:
+                                            id: UniProtKB:P49841
+                                            label: Glycogen synthase kinase-3 beta
+                                  role: processive kinase generating the phosphodegron
+                                  function:
+                                    preferred_term: protein serine/threonine kinase activity
+                                    term:
+                                      id: GO:0004674
+                                      label: protein serine/threonine kinase activity
+                          function:
+                            preferred_term: beta-catenin phosphorylation for destruction
+                            term:
+                              id: GO:0004674
+                              label: protein serine/threonine kinase activity
+                            targets:
+                              - preferred_term: beta-catenin
+                          role_description: >-
+                            CK1 priming (Ser45) followed by GSK3 phosphorylation
+                            (Thr41/Ser37/Ser33) creates the beta-TrCP degron.
+                        - id: btrc_ubiquitination
+                          label: SCF(beta-TrCP) ubiquitination of beta-catenin
+                          participant:
+                            selector_type: FAMILY
+                            family:
+                              preferred_term: beta-TrCP F-box family (SCF E3 ligase substrate receptor)
+                              description: F-box protein recognizing the doubly-phosphorylated beta-catenin degron.
+                              representative_members:
+                                - preferred_term: BTRC (human)
+                                  term:
+                                    id: UniProtKB:Q9Y297
+                                    label: F-box/WD repeat-containing protein 1A
+                          function:
+                            preferred_term: ubiquitin-protein transferase activity (phosphodegron-dependent)
+                            term:
+                              id: GO:0004842
+                              label: ubiquitin-protein transferase activity
+                            targets:
+                              - preferred_term: phosphorylated beta-catenin
+                          processes:
+                            - preferred_term: protein ubiquitination
+                              term:
+                                id: GO:0016567
+                                label: protein ubiquitination
+                          role_description: Polyubiquitinates phospho-beta-catenin, targeting it to the 26S proteasome.
+                  - order: 2
+                    role: ligand-on state - signalosome and destruction-complex inhibition
+                    node:
+                      id: signalosome_on_state
+                      label: Wnt signalosome and destruction-complex inhibition (Wnt-on)
+                      module_type: REGULATORY_STEP
+                      description: >-
+                        Wnt engagement clusters Frizzled-LRP6 with
+                        Dishevelled into a Wnt signalosome. CK1/GSK3 phosphorylate
+                        the LRP6 cytoplasmic PPPSP motifs, which recruit Axin to
+                        the membrane and inhibit the destruction complex, so
+                        beta-catenin is no longer phosphorylated and degraded.
+                      concepts:
+                        - preferred_term: Wnt signalosome
+                          term:
+                            id: GO:1990909
+                            label: Wnt signalosome
+                      annotons:
+                        - id: signalosome_assembly
+                          label: Wnt signalosome assembly and LRP6 phosphorylation
+                          participant:
+                            selector_type: PROTEIN_COMPLEX
+                            protein_complex:
+                              preferred_term: Wnt signalosome (Frizzled-LRP6-Dishevelled-Axin)
+                              term:
+                                id: GO:1990909
+                                label: Wnt signalosome
+                          function:
+                            preferred_term: signalosome-dependent sequestration/inhibition of the destruction complex
+                            term:
+                              id: GO:0090263
+                              label: positive regulation of canonical Wnt signaling pathway
+                            targets:
+                              - preferred_term: beta-catenin destruction complex
+                          processes:
+                            - preferred_term: Wnt signalosome assembly
+                              term:
+                                id: GO:1904887
+                                label: Wnt signalosome assembly
+                          role_description: >-
+                            Membrane recruitment of Axin to phospho-LRP6 disables
+                            beta-catenin phosphorylation, the switch that turns the
+                            canonical pathway on.
+                  - order: 3
+                    role: beta-catenin stabilization and nuclear entry
+                    node:
+                      id: beta_catenin_stabilization
+                      label: Beta-catenin stabilization and nuclear translocation
+                      module_type: REGULATORY_STEP
+                      description: >-
+                        Newly synthesized beta-catenin, no longer degraded,
+                        accumulates in the cytoplasm and translocates to the
+                        nucleus.
+                      annotons:
+                        - id: beta_catenin
+                          label: Beta-catenin (stabilized effector)
+                          participant:
+                            selector_type: FAMILY
+                            family:
+                              preferred_term: beta-catenin / Armadillo family
+                              description: Armadillo-repeat effector and transcriptional co-activator of the canonical branch (moonlights at adherens junctions).
+                              representative_members:
+                                - preferred_term: CTNNB1 (human)
+                                  term:
+                                    id: UniProtKB:P35222
+                                    label: Catenin beta-1
+                          function:
+                            preferred_term: beta-catenin binding / co-activator recruitment scaffold
+                            term:
+                              id: GO:0008013
+                              label: beta-catenin binding
+                            targets:
+                              - preferred_term: TCF/LEF transcription factor
+                          locations:
+                            - preferred_term: cytosol
+                              term:
+                                id: GO:0005829
+                                label: cytosol
+                            - preferred_term: nucleus
+                              term:
+                                id: GO:0005634
+                                label: nucleus
+                          role_description: >-
+                            Accumulation and nuclear import of beta-catenin is the
+                            quantitative readout of canonical pathway activation.
+                  - order: 4
+                    role: nuclear transcriptional output
+                    node:
+                      id: tcf_lef_transactivation
+                      label: TCF/LEF-dependent transcriptional activation
+                      module_type: REGULATORY_STEP
+                      description: >-
+                        In the nucleus, beta-catenin binds TCF/LEF DNA-binding
+                        factors, displacing Groucho/TLE co-repressors and
+                        recruiting co-activators to switch Wnt target genes from
+                        repressed to active.
+                      concepts:
+                        - preferred_term: beta-catenin-TCF complex
+                          term:
+                            id: GO:1990907
+                            label: beta-catenin-TCF complex
+                      annotons:
+                        - id: tcf_lef_factor
+                          label: TCF/LEF DNA-binding factor
+                          participant:
+                            selector_type: FAMILY
+                            family:
+                              preferred_term: TCF/LEF HMG-box transcription factor family
+                              description: Sequence-specific DNA-binding factors that switch between repression (with TLE) and activation (with beta-catenin).
+                              representative_members:
+                                - preferred_term: TCF7L2 (human)
+                                  term:
+                                    id: UniProtKB:Q9NQB0
+                                    label: Transcription factor 7-like 2
+                          function:
+                            preferred_term: DNA-binding transcription factor activity (beta-catenin-dependent switch)
+                            term:
+                              id: GO:0003700
+                              label: DNA-binding transcription factor activity
+                          locations:
+                            - preferred_term: nucleus
+                              term:
+                                id: GO:0005634
+                                label: nucleus
+                          role_description: Provides DNA-binding specificity; beta-catenin supplies the transactivation function.
+                        - id: beta_catenin_coactivator
+                          label: Beta-catenin transcriptional co-activator role
+                          participant:
+                            selector_type: ANY_WITH_FUNCTION
+                            required_function:
+                              preferred_term: transcription coactivator activity
+                              term:
+                                id: GO:0003713
+                                label: transcription coactivator activity
+                              description: Stabilized beta-catenin acting in the nucleus.
+                          function:
+                            preferred_term: transcription coactivator activity
+                            term:
+                              id: GO:0003713
+                              label: transcription coactivator activity
+                            targets:
+                              - preferred_term: TCF/LEF-bound Wnt target promoters
+                          role_description: Converts TCF/LEF from repressor to activator at Wnt target genes.
+                connections:
+                  - source: destruction_complex_off_state
+                    target: beta_catenin_stabilization
+                    connection_type: NEGATIVELY_REGULATES
+                    description: In the Wnt-off state the destruction complex keeps beta-catenin low.
+                  - source: signalosome_on_state
+                    target: destruction_complex_off_state
+                    connection_type: NEGATIVELY_REGULATES
+                    description: Wnt-on signalosome inhibits the destruction complex.
+                  - source: signalosome_on_state
+                    target: beta_catenin_stabilization
+                    connection_type: POSITIVELY_REGULATES
+                    description: Relief of degradation allows beta-catenin to accumulate.
+                  - source: beta_catenin_stabilization
+                    target: tcf_lef_transactivation
+                    connection_type: PROVIDES_INPUT_FOR
+                    description: Nuclear beta-catenin partners with TCF/LEF to activate transcription.
+              - id: pcp_branch
+                label: Non-canonical planar cell polarity (PCP) branch
+                module_type: SIGNALING_PATHWAY
+                description: >-
+                  Beta-catenin-independent branch in which Wnt-Frizzled-Dishevelled
+                  signaling, via ROR/RYK and the core PCP proteins, activates small
+                  GTPases (RhoA, Rac1) and downstream kinases (ROCK, JNK) to
+                  control cytoskeletal organization, oriented cell behavior, and
+                  convergent extension.
+                concepts:
+                  - preferred_term: Wnt signaling pathway, planar cell polarity pathway
+                    term:
+                      id: GO:0060071
+                      label: "Wnt signaling pathway, planar cell polarity pathway"
+                annotons:
+                  - id: pcp_rho_rac_effectors
+                    label: Rho/Rac GTPase and JNK effector arm
+                    participant:
+                      selector_type: ANY_WITH_FUNCTION
+                      required_function:
+                        preferred_term: Rho/Rac-dependent cytoskeletal effector signaling
+                      description: Dishevelled-organized small-GTPase and kinase effectors controlling polarity.
+                    role_description: Couples Wnt input to actin/microtubule polarity rather than transcription.
+              - id: calcium_branch
+                label: Non-canonical Wnt/calcium branch
+                module_type: SIGNALING_PATHWAY
+                description: >-
+                  Beta-catenin-independent branch in which Wnt-Frizzled signaling
+                  acts through heterotrimeric G proteins and phospholipase C to
+                  raise intracellular calcium, activating CaMKII, calcineurin/NFAT,
+                  and PKC.
+                concepts:
+                  - preferred_term: "Wnt signaling pathway, calcium modulating pathway"
+                    term:
+                      id: GO:0007223
+                      label: "Wnt signaling pathway, calcium modulating pathway"
+                annotons:
+                  - id: calcium_effectors
+                    label: PLC / Ca2+ / CaMKII-PKC effector arm
+                    participant:
+                      selector_type: ANY_WITH_FUNCTION
+                      required_function:
+                        preferred_term: calcium-mobilizing Wnt effector signaling
+                      description: G-protein/PLC-driven calcium release and calcium-dependent kinases/phosphatases.
+                    role_description: >-
+                      Calcium-dependent output; can antagonize the canonical
+                      branch in some contexts.
+    - order: 4
+      role: extracellular and receptor-level regulatory interface
+      optional: true
+      node:
+        id: wnt_regulatory_interface
+        label: Wnt regulatory interface
+        module_type: REGULATORY_STEP
+        description: >-
+          Conserved modulators that set pathway sensitivity. Secreted antagonists
+          (DKK acting on LRP5/6; SFRP and WIF sequestering Wnt) dampen signaling,
+          while the R-spondin/LGR4-6 system blocks RNF43/ZNRF3-mediated
+          ubiquitination and turnover of Frizzled, thereby potentiating signaling.
+        annotons:
+          - id: rnf43_znrf3_receptor_turnover
+            label: RNF43/ZNRF3 Frizzled turnover (negative)
+            participant:
+              selector_type: ANY_WITH_FUNCTION
+              required_function:
+                preferred_term: ubiquitin-protein transferase activity (Frizzled receptor)
+                term:
+                  id: GO:0004842
+                  label: ubiquitin-protein transferase activity
+              description: Transmembrane E3 ligases that ubiquitinate Frizzled to reduce surface receptor.
+            function:
+              preferred_term: ubiquitin-protein transferase activity
+              term:
+                id: GO:0004842
+                label: ubiquitin-protein transferase activity
+              targets:
+                - preferred_term: Frizzled receptor
+            processes:
+              - preferred_term: negative regulation of canonical Wnt signaling pathway
+                term:
+                  id: GO:0090090
+                  label: negative regulation of canonical Wnt signaling pathway
+            role_description: Lowers Frizzled abundance; antagonized by R-spondin/LGR.
+          - id: rspo_lgr_potentiation
+            label: R-spondin/LGR potentiation (positive)
+            participant:
+              selector_type: ANY_WITH_FUNCTION
+              required_function:
+                preferred_term: R-spondin receptor / Wnt-potentiating activity
+              description: R-spondin ligands with LGR4-6 receptors that neutralize RNF43/ZNRF3.
+            processes:
+              - preferred_term: positive regulation of canonical Wnt signaling pathway
+                term:
+                  id: GO:0090263
+                  label: positive regulation of canonical Wnt signaling pathway
+            role_description: Stabilizes surface Frizzled, sensitizing cells (notably stem cells) to Wnt.
+          - id: secreted_antagonists
+            label: Secreted Wnt antagonists (DKK/SFRP/WIF)
+            participant:
+              selector_type: ANY_WITH_FUNCTION
+              required_function:
+                preferred_term: Wnt-protein binding / co-receptor antagonist
+                term:
+                  id: GO:0017147
+                  label: Wnt-protein binding
+              description: Secreted factors that sequester Wnt or block LRP5/6.
+            processes:
+              - preferred_term: negative regulation of Wnt signaling pathway
+                term:
+                  id: GO:0030178
+                  label: negative regulation of Wnt signaling pathway
+            role_description: Extracellular dampening of pathway input.
+  connections:
+    - source: wnt_ligand_biogenesis
+      target: wnt_receptor_engagement
+      connection_type: PROVIDES_INPUT_FOR
+      description: Secreted, acylated Wnt from the sending cell engages receptors on the receiving cell.
+    - source: wnt_receptor_engagement
+      target: wnt_branch_transduction
+      connection_type: PRECEDES
+      description: Receptor/co-receptor engagement selects and initiates the downstream branch.
+    - source: wnt_regulatory_interface
+      target: wnt_receptor_engagement
+      connection_type: NEGATIVELY_REGULATES
+      description: The regulatory interface tunes receptor availability and ligand access (net positive or negative).

--- a/modules/wnt_signaling.yaml
+++ b/modules/wnt_signaling.yaml
@@ -533,10 +533,10 @@ module:
                                     id: UniProtKB:P35222
                                     label: Catenin beta-1
                           function:
-                            preferred_term: beta-catenin binding / co-activator recruitment scaffold
+                            preferred_term: transcription factor binding (binds TCF/LEF to recruit co-activators)
                             term:
-                              id: GO:0008013
-                              label: beta-catenin binding
+                              id: GO:0008134
+                              label: transcription factor binding
                             targets:
                               - preferred_term: TCF/LEF transcription factor
                           locations:

--- a/modules/wnt_signaling.yaml
+++ b/modules/wnt_signaling.yaml
@@ -300,10 +300,10 @@ module:
                       id: UniProtKB:O14640
                       label: Segment polarity protein dishevelled homolog DVL-1
             function:
-              preferred_term: frizzled binding / signal-transducing scaffold
+              preferred_term: signaling adaptor activity (Frizzled-recruited scaffold)
               term:
-                id: GO:0005109
-                label: frizzled binding
+                id: GO:0035591
+                label: signaling adaptor activity
             locations:
               - preferred_term: plasma membrane
                 term:

--- a/modules/wnt_signaling.yaml
+++ b/modules/wnt_signaling.yaml
@@ -115,6 +115,9 @@ module:
                 - preferred_term: palmitoleoylated Wnt protein
             locations:
               - preferred_term: endoplasmic reticulum membrane
+                term:
+                  id: GO:0005789
+                  label: endoplasmic reticulum membrane
             role_description: >-
               Committed, rate-limiting modification that licenses Wnt for
               secretion and high-affinity receptor binding; the principal target

--- a/modules/wnt_signaling.yaml
+++ b/modules/wnt_signaling.yaml
@@ -59,6 +59,9 @@ module:
   context:
     taxa:
       - preferred_term: metazoa
+        term:
+          id: NCBITaxon:33208
+          label: Metazoa
         description: >-
           Wnt signaling is conserved across metazoans; Wnt ligands, Frizzled
           receptors, Dishevelled, and beta-catenin/Armadillo are present from
@@ -481,10 +484,10 @@ module:
                                 id: GO:1990909
                                 label: Wnt signalosome
                           function:
-                            preferred_term: signalosome-dependent sequestration/inhibition of the destruction complex
+                            preferred_term: signaling adaptor activity (recruits Axin to phospho-LRP6, sequestering the destruction complex)
                             term:
-                              id: GO:0090263
-                              label: positive regulation of canonical Wnt signaling pathway
+                              id: GO:0035591
+                              label: signaling adaptor activity
                             targets:
                               - preferred_term: beta-catenin destruction complex
                                 term:
@@ -495,6 +498,10 @@ module:
                               term:
                                 id: GO:1904887
                                 label: Wnt signalosome assembly
+                            - preferred_term: positive regulation of canonical Wnt signaling pathway
+                              term:
+                                id: GO:0090263
+                                label: positive regulation of canonical Wnt signaling pathway
                           role_description: >-
                             Membrane recruitment of Axin to phospho-LRP6 disables
                             beta-catenin phosphorylation, the switch that turns the
@@ -759,7 +766,15 @@ module:
       target: wnt_branch_transduction
       connection_type: PRECEDES
       description: Receptor/co-receptor engagement selects and initiates the downstream branch.
-    - source: wnt_regulatory_interface
+    - source: rspo_lgr_potentiation
+      target: wnt_receptor_engagement
+      connection_type: POSITIVELY_REGULATES
+      description: R-spondin/LGR blocks RNF43/ZNRF3-mediated Frizzled turnover, raising surface receptor and sensitizing cells to Wnt.
+    - source: rnf43_znrf3_receptor_turnover
       target: wnt_receptor_engagement
       connection_type: NEGATIVELY_REGULATES
-      description: The regulatory interface tunes receptor availability and ligand access (net positive or negative).
+      description: RNF43/ZNRF3 ubiquitinate Frizzled to lower surface receptor abundance.
+    - source: secreted_antagonists
+      target: wnt_receptor_engagement
+      connection_type: NEGATIVELY_REGULATES
+      description: Secreted DKK (on LRP5/6) and SFRP/WIF (sequestering Wnt) reduce productive receptor engagement.

--- a/modules/wnt_signaling.yaml
+++ b/modules/wnt_signaling.yaml
@@ -144,6 +144,9 @@ module:
                       label: Protein wntless homolog
             function:
               preferred_term: Wnt cargo receptor / secretion transporter
+              term:
+                id: GO:0038024
+                label: cargo receptor activity
               cargo:
                 - preferred_term: palmitoleoylated Wnt protein
             processes:

--- a/modules/wnt_signaling.yaml
+++ b/modules/wnt_signaling.yaml
@@ -90,6 +90,11 @@ module:
           Wnt secretion and for receptor binding. The acylated Wnt is then bound
           by the dedicated cargo receptor Wntless/WLS and trafficked to the cell
           surface for release.
+        concepts:
+          - preferred_term: Wnt protein secretion
+            term:
+              id: GO:0061355
+              label: Wnt protein secretion
         annotons:
           - id: porcn_wnt_acylation
             label: Porcupine-mediated Wnt palmitoleoylation
@@ -138,6 +143,11 @@ module:
               preferred_term: Wnt cargo receptor / secretion transporter
               cargo:
                 - preferred_term: palmitoleoylated Wnt protein
+            processes:
+              - preferred_term: Wnt protein secretion
+                term:
+                  id: GO:0061355
+                  label: Wnt protein secretion
             role_description: >-
               Binds lipidated Wnt and traffics it through the secretory pathway;
               recycled via retromer back to the Golgi.
@@ -477,6 +487,9 @@ module:
                               label: positive regulation of canonical Wnt signaling pathway
                             targets:
                               - preferred_term: beta-catenin destruction complex
+                                term:
+                                  id: GO:0030877
+                                  label: beta-catenin destruction complex
                           processes:
                             - preferred_term: Wnt signalosome assembly
                               term:
@@ -625,6 +638,19 @@ module:
                       required_function:
                         preferred_term: Rho/Rac-dependent cytoskeletal effector signaling
                       description: Dishevelled-organized small-GTPase and kinase effectors controlling polarity.
+                    processes:
+                      - preferred_term: Rho protein signal transduction
+                        term:
+                          id: GO:0007266
+                          label: Rho protein signal transduction
+                      - preferred_term: establishment of planar polarity
+                        term:
+                          id: GO:0001736
+                          label: establishment of planar polarity
+                      - preferred_term: JNK cascade
+                        term:
+                          id: GO:0007254
+                          label: JNK cascade
                     role_description: Couples Wnt input to actin/microtubule polarity rather than transcription.
               - id: calcium_branch
                 label: Non-canonical Wnt/calcium branch
@@ -647,6 +673,15 @@ module:
                       required_function:
                         preferred_term: calcium-mobilizing Wnt effector signaling
                       description: G-protein/PLC-driven calcium release and calcium-dependent kinases/phosphatases.
+                    processes:
+                      - preferred_term: phospholipase C-activating G protein-coupled receptor signaling pathway
+                        term:
+                          id: GO:0007200
+                          label: phospholipase C-activating G protein-coupled receptor signaling pathway
+                      - preferred_term: release of sequestered calcium ion into cytosol
+                        term:
+                          id: GO:0051209
+                          label: release of sequestered calcium ion into cytosol
                     role_description: >-
                       Calcium-dependent output; can antagonize the canonical
                       branch in some contexts.


### PR DESCRIPTION
Add a taxon-neutral ModuleReview document for Wnt signaling under modules/.
Models shared upstream events (Porcupine acylation, WLS secretion, Wnt-Frizzled
-co-receptor engagement) and branches into the canonical beta-catenin-dependent
pathway (destruction-complex off-state, signalosome on-state, beta-catenin
stabilization, TCF/LEF transactivation) plus the non-canonical PCP and Ca2+
branches, with an R-spondin/RNF43-ZNRF3/DKK regulatory interface.

Uses FAMILY and ANY_WITH_FUNCTION selectors with verified GO term groundings and
representative UniProt members. Passes linkml-validate and linkml-term-validator
against ModuleReview.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01DDFBZdGFFxH1dPtqNUz6NW