### PR TITLE
Add plant cellulose biosynthesis module

### DIFF
--- a/modules/cellulose_biosynthesis.yaml
+++ b/modules/cellulose_biosynthesis.yaml
@@ -1,0 +1,468 @@
+id: MODULE:plant_cellulose_biosynthesis
+title: Plant cellulose biosynthesis module
+description: >-
+  A taxon-neutral decomposition of plant cellulose biosynthesis as a recursively
+  decomposable module. Cellulose is synthesized at the plasma membrane by the
+  cellulose synthase complex (CSC, the "rosette"), which polymerizes UDP-glucose
+  into (1->4)-beta-D-glucan chains that coalesce into crystalline microfibrils in
+  the apoplast. The module separates (1) UDP-glucose substrate supply, (2) glucan
+  polymerization by the CSC with distinct primary- and secondary-cell-wall CESA
+  isoform sets, (3) guidance of CSC trajectory by the cortical microtubule
+  cytoskeleton, (4) accessory enzymes/proteins required for productive synthesis
+  (KORRIGAN endoglucanase, COBRA), and (5) microfibril assembly and organization.
+  It is phrased as functions, complexes, and pathway segments rather than a fixed
+  gene list so it can represent angiosperm, grass, and (with substitution) algal
+  implementations. Concrete UniProt members are Arabidopsis exemplars, not
+  species-restricting claims. Cellulose synthase-like (CSL) backbones of
+  hemicelluloses, lignin biosynthesis, and the bacterial BcsA-type machinery are
+  out of scope. As a bioenergy module, the polymerization step and its CESA
+  isoform composition are the principal determinants of biomass recalcitrance and
+  the main engineering targets for improved lignocellulosic saccharification.
+status: DRAFT
+evidence:
+  - source_id: GO:0030244
+    title: cellulose biosynthetic process
+    statement: The module is grounded in the GO biological-process term for cellulose biosynthesis.
+  - source_id: GO:0052324
+    title: plant-type cell wall cellulose biosynthetic process
+    statement: >-
+      The plant-specific child term scoping the module to plant-type cell wall
+      cellulose, as opposed to bacterial or tunicate cellulose.
+  - source_id: GO:0010330
+    title: cellulose synthase complex
+    statement: >-
+      The CSC ("rosette") is the membrane machine that polymerizes UDP-glucose at
+      the plasma membrane; GO distinguishes primary (GO:0044567) and secondary
+      (GO:0044568) cell wall CSCs by their CESA subunit composition.
+  - source_id: UniProtKB:O48946
+    title: Cellulose synthase A catalytic subunit 1 [UDP-forming] (AtCesA1 / RSW1)
+    statement: >-
+      Arabidopsis primary-wall CESA exemplar; the temperature-sensitive rsw1
+      lesion establishes CESA1 as essential for primary-wall cellulose synthesis.
+  - source_id: UniProtKB:Q8LPK5
+    title: Cellulose synthase A catalytic subunit 8 [UDP-forming] (AtCesA8 / IRX1)
+    statement: >-
+      Arabidopsis secondary-wall CESA exemplar; irx1 (irregular xylem) collapses
+      xylem vessels, defining a distinct secondary-wall CESA set.
+  - source_id: UniProtKB:Q38890
+    title: Endoglucanase 25 / KORRIGAN (AtKOR1)
+    statement: >-
+      Membrane-anchored endo-1,4-beta-glucanase required for normal cellulose
+      synthesis; supports the KORRIGAN accessory role in the module.
+  - source_id: UniProtKB:F4IIM1
+    title: CELLULOSE SYNTHASE INTERACTIVE 1 (AtCSI1 / POM2)
+    statement: >-
+      Scaffold linking the CSC to cortical microtubules; supports microtubule
+      guidance of CSC trajectory as a distinct module part.
+notes: >-
+  Identifiers are grounded only where verified against the local GO term cache or
+  UniProt; descriptors without a `term` (e.g. UDP-glucose substrate) are
+  deliberate rather than oversights. Representative UniProt members are concrete
+  Arabidopsis exemplars for orientation, not exhaustive or species-restricting.
+  In grasses (Brachypodium, Sorghum, maize) the CESA isoform numbering differs
+  but the primary/secondary CSC distinction is conserved; mixed-linkage glucan
+  (CSLF/CSLH) is a separate, grass-specific module.
+module:
+  id: plant_cellulose_biosynthesis
+  label: Plant cellulose biosynthesis
+  module_type: METABOLIC_PATHWAY
+  concepts:
+    - preferred_term: plant-type cell wall cellulose biosynthetic process
+      term:
+        id: GO:0052324
+        label: plant-type cell wall cellulose biosynthetic process
+      description: >-
+        Synthesis of crystalline (1->4)-beta-D-glucan (cellulose) microfibrils of
+        the plant cell wall from UDP-glucose at the plasma membrane.
+    - preferred_term: cellulose biosynthetic process
+      term:
+        id: GO:0030244
+        label: cellulose biosynthetic process
+  context:
+    taxa:
+      - preferred_term: land plants
+      - preferred_term: charophyte / eukaryotic algae (with isoform substitution)
+    cellular_components:
+      - preferred_term: plasma membrane (site of synthesis)
+        term:
+          id: GO:0005886
+          label: plasma membrane
+      - preferred_term: apoplast (site of microfibril deposition)
+        term:
+          id: GO:0048046
+          label: apoplast
+  parts:
+    - order: 1
+      role: UDP-glucose substrate supply
+      node:
+        id: udp_glucose_supply
+        label: UDP-glucose provision to the cellulose synthase complex
+        module_type: METABOLIC_PATHWAY
+        description: >-
+          Supplies the nucleotide-sugar donor (UDP-glucose) consumed by the CSC.
+          The dominant route is debated and likely context-dependent: sucrose
+          synthase can channel UDP-glucose locally at the plasma membrane, while
+          UDP-glucose pyrophosphorylase supplies the bulk cytosolic pool.
+        variant_sets:
+          - id: udp_glucose_source
+            label: UDP-glucose sourcing route
+            axis: enzyme chemistry / metabolic route
+            selection: ONE_OR_MORE
+            variants:
+              - id: sucrose_synthase_route
+                label: Sucrose synthase channeling
+                module_type: REACTION
+                annotons:
+                  - id: sucrose_synthase_activity
+                    label: Sucrose synthase (UDP-glucose-forming)
+                    participant:
+                      selector_type: ANY_WITH_FUNCTION
+                      required_function:
+                        preferred_term: sucrose synthase activity
+                        term:
+                          id: GO:0016157
+                          label: sucrose synthase activity
+                    function:
+                      preferred_term: sucrose synthase activity
+                      term:
+                        id: GO:0016157
+                        label: sucrose synthase activity
+                      substrates:
+                        - preferred_term: sucrose
+                        - preferred_term: UDP
+                      products:
+                        - preferred_term: UDP-glucose
+                        - preferred_term: D-fructose
+                    role_description: >-
+                      A plasma-membrane-associated pool of sucrose synthase has
+                      been proposed to channel UDP-glucose directly to the CSC.
+              - id: ugpase_route
+                label: UDP-glucose pyrophosphorylase
+                module_type: REACTION
+                annotons:
+                  - id: ugpase_activity
+                    label: UTP--glucose-1-phosphate uridylyltransferase
+                    participant:
+                      selector_type: ANY_WITH_FUNCTION
+                      required_function:
+                        preferred_term: UTP:glucose-1-phosphate uridylyltransferase activity
+                        term:
+                          id: GO:0003983
+                          label: UTP:glucose-1-phosphate uridylyltransferase activity
+                    function:
+                      preferred_term: UTP:glucose-1-phosphate uridylyltransferase activity
+                      term:
+                        id: GO:0003983
+                        label: UTP:glucose-1-phosphate uridylyltransferase activity
+                      substrates:
+                        - preferred_term: glucose 1-phosphate
+                        - preferred_term: UTP
+                      products:
+                        - preferred_term: UDP-glucose
+                        - preferred_term: diphosphate
+                    role_description: Generates the bulk cytosolic UDP-glucose pool.
+    - order: 2
+      role: glucan polymerization at the cellulose synthase complex
+      node:
+        id: glucan_polymerization
+        label: (1->4)-beta-D-glucan polymerization by the CSC
+        module_type: PROTEIN_COMPLEX
+        concepts:
+          - preferred_term: cellulose synthase complex
+            term:
+              id: GO:0010330
+              label: cellulose synthase complex
+        annotons:
+          - id: cellulose_synthase_activity
+            label: Cellulose synthase (UDP-forming)
+            participant:
+              selector_type: PROTEIN_COMPLEX
+              protein_complex:
+                preferred_term: cellulose synthase complex (rosette / CSC)
+                term:
+                  id: GO:0010330
+                  label: cellulose synthase complex
+                description: >-
+                  Hexameric rosette of CESA trimers in the plasma membrane; each
+                  CESA is a processive UDP-glucose glucosyltransferase. The
+                  catalytic CESA subunits are made explicit as active units.
+            function:
+              preferred_term: cellulose synthase (UDP-forming) activity
+              term:
+                id: GO:0016760
+                label: cellulose synthase (UDP-forming) activity
+              substrates:
+                - preferred_term: UDP-glucose
+                - preferred_term: "(1->4)-beta-D-glucan (n)"
+              products:
+                - preferred_term: "(1->4)-beta-D-glucan (n+1)"
+                - preferred_term: UDP
+            locations:
+              - preferred_term: plasma membrane
+                term:
+                  id: GO:0005886
+                  label: plasma membrane
+            role_description: >-
+              Processively polymerizes UDP-glucose into beta-1,4-glucan chains that
+              are extruded across the plasma membrane; the rate-determining,
+              recalcitrance-defining step of the module.
+        variant_sets:
+          - id: csc_isoform_set
+            label: Primary vs secondary cell wall CSC
+            axis: cell wall type / developmental context
+            selection: ONE_OR_MORE
+            variants:
+              - id: primary_wall_csc
+                label: Primary cell wall CSC (CESA1/CESA3/CESA6-like)
+                module_type: PROTEIN_COMPLEX
+                concepts:
+                  - preferred_term: primary cell wall cellulose synthase complex
+                    term:
+                      id: GO:0044567
+                      label: primary cell wall cellulose synthase complex
+                annotons:
+                  - id: primary_csc_cesa
+                    label: Primary-wall CESA catalytic subunits
+                    participant:
+                      selector_type: FAMILY
+                      family:
+                        preferred_term: primary-wall cellulose synthase (CESA1, CESA3, CESA6-like)
+                        description: >-
+                          Non-redundant triad; CESA1 and CESA3 are obligate, with a
+                          CESA6-like subunit (CESA2/5/6/9) completing the complex.
+                        representative_members:
+                          - preferred_term: Arabidopsis CESA1 (RSW1)
+                            term:
+                              id: UniProtKB:O48946
+                              label: Cellulose synthase A catalytic subunit 1 [UDP-forming]
+                          - preferred_term: Arabidopsis CESA3 (IXR1)
+                            term:
+                              id: UniProtKB:Q941L0
+                              label: Cellulose synthase A catalytic subunit 3 [UDP-forming]
+                          - preferred_term: Arabidopsis CESA6
+                            term:
+                              id: UniProtKB:Q94JQ6
+                              label: Cellulose synthase A catalytic subunit 6 [UDP-forming]
+                    function:
+                      preferred_term: cellulose synthase (UDP-forming) activity
+                      term:
+                        id: GO:0016760
+                        label: cellulose synthase (UDP-forming) activity
+                    processes:
+                      - preferred_term: plant-type primary cell wall biogenesis
+                        term:
+                          id: GO:0009833
+                          label: plant-type primary cell wall biogenesis
+                    role_description: >-
+                      Deposits the dispersed, less-crystalline cellulose of the
+                      expanding primary wall.
+              - id: secondary_wall_csc
+                label: Secondary cell wall CSC (CESA4/CESA7/CESA8)
+                module_type: PROTEIN_COMPLEX
+                concepts:
+                  - preferred_term: secondary cell wall cellulose synthase complex
+                    term:
+                      id: GO:0044568
+                      label: secondary cell wall cellulose synthase complex
+                annotons:
+                  - id: secondary_csc_cesa
+                    label: Secondary-wall CESA catalytic subunits
+                    participant:
+                      selector_type: FAMILY
+                      family:
+                        preferred_term: secondary-wall cellulose synthase (CESA4/IRX5, CESA7/IRX3, CESA8/IRX1)
+                        description: >-
+                          The xylem/fiber triad; loss of any member gives the
+                          irregular-xylem (irx) collapsed-vessel phenotype.
+                        representative_members:
+                          - preferred_term: Arabidopsis CESA8 (IRX1)
+                            term:
+                              id: UniProtKB:Q8LPK5
+                              label: Cellulose synthase A catalytic subunit 8 [UDP-forming]
+                          - preferred_term: Arabidopsis CESA7 (IRX3)
+                            term:
+                              id: UniProtKB:Q9SWW6
+                              label: Cellulose synthase A catalytic subunit 7 [UDP-forming]
+                          - preferred_term: Arabidopsis CESA4 (IRX5)
+                            term:
+                              id: UniProtKB:Q84JA6
+                              label: Cellulose synthase A catalytic subunit 4 [UDP-forming]
+                    function:
+                      preferred_term: cellulose synthase (UDP-forming) activity
+                      term:
+                        id: GO:0016760
+                        label: cellulose synthase (UDP-forming) activity
+                    processes:
+                      - preferred_term: plant-type secondary cell wall biogenesis
+                        term:
+                          id: GO:0009834
+                          label: plant-type secondary cell wall biogenesis
+                    role_description: >-
+                      Deposits the thick, highly crystalline cellulose of xylem and
+                      fiber secondary walls; the dominant feedstock cellulose and
+                      the primary bioenergy recalcitrance target.
+    - order: 3
+      role: cortical-microtubule guidance of CSC trajectory
+      optional: true
+      node:
+        id: microtubule_guidance
+        label: CSC guidance by the cortical microtubule cytoskeleton
+        module_type: REGULATORY_STEP
+        concepts:
+          - preferred_term: cortical microtubule cytoskeleton
+            term:
+              id: GO:0030981
+              label: cortical microtubule cytoskeleton
+        annotons:
+          - id: csi1_microtubule_tethering
+            label: CSI1/POM2 tethering of the CSC to cortical microtubules
+            participant:
+              selector_type: FAMILY
+              family:
+                preferred_term: CELLULOSE SYNTHASE INTERACTIVE 1 (CSI1 / POM2)
+                representative_members:
+                  - preferred_term: Arabidopsis CSI1 (POM2)
+                    term:
+                      id: UniProtKB:F4IIM1
+                      label: Protein CELLULOSE SYNTHASE INTERACTIVE 1
+            function:
+              preferred_term: scaffold linking the CSC to cortical microtubules
+              description: >-
+                CSI1 bridges moving CSCs and cortical microtubules so that
+                microfibril deposition follows microtubule arrays; no confident
+                exact GO MF id is asserted here.
+            processes:
+              - preferred_term: cortical microtubule organization
+                term:
+                  id: GO:0043622
+                  label: cortical microtubule organization
+            role_description: >-
+              Orients microfibril deposition, controlling wall anisotropy and
+              directional cell expansion (does not catalyze synthesis itself).
+    - order: 4
+      role: accessory enzymes/proteins required for productive synthesis
+      node:
+        id: accessory_factors
+        label: KORRIGAN endoglucanase and COBRA
+        module_type: MOLECULAR_FUNCTION
+        description: >-
+          Non-CESA factors that are nonetheless required for normal cellulose
+          synthesis and microfibril quality.
+        parts:
+          - order: 1
+            role: membrane endo-1,4-beta-glucanase
+            node:
+              id: korrigan_endoglucanase
+              label: KORRIGAN (KOR1) endo-1,4-beta-glucanase
+              module_type: REACTION
+              annotons:
+                - id: kor1_cellulase_activity
+                  label: KORRIGAN endo-1,4-beta-glucanase
+                  participant:
+                    selector_type: FAMILY
+                    family:
+                      preferred_term: KORRIGAN membrane endo-1,4-beta-glucanase
+                      representative_members:
+                        - preferred_term: Arabidopsis KOR1 (KORRIGAN / RSW2)
+                          term:
+                            id: UniProtKB:Q38890
+                            label: Endoglucanase 25
+                  function:
+                    preferred_term: cellulase activity
+                    term:
+                      id: GO:0008810
+                      label: cellulase activity
+                    substrates:
+                      - preferred_term: "(1->4)-beta-D-glucan"
+                  locations:
+                    - preferred_term: plasma membrane
+                      term:
+                        id: GO:0005886
+                        label: plasma membrane
+                  role_description: >-
+                    Membrane-anchored endoglucanase associated with the CSC;
+                    required for normal cellulose synthesis, possibly trimming or
+                    editing nascent glucan chains during microfibril assembly.
+          - order: 2
+            role: GPI-anchored microfibril organizer
+            node:
+              id: cobra_organizer
+              label: COBRA microfibril organization
+              module_type: MOLECULAR_FUNCTION
+              annotons:
+                - id: cobra_microfibril_organization
+                  label: COBRA-dependent microfibril orientation/crystallinity
+                  participant:
+                    selector_type: FAMILY
+                    family:
+                      preferred_term: COBRA GPI-anchored cell-expansion protein
+                      representative_members:
+                        - preferred_term: Arabidopsis COBRA (COB)
+                          term:
+                            id: UniProtKB:Q94KT8
+                            label: Protein COBRA
+                  function:
+                    preferred_term: cellulose microfibril organization
+                    term:
+                      id: GO:0010215
+                      label: cellulose microfibril organization
+                  locations:
+                    - preferred_term: plasma membrane / apoplast (GPI-anchored)
+                      term:
+                        id: GO:0005886
+                        label: plasma membrane
+                  role_description: >-
+                    GPI-anchored protein influencing microfibril orientation and
+                    crystallinity; cob mutants have reduced, disorganized cellulose.
+    - order: 5
+      role: microfibril assembly and organization
+      optional: true
+      node:
+        id: microfibril_assembly
+        label: Crystalline microfibril assembly in the apoplast
+        module_type: CELLULAR_COMPONENT
+        annotons:
+          - id: microfibril_organization
+            label: Coalescence of glucan chains into crystalline microfibrils
+            participant:
+              selector_type: ANY_WITH_FUNCTION
+              required_function:
+                preferred_term: cellulose microfibril organization
+                term:
+                  id: GO:0010215
+                  label: cellulose microfibril organization
+            function:
+              preferred_term: cellulose microfibril organization
+              term:
+                id: GO:0010215
+                label: cellulose microfibril organization
+            locations:
+              - preferred_term: apoplast
+                term:
+                  id: GO:0048046
+                  label: apoplast
+            role_description: >-
+              Multiple coordinately extruded beta-1,4-glucan chains hydrogen-bond
+              into crystalline microfibrils; crystallinity is a key determinant of
+              enzymatic digestibility for bioenergy.
+  connections:
+    - source: udp_glucose_supply
+      target: glucan_polymerization
+      connection_type: PROVIDES_INPUT_FOR
+      description: UDP-glucose supply provides the donor substrate consumed by the CSC.
+    - source: microtubule_guidance
+      target: glucan_polymerization
+      connection_type: POSITIVELY_REGULATES
+      description: >-
+        Cortical microtubules (via CSI1) guide the trajectory of active CSCs,
+        directing where microfibrils are deposited.
+    - source: glucan_polymerization
+      target: microfibril_assembly
+      connection_type: PROVIDES_INPUT_FOR
+      description: Extruded glucan chains coalesce into crystalline microfibrils.
+    - source: accessory_factors
+      target: glucan_polymerization
+      connection_type: POSITIVELY_REGULATES
+      description: >-
+        KORRIGAN and COBRA are required for productive, well-ordered synthesis;
+        their loss reduces cellulose amount and microfibril quality.


### PR DESCRIPTION
## Summary

Adds a comprehensive, taxon-neutral module for plant cellulose biosynthesis (`modules/cellulose_biosynthesis.yaml`). This module decomposes the cellulose synthesis pathway into five key functional parts:

1. UDP-glucose substrate supply (via sucrose synthase or UDP-glucose pyrophosphorylase)
2. Glucan polymerization by the cellulose synthase complex (CSC), with distinct primary- and secondary-wall CESA isoform sets
3. Cortical microtubule guidance of CSC trajectory (via CSI1/POM2 tethering)
4. Accessory factors (KORRIGAN endoglucanase and COBRA)
5. Crystalline microfibril assembly in the apoplast

The module is grounded in GO terms (GO:0052324, GO:0030244, GO:0010330) and uses Arabidopsis exemplars (AtCESA1, AtCESA8, AtKOR1, AtCSI1, AtCOBRA) with representative UniProt identifiers. It explicitly separates primary-wall (CESA1/CESA3/CESA6-like) and secondary-wall (CESA4/CESA7/CESA8) CSC variants, reflecting the distinct developmental contexts and bioenergy relevance of secondary-wall cellulose. The module is designed to be implementable across angiosperms, grasses, and (with substitution) algae, while excluding CSL backbones, hemicelluloses, lignin, and bacterial machinery.

## Validation

N/A — This is a module definition file, not a gene review. No `just validate` command applies.

## Test plan

- [ ] Module YAML validates against the LinkML schema
- [ ] All GO term IDs (GO:0052324, GO:0030244, GO:0010330, etc.) are resolvable
- [ ] All UniProt IDs (O48946, Q8LPK5, Q38890, F4IIM1, Q94KT8, etc.) are valid
- [ ] Cross-references between module parts and connections are consistent

https://claude.ai/code/session_01GKsCFAAFJ3w3XDNjkFKJdC