### PR TITLE
Add nicotine biosynthesis pathway module

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -56,6 +56,9 @@ jobs:
               - 'uv.lock'
             genes:
               - 'genes/**/*-ai-review.yaml'
+            modules:
+              - 'modules/**/*.yaml'
+              - 'modules/**/*.yml'
             # Anything that can change validation behaviour for ALL genes. If any of
             # these change we cannot trust per-gene scoping, so we validate everything.
             infra:
@@ -121,6 +124,18 @@ jobs:
           else
             echo "No gene-review or validation-infrastructure changes; skipping gene validation."
           fi
+
+      # Module YAMLs are validated against the ModuleReview schema. They are not
+      # covered by validate-all (which is gene-review scoped), so validate them
+      # whenever a module changes, the schema/validators change, or on the weekly
+      # full run.
+      - name: Validate modules (scoped)
+        if: >-
+          github.event_name == 'schedule' ||
+          github.event_name == 'workflow_dispatch' ||
+          steps.changes.outputs.infra == 'true' ||
+          steps.changes.outputs.modules == 'true'
+        run: just validate-modules
 
       - name: Test valid/invalid examples
         if: steps.changes.outputs.infra == 'true' || steps.changes.outputs.src == 'true'

--- a/conf/oak_config.yaml
+++ b/conf/oak_config.yaml
@@ -43,3 +43,9 @@ ontology_adapters:
   PATO: sqlite:obo:pato
   NCBITaxon: sqlite:obo:ncbitaxon
   RHEA: sqlite:obo:rhea
+  PO: sqlite:obo:po  # Plant Ontology - anatomical locations in plant modules (e.g. root)
+  SBO: null  # Systems Biology Ontology (module regulation predicates) - no working
+             # offline sqlite:obo build (labels resolve to None), so not label-validated here
+  MetaCyc: null  # MetaCyc pathway/reaction ids - not OBO label-validated here
+  MIBiG: null  # Minimum Info about a Biosynthetic Gene cluster - not label-validated here
+  PANTHER: null  # PANTHER family/subfamily ids - not OBO label-validated here

--- a/modules/erythromycin_biosynthesis.yaml
+++ b/modules/erythromycin_biosynthesis.yaml
@@ -32,7 +32,7 @@ module:
       - preferred_term: Saccharopolyspora erythraea NRRL 2338
         term:
           id: NCBITaxon:405948
-          label: Saccharopolyspora erythraea
+          label: Saccharopolyspora erythraea NRRL 2338
   concepts:
     - preferred_term: erythromycin biosynthetic process
       term:

--- a/modules/nicotine_biosynthesis.yaml
+++ b/modules/nicotine_biosynthesis.yaml
@@ -1,0 +1,691 @@
+id: MODULE:nicotine_biosynthesis
+title: Nicotine biosynthesis module (Nicotiana / Solanaceae)
+description: >-
+  A plant-scoped, recursively decomposable decomposition of nicotine
+  biosynthesis as it operates in Nicotiana (tobacco / wild tobacco). Nicotine is
+  an alkaloid built by condensing two separately made rings: a PYRIDINE ring
+  supplied by the aspartate-derived NAD/quinolinate (pyridine nucleotide) branch,
+  and a PYRROLIDINE ring (the N-methyl-Delta1-pyrrolinium cation) supplied by the
+  polyamine/ornithine branch. The module separates these two upstream supply
+  branches from the late "nicotine synthase" cascade that joins the rings, and
+  from the vacuolar transport/metabolon step.
+
+  This module is intentionally NOT a flat gene list (that lives in the
+  per-gene NICAT reviews and the NICOTINE_BIOSYNTHESIS project). Its purpose is
+  to capture the pathway-level structure that the individual gene reviews cannot:
+  the two-branch convergence, the recently revised late steps, and the
+  co-clustered transport component.
+
+  The late steps are phrased to reflect the 2025-2026 revision of the pathway. In
+  the classical model the N-methylpyrrolinium cation condensed with a nicotinic
+  acid derivative directly. The new model ("complete biosynthesis of nicotine",
+  Cell 2026; "cryptic activating glucosylation", bioRxiv 2025) routes nicotinic
+  acid through a hidden N-glucosylation/reduction/condensation/deglucosylation
+  relay: a UDP-glucosyltransferase (UGT1/NaGT) glucosylates nicotinic acid to
+  nicotinic acid N-glucoside, an A622/NaGR reductase and a BBL oxidase act on the
+  activated glucoside during condensation with the pyrrolidine ring, and a
+  beta-glucosidase (beta-GD1/NicGH) removes the sugar to release nicotine. A
+  vacuolar-membrane MATE transporter (MATE1) co-clusters with A622 and beta-GD1
+  and is required for high heterologous production. This activating-glucosylation
+  relay and the A622-MATE1-beta-GD1 metabolon are the parts of the pathway that
+  GO biological-process and molecular-function terms flatten away.
+status: DRAFT
+evidence:
+  - source_id: GO:0042179
+    title: nicotine biosynthetic process
+    statement: The module is grounded in the GO biological-process term for nicotine biosynthesis.
+  - source_id: file:projects/NICOTINE_BIOSYNTHESIS.md
+    title: Nicotine Biosynthesis Project
+    statement: >-
+      The per-gene NICAT review seed set, canonical pathway gene list, candidate
+      accession mappings, and source bibliography that this module summarizes at
+      the pathway level.
+  - source_id: DOI:10.1016/j.cell.2026.03.0
+    title: "Chang L, et al. 2026. Complete biosynthesis of nicotine. Cell."
+    statement: >-
+      Reports the complete N. attenuata nicotine pathway, the new glycosylation
+      (UGT1/NaGT) and deglycosylation (beta-GD1/NicGH) steps, the A622-MATE1-beta-GD1
+      cluster, and a minimal heterologous reconstruction set
+      (NaODC, NaPMT1, NaMPO, NaUGT1, NaA622, NaBBL2, NaBGL1, NaMATE1).
+    url: https://www.cell.com/cell/fulltext/S0092-8674(26)00335-1
+    notes: >-
+      Cited via the project page and the Cell fulltext URL. A stable PMID was not
+      verified at module-authoring time, so the DOI form here is approximate; the
+      authoritative pointer is the URL and the project bibliography.
+  - source_id: DOI:10.64898/2025.12.04.692101
+    title: "Schwabe BTW, et al. 2025. Nicotine biosynthesis completed by cryptic activating glucosylation. bioRxiv."
+    statement: >-
+      Independent preprint establishing the four-enzyme nicotine-synthase cascade
+      (UGT1 -> A622 -> BBLa -> beta-GD1) in which a cryptic N-glucosylation
+      activates nicotinic acid for condensation and is then removed.
+    url: https://www.biorxiv.org/content/10.64898/2025.12.04.692101v1
+  - source_id: file:genes/NICAT/NaPMT1.1/NaPMT1.1-ai-review.yaml
+    title: NaPMT1.1 NICAT review
+    statement: Source of the verified putrescine N-methyltransferase grounding (GO:0030750) used in the pyrrolidine branch.
+references:
+  - id: file:projects/NICOTINE_BIOSYNTHESIS.md
+    title: Nicotine Biosynthesis Project (canonical pathway gene list, candidate accessions, and sources)
+  - id: PMID:28584129
+    title: "Wild tobacco genomes reveal the evolution of nicotine biosynthesis"
+    reference_review:
+      relevance: HIGH
+      correctness: UNVERIFIED
+      review_notes: >-
+        PNAS 2017 (PMC5468653) establishing the N. attenuata pathway/evolution
+        framing. PMID asserted from the project bibliography and not yet
+        independently re-verified against PubMed here.
+notes: >-
+  Grounding policy: GO molecular-function and biological-process identifiers were
+  copied from the verified per-gene NICAT reviews (each harvested term is used in
+  that gene's core_functions), so they are trusted. Metabolite/intermediate
+  descriptors are deliberately left WITHOUT ChEBI ids (preferred_term only) rather
+  than risk guessed identifiers; they can be grounded later from a verified ChEBI
+  lookup. Representative UniProt members are the project's current sequence-backed
+  NICAT candidate accessions (see the 2026-04-05 mapping dive in the project
+  page); they are orienting exemplars, not official symbol normalizations and not
+  a claim that the pathway is limited to those accessions. The NAMN-hydrolase step
+  (NaNAMNH) and the ring-condensation step are real pathway steps for which no
+  confident GO molecular-function id was available, so their function descriptors
+  carry no term.
+module:
+  id: nicotine_biosynthesis
+  label: Nicotine biosynthesis (Nicotiana)
+  module_type: METABOLIC_PATHWAY
+  concepts:
+    - preferred_term: nicotine biosynthetic process
+      term:
+        id: GO:0042179
+        label: nicotine biosynthetic process
+      description: >-
+        Root-localized biosynthesis of nicotine by condensation of a pyridine
+        ring (NAD/quinolinate branch) with a pyrrolidine ring
+        (N-methyl-Delta1-pyrrolinium cation, polyamine branch), followed by an
+        activating-glucosylation relay and vacuolar accumulation.
+  context:
+    taxa:
+      - preferred_term: Nicotiana (wild and cultivated tobacco)
+        description: >-
+          Pathway is described for Nicotiana, with N. attenuata as the reference
+          species for the complete (Cell 2026) pathway and N. tabacum for much of
+          the classical enzymology. Broadly applicable across nicotine-accumulating
+          Solanaceae.
+    anatomical_locations:
+      - preferred_term: root
+        description: >-
+          Nicotine biosynthesis is root-specific in Nicotiana; the biosynthetic
+          genes are root-enriched and jasmonate-inducible, while accumulation is
+          largely in leaves after transport.
+    cellular_components:
+      - preferred_term: cytosol / vacuole metabolon
+        description: >-
+          Upstream and condensation chemistry is largely cytosolic; the late
+          A622-MATE1-beta-GD1 module is associated with the vacuolar membrane,
+          with MATE1 as the transport component and vacuolar accumulation of the
+          product.
+  parts:
+    - order: 1
+      role: pyridine ring supply (aspartate / NAD / quinolinate branch)
+      node:
+        id: pyridine_branch
+        label: Pyridine ring branch (aspartate -> nicotinic acid)
+        module_type: METABOLIC_PATHWAY
+        description: >-
+          Supplies the pyridine ring of nicotine via the early NAD (de novo
+          pyridine nucleotide) pathway from aspartate, diverted at
+          nicotinic acid mononucleotide and hydrolyzed to free nicotinic acid for
+          the late condensation. The duplicated, root-recruited copies (NaAO2,
+          NaQPT2) are the nicotine-dedicated paralogs distinguished from the
+          housekeeping NAD-pathway copies.
+        parts:
+          - order: 1
+            role: aspartate entry into the pyridine branch
+            node:
+              id: ao_step
+              label: L-aspartate -> iminoaspartate (L-aspartate oxidase)
+              module_type: REACTION
+              annotons:
+                - id: ao_activity
+                  label: L-aspartate oxidase activity (NaAO2)
+                  participant:
+                    selector_type: FAMILY
+                    family:
+                      preferred_term: nicotine-pathway L-aspartate oxidase (NaAO2 / AO paralogs)
+                      description: Root-recruited aspartate oxidase paralog of the de novo NAD pathway.
+                      representative_members:
+                        - preferred_term: NaAO2 candidate AO_0 (NICAT)
+                          term:
+                            id: UniProtKB:A0A1J6KBX2
+                            label: A0A1J6KBX2
+                  function:
+                    preferred_term: L-aspartate oxidase activity
+                    term:
+                      id: GO:0008734
+                      label: L-aspartate oxidase activity
+                    substrates:
+                      - preferred_term: L-aspartate
+                      - preferred_term: dioxygen
+                    products:
+                      - preferred_term: iminoaspartate (2-iminobutanedioate)
+                      - preferred_term: hydrogen peroxide
+                  processes:
+                    - preferred_term: NAD(+) biosynthetic process (pyridine ring supply)
+                      term:
+                        id: GO:0009435
+                        label: NAD+ biosynthetic process
+          - order: 2
+            role: quinolinate -> nicotinic acid mononucleotide
+            node:
+              id: qpt_step
+              label: Quinolinate -> nicotinic acid mononucleotide (quinolinate phosphoribosyltransferase)
+              module_type: REACTION
+              description: >-
+                NaQPT2 is the root-specific, nicotine-dedicated quinolinate
+                phosphoribosyltransferase paralog that channels quinolinate into
+                nicotinic acid mononucleotide for the nicotine branch rather than
+                only for housekeeping NAD synthesis.
+              annotons:
+                - id: qpt_activity
+                  label: nicotinate-nucleotide diphosphorylase (carboxylating) activity (NaQPT2)
+                  participant:
+                    selector_type: FAMILY
+                    family:
+                      preferred_term: nicotine-pathway QPT (NaQPT2 / QPT paralogs)
+                      representative_members:
+                        - preferred_term: NaQPT2 candidate QPT_0 (NICAT)
+                          term:
+                            id: UniProtKB:A0A1J6KEF3
+                            label: A0A1J6KEF3
+                  function:
+                    preferred_term: nicotinate-nucleotide diphosphorylase (carboxylating) activity
+                    term:
+                      id: GO:0004514
+                      label: nicotinate-nucleotide diphosphorylase (carboxylating) activity
+                    substrates:
+                      - preferred_term: quinolinate
+                      - preferred_term: 5-phospho-alpha-D-ribose 1-diphosphate (PRPP)
+                    products:
+                      - preferred_term: nicotinic acid mononucleotide (NaMN)
+                      - preferred_term: diphosphate
+                      - preferred_term: carbon dioxide
+                  processes:
+                    - preferred_term: NAD(+) biosynthetic process
+                      term:
+                        id: GO:0009435
+                        label: NAD+ biosynthetic process
+          - order: 3
+            role: release of free nicotinic acid (new Cell 2026 step)
+            node:
+              id: namnh_step
+              label: Nicotinic acid mononucleotide -> nicotinic acid (NaMN hydrolase, NaNAMNH)
+              module_type: REACTION
+              description: >-
+                The Cell 2026 paper assigns a NAMN hydrolase (NaNAMNH) that
+                liberates free nicotinic acid as the pyridine-ring precursor fed
+                into the late glucosylation relay. No confident GO molecular-function
+                identifier is grounded here yet, and a stable public NICAT accession
+                for NaNAMNH was still unresolved at module-authoring time.
+              annotons:
+                - id: namnh_activity
+                  label: nicotinic acid mononucleotide hydrolase activity (NaNAMNH)
+                  participant:
+                    selector_type: ANY_WITH_FUNCTION
+                    required_function:
+                      preferred_term: nicotinate mononucleotide hydrolase / phosphatase-glycohydrolase activity
+                    description: >-
+                      Function is biochemically assigned by the Cell 2026 paper;
+                      participant accession not yet resolved in public NICAT
+                      annotation.
+                  function:
+                    preferred_term: nicotinic acid mononucleotide -> nicotinic acid (hydrolytic release)
+                    substrates:
+                      - preferred_term: nicotinic acid mononucleotide (NaMN)
+                    products:
+                      - preferred_term: nicotinic acid
+                  notes: >-
+                    Function descriptor intentionally carries no GO term: no
+                    confident grounding was available without guessing.
+    - order: 2
+      role: pyrrolidine ring supply (ornithine / polyamine branch)
+      node:
+        id: pyrrolidine_branch
+        label: Pyrrolidine ring branch (ornithine -> N-methyl-Delta1-pyrrolinium cation)
+        module_type: METABOLIC_PATHWAY
+        description: >-
+          Supplies the pyrrolidine ring as the N-methyl-Delta1-pyrrolinium cation
+          via putrescine, N-methylputrescine, and 4-methylaminobutanal. PMT
+          (putrescine N-methyltransferase) is the committed, root-specific entry
+          that diverts polyamine metabolism toward alkaloids.
+        parts:
+          - order: 1
+            role: putrescine supply
+            node:
+              id: odc_step
+              label: L-ornithine -> putrescine (ornithine decarboxylase)
+              module_type: REACTION
+              annotons:
+                - id: odc_activity
+                  label: ornithine decarboxylase activity (NaODC1/NaODC2)
+                  participant:
+                    selector_type: FAMILY
+                    family:
+                      preferred_term: nicotine-pathway ornithine decarboxylase (NaODC paralogs)
+                      representative_members:
+                        - preferred_term: NaODC candidate ODC (NICAT)
+                          term:
+                            id: UniProtKB:A0A314KUM9
+                            label: A0A314KUM9
+                  function:
+                    preferred_term: ornithine decarboxylase activity
+                    term:
+                      id: GO:0004586
+                      label: ornithine decarboxylase activity
+                    substrates:
+                      - preferred_term: L-ornithine
+                    products:
+                      - preferred_term: putrescine
+                      - preferred_term: carbon dioxide
+                  processes:
+                    - preferred_term: putrescine biosynthetic process from arginine, via ornithine
+                      term:
+                        id: GO:0033387
+                        label: putrescine biosynthetic process from arginine, via ornithine
+          - order: 2
+            role: committed methylation step (pathway entry)
+            node:
+              id: pmt_step
+              label: putrescine -> N-methylputrescine (putrescine N-methyltransferase)
+              module_type: REACTION
+              description: >-
+                The committed, rate-influencing entry into the pyrrolidine
+                alkaloid branch. Represented with isozyme variants because
+                Nicotiana carries co-expressed PMT paralogs (NaPMT1.1, NaPMT1.2)
+                that catalyze the same reaction.
+              variant_sets:
+                - id: pmt_paralog
+                  label: PMT paralogs
+                  axis: paralog / gene copy
+                  selection: ONE_OR_MORE
+                  variants:
+                    - id: pmt11_form
+                      label: NaPMT1.1
+                      module_type: REACTION
+                      annotons:
+                        - id: pmt11_activity
+                          label: putrescine N-methyltransferase activity (NaPMT1.1)
+                          participant:
+                            selector_type: GENE_PRODUCT
+                            gene_product:
+                              preferred_term: NaPMT1.1 (NICAT)
+                              description: Cell minimal-reconstruction PMT component; maps cleanly to UniProt PMT1.
+                              term:
+                                id: UniProtKB:Q93XQ5
+                                label: Q93XQ5
+                          function:
+                            preferred_term: putrescine N-methyltransferase activity
+                            term:
+                              id: GO:0030750
+                              label: putrescine N-methyltransferase activity
+                            substrates:
+                              - preferred_term: putrescine
+                              - preferred_term: S-adenosyl-L-methionine
+                            products:
+                              - preferred_term: N-methylputrescine
+                              - preferred_term: S-adenosyl-L-homocysteine
+                    - id: pmt12_form
+                      label: NaPMT1.2
+                      module_type: REACTION
+                      annotons:
+                        - id: pmt12_activity
+                          label: putrescine N-methyltransferase activity (NaPMT1.2)
+                          participant:
+                            selector_type: GENE_PRODUCT
+                            gene_product:
+                              preferred_term: NaPMT1.2 (NICAT)
+                              description: Root-specific PMT paralog; maps cleanly to UniProt PMT2.
+                              term:
+                                id: UniProtKB:Q93XQ4
+                                label: Q93XQ4
+                          function:
+                            preferred_term: putrescine N-methyltransferase activity
+                            term:
+                              id: GO:0030750
+                              label: putrescine N-methyltransferase activity
+                            substrates:
+                              - preferred_term: putrescine
+                              - preferred_term: S-adenosyl-L-methionine
+                            products:
+                              - preferred_term: N-methylputrescine
+                              - preferred_term: S-adenosyl-L-homocysteine
+          - order: 3
+            role: oxidative cyclization to the pyrrolinium cation
+            node:
+              id: mpo_step
+              label: N-methylputrescine -> N-methyl-Delta1-pyrrolinium cation (N-methylputrescine oxidase)
+              module_type: REACTION
+              description: >-
+                Oxidative deamination of N-methylputrescine to 4-methylaminobutanal,
+                which cyclizes spontaneously to the N-methyl-Delta1-pyrrolinium
+                cation - the reactive pyrrolidine-ring donor for condensation.
+              annotons:
+                - id: mpo_activity
+                  label: N-methylputrescine oxidase activity (NaMPO1)
+                  participant:
+                    selector_type: FAMILY
+                    family:
+                      preferred_term: N-methylputrescine oxidase (NaMPO1 / copper amine oxidase, AMO)
+                      representative_members:
+                        - preferred_term: NaMPO1 candidate AMO_3 (NICAT)
+                          term:
+                            id: UniProtKB:A0A314KPU1
+                            label: A0A314KPU1
+                  function:
+                    preferred_term: N-methylputrescine oxidase activity
+                    term:
+                      id: GO:0008131
+                      label: primary methylamine oxidase activity
+                    substrates:
+                      - preferred_term: N-methylputrescine
+                      - preferred_term: dioxygen
+                      - preferred_term: water
+                    products:
+                      - preferred_term: 4-methylaminobutanal (cyclizes to N-methyl-Delta1-pyrrolinium cation)
+                      - preferred_term: ammonia
+                      - preferred_term: hydrogen peroxide
+                  notes: >-
+                    Grounded to GO:0008131 (primary methylamine oxidase activity),
+                    the verified term used in the NaMPO1 NICAT review; the
+                    physiological substrate is N-methylputrescine.
+    - order: 3
+      role: ring condensation and activating-glucosylation relay (nicotine synthase)
+      node:
+        id: nicotine_synthase_cascade
+        label: Nicotine synthase cascade (cryptic activating glucosylation)
+        module_type: METABOLIC_PATHWAY
+        description: >-
+          Joins the pyridine and pyrrolidine rings into nicotine. In the revised
+          model nicotinic acid is first N-glucosylated to nicotinic acid
+          N-glucoside (an activating, ultimately cryptic modification), the
+          glucoside is reduced (A622/NaGR) and oxidized (BBL) during condensation
+          with the N-methyl-Delta1-pyrrolinium cation, and a beta-glucosidase
+          (beta-GD1/NicGH) finally removes the sugar to release nicotine.
+        parts:
+          - order: 1
+            role: activating N-glucosylation of nicotinic acid
+            node:
+              id: ugt_step
+              label: nicotinic acid -> nicotinic acid N-glucoside (UGT1 / NaGT)
+              module_type: REACTION
+              annotons:
+                - id: ugt_activity
+                  label: nicotinic acid N-glucosyltransferase activity (NaUGT1)
+                  participant:
+                    selector_type: FAMILY
+                    family:
+                      preferred_term: nicotinic acid glucosyltransferase (NaUGT1 / NaGT, UGT85A2-like)
+                      representative_members:
+                        - preferred_term: NaUGT1 candidate UGT85A2_0 (NICAT)
+                          term:
+                            id: UniProtKB:A0A2H4GSI3
+                            label: A0A2H4GSI3
+                  function:
+                    preferred_term: UDP-glucosyltransferase activity (nicotinic acid N-glucosylation)
+                    term:
+                      id: GO:0035251
+                      label: UDP-glucosyltransferase activity
+                    substrates:
+                      - preferred_term: nicotinic acid
+                      - preferred_term: UDP-glucose
+                    products:
+                      - preferred_term: nicotinic acid N-glucoside (NG)
+                      - preferred_term: UDP
+          - order: 2
+            role: reduction of the activated glucoside during condensation
+            node:
+              id: a622_step
+              label: nicotinic acid N-glucoside reduction (A622 / NaGR)
+              module_type: REACTION
+              description: >-
+                A622, an isoflavone-reductase-like (PIP-family) enzyme, redefined
+                in the new model as the nicotinic acid N-glucoside reductase (NaGR)
+                acting in the condensation with the pyrrolidine ring.
+              annotons:
+                - id: a622_activity
+                  label: nicotinic acid N-glucoside reductase activity (NaA622)
+                  participant:
+                    selector_type: FAMILY
+                    family:
+                      preferred_term: A622 / NaGR (isoflavone-reductase-like, PIP family)
+                      representative_members:
+                        - preferred_term: NaA622 (NICAT, via NCBI LOC109206509 / IFRH_2)
+                          term:
+                            id: UniProtKB:A0A314KUK7
+                            label: A0A314KUK7
+                  function:
+                    preferred_term: nicotinic acid N-glucoside reductase / oxidoreductase activity
+                    term:
+                      id: GO:0016491
+                      label: oxidoreductase activity
+                    substrates:
+                      - preferred_term: nicotinic acid N-glucoside (NG)
+                      - preferred_term: NADPH
+                    products:
+                      - preferred_term: reduced (dihydro) nicotinic acid N-glucoside intermediate
+          - order: 3
+            role: late oxidation joining the rings
+            node:
+              id: bbl_step
+              label: berberine-bridge-like oxidation (BBL / BBLa)
+              module_type: REACTION
+              description: >-
+                FAD-dependent berberine-bridge-enzyme-like oxidase acting late in
+                the condensation. Represented with paralog variants because
+                Nicotiana carries multiple BBL copies (NaBBL1, NaBBL2), with NaBBL2
+                used in the Cell minimal yeast reconstruction.
+              variant_sets:
+                - id: bbl_paralog
+                  label: BBL paralogs
+                  axis: paralog / gene copy
+                  selection: ONE_OR_MORE
+                  variants:
+                    - id: bbl2_form
+                      label: NaBBL2 (FOX1_2, minimal-set component)
+                      module_type: REACTION
+                      annotons:
+                        - id: bbl2_activity
+                          label: BBL oxidase activity (NaBBL2)
+                          participant:
+                            selector_type: GENE_PRODUCT
+                            gene_product:
+                              preferred_term: NaBBL2 candidate FOX1_2 (NICAT)
+                              term:
+                                id: UniProtKB:A0A1J6KPK0
+                                label: A0A1J6KPK0
+                          function:
+                            preferred_term: FAD-dependent (berberine-bridge-like) oxidoreductase activity
+                            term:
+                              id: GO:0016491
+                              label: oxidoreductase activity
+                    - id: bbl1_form
+                      label: NaBBL1 (FOX1_0)
+                      module_type: REACTION
+                      annotons:
+                        - id: bbl1_activity
+                          label: BBL oxidase activity (NaBBL1)
+                          participant:
+                            selector_type: GENE_PRODUCT
+                            gene_product:
+                              preferred_term: NaBBL1 candidate FOX1_0 (NICAT)
+                              term:
+                                id: UniProtKB:A0A1J6JGR6
+                                label: A0A1J6JGR6
+                          function:
+                            preferred_term: FAD-dependent (berberine-bridge-like) oxidoreductase activity
+                            term:
+                              id: GO:0016491
+                              label: oxidoreductase activity
+          - order: 4
+            role: deglucosylation releasing nicotine
+            node:
+              id: bgd_step
+              label: glucoside hydrolysis to nicotine (beta-GD1 / NicGH, NaBGL1)
+              module_type: REACTION
+              description: >-
+                The cryptic sugar added by UGT1 is removed by a beta-glucosidase
+                (beta-GD1 / NicGH), releasing free nicotine. Represented with
+                paralog variants (NaBGL1 / NaBGL2; BGLU18 family) per the project's
+                sequence-backed mapping that favors BGLU18 over the older BGLU42
+                comparator.
+              variant_sets:
+                - id: bgd_paralog
+                  label: beta-GD paralogs
+                  axis: paralog / gene copy
+                  selection: ONE_OR_MORE
+                  variants:
+                    - id: bgl1_form
+                      label: NaBGL1 / beta-GD1 (BGLU18_6)
+                      module_type: REACTION
+                      annotons:
+                        - id: bgl1_activity
+                          label: beta-glucosidase activity (NaBGL1)
+                          participant:
+                            selector_type: GENE_PRODUCT
+                            gene_product:
+                              preferred_term: NaBGL1 candidate BGLU18_6 (NICAT)
+                              term:
+                                id: UniProtKB:A0A1J6KFZ7
+                                label: A0A1J6KFZ7
+                          function:
+                            preferred_term: beta-glucosidase activity (nicotine glucoside hydrolysis)
+                            term:
+                              id: GO:0008422
+                              label: beta-glucosidase activity
+                            substrates:
+                              - preferred_term: nicotine N-glucoside intermediate
+                            products:
+                              - preferred_term: nicotine
+                              - preferred_term: D-glucose
+                    - id: bgl2_form
+                      label: NaBGL2 / beta-GD2 (BGLU18_1)
+                      module_type: REACTION
+                      annotons:
+                        - id: bgl2_activity
+                          label: beta-glucosidase activity (NaBGL2)
+                          participant:
+                            selector_type: GENE_PRODUCT
+                            gene_product:
+                              preferred_term: NaBGL2 candidate BGLU18_1 (NICAT)
+                              term:
+                                id: UniProtKB:A0A314KWB2
+                                label: A0A314KWB2
+                          function:
+                            preferred_term: beta-glucosidase activity (nicotine glucoside hydrolysis)
+                            term:
+                              id: GO:0008422
+                              label: beta-glucosidase activity
+    - order: 4
+      optional: true
+      role: vacuolar transport / metabolon component
+      node:
+        id: transport_metabolon
+        label: MATE1 vacuolar transport (A622-MATE1-beta-GD1 metabolon)
+        module_type: TRANSPORT_STEP
+        description: >-
+          A MATE/DTX-family proton-antiporter (MATE1) co-clusters and is
+          tightly co-expressed with A622 and beta-GD1, and is required for high
+          heterologous nicotine production. The exact transported metabolite (a
+          glucosylated intermediate vs nicotine itself) is unresolved, so this is
+          modelled as an optional transport component of the late metabolon rather
+          than a defined catalytic step.
+        annotons:
+          - id: mate1_activity
+            label: MATE/antiporter transport activity (NaMATE1)
+            participant:
+              selector_type: FAMILY
+              family:
+                preferred_term: MATE1 / DTX40 (multidrug-and-toxic-compound-extrusion antiporter)
+                representative_members:
+                  - preferred_term: NaMATE1 candidate DTX40_3 (NICAT)
+                    term:
+                      id: UniProtKB:A0A314KVN4
+                      label: A0A314KVN4
+            function:
+              preferred_term: proton-coupled antiporter activity (alkaloid/intermediate transport)
+              term:
+                id: GO:0015297
+                label: antiporter activity
+            locations:
+              - preferred_term: vacuolar membrane / tonoplast
+            role_description: >-
+              Transport/sequestration component of the late nicotine metabolon;
+              specific transported species not yet defined.
+  connections:
+    # ---- Flux backbone: the two ring-supply branches converge on the cascade ----
+    - source: pyridine_branch
+      target: ugt_step
+      connection_type: PROVIDES_INPUT_FOR
+      description: The pyridine branch delivers free nicotinic acid, the substrate that UGT1 glucosylates to begin the cascade.
+    - source: pyrrolidine_branch
+      target: a622_step
+      connection_type: PROVIDES_INPUT_FOR
+      description: >-
+        The pyrrolidine branch delivers the N-methyl-Delta1-pyrrolinium cation,
+        the ring partner condensed with the activated nicotinic acid glucoside
+        during the A622/BBL steps.
+    # ---- Intra-branch ordering ----
+    - source: ao_step
+      target: qpt_step
+      connection_type: PRECEDES
+      description: Aspartate oxidation feeds the early NAD/quinolinate pathway upstream of the QPT diversion point.
+    - source: qpt_step
+      target: namnh_step
+      connection_type: PROVIDES_INPUT_FOR
+      description: QPT makes nicotinic acid mononucleotide, which NaNAMNH hydrolyzes to free nicotinic acid.
+    - source: namnh_step
+      target: ugt_step
+      connection_type: PROVIDES_INPUT_FOR
+      description: Free nicotinic acid from the NaMN hydrolase is the entry substrate of the glucosylation relay.
+    - source: odc_step
+      target: pmt_step
+      connection_type: PROVIDES_INPUT_FOR
+      description: Ornithine decarboxylase supplies putrescine, the substrate methylated by PMT.
+    - source: pmt_step
+      target: mpo_step
+      connection_type: PROVIDES_INPUT_FOR
+      description: PMT makes N-methylputrescine, oxidatively cyclized by MPO to the pyrrolinium cation.
+    # ---- Cascade ordering ----
+    - source: ugt_step
+      target: a622_step
+      connection_type: PROVIDES_INPUT_FOR
+      description: Nicotinic acid N-glucoside made by UGT1 is the substrate reduced by A622/NaGR.
+    - source: a622_step
+      target: bbl_step
+      connection_type: PRECEDES
+      description: A622 reduction and BBL oxidation act in series during the ring condensation.
+    - source: bbl_step
+      target: bgd_step
+      connection_type: PROVIDES_INPUT_FOR
+      description: The condensed, still-glucosylated nicotine intermediate is the substrate of the beta-glucosidase.
+    # ---- Metabolon / transport coupling ----
+    - source: transport_metabolon
+      target: bgd_step
+      connection_type: PART_OF
+      description: >-
+        MATE1 is part of the same root-enriched, co-expressed A622-MATE1-beta-GD1
+        late metabolon as the deglucosylation step; required for high heterologous
+        nicotine yield.
+  notes: >-
+    Layering: catalytic steps ground to the GO molecular-function terms verified
+    in the per-gene NICAT reviews (GO:0008734, GO:0004514, GO:0004586, GO:0030750,
+    GO:0008131, GO:0035251, GO:0016491, GO:0008422, GO:0015297); the pathway
+    grounds to GO:0042179. The information this module adds beyond per-gene GO
+    annotation is the PATHWAY SHAPE: (1) two independently synthesized rings
+    (pyridine via NAD/quinolinate, pyrrolidine via polyamines) that converge only
+    at condensation; (2) the revised late steps in which a cryptic activating
+    N-glucosylation (UGT1) is later removed (beta-GD1), with A622 and BBL acting on
+    the glucoside in between - a relay no single GO term captures; and (3) the
+    co-clustered MATE1 transport component of the A622-MATE1-beta-GD1 metabolon.
+    The NaNAMNH hydrolysis and the ring-condensation chemistry are real steps left
+    without GO molecular-function ids rather than guessing. Quinolinate synthase
+    (NaQS) and the regulators (NaERF1-like, NaMYC2) and the transport follow-up
+    NaNUP are deliberately out of this core module's scope, consistent with the
+    project's seed boundaries.

--- a/modules/nicotine_biosynthesis.yaml
+++ b/modules/nicotine_biosynthesis.yaml
@@ -19,16 +19,17 @@ description: >-
   The late steps are phrased to reflect the 2025-2026 revision of the pathway. In
   the classical model the N-methylpyrrolinium cation condensed with a nicotinic
   acid derivative directly. The new model ("complete biosynthesis of nicotine",
-  Cell 2026; "cryptic activating glucosylation", bioRxiv 2025) routes nicotinic
-  acid through a hidden N-glucosylation/reduction/condensation/deglucosylation
-  relay: a UDP-glucosyltransferase (UGT1/NaGT) glucosylates nicotinic acid to
-  nicotinic acid N-glucoside, an A622/NaGR reductase and a BBL oxidase act on the
-  activated glucoside during condensation with the pyrrolidine ring, and a
-  beta-glucosidase (beta-GD1/NicGH) removes the sugar to release nicotine. A
-  vacuolar-membrane MATE transporter (MATE1) co-clusters with A622 and beta-GD1
-  and is required for high heterologous production. This activating-glucosylation
-  relay and the A622-MATE1-beta-GD1 metabolon are the parts of the pathway that
-  GO biological-process and molecular-function terms flatten away.
+  Cell 2026, PMID:41928514; "nicotine biosynthesis completed by cryptic activating
+  glucosylation", Nat Commun 2026, PMID:42151135) routes nicotinic acid through a
+  hidden N-glucosylation/reduction/condensation/deglucosylation relay: a
+  UDP-glucosyltransferase (UGT1/NaGT) glucosylates nicotinic acid to nicotinic
+  acid N-glucoside, an A622/NaGR reductase and a BBL oxidase act on the activated
+  glucoside during condensation with the pyrrolidine ring, and a beta-glucosidase
+  (beta-GD1/NicGH) removes the sugar to release nicotine. A vacuolar-membrane MATE
+  transporter (MATE1) co-clusters with A622 and beta-GD1 and is required for high
+  heterologous production. This activating-glucosylation relay and the
+  A622-MATE1-beta-GD1 metabolon are the parts of the pathway that GO
+  biological-process and molecular-function terms flatten away.
 status: DRAFT
 evidence:
   - source_id: GO:0042179
@@ -40,53 +41,72 @@ evidence:
       The per-gene NICAT review seed set, canonical pathway gene list, candidate
       accession mappings, and source bibliography that this module summarizes at
       the pathway level.
-  - source_id: DOI:10.1016/j.cell.2026.03.0
-    title: "Chang L, et al. 2026. Complete biosynthesis of nicotine. Cell."
+  - source_id: PMID:41928514
+    title: "Chang L, et al. 2026. Complete biosynthesis of nicotine. Cell 2026 Apr 30."
     statement: >-
       Reports the complete N. attenuata nicotine pathway, the new glycosylation
       (UGT1/NaGT) and deglycosylation (beta-GD1/NicGH) steps, the A622-MATE1-beta-GD1
       cluster, and a minimal heterologous reconstruction set
       (NaODC, NaPMT1, NaMPO, NaUGT1, NaA622, NaBBL2, NaBGL1, NaMATE1).
     url: https://www.cell.com/cell/fulltext/S0092-8674(26)00335-1
-    notes: >-
-      Cited via the project page and the Cell fulltext URL. A stable PMID was not
-      verified at module-authoring time, so the DOI form here is approximate; the
-      authoritative pointer is the URL and the project bibliography.
-  - source_id: DOI:10.64898/2025.12.04.692101
-    title: "Schwabe BTW, et al. 2025. Nicotine biosynthesis completed by cryptic activating glucosylation. bioRxiv."
+  - source_id: PMID:42151135
+    title: "Schwabe BTW, et al. 2026. Nicotine biosynthesis is completed by cryptic activating glucosylation. Nat Commun."
     statement: >-
-      Independent preprint establishing the four-enzyme nicotine-synthase cascade
+      Independent study (published version of the 2025 bioRxiv preprint)
+      establishing the four-enzyme nicotine-synthase cascade
       (UGT1 -> A622 -> BBLa -> beta-GD1) in which a cryptic N-glucosylation
       activates nicotinic acid for condensation and is then removed.
-    url: https://www.biorxiv.org/content/10.64898/2025.12.04.692101v1
+    url: https://www.nature.com/articles/s41467-026-72705-0
   - source_id: file:genes/NICAT/NaPMT1.1/NaPMT1.1-ai-review.yaml
     title: NaPMT1.1 NICAT review
     statement: Source of the verified putrescine N-methyltransferase grounding (GO:0030750) used in the pyrrolidine branch.
 references:
-  - id: file:projects/NICOTINE_BIOSYNTHESIS.md
-    title: Nicotine Biosynthesis Project (canonical pathway gene list, candidate accessions, and sources)
-  - id: PMID:28584129
+  - id: PMID:41928514
+    title: "Complete biosynthesis of nicotine"
+    reference_review:
+      relevance: HIGH
+      correctness: VERIFIED
+      review_notes: >-
+        PMID verified against PubMed (Cell, 2026 Apr 30, Chang L et al.,
+        doi:10.1016/j.cell.2026.03.034). Primary source for the complete pathway,
+        the glycosylation/deglycosylation steps, the A622-MATE1-beta-GD1 metabolon,
+        and the minimal heterologous set.
+  - id: PMID:42151135
+    title: "Nicotine biosynthesis is completed by cryptic activating glucosylation"
+    reference_review:
+      relevance: HIGH
+      correctness: VERIFIED
+      review_notes: >-
+        PMID verified against PubMed (Nat Commun, 2026, doi:10.1038/s41467-026-72705-0);
+        this is the published version of the 2025 bioRxiv preprint. Independent
+        confirmation of the cryptic-activating-glucosylation cascade.
+  - id: PMID:28536194
     title: "Wild tobacco genomes reveal the evolution of nicotine biosynthesis"
     reference_review:
       relevance: HIGH
-      correctness: UNVERIFIED
+      correctness: VERIFIED
       review_notes: >-
-        PNAS 2017 (PMC5468653) establishing the N. attenuata pathway/evolution
-        framing. PMID asserted from the project bibliography and not yet
-        independently re-verified against PubMed here.
+        PMID verified against PubMed (PNAS, 2017 Jun 6, PMC5468653). Establishes
+        the N. attenuata pathway/evolution framing and the duplicated,
+        root-recruited NAD-pathway paralogs. (Corrects the project bibliography,
+        which cited only the PMC id.)
+  - id: file:projects/NICOTINE_BIOSYNTHESIS.md
+    title: Nicotine Biosynthesis Project (canonical pathway gene list, candidate accessions, and sources)
 notes: >-
   Grounding policy: GO molecular-function and biological-process identifiers were
   copied from the verified per-gene NICAT reviews (each harvested term is used in
   that gene's core_functions), so they are trusted. Metabolite/intermediate
-  descriptors are deliberately left WITHOUT ChEBI ids (preferred_term only) rather
-  than risk guessed identifiers; they can be grounded later from a verified ChEBI
-  lookup. Representative UniProt members are the project's current sequence-backed
-  NICAT candidate accessions (see the 2026-04-05 mapping dive in the project
-  page); they are orienting exemplars, not official symbol normalizations and not
-  a claim that the pathway is limited to those accessions. The NAMN-hydrolase step
-  (NaNAMNH) and the ring-condensation step are real pathway steps for which no
-  confident GO molecular-function id was available, so their function descriptors
-  carry no term.
+  descriptors were grounded to ChEBI via EBI OLS exact-label lookup; descriptors
+  that still lack a `term` (the N-methyl-Delta1-pyrrolinium cation, the nicotinic
+  acid N-glucoside / reduced-glucoside intermediates, and small byproducts such as
+  dioxygen / CO2 / ammonia / diphosphate where no unambiguous ChEBI exact match was
+  returned) were left ungrounded rather than guessed. Representative UniProt members
+  are the project's current sequence-backed NICAT candidate accessions (see the
+  2026-04-05 mapping dive in the project page); they are orienting exemplars, not
+  official symbol normalizations and not a claim that the pathway is limited to
+  those accessions. The NAMN-hydrolase step (NaNAMNH) and the ring-condensation
+  step are real pathway steps for which no confident GO molecular-function id was
+  available, so their function descriptors carry no term.
 module:
   id: nicotine_biosynthesis
   label: Nicotine biosynthesis (Nicotiana)
@@ -111,6 +131,9 @@ module:
           Solanaceae.
     anatomical_locations:
       - preferred_term: root
+        term:
+          id: PO:0009005
+          label: root
         description: >-
           Nicotine biosynthesis is root-specific in Nicotiana; the biosynthetic
           genes are root-enriched and jasmonate-inducible, while accumulation is
@@ -163,10 +186,19 @@ module:
                       label: L-aspartate oxidase activity
                     substrates:
                       - preferred_term: L-aspartate
+                        term:
+                          id: CHEBI:29991
+                          label: L-aspartate(1-)
                       - preferred_term: dioxygen
                     products:
                       - preferred_term: iminoaspartate (2-iminobutanedioate)
+                        term:
+                          id: CHEBI:58831
+                          label: iminoaspartate
                       - preferred_term: hydrogen peroxide
+                        term:
+                          id: CHEBI:16240
+                          label: hydrogen peroxide
                   processes:
                     - preferred_term: NAD(+) biosynthetic process (pyridine ring supply)
                       term:
@@ -202,9 +234,18 @@ module:
                       label: nicotinate-nucleotide diphosphorylase (carboxylating) activity
                     substrates:
                       - preferred_term: quinolinate
+                        term:
+                          id: CHEBI:16675
+                          label: quinolinic acid
                       - preferred_term: 5-phospho-alpha-D-ribose 1-diphosphate (PRPP)
+                        term:
+                          id: CHEBI:17111
+                          label: 5-O-phosphono-alpha-D-ribofuranosyl diphosphate
                     products:
                       - preferred_term: nicotinic acid mononucleotide (NaMN)
+                        term:
+                          id: CHEBI:15763
+                          label: nicotinic acid D-ribonucleotide
                       - preferred_term: diphosphate
                       - preferred_term: carbon dioxide
                   processes:
@@ -239,8 +280,14 @@ module:
                     preferred_term: nicotinic acid mononucleotide -> nicotinic acid (hydrolytic release)
                     substrates:
                       - preferred_term: nicotinic acid mononucleotide (NaMN)
+                        term:
+                          id: CHEBI:15763
+                          label: nicotinic acid D-ribonucleotide
                     products:
                       - preferred_term: nicotinic acid
+                        term:
+                          id: CHEBI:15940
+                          label: nicotinic acid
                   notes: >-
                     Function descriptor intentionally carries no GO term: no
                     confident grounding was available without guessing.
@@ -281,8 +328,14 @@ module:
                       label: ornithine decarboxylase activity
                     substrates:
                       - preferred_term: L-ornithine
+                        term:
+                          id: CHEBI:15729
+                          label: L-ornithine
                     products:
                       - preferred_term: putrescine
+                        term:
+                          id: CHEBI:17148
+                          label: putrescine
                       - preferred_term: carbon dioxide
                   processes:
                     - preferred_term: putrescine biosynthetic process from arginine, via ornithine
@@ -327,10 +380,22 @@ module:
                               label: putrescine N-methyltransferase activity
                             substrates:
                               - preferred_term: putrescine
+                                term:
+                                  id: CHEBI:17148
+                                  label: putrescine
                               - preferred_term: S-adenosyl-L-methionine
+                                term:
+                                  id: CHEBI:15414
+                                  label: S-adenosyl-L-methionine
                             products:
                               - preferred_term: N-methylputrescine
+                                term:
+                                  id: CHEBI:17166
+                                  label: N-methylputrescine
                               - preferred_term: S-adenosyl-L-homocysteine
+                                term:
+                                  id: CHEBI:16680
+                                  label: S-adenosyl-L-homocysteine
                     - id: pmt12_form
                       label: NaPMT1.2
                       module_type: REACTION
@@ -352,10 +417,22 @@ module:
                               label: putrescine N-methyltransferase activity
                             substrates:
                               - preferred_term: putrescine
+                                term:
+                                  id: CHEBI:17148
+                                  label: putrescine
                               - preferred_term: S-adenosyl-L-methionine
+                                term:
+                                  id: CHEBI:15414
+                                  label: S-adenosyl-L-methionine
                             products:
                               - preferred_term: N-methylputrescine
+                                term:
+                                  id: CHEBI:17166
+                                  label: N-methylputrescine
                               - preferred_term: S-adenosyl-L-homocysteine
+                                term:
+                                  id: CHEBI:16680
+                                  label: S-adenosyl-L-homocysteine
           - order: 3
             role: oxidative cyclization to the pyrrolinium cation
             node:
@@ -385,12 +462,24 @@ module:
                       label: primary methylamine oxidase activity
                     substrates:
                       - preferred_term: N-methylputrescine
+                        term:
+                          id: CHEBI:17166
+                          label: N-methylputrescine
                       - preferred_term: dioxygen
                       - preferred_term: water
+                        term:
+                          id: CHEBI:15377
+                          label: water
                     products:
                       - preferred_term: 4-methylaminobutanal (cyclizes to N-methyl-Delta1-pyrrolinium cation)
+                        term:
+                          id: CHEBI:1894
+                          label: 4-Methylaminobutanal
                       - preferred_term: ammonia
                       - preferred_term: hydrogen peroxide
+                        term:
+                          id: CHEBI:16240
+                          label: hydrogen peroxide
                   notes: >-
                     Grounded to GO:0008131 (primary methylamine oxidase activity),
                     the verified term used in the NaMPO1 NICAT review; the
@@ -434,10 +523,19 @@ module:
                       label: UDP-glucosyltransferase activity
                     substrates:
                       - preferred_term: nicotinic acid
+                        term:
+                          id: CHEBI:15940
+                          label: nicotinic acid
                       - preferred_term: UDP-glucose
+                        term:
+                          id: CHEBI:18066
+                          label: UDP-D-glucose
                     products:
                       - preferred_term: nicotinic acid N-glucoside (NG)
                       - preferred_term: UDP
+                        term:
+                          id: CHEBI:17659
+                          label: UDP
           - order: 2
             role: reduction of the activated glucoside during condensation
             node:
@@ -468,6 +566,9 @@ module:
                     substrates:
                       - preferred_term: nicotinic acid N-glucoside (NG)
                       - preferred_term: NADPH
+                        term:
+                          id: CHEBI:16474
+                          label: NADPH
                     products:
                       - preferred_term: reduced (dihydro) nicotinic acid N-glucoside intermediate
           - order: 3
@@ -563,7 +664,13 @@ module:
                               - preferred_term: nicotine N-glucoside intermediate
                             products:
                               - preferred_term: nicotine
+                                term:
+                                  id: CHEBI:18723
+                                  label: nicotine
                               - preferred_term: D-glucose
+                                term:
+                                  id: CHEBI:17634
+                                  label: D-glucose
                     - id: bgl2_form
                       label: NaBGL2 / beta-GD2 (BGLU18_1)
                       module_type: REACTION
@@ -615,6 +722,9 @@ module:
                 label: antiporter activity
             locations:
               - preferred_term: vacuolar membrane / tonoplast
+                term:
+                  id: GO:0005774
+                  label: vacuolar membrane
             role_description: >-
               Transport/sequestration component of the late nicotine metabolon;
               specific transported species not yet defined.
@@ -677,15 +787,15 @@ module:
     Layering: catalytic steps ground to the GO molecular-function terms verified
     in the per-gene NICAT reviews (GO:0008734, GO:0004514, GO:0004586, GO:0030750,
     GO:0008131, GO:0035251, GO:0016491, GO:0008422, GO:0015297); the pathway
-    grounds to GO:0042179. The information this module adds beyond per-gene GO
-    annotation is the PATHWAY SHAPE: (1) two independently synthesized rings
-    (pyridine via NAD/quinolinate, pyrrolidine via polyamines) that converge only
-    at condensation; (2) the revised late steps in which a cryptic activating
-    N-glucosylation (UGT1) is later removed (beta-GD1), with A622 and BBL acting on
-    the glucoside in between - a relay no single GO term captures; and (3) the
-    co-clustered MATE1 transport component of the A622-MATE1-beta-GD1 metabolon.
-    The NaNAMNH hydrolysis and the ring-condensation chemistry are real steps left
-    without GO molecular-function ids rather than guessing. Quinolinate synthase
-    (NaQS) and the regulators (NaERF1-like, NaMYC2) and the transport follow-up
-    NaNUP are deliberately out of this core module's scope, consistent with the
-    project's seed boundaries.
+    grounds to GO:0042179, and metabolite intermediates to ChEBI. The information
+    this module adds beyond per-gene GO annotation is the PATHWAY SHAPE: (1) two
+    independently synthesized rings (pyridine via NAD/quinolinate, pyrrolidine via
+    polyamines) that converge only at condensation; (2) the revised late steps in
+    which a cryptic activating N-glucosylation (UGT1) is later removed (beta-GD1),
+    with A622 and BBL acting on the glucoside in between - a relay no single GO term
+    captures; and (3) the co-clustered MATE1 transport component of the
+    A622-MATE1-beta-GD1 metabolon. The NaNAMNH hydrolysis and the ring-condensation
+    chemistry are real steps left without GO molecular-function ids rather than
+    guessing. Quinolinate synthase (NaQS) and the regulators (NaERF1-like, NaMYC2)
+    and the transport follow-up NaNUP are deliberately out of this core module's
+    scope, consistent with the project's seed boundaries.

--- a/project.justfile
+++ b/project.justfile
@@ -483,7 +483,11 @@ validate-files files:
 validate-deep-research:
     uv run python scripts/validate_deep_research.py
 
-# Validate module YAML files against the ModuleReview schema
+# Validate module YAML files: (1) structural schema validation against
+# ModuleReview, and (2) ontology term-label validation (GO/CHEBI/PO/SBO/... ids
+# resolve and their labels match). The external linkml-term-validator only
+# checks enum-bound slots, which ModuleReview lacks, so module term labels are
+# checked by the project's module_validator instead.
 validate-modules:
     #!/usr/bin/env bash
     set -uo pipefail
@@ -494,9 +498,12 @@ validate-modules:
     fi
     rc=0
     while IFS= read -r f; do
-        echo "Validating $f"
+        echo "Schema-validating $f"
         uv run linkml-validate --schema {{schema_path}} --target-class ModuleReview "$f" || rc=1
     done <<< "$files"
+    echo "Validating module term labels..."
+    # shellcheck disable=SC2086
+    uv run python -m ai_gene_review.validation.module_validator $files || rc=1
     exit "$rc"
 
 # Full validation of a single gene file (schema + terms + references + best practices)

--- a/publications/PMID_41928514.md
+++ b/publications/PMID_41928514.md
@@ -1,0 +1,96 @@
+---
+reference_id: PMID:41928514
+title: Complete biosynthesis of nicotine.
+authors:
+- Chang L
+- Xu Z
+- Deng P
+- Zhang N
+- He T
+- Liu X
+- He W
+- Zheng A
+- Hu W
+- Pan M
+- Li W
+- Halitschke R
+- Li R
+- Fan M
+- Baldwin IT
+- Zhang Y
+- Li D
+journal: Cell
+year: '2026'
+doi: 10.1016/j.cell.2026.03.034
+keywords:
+- Nicotine/biosynthesis
+- Nicotiana/metabolism
+- Glycosylation
+- Plant Proteins/metabolism
+- Glycosyltransferases/metabolism
+content_type: abstract_only
+full_text_attempted: true
+---
+
+# Complete biosynthesis of nicotine.
+**Authors:** Chang L, Xu Z, Deng P, Zhang N, He T, Liu X, He W, Zheng A, Hu W, Pan M, Li W, Halitschke R, Li R, Fan M, Baldwin IT, Zhang Y, Li D
+**Journal:** Cell (2026)
+**DOI:** [10.1016/j.cell.2026.03.034](https://doi.org/10.1016/j.cell.2026.03.034)
+
+## Content
+
+1. Cell. 2026 Apr 30;189(9):2700-2713.e20. doi: 10.1016/j.cell.2026.03.034. Epub 
+2026 Apr 1.
+
+Complete biosynthesis of nicotine.
+
+Chang L(1), Xu Z(1), Deng P(1), Zhang N(1), He T(2), Liu X(2), He W(2), Zheng 
+A(2), Hu W(2), Pan M(2), Li W(1), Halitschke R(3), Li R(4), Fan M(1), Baldwin 
+IT(5), Zhang Y(1), Li D(6).
+
+Author information:
+(1)State Key Laboratory of Plant Trait Design, CAS Center for Excellence in 
+Molecular Plant Sciences, Institute of Plant Physiology and Ecology, Chinese 
+Academy of Sciences, Shanghai, China.
+(2)State Key Laboratory of Plant Trait Design, CAS Center for Excellence in 
+Molecular Plant Sciences, Institute of Plant Physiology and Ecology, Chinese 
+Academy of Sciences, Shanghai, China; University of Chinese Academy of Sciences, 
+Beijing, China.
+(3)Max Planck Institute for Chemical Ecology, Jena, Germany.
+(4)State Key Laboratory of Rice Biology and Breeding, Zhejiang Key Laboratory of 
+Biology and Ecological Regulation of Crop Pathogens and Insects, Institute of 
+Insect Sciences, Zhejiang University, Hangzhou, China.
+(5)State Key Laboratory of Plant Trait Design, CAS Center for Excellence in 
+Molecular Plant Sciences, Institute of Plant Physiology and Ecology, Chinese 
+Academy of Sciences, Shanghai, China; Max Planck Institute for Chemical Ecology, 
+Jena, Germany.
+(6)State Key Laboratory of Plant Trait Design, CAS Center for Excellence in 
+Molecular Plant Sciences, Institute of Plant Physiology and Ecology, Chinese 
+Academy of Sciences, Shanghai, China; CAS-JIC Center of Excellence for Plant and 
+Microbial Sciences (CEPAMS), Institute of Plant Physiology and Ecology, Chinese 
+Academy of Sciences, Shanghai, China. Electronic address: dpli@cemps.ac.cn.
+
+Nicotine, tobacco's addictive and potent insecticidal alkaloid, has shaped human 
+history, agriculture, and the plants that produce it. However, the enzymatic 
+steps and reaction mechanisms involved in nicotine biosynthesis remain elusive. 
+Here, we reveal that the final coupling reaction is stabilized by glycosylation 
+via a uridine diphosphate (UDP)-glycosyltransferase, reduced and activated by an 
+A622, condensed through a stereoselective intermolecular Mannich-like reaction, 
+sequentially oxidized by a berberine bridge enzyme-like (BBL), and finally 
+deglycosylated by a β-glucosidase to yield nicotine. A 5-component metabolon 
+assembles at vacuolar membranes to channel both nicotine biosynthesis and its 
+transport. We reconstituted this metabolon both in vitro and heterologously in 
+vivo. Abrogating any of these components depletes nicotine accumulations. A 
+multidrug and toxic compound extrusion (MATE) transporter is essential for 
+efficiently engineering nicotine production in heterologous plant species, which 
+confers pest resistance. This work completes the nicotine biosynthesis pathway 
+and provides critical insights into the intermolecular Mannich-like reaction, a 
+fundamental mechanism for scaffold formation in many plant alkaloids.
+
+Copyright © 2026 The Author(s). Published by Elsevier Inc. All rights reserved.
+
+DOI: 10.1016/j.cell.2026.03.034
+PMID: 41928514 [Indexed for MEDLINE]
+
+Conflict of interest statement: Declaration of interests The authors have filed 
+two patents (202511463398.7 and 2025111278023) from this work.

--- a/publications/PMID_42151135.md
+++ b/publications/PMID_42151135.md
@@ -1,0 +1,2253 @@
+---
+reference_id: PMID:42151135
+title: Nicotine biosynthesis is completed by cryptic activating glucosylation.
+authors:
+- Schwabe BTW
+- Angstman IM
+- Vollheyde K
+- Ingold Z
+- Li J
+- Stankevich KS
+- Spicer CD
+- Fascione MA
+- Grogan G
+- Geu-Flores F
+- Lichman BR
+journal: Nat Commun
+year: '2026'
+doi: 10.1038/s41467-026-72705-0
+keywords:
+- "Nicotine/biosynthesis, chemistry"
+- "Nicotiana/metabolism, genetics, enzymology"
+- Glycosylation
+- "Plant Proteins/metabolism, genetics, chemistry"
+- Biosynthetic Pathways
+- "Crystallography, X-Ray"
+- Glucose/metabolism
+- Alkaloids
+- Biocatalysis
+content_type: full_text_pdf
+full_text_attempted: true
+full_text_provider: openalex
+full_text_url: "https://www.nature.com/articles/s41467-026-72705-0.pdf"
+oa_status: gold
+license: cc-by
+local_pdf_path: files/PMID_42151135.pdf
+---
+
+# Nicotine biosynthesis is completed by cryptic activating glucosylation.
+**Authors:** Schwabe BTW, Angstman IM, Vollheyde K, Ingold Z, Li J, Stankevich KS, Spicer CD, Fascione MA, Grogan G, Geu-Flores F, Lichman BR
+**Journal:** Nat Commun (2026)
+**DOI:** [10.1038/s41467-026-72705-0](https://doi.org/10.1038/s41467-026-72705-0)
+
+## Content
+
+1. Nat Commun. 2026 May 18;17(1):4221. doi: 10.1038/s41467-026-72705-0.
+
+Nicotine biosynthesis is completed by cryptic activating glucosylation.
+
+Schwabe BTW(1)(2), Angstman IM(3), Vollheyde K(3), Ingold Z(1)(2), Li J(2), 
+Stankevich KS(2)(4), Spicer CD(2)(4), Fascione MA(2)(4), Grogan G(2), Geu-Flores 
+F(3), Lichman BR(5).
+
+Author information:
+(1)Centre for Novel Agricultural Products, Department of Biology, University of 
+York, York, UK.
+(2)Department of Chemistry, University of York, York, UK.
+(3)Section for Plant Biochemistry and Copenhagen Plant Science Centre, 
+Department of Plant and Environmental Sciences, University of Copenhagen, 
+Frederiksberg, Denmark.
+(4)York Biomedical Research Institute, University of York, York, UK.
+(5)Centre for Novel Agricultural Products, Department of Biology, University of 
+York, York, UK. benjamin.lichman@york.ac.uk.
+
+Nicotine is a neuroactive alkaloid produced by tobacco (Nicotiana tabacum) as a 
+defence against herbivory, and an addictive stimulant that has been used by 
+humans for millennia. Despite its significance, the core steps of its 
+biosynthesis have remained elusive. Here, we demonstrate the in vitro 
+reconstruction of a four-enzyme stereoselective biocatalytic cascade that forms 
+(S)-nicotine from nicotinic acid and N-methylpyrrolinium. This cascade includes 
+two glucose-processing enzymes that participate in a cryptic activating 
+glucosylation step. We also reconstruct this pathway in planta and present high 
+resolution X-ray structures of the key carbon-carbon bond forming 
+reductase-oxidase pair bound to their substrate and product, respectively. This 
+work establishes the complete biosynthetic pathway to nicotine, providing new 
+gene targets for controlling alkaloid production in Nicotiana and unlocking 
+enzymatic routes to pyridine alkaloids.
+
+© 2026. The Author(s).
+
+DOI: 10.1038/s41467-026-72705-0
+PMCID: PMC13184244
+PMID: 42151135 [Indexed for MEDLINE]
+
+Conflict of interest statement: Competing interests: C.D.S. and K.S.S. are 
+inventors on a pending patent related to the production of deuterated compounds. 
+The remaining authors declare no competing interests.
+
+Article https://doi.org/10.1038/s41467-026-72705-0
+Nicotine biosynthesis is completed by
+cryptic activating glucosylation
+Benjamin T. W. Schwabe 1,2,I s a b e l l eM .A n g s t m a n3, Katharina Vollheyde 3,
+Zoe Ingold 1,2,J i a c h e n gL i2,K s e n i aS .S t a n k e v i c h2,4,
+Christopher D. Spicer 2,4,M a r t i nA .F a s c i o n e2,4,G i d e o nG r o g a n2,
+Fernando Geu-Flores 3 & Benjamin R. Lichman 1
+Nicotine is a neuroactive alkaloid produced by tobacco (Nicotiana tabacum)a s
+a defence against herbivory, and an addictive stimulant that has been used by
+humans for millennia. Despite its signiﬁcance, the core steps of its biosynthesis
+have remained elusive. Here, we demonstrate the in vitro reconstruction of a
+four-enzyme stereoselective biocatalytic cascade that forms (S)-nicotine from
+nicotinic acid and N-methylpyrrolinium. This cascade includes two glucose-
+processing enzymes that participate in a cryptic activating glucosylation step.
+We also reconstruct this pathway in planta and present high resolution X-ray
+structures of the key carbon-carbon bond forming reductase-oxidase pair
+bound to their substrate and product, respectively. This work establishes the
+complete biosynthetic pathway to nicotine, providing new gene targets for
+controlling alkaloid production inNicotiana and unlocking enzymatic routes
+to pyridine alkaloids.
+Nicotine (1) is a plant-derived alkaloid of profound societal and sci-
+entiﬁc importance. It is the major neuroactive and addictive compo-
+nent of cultivated tobacco (Nicotiana tabacum) products, which have
+been used by humans for over 10,000 years1 and are responsible for an
+ongoing global health epidemic2. Its neurological properties are due to
+its agonistic interaction with eponymous nicotinic acetylcholine
+receptors
+3. The alkaloid protects plants from herbivory 4 and its
+insecticidal activity led to its use as an agricultural pesticide, prior to
+replacement by neo-nicotinoids5.
+Tobacco and its alkaloids have formed the basis of extensive
+investigations into plant biology including chemical ecology 6,m e t a -
+bolite transport 7, genetic regulation 8 and metabolic evolution 9.
+Recently, tobacco species, especially Nicotiana benthamiana, have
+gained traction as chassis for the recombinant production of ther-
+apeutic molecules and proteins, including vaccines
+10.H o w e v e r ,t h e
+presence of nicotine can cause challenges for downstream
+processing
+11. Despite its notability, nicotine’s biosynthesis has not been
+elucidated: solving it will enable genetic manipulation of the pathway
+in native and heterologous producers, and will provide biocatalytic
+tools for the formation of pyridine-containing compounds.
+Alkaloid scaffolds are typically formed via Mannich-like reactions,
+wherein an iminium electrophile is attacked by a carbon nucleophile,
+forming a carbon-carbon bond and a chiral center
+12. Nicotine (1)c o n -
+sists of pyridine andN-methylpyrrolidine rings, derived from nicotinic
+acid (2)a n d N-methylpyrrolinium (3)r e s p e c t i v e l y( F i g .1)13,14. Labelled
+precursor feeding studies indicate that2 undergoes C6-reduction and
+decarboxylation to yield the unusual nucleophile 1,2-dihydropyridine
+(4a), which reacts at C3 with the electrophilic iminium 3 to form 3,6-
+dihydronicotine (5a) followed by stereoselective removal of the C6-
+hydrogen to form 1 (Fig. 1,r e dh y d r o g e n )
+15– 22. The formation of 1
+a p p e a r st ob es t e r e o s e l e c t i v e ,a st h e(S)−1 enantiomer makes up 96% of
+1 formed inN. tabacumroots, prior to its enrichment in leaves through
+enantioselective demethylation of (R)−123. Related pyridine alkaloids
+anabasine (6) and anatabine ( 7) are formed when 3 is replaced by
+lysine-derivedΔ1-piperideinium (8) or nicotinic acid-derived 2,5-dihy-
+dropyridinium (9) respectively (Fig. 1)24.
+Received: 11 November 2025
+Accepted: 21 April 2026
+Check for updates
+1Centre for Novel Agricultural Products, Department of Biology, University of York, York, UK.2Department of Chemistry, University of York, York, UK.3Section
+for Plant Biochemistry and Copenhagen Plant Science Centre, Department of Plant and Environmental Sciences, University of Copenhagen,
+Frederiksberg, Denmark.4York Biomedical Research Institute, University of York, York, UK. e-mail: benjamin.lichman@york.ac.uk
+Nature Communications|         (2026) 17:4221 1
+1234567890():,;
+1234567890():,;
+
+In 1990, the isolation of ‘nicotine synthase’was reported, a crude
+enzyme preparation fromN. tabacum capable of forming (S)−1 from 2
+and 316. Subsequently, A622 and BBL were described, two oxidor-
+eductases involved in nicotine scaffold formation, ﬁrst identiﬁed in
+low-nicotine tobacco mutants25– 31. However, their substrates and pro-
+ducts have not been determined. Silencing of A622 and its close
+homolog A622L in hairy root cultures led to a reduction in pyridine
+alkaloids and an increase in nicotinic acid N-glucoside (10)( F i g .1)26,
+suggesting that A622, a cytosolically localised iso ﬂavone reductase-
+like enzyme32, is responsible for the reduction of 2 or a derivative.
+However, recombinant enzyme assays failed to demonstrate activity of
+A622 with 2 or 10
+26. BBLs encode vacuolar-localisedﬂavin-containing
+oxidases from the berberine bridge enzyme family 33. RNAi-based
+suppression or CRISPR-based inactivation ofBBLs led to a decrease in
+alkaloid content and an accumulation of dihydrometanicotine ( 11),
+which may be derived from dihydronicotine ( 5a)( F i g .1)30,31.F u r t h e r -
+more, residual1 in quintupleBBL knockouts was racemic and displayed
+a labelling pattern consistent with disruption of stereoselective H-loss
+at C6
+31. Single gene knockouts suggest that BBLa and BBLb are
+responsible for (S)−1 formation whereas BBLc may be responsible for
+(R)−1 formation34. Whilst it appears that BBL paralogs have roles in
+both oxidation and stereochemical control, the accumulation of11 in
+knockouts suggests they are not responsible for the ring coupling step.
+It is nearing two hundred years since theﬁrst isolation of nicotine,
+in 1828, by Posselt and Reimann35. Since then, the nicotine biosynthesis
+pathway has been under intense scrutiny due to its commercial and
+scientiﬁcs i g n iﬁcance. Nevertheless, progress in de ﬁning the crucial
+step in its formation — the coupling of the two rings — has been
+remarkably static, with current conceptions remaining essentially
+unchanged since those proposed in the 1960s
+15.
+In this work, we resolve this enduring mystery, discovering two
+glucosyl-processing enzymes that complete nicotine biosynthesis via a
+cryptic activating glucosylation. We demonstrate this by reconstruct-
+ing in vitro a four-enzyme stereoselective biocatalytic cascade that
+forms (S)-nicotine from nicotinic acid and N-methylpyrrolinium. Fur-
+thermore, X-ray crystal structures of the key oxidoreductases, along-
+side in planta pathway reconstruction and metabolite analysis, reveal
+the molecular and enzymatic basis for nicotine biosynthesis.
+Results
+Proposal of glucosylated intermediates in nicotine biosynthesis
+Genes involved in plant specialised metabolism pathways can be
+arranged in biosynthetic gene clusters, where non-homologous but
+functionally related genes are found in close genomic proximity
+36.W e
+investigated the genomic context of nicotine biosynthesis genes
+(Supplementary Data 1), and identi ﬁed a cluster consisting of A622
+(884g0010 from Edwards et al.
+37), the nicotine-related tonoplastic
+MATE1 transporter (884g0030)26,38,39 and a previously unreported gene
+predicted to encode a vacuolar localised β-glucosidase ( β-GD1,
+884g0020)( F i g . 2A and Supplementary Fig. 1). We identi ﬁed the
+homeologous cluster on chromosome 12, featuring A622L (31g0370),
+MATE2 (31g0420)a n da β-GD paralog (β-GD2, 31g0400)( F i g .2A). All
+clustered genes, as well as an unclustered β-GD paralog ( β-GD3,
+795g0060) (Supplementary Data 1), had highest expression in roots
+and co-expressed tightly with known nicotine biosynthesis genes
+(Fig. 2B, C and Supplementary Data 2)
+40.
+The clustering and co-expression pattern of theβ-GDss u g g e s t e d
+they are involved in nicotine biosynthesis, implying on-pathway
+deglucosylation. This led us to reconsider nicotinic acid N-glucoside
+(10) as the substrate of A622, hypothesising that 1,2-dihydropyridine
+glucoside (4b, R=Glc) and 1,2-dihydronicotine glucoside ( 5b,R = G l c )
+may be pathway intermediates (Fig. 1). Therefore, the remaining step
+requiring a candidate gene was the glucosylation of nicotinic acid (2).
+We identiﬁed a UDP-dependent glycosyltransferase (UGT) candidate
+(UGT1, 6222g0020) whose expression mirrored A622 expression after
+topping, a process that elicits nicotine biosynthesis (Fig. 2D)41. UGT1
+expression closely correlates with nicotine biosynthesis genes across
+multiple tissues (Fig.2B, C and Supplementary Data 3). It was given the
+systematic UDP-glycosyltransferase nameUGT709L18. Having identi-
+ﬁed β-GD and UGT candidates and proposed functions for A622 and
+BBL, we set out to test our hypothesis through pathway
+reconstruction.
+In vitro reconstitution of nicotine biosynthesis
+We ﬁrst reconstructed the nicotine biosynthesis pathway in vitro,
+selecting this simple system as it lacks interfering enzymes, non-
+relevant metabolites and complications of subcellular and tissue
+localisation. For expediency, we elected to test a single representative
+paralog of each enzyme type. Four heterologously expressed and
+puriﬁed enzymes (UGT1, A622, BBLa andβ-GD1, Supplementary Data 4,
+and Supplementary Fig. 2) were combined in one-pot reactions
+alongside co-substrates (UDP-glucose, NADPH) and precursors (Fig.3).
+In the presence of all four enzymes, ( S)-nicotine ((S)−1) was formed
+from nicotinic acid (2)a n dN-methylpyrrolinium (3), reconstituting the
+activity previously observed in the ‘nicotine synthase’ crude enzyme
+preparation (Figs.3; 4A and Supplementary Fig. 3)
+16.
+N
+6 N
+3
+N
+N
+N
+H
+N
+N
+H
+N
+H
+N
+N
+N
+N
+HN
+6
+N
+3
+OH
+O
+R
+A622?
+NADPH BBL?
+N
+H
+N-methyl-
+pyrrolinium (3) 1
+dihydrometanicotine (11)
+in BBL knock-outs
+anabasine (6) anatabine (7)
+(8)
+2,5-dihydropyridinium
+nicotinic acid (2) R=H, 4a
+R=Glc, 4b R=H, 5a
+R=Glc, 5b
+N
+O OH
+OH
+HO
+OH
+OH
+O
+nicotinic acid N-Glc (10)
+in A622 knock-down
+N
+N
+nicotine ((S)-1)
+HH
+H
+R
+H
+H
+"nicotinesynthase"cascade
+Δ1-piperideinium
+(9)
+H
+electrophilenucleophile?
+electrophiles
+alternative BBL?BBL?
+Fig. 1 | Proposed biosynthesis of nicotine.Hypothesized biosynthetic route to (S)-
+nicotine ((S)-1), showing origins of the pyridine (blue) and N-methylpyrrolidine
+(purple) rings. The Mannich-like scaffold formation is proposed to proceed via a
+multi-step ‘nicotine synthase’cascade16. Compounds that accumulate in Nicotiana
+silencing/knock-out experiments are depicted. The red hydrogens follow the fate
+of the hydride transferred via enzymatic reduction of 2.
+Article https://doi.org/10.1038/s41467-026-72705-0
+Nature Communications|         (2026) 17:4221 2
+
+The UGT1 enzyme was determined to be a nicotinic acid N-glu-
+cosyltransferase (NaGT), producing nicotinic acid N-glucoside ( 10)
+from nicotinic acid ( 2) and UDP-glucose (Fig. 3 and Supplementary
+Fig. 4). NaGT could also catalyse the formation of pyridine glucoside
+(12) from pyridine and UDP-glucose, but could not form nicotine
+glucoside (13) from nicotine and UDP-glucose (Supplementary Fig. 4).
+A622 was determined to be a nicotinic acidN-glucoside reductase
+(NaGR), catalysing the NADPH-dependent reduction of10 (Fig. 3 and
+Supplementary Fig. 5), with the inferred product 1,2-dihydropyridine
+glucoside (4b) undergoing non-enzymatic oxidation to yield pyridine
+glucoside (12). No peak corresponding to the expected mass of 1,2-
+dihydropyridine glucoside (4b)( [ M+H ]
++ = m/z 244) could be observed
+in NaGR-catalysed reactions. The formation of 4b from dihy-
+dronicotinic acid N-glucoside ( 14) could occur non-enzymatically
+through an enamine-imine tautomerisation followed by
+decarboxylation (Supplementary Fig. 5C). The subsequent oxidation of
+4b to form 12 likely occurs through reaction with molecular oxygen.
+When N-methylpyrrolinium (3) was included in reactions with
+NaGR and 10,t h el e v e l so f12 decreased, and a diastereomeric mixture
+of (R, S)-nicotine glucoside ((R, S)−13) appeared (Figs.3 and 4B). This is
+likely due to a non-stereoselective Mannich reaction between3 and 4b,
+forming (R, S)-dihydronicotine glucoside (5b), which undergoes non-
+enzymatic oxidation to yield (R, S)−13.W ew e r ea l s oa b l et oi d e n t i f ya
+small peak matching the expected mass of dihydronicotine glucoside
+(5b)( [ M + H ]
++ = m/z 327) but this peak was assigned as its isomer
+dihydrometanicotineN-glucoside (Glc-11) via comparison to a chemi-
+cally synthesised standard (Supplementary Fig. 5). We also identiﬁed
+traces of the aglycone dihydrometanicotine11 (Supplementary Fig. 5).
+We propose that ( R, S)-dihydronicotine glucoside ( 5b)c a ne i t h e r
+decompose into Glc-11 or oxidise into (R, S)−13. The former can occur
+A622β-GD MATE
+Scaffold 884
+A622β-GD1 MATE1
+884g0020 884g0010 884g0030
+1 250,000
+Chromosome 12
+A622L MATE2
+31g0400 31g0370 31g4200
+33,650,00033,420,000
+β-GD2
+Z-Score TPM
+A622
+A622L
+BBLa
+BBLb
+BBLc1
+BBLc2
+MATE1
+MATE2
+MPO1
+ODC1
+PMT1
+QS1
+UGT1
+β-GD1
+β-GD2
+β-GD3
+-3
+-2
+-1
+0
+1
+2
+3
+anther
+flower
+leaf
+petal
+pollen
+root
+seed
+shoot system
+stem
+stem internode
+trichome
+whole plant
+ERF221
+ERF179
+ERF115
+ERF163
+ERF91
+BBLc2
+BBLc1
+ERF199
+β-GD2
+AO2B
+β-GD3
+PMT1
+PMT3
+β-GD1
+PMT2
+PMT4
+ERF189
+NUP1
+QS1
+QS2
+NUP2
+DAO1
+MPO1
+BBLb
+BBLa
+MATE2
+MATE1
+A622L
+A622
+JAT1b
+QPT2
+ODC2
+ODC1
+ERF32
+ERF4
+UGT1
+MYC2b
+UGT3
+JAM1
+COI1
+ADC1A
+ADC1B
+JAT1a
+MYC1a
+ERF5
+MYC1b
+JAZ1
+MYC2a
+SS1
+SS2
+JAT2
+ERF3
+AO2A
+CYP82E3
+BBLd1
+BBLd2
+UGT2
+CYP82E4
+QPT1
+0
+0.2
+0.4
+0.6
+0.8
+1
+PCC
+n 2 57 491 18 2 119 11 22 92 1 2 7
+A
+0
+2
+4
+6
+8
+10
+12
+0 5 10 15 20 25
+log/g3676(FPKM)
+Time after topping (h)
+A622
+BBLa
+β-GD1
+UGT1
+UGT2
+UGT3
+0.99
+0.94
+0.88
+0.96
+0.99
+1.00
+PCCA622
+B
+ C
+ D
+ERF221
+ERF179
+ERF115
+ERF163
+ERF91
+BBLc2
+BBLc1
+ERF199
+β-GD2
+AO2B
+β-GD3
+PMT1
+PMT3
+β-GD1
+PMT2
+PMT4
+ERF189
+NUP1
+QS1
+QS2
+NUP2
+DAO1
+MPO1
+BBLb
+BBLa
+MATE2
+MATE1
+A622L
+A622
+JAT1b
+QPT2
+ODC2
+ODC1
+ERF32
+ERF4
+UGT1
+MYC2b
+UGT3
+JAM1
+COI1
+ADC1A
+ADC1B
+JAT1a
+MYC1a
+ERF5
+MYC1b
+JAZ1
+MYC2a
+SS1
+SS2
+JAT2
+ERF3
+AO2A
+CYP82E3
+BBLd1
+BBLd2
+UGT2
+CYP82E4
+QPT1
+Fig. 2 | Identiﬁcation of biosynthetic gene clusters and gene candidates.
+A Homeologous biosynthetic gene clusters identiﬁed in the N. tabacum 2017
+genome assembly37 consisting of β-glucosidase (β-GD, blue), reductase (A622,r e d )
+and transporter (MATE, yellow) genes. Scaffold/chromosome number is described
+above the linear genome strand, with numbers at either end representing nucleo-
+tide position. Scaffold 884 is unplaced in this assembly but in the Sierro et al. 2024
+assembly it is part of chromosome 16
+75.T h eg e n em o d e lb e t w e e nA622 and MATE1
+in scaffold 884 (884g0040) encodes a protein that contains a domain with
+homology to a reverse transcriptase domain (PANTHER ID PTHR33116).B Heatmap
+of expression of selected nicotine genes, includingβ-GD and UGT candidates across
+tissue types. Average expression calculated in each tissue type and values nor-
+malized per gene. Number of samples in each category above each column.
+C Clustered heatmap showing all-by-all correlations (PCC) of nicotine biosynthesis
+and related genes across 824 samples. TPM values obtained from PEO
+40. D Root
+expression levels of selected nicotine biosynthesis genes and UGT candidates fol-
+lowing topping treatment, and their correlation (PCC) with A622 responses. Data
+obtained from Qin et al. 2020
+41. Details of genes available in Supplementary Data 1.
+Article https://doi.org/10.1038/s41467-026-72705-0
+Nature Communications|         (2026) 17:4221 3
+
+[O]NaGR
+(A622)
+NADPH
+NicGS
+(BBL)
+A
+3
+CO2
+5b
+m/z = 325.2
+Retention time (min)
+m/z = 163.1
+Retention time (min)
+1
+Retention time (min)
+m/z = 286.1
+4b
+m/z = 242.1
+12
+Retention time (min)
+NaGT
+UDP-glucose
+10
+NA (
+2)
+NaGTNaGR
+NMP (
+3)
+NicGSNicGH
+B
+2
+NicGH
+13
+N
+N
+N
+OH
+O
+N
+N
+O OH
+OHHO
+OH
+OH
+O
+H
+H
+N
+O OH
+OHHO
+OH
+H
+H
+N
+N
+O OH
+OHHO
+OH
+H
+H
+N
+O OH
+OHHO
+OH
+OH
+O
+N
+O OH
+OHHO
+OH
+N
+N
+O OH
+OHHO
+OH
+11210 13
+14
+C a
+a
+a
+a
+a
+a
+a
+a
+a
+b
+c
+b
+b
+a
+a
+a
+a
+a
+c
+d
+d
+b
+a
+a
+NaGTNaGRNMP (
+3)
+NicGSNicGH
+a
+a
+d
+a
+a
+a c
+b
+a
+a a
+a
+c
+ab a
+11210 13NA (
+2)
+Fig. 3 | In vitro reconstitution of nicotine biosynthesis. A Proposed chemical
+transformations in nicotine biosynthesis reconstitution.B Products of in vitro cas-
+cades. Each row corresponds to an in vitro reaction, with the matrix showing pre-
+sence/absence (blue/white) of reaction components, alongside UDP-Glc and NADPH.
+Each column shows extracted ion chromatograms (EICs,m/z± 0.15). Blue chroma-
+tograms are chemically veriﬁed standards, scaled for clarity. Red chromatograms
+highlight key products. MS
+2 data is available in Supplementary Fig. 3.C Quantiﬁcation
+of in vitro cascades. Each row of bars corresponds to an in vitro reaction, with the
+matrix showing presence/absence (blue/white) of reaction components. Each
+column of bars shows the peak area of EICs (m/z± 0.15) corresponding to the masses
+of the chemical depicted above (left-to-right:10, 12, 13, 1). Compound identity was
+validated by standard retention time, and MS2 spectra (Supplementary Fig. 3). Red
+bars highlight key products. The letters above bars are signiﬁcant groupings of peak
+area, determined per chemical (p < 0.05, Tukey post-hoc test, see Supplementary
+Data 5). The concentration of nicotine produced (from 1 mM of2)w a sd e t e r m i n e dv i a
+an external standard curve; error bars show standard error (inset). Bars show mean
+EIC peak area (n = 3); points are individual replicates; error bars show standard
+deviation. Source data are provided as a Source Dataﬁle.
+Article https://doi.org/10.1038/s41467-026-72705-0
+Nature Communications|         (2026) 17:4221 4
+
+through a series of tautomerisation steps forming Glc- 11 and be fol-
+lowed by hydrolysis to yield11 (Supplementary Fig. 5D). Notably, NaGR
+failed to catalyse the reduction of pyridine glucoside (12), conﬁrming
+that this is a dead-end shunt metabolite (Supplementary Fig. 6A).
+Inclusion of BBLa led to a signiﬁcant decrease in12, increase in 13
+and rendered the reaction diastereoselective, with the (S)−13 isomer in
+excess (Figs.3 and 4B), reﬂected in the exclusive production of the (S)
+−1 enantiomer in the full pathway reconstruction (Fig. 4A). In the
+cascades, the peaks corresponding to 11 and Glc-11 are absent in the
+presence of BBLa; yet Glc- 11 is not a substrate of the enzyme, as it
+cannot be converted into 13 by BBLa (Supplementary Fig. 6B). This
+suggests that BBLa ’ss u b s t r a t ei s5b, which is upstream of Glc- 11:
+conversion of 5b to (S)−13 prevents accumulation of Glc-11 (Supple-
+m e n t a r yF i g .5 D ) .T h ep r e s e n c eo f11 in the absence of BBLa matches
+plant silencing experiments of the BBLs 30,31. These results rede ﬁne
+BBLa as (S)-nicotine glucoside synthase (NicGS).
+The ﬁnal step of the pathway is the deglucosylation of ( S)−13 to
+form (S)−1, which can be catalyzed byβ-GD1, now redeﬁned as nicotine
+glucoside hydrolase (NicGH) (Fig.3). The enzyme NicGH can catalyze
+the deglucosylation of both diastereomers of 13 but cannot accept
+nicotinic acidN-glucoside10, dihydrometanicotine glucoside Glc-11 or
+pyridine glucoside12 as substrates (Supplementary Fig. 7).
+In vitro biosynthesis of alternative tobacco alkaloids
+We anticipated that we could exchange N-methylpyrrolinium (3)f o r
+different electrophiles to form related pyridine alkaloids. We demon-
+strated this with Δ
+1-pyrrolinium (15)a n dΔ1-piperideinium (8), to form
+the natural products nornicotine (16) and anabasine (6), respectively
+(Fig. 4C, D). We generated the electrophiles via two approaches, che-
+mically and via in situ oxidative decarboxylation from ornithine and
+lysine respectively, catalysed by a recently discovered ornithine/
+lysine/arginine decarboxylase-oxidase (OLADO) fromN. tabacum
+42.
+In vitro assays with isotopically labelled nicotinic acid
+Feeding experiments with isotopically labelled precursors have been
+crucial in establishing atomic-level information about nicotine bio-
+synthesis, such as the loss of the C6 hydrogen from nicotinic acid
+(Fig. 1)
+17– 19,31. We reconstructed the four-enzyme nicotine biosynthesis
+cascade using isotopically labelled nicotinic acid-(ring-d4)( 2-d4)a sa
+substrate (Fig. 5 and Supplementary Fig. 8; Supplementary Data 6).
+With the full cascade, we observed accumulation of the major product
+1-d3 (Fig. 5B, row i). A similar labelling pattern is observed for nicotine
+glucoside (13) in the absence of NicGH (Fig. 5B, row ii). In contrast,
+when NicGS (BBLa) was absent, then not only is the yield of1 reduced,
+but the labelling pattern of 1 is changed, with 1-d4 now the major
+isotopologue (Fig.5B, row iii). This suggests that NicGS is responsible
+for the selective formation of 1-d3 in the full cascade.
+To pinpoint exactly which deuterium was being exchanged, we
+used the singly labelled nicotinic acid-d6 (2-d6). With NicGS present, we
+saw formation of the major product 1-d0; without NicGS, 1-d1 was the
+major product (Fig. 5C). This veri ﬁes that the isotope exchange
+determined by NicGS occurs at position C6 (Fig. 5C). This labelling
+pattern, where the C6 deuterium from labelled2 is lost in the product
+1, is consistent with a cascade where NaGR (A622) catalyses reduction
+of 2, transferring an unlabelled hydride (i.e. a protide) from NADPH
+onto C6, followed by the NicGS (BBLa) catalysing speciﬁc removal of
+the deuteride from the intermediat e 1,2-dihydronicotine glucoside
+(5b)( F i g .5A). The overall effect is a swapping of the deuteride for
+protide at C6, consistent with previous observations17– 19,31.
+In the absence of NicGS, the ratio of isotopologues is not
+equal, but reversed, with the dominant isotopologue products
+being the fully labelled 1-d
+1 or 1-d4 from 2-d6 or 2-d4 respectively
+(Fig. 5B, row iii,a n dF i g .5C). This indicates that the non-enzymatic
+oxidation of 5b favours the abstraction of the unlabelled protide
+(introduced by NaGR from NADPH) rather than the deuteride (from
+the labelled substrate 2). This bias occurs due to the kinetic isotope
+effect, which renders carbon-deuterium bonds stronger than carbon-
+protium bonds, so the latter are broken more readily in the non-
+enzymatic reaction, where selectivity is determined by bond energy
+rather than spatial context.
+When 2-d
+4 is used a substrate, the NicGS (BBLa) also appears
+to have an effect on the labelling of pyridine glucoside 12,
+which accumulates in the absence of N-methylpyrrolinium ( 3).
+Without NicGS (BBLa), the ratio of fully labelled 12-d4 to partially
+labelled12-d3 is signiﬁcantly greater than when NicGS (BBLa) is present
+(Fig. 5B, rows iv and v, Supplementary Data 6). This implies that NicGS
+can bind and catalyse the oxidation 4b as well as 5b. Cascade
+formation of nornicotine-d3 (15-d3) and anabasine-d3 (6-d3)f r o m2-d4
+conﬁrmed they are also formed via NicGS (BBLa)-catalysed oxidation
+(Fig. 5D, E).
+(R,S)-1 (R,S)-13
+Retention time (min)
+m/z = 325.2
+-NicGS
++NicGS
+(R,S)-13
+(S)-13
+BA
++NicGS
+-NicGS
+Retention time (min)
+15.0 20.0 25.0 30.0 35.0
+Retention time (min)
+Y = Δ¹-piperideinium
+Y = Lysine,
+      PLP
+-OLADO
++OLADO
+anabasine
+m/z = 163.1
+-NaGT
++NaGT
+N
+H
+Retention time (min)
+m/z = 149.1
+X = Ornithine,
+       PLP
+-NaGT
+-OLADO
++OLADO
++NaGT
+nornicotine
+N
+H
+X = Δ¹-pyrrolinium
+N
+N
+GlcN
+N
++ Y
+nicotine  
+cascade
+N
+OH
+O
+N
+N
+H
+C
++ X 
+nicotine  
+cascade
+N
+N
+H
+N
+OH
+O
+21 6 2 6
+15
+8
+(R,S)-1
+(S)-1
+16 6
+x10x20
+D
+Fig. 4 | Stereoselectivity and substrate scope of nicotine biosynthetic cascade.
+A Stereoselective formation of (S)-nicotine (1). Nicotine formation was achieved
+through one-pot enzymatic cascade (2, 3, NaGT, NaGR, NicGH) with and without
+NicGS detected by chiral HPLC (260 nm). Signal intensity of peaks and standards
+(blue) was scaled for comparison. B Induction of stereoselectivity by NicGS. EIC
+(m/z 325.2 ± 0.15) showing (R, S)-nicotine glucoside (13) formation from 2 with
+NaGT, NaGR and NMP, with or without NicGS. Chemically veriﬁed standards are
+blue. Signal intensity was scaled for comparison.C Formation of nornicotine (16)
+and D anabasine (6) via the nicotine biosynthetic cascade (2, NaGT, NaGR, NicGS,
+NicGH) with 15 or 8, respectively, either synthesized or formed enzymatically
+by OLADO.
+Article https://doi.org/10.1038/s41467-026-72705-0
+Nature Communications|         (2026) 17:4221 5
+
+B
+NA (
+2)
+NaGTNaGRNMP (
+3)
+NicGSNicGH
+[O]NaGR
+(A622)
+NADPH
+NicGS
+(BBL)
+A
+3
+CO2
+5b
+1
+4b
+12
+NaGT
+UDP-glucose
+102
+NicGH
+N
+N
+OH
+O
+D
+D
+D
+D
+N
+O OH
+OHHO
+OH
+OH
+O
+DD
+D
+D
+N
+O OH
+OHHO
+OH
+OH
+O
+H
+D
+D
+D
+D N
+O OH
+OHHO
+OH
+H
+D
+D
+D
+D
+H
+N
+O OH
+OHHO
+OH
+H/D
+D
+D
+D
+H
+N
+N
+O OH
+OHHO
+OH
+D
+D
+D
+H/D
+N
+N
+O OH
+OHHO
+OH
+H
+D
+D
+D
+D
+N
+N
+H/D
+D
+D
+D
+13
+a
+a b
+c
+d
+bd
+a
+bc
+a
+14
+nicotine  
+cascade N
+H
+N
+OH
+O
+D D
+D
+D
+N
+N
+H
+H/D
+D
+D
+D
+15
+16-d3/d4
+15 d4
+d3
+nicotine  
+cascade
+N
+OH
+O
+D D
+D
+D
+N
+H
+NH/D
+D
+D
+D
+N
+H
+8
+6-d3/d4
+6 d4
+d3-NicGS
++NicGS
+-NicGS
++NicGS
+2-d4 2-d4
+v
+iv
+ii
+iii
+i
+D E
+nicotine  
+cascade N
+N
+OH
+O
+D
+N
+N
+H/D
+1-d0/d6
+2-d6
+3
+6
+6
+C
+-NicGS
++NicGS
+1 d1
+d0
+10 d4
+d3 12 d4
+d3 13 d4
+d3 1 d4
+d3
+Fig. 5 | In vitro enzymatic cascade with labelled nicotinic acid. A Schematic of
+reaction cascade with nicotinic acid-(ring-d4)( 2-d4). B Selected in vitro cascades
+with 2-d4 substrate. Bar charts show EIC peak areas of product (from L-to-R:10, 12,
+13, 1)i s o t o p o l o g u e s( a l lm/z ± 0.15 except for d3-12 which was m/z ±0 . 5d u et op e a k
+shape distortion). Reactions performed in triplicate, bars show mean peak area,
+points show individual measurements, and error bars show standard deviation.
+Each row corresponds to an in vitro reaction, with the matrix showing presence/
+absence (blue/white) of reaction components. Letters above bars are signiﬁcant
+groupings of d
+3/d4 isotopologue ratios, determined per chemical across all reaction
+combinations (p < 0.05, Tukey’s HSD test, Supplementary Data 6, see Supplemen-
+tary Fig. 8 for all reactions). C– E Conversion of nicotinic acid (2) isotopologues by
+the nicotine biosynthetic cascade (NaGT, NaGR, NicGH, NADPH and UDP-Glc) with
+and without NicGS. Bar charts show peak areas of products from EICs. Reactions
+were performed in triplicate (points); bars show mean peak area; error bars show
+standard deviation. Source data are provided as a Source Data ﬁle.
+Article https://doi.org/10.1038/s41467-026-72705-0
+Nature Communications|         (2026) 17:4221 6
+
+Structure of NaGR (A622)
+To shed light on the mechanisms of NaGR (A622) and NicGS (BBLa), we
+determined their structures in complex with co-factors and relevant
+ligands using X-ray crystallography (Supplementary Data 7). In the case
+of NaGR (A622), we obtained a 1.3 Å resolution crystal structure in
+complex with NADP
++ and nicotinic acid N-glucoside ( 10) (9RDD)
+(Supplementary Fig. 9). NaGR (A622) is most similar to dehy-
+drogenases of the iso ﬂavone reductase family ( e.g. 2GAS, 57%
+sequence identity)
+43, with the cofactor NADP + bound between the
+Rossmann fold and the substrate binding domain. Omit density cor-
+responding to the ligand nicotinic acid N-glucoside 10 was observed
+adjacent to the cofactor, with the C6 atom of the pyridine ring poised
+to receive hydride from C4 of the nicotinamide ring of the cofactor at a
+distance of 3.4 Å (Fig. 6A). This matches the regio- and stereo-
+selectivity of the hydride transfer from NADPH onto there-face of10 at
+C-6, and into the pro-R position (Fig.6B). The carboxylate is bound by
+the side chain of Lys135. The sugar density was not complete, but an
+interaction was observed between the side chain of Asn264 and the C2
+hydroxyl of the sugar.
+Structure of NicGS (BBLa)
+We obtained 2.5 Å resolution structures of NicGS (BBLa) in complex
+with FAD (9RUW), and with both FAD and the putative reaction pro-
+duct ( S)-nicotine glucoside (13) (9RDR) (Supplementary Data 7 and
+Fig. 6C; Supplementary Fig. 9). NicGS is structurally most similar to the
+reticuline oxidase/berberine bridge enzyme from Eschscholzia cali-
+fornica (3D2D, 44.6% amino acid identity)
+44,b u tt h eF A Di sn o t
+bi-covalently bound as in the case of 3D2D, with C166 replaced by
+G165 in NicGS. Omit density was observed adjacent to the FAD
+density that was successfully modelled as ( S)-13 (Fig. 6C). The C-6
+position of 13 is 3.2 Å from the reactive nitrogen of the FAD
+cofactor, with the si-face of the pyridine ring facing the FAD. This
+proximity indicates that the C6 pro- S hydride of the proposed
+dihydronicotine glucoside (5b) substrate reduces the FAD cofactor
+(Fig. 6D). The side chain of E348, not conserved in 3D2D, has a
+role in substrate recognition, interacting with the nitrogen of
+the pyrrolidine ring and also the exocyclic C6 hydroxyl of 13 at
+distances of 3.0 and 2.8 Å respectively. In the absence of ligand
+binding (9RUW) the loop containing this residue is unstructured
+(Supplementary Fig. 9). Overall, the structures of NaGR (A622) and
+NicGS (BBLa), with bound glucoside substrates or products lend
+strong support to our pathway proposal. Furthermore, the atomic
+details provide a structural/mechanistic validation of isotope labelling
+experiments, where NicGS (BBLa) abstracts the opposite hydride to
+that added by NaGR (A622).
+In planta pathway reconstitution
+To demonstrate that the pathway assembled in vitro could be opera-
+tional in planta, we reconstituted nicotine biosynthesis in leaves ofN.
+benthamianavia transient gene expression (Fig.7 and Supplementary
+A B
+C
+3.4
+Lys135
+Asn264
+NADP
+N
+O
+O
+O
+OH
+HO
+HO
+OH
+N
+NH2
+O
+R
+H
+H
+N
+O
+O
+O
+OH
+HO
+HO
+OH
+N
+NH2
+O
+R
+H
+D
+H
+D
+D
+N
+N
+H D
+OHO
+HO
+OH
+OH
+HN
+N
+N
+N
+O
+O
+R
+N
+N
+N
+N
+OHO
+HO
+OH
+OH
+HN
+N
+N
+N
+HO
+O
+R
+N
+N
+H
+H
+D3.2
+2.8 3.0
+Glu348
+His101
+His101 His101
+13
+10
+6
+3
+6
+3
+6
+3
+FAD
+6
+3
+5b
+FAD
+NADPH
+2.7
+2.5
+Fig. 6 | X-ray crystal structures of NaGR (A622) and NicGS (BBLa). AThe crystal
+structure of NaGR bound to NADP+ and nicotinic acidN-glucoside (green net shows
+unreﬁned ligand density Fo-Fc at 3 σ). B Proposed mechanism of NaGR: NADPH
+reduces nicotinic acidN-glucoside-d6 on the re-face, adding a hydride in the pro-R
+position.C The crystal structure of NicGS with covalently bound FAD and ligand (S)-
+nicotine glucoside (green net shows unreﬁned ligand density Fo-Fc at 3 σ).
+D Proposed mechanism of NicGS, abstracting the pro-S hydride from dihy-
+dronicotine glucoside-d6 to yield nicotine glucoside.
+Article https://doi.org/10.1038/s41467-026-72705-0
+Nature Communications|         (2026) 17:4221 7
+
+Data 8)45. Whilst N. benthamiana is capable of producing nicotine, we
+were able to independently study ther e c o n s t i t u t e dp a t h w a ya st h ek e y
+endogenous genes A622 and BBL are not expressed in leaves (Sup-
+plementary Fig. 10 and Supplementary Data 9) 46. Furthermore, we
+could distinguish between the native nicotine transported into the
+leaves and the nicotine produced in situ by feeding the engineered
+leaves with a labelled precursor (nicotinamide-d
+4) and analysing
+labelled nicotine.
+To produceN-methylpyrrolinium (3), we co-expressed the known
+tobacco enzymes ODC, PMT and MPO (Supplementary
+Data 1 and 8)
+47– 49. When the entire pathway was expressed, we
+observed substantial production of (S)-nicotine-d3 ((S)-1-d3)( F i g .7 and
+Supplementary Fig. 12), validating our in vitro observations. Addi-
+tionally, stepwise reconstruction of the pathway mirrored results from
+the in vitro stepwise reconstruction, including production of
+anabasine-d
+3 (6-d3) enabled by co-expression of OLADO in place of the
+enzymes forming 3 (Supplementary Fig. 11 and Supplementary
+Data 10).
+We then conducted a drop-out experiment to validate the role
+of the individual components (Fig. 7 and Supplementary Data 11).
+Drop-out of NicGH ( β-GD1) led to a decrease in labelled nicotine
+(1) and accumulation of labelled nicotine glucoside ( 13), which
+we did not detect in any other combination. Dropping out NicGS
+(BBLa/b), resulted in a similar reduction in labelled nicotine but the
+residual nicotine was racemic (Fig. 7A). Omission of the N-
+methylpyrrolinium forming enzymes eliminated nicotine
+production and led to the accumulation of labelled pyridine glucoside
+(12). Dropping out NaGR (A622) abolished production of labelled
+pyridine glucoside (12), blocking the pathway at nicotinic acid N-glu-
+coside (10). It was not possible to con ﬁrm the in planta activity of
+NaGT (UGT1), as control leaves fed with labelled precursor accumu-
+lated labelled 10, likely due to high leaf expression of the native UGT1
+homolog (Supplementary Fig. 10). Similar to the in vitro experiments,
+the in plantaexperiments were able to ascribe the loss of deuterium to
+NicGS (BBLa/b) (Fig. 7 and Supplementary Fig. 11; Supplementary
+Data 10 and 11).
+Metabolites in wild-type and mutant plants
+We further probed our pathway hypothesis by searching for proposed
+intermediates or shunt metabolites in wild-type roots of N. tabacum
+and N. benthamiana. We were able to detect nicotine glucoside (13)i n
+N. tabacum and pyridine glucoside ( 12) in both N. tabacum and N.
+benthamiana (Fig. 8 and Supplementary Figs. 13; S14). We also exam-
+ined roots of existing N. benthamiana knockout lines in NaGR (A622/
+A622L)
+29 and NicGS ( BBLa/b/c/d/d’)31. The NaGR (A622) knockout
+accumulated nicotinic acidN-glucoside (10) but not pyridine glucoside
+(12), supporting the identity of 12 as a shunt product of NaGR (A622)
+(Fig. 8A). The NicGS (BBL) knockout accumulated pyridine glucoside
+(12) and nicotine glucoside ( 10), similar to wildtype N. tabacum
+roots (Fig. 8A).
+B
+Normalized Peak Area
+0 0.005 0.010 0.015 0.020
+Normalized Peak Area
+0 0.02 0.04 0.06 0.08
+Normalized Peak Area
+0 0.2 0.4 0.6
+Normalized Peak Area
+0 0.2 0.4 0.6
+A
+ND-d/g3678NaGTNaGRNMPNicGSNicGH
+16
+10 12 1410 2021 21 2
+RT (min)
+(S)-1 (R)-1
+NicGS D.O.
+All genes
+12 13 14
+ND-d/g3678NaG
+T
+NaGRNMPNicGSNicGH
+nicotinic acid N-Glc
+10-d3/d4
+pyridine N-Glc
+12-d3/d4
+nicotine N-Glc
+13-d3/d4
+nicotine
+1-d3/d4
+chiral analysis
+of nicotine
+rac-nicotine
+standard
+Retention time (min) Retention time (min) Retention time (min) Retention time (min)
+d3
+d4
+d3
+d4
+d3
+d4
+d3
+d4
+Fig. 7 | In planta reconstitution of nicotine biosynthesis.Leaves of N. ben-
+thamiana were agroinﬁltrated with a combination of nicotine biosynthesis genes
+(day 0), fed with nicotinamide-d4 (ND-d4) at day 4, and harvested for metabolite
+analysis at day 6. The gene combination producing theN-methylpyrrolinium (ODC,
+PMT and MPO) is abbreviated as NMP.A Accumulation of the labelled compounds
+is indicated at the top (d3 and d4 versions together). Each row corresponds to
+the gene combination shown in the matrix on the left (green/white indicates pre-
+sence/absence). Traces are representative extracted ion chromatograms (EICs,
+m/z ± 0.005) corresponding to the labelled compounds (black) in comparison to
+chemically synthesized or commercial standards (blue) (see Supplementary Fig. 12
+for MS2 spectra). Signal intensities are normalized to the largest peak on each
+column; standards were rescaled to match the largest peak. The nicotine and
+anabasine standards were analysed as a mixed sample. The insert on the right
+shows the chiral analysis of nicotine in the presence of all genes and in the NicGS
+drop-out (D.O.). B Individual quantiﬁcation of d
+3 and d4 isotopologues corre-
+sponding to the compounds and gene combinations shown in (A). Bars show mean
+EIC peak area (n = 8); points are individual replicates; error bars show standard
+deviation (see statistics in Supplementary Data 11). Source data are provided as a
+Source Data ﬁle.
+Article https://doi.org/10.1038/s41467-026-72705-0
+Nature Communications|         (2026) 17:4221 8
+
+Discussion
+It is remarkable that, despite the massive global use of tobacco, its
+economic importance, and the volume of investigation into nicotine
+biosynthesis, key steps in its formation have remained enigmatic. Here,
+we have reconstituted, in vitro and in planta, a minimal nicotine bio-
+synthetic cascade, forming (S)-nicotine (S)-(1) from nicotinic acid ( 2)
+and N-methylpyrrolinium (3). It consists of four enzymes: NaGT, NaGR,
+NicGS, and NicGH.
+Whilst we elected to test only a single representative paralog for
+each enzyme type in our in vitro assays, there is considerable evidence
+to suggest that the highly similar paralogs (or homeologs, i.e., paralogs
+derived from whole genome duplications) are functionally equivalent.
+NaGR (A622) has 95.5% protein sequence identity to its homeolog
+A622L and has similar expression patterns (Supplementary Data 2).
+Genome editing experiments show that both homeologs must be
+knocked out to guarantee ultra-low nicotine content in mutant
+tobacco lines
+28,50. Similarly, BBLa (NicGS) and BBLb are homeologs
+with 92.8% protein sequence identity, similar expression patterns
+(Fig. 2C), and genome editing experiments implicate both genes in the
+formation of (S)-nicotine
+34. The newly described NicGH (β-GD1)s h a r e s
+91.8% with its homeolog β-GD2 and 83.6% protein sequence identity
+with its non-syntenic paralogβ-GD3; all genes have similar expression
+patterns across tissues (Fig.2C). During the revision of this manuscript,
+a report was published describing the systematic assessment of β-
+glucosidase genes in N. tabacum51. It revealed that the expression of
+NicGH (β-GD1) and its paralogsβ-GD2 and β-GD3 (named NtBGLU51, 50
+and 49, respectively in theβ-GD manuscript) were all strongly induced
+by methyl jasmonate, supporting their role in defence response.
+Cryptic biosynthetic steps cannot be predicted based on the
+structures of precursors or products, making them a bottleneck in
+pathway elucidation. In nicotine biosynthesis, NaGT and NicGH are
+responsible for a cryptic glucosylation, which acts like an activating
+group, increasing the electrophilicity of nicotinic acid (2) and making it
+susceptible to reduction by NADPH. Glucosylation steps are common
+in natural product biosynthesis, but the use of the glucoside in nicotine
+biosynthesis as an activating group is distinct from other known
+examples of glucosylation. Natural product glucose conjugates are
+usually seen in the context of detoxiﬁcation, allowing the host plant to
+store otherwise highly toxic molecules as inactivated glucosides, ready
+for future activation by deglucosylation
+52.F o re x a m p l e ,t h eb e n z o x -
+azinoids DIBOA and DIMBOA are produced as defense compounds in
+grasses. These are sequestered in the plant vacuole as inactivated
+glucosides, which can be released by a speciﬁc glycosyl hydrolase for
+defense-related purposes
+53. This kind of conditional detoxi ﬁcation/
+activation is also seen for cyanogenic glucosides e.g. in sorghum54 and
+in the regulation of brassinosteroid and cytokinin hormone
+homeostasis
+55.
+In plant metabolism, glucose esters are commonly used as acyl
+donors. This involves a glucose moiety being added to a carboxylic
+acid, and the glucose ester product undergoes transesteri ﬁcation, a
+step catalysed by serine carboxypeptidase-like acyltransferases (SCPL-
+ATs)
+56. This is analogous to coenzyme A thioesters, which are acyl
+donors that undergo transesteri ﬁcation catalysed by BAHD-
+acyltransferases56. Glucose ester intermediates feature in the bio-
+synthesis of sinapate (sinapoylcholine) and the UV-protectant sina-
+poylmalate from sinapic acid via the activated sinapoylglucose ester
+intermediate in Brassicaceae
+57, as well as in hormone homeostasis,
+forming IAA-myo-inositol conjugates via indoleacetic acid-glucoside58.
+Interestingly, a glucoside ester is an intermediate in tropane alkaloid
+biosynthesis, a pathway from Solanaceae species that shares many
+features with nicotine biosynthesis. In particular, a UGT glucosylates
+phenyllactate to phenyllactylglucoside, enabling SCPL-AT catalysed
+transesteriﬁcation to littorine with tropine
+59. The glucosyl group in
+glucose esters acts to activate the carboxylic acid by forming an ester
+and becoming a favourable leaving group, with glucose being a pro-
+duct of the transesteriﬁcation reaction. This is distinct from the pro-
+posed glucose activation in nicotine biosynthesis, where the glucose is
+not a direct product of the core reaction but instead modulates the
+activity of intermediates and requires a dedicated removal step: NicGH
+catalysed hydrolysis.
+A cryptic glycosylation was recently described in Solanaceae
+steroidal glycoalkaloid biosynthesis, involving the cholesterol glucur-
+onosyl transferase GAME15
+60,61. A cryptic glucosylation was also dis-
+covered in the biosynthesis of the yeast antibiotic anisomycin 62.I n
+both of these examples, it appears that the glycosyl moiety acts mostly
+as a protecting group/recognition handle for the downstream
+nicotinic acid 
+N-glucoside (10)
+nicotine 
+N-glucoside (13)
+pyridine 
+N-glucoside (12)
+m/z = 242.1 m/z = 163.1m/z = 286.1 m/z = 325.2
+A
+B
+nicotine (1)
+1 2 3 0 10 2010.4 1.6
+WT
+N. benthamiana
+Standards
+Standards
+ΔNaGR 
+(a622 + a622l)
+ΔNicGS 
+(bbl a-d)
+10 12
+N. tabacum
+var. Samsun
+sample
+sample + 13
+10 12 13 1 6
+12 13
+Fig. 8 | Identiﬁcation of pathway intermediates and shunt products in
+Nicotiana roots. A Metabolite analysis of roots from N. benthamiana wild type,
+ΔNaGR29 and ΔNicGS31 lines (black) in comparison to standards (blue) (see MS2
+veriﬁcation in Supplementary Fig. 13). Traces are representative extracted ion
+chromatograms (EICs,m/z ± 0.005) and were normalized to the largest peak in each
+column; standards were re-scaled to match the largest peak.B Metabolite analysis
+of roots from N. tabacum var Samsun (black), compared to standards (blue) (see
+MS2 veriﬁcation in Supplementary Fig. 14). The red trace is root extract sample
+spiked with 10 μM nicotine N-glucoside (13) to verify peak identity. Traces are
+representative EICs (m/z ± 005); standards were re-scaled to match the corre-
+sponding peaks in the N. tabacum samples.
+Article https://doi.org/10.1038/s41467-026-72705-0
+Nature Communications|         (2026) 17:4221 9
+
+biosynthetic enzymes, rather than having an activation effect as we
+propose for nicotine biosynthesis.
+As well as modulating reactivity, the detoxi ﬁcation effect of
+glucoside-conjugates in plants can be attributed to driving vacuolar
+localisation of metabolites. This may also be true for nicotine
+biosynthesis, given the known subcellular localisation of NaGR (A622)
+to the cytosol
+32, and NicGS (BBL) to the vacuole 30,a n da l s og i v e n
+that nicotine accumulates in vacuoles of tobacco root cells during
+biosynthesis38. The predictedN-terminal signal peptide andC-terminal
+vacuolar sorting signal of NicGH strongly suggest it will also localise
+to the vacuole (Supplementary Fig. 1). The recent manuscript repor-
+ting tobacco β-glucosidases included an experiment where GFP
+was fused to the C-terminus of β-GD2 (NtBGLU50) and the
+fusion protein was transiently expressed in N. benthamiana .
+Surprisingly, the protein appeared to localise to the endoplasmic
+reticulum, despite its predicted vacuolar localisation sequence. Fur-
+ther investigation of the subcellular localisation of β-GDs is required
+for a conclusive outcome.
+The division of the nicotine biosynthetic cascade across sub-
+cellular compartments— the cytosol and the vacuole— does not support
+the hypothesis that the cascade can operate as a structurally de ﬁned
+multi-enzyme complex. Furthermore, the reported‘nicotine synthase’
+enzyme isolated from tobacco roots by Friesen and Leete in 1990 was
+obtained with minimal puriﬁcation: just ﬁltration, desalting and crude
+ammonium sulfate protein fractionation, with activity observed in the
+25– 75% fraction
+16. Therefore, whilst the nicotine biosynthetic cascade
+enzymes (NaGT, NaGR, NicGS, NicGH) and their cofactors must have
+been present and soluble in this broad fraction, without further pur-
+iﬁcation or alternative evidence, there is no reason to presume that the
+cascade acts as a ‘nicotine synthase’enzyme complex.
+The substrate for NaGR (A622) is nicotinic acid N-glucoside (10),
+which is consistent with its accumulation when A622 is silenced or
+knocked out
+26.P r e v i o u sa t t e m p t st oc h a r a c t e r i s et h i sr e a c t i o nt h r o u g h
+spectrophotometry, typical for NADPH-dependent reactions, may
+have been hampered by overlapping absorbance spectra in the NADPH
+substrate and the 1,2-dihydropyridine glucoside ( 4b)p r o d u c t .F u r -
+thermore, 4b appears unstable in vitro: here, its presence is inferred
+through the identiﬁcation of pyridine glucoside ( 12)o rt h r o u g ht h e
+reaction outcome in the presence of an electrophile. The cascade
+operates stereoselectively, with formation of ( S)-enantiomer of 1
+d o m i n a t i n gb o t hi nv i t r oa n din planta (Figs. 4Aa n d7A). NicGS (BBLa)
+is responsible for determining the stereoselectivity of the pathway, as
+we previously showedin planta
+31. The crystal structure of NicGS bound
+to ( S)-nicotine glucoside (( S)-13) indicates it catalyses the diaster-
+eoselective oxidation of dihydronicotine glucoside ( 5b) ,b u ti ti s
+unclear whether it also catalyses a stereoselective Mannich reaction
+or a dynamic kinetic resolution process. The accumulation of the
+shunt product pyridine glucoside 12 is inhibited in the presence of
+3,e v e ni nt h ea b s e n c eo fN i c G S ,i n d i c a t i n gf a c i l en o n - e n z y m a t i c
+coupling between4b and 3. However, the decreased concentration of
+12, higher conversion into 13 and induction of stereoselectivity in the
+presence of NicGS suggest enzymatic control of this step, as does the
+observation that NicGS can catalyse oxidation of 4b, which would
+match stepwise binding of 4b and 3. Further work is required to
+resolve the intricacies of the NicGS mechanism, given the complexity
+o ft h ee n z y m ec a s c a d e( F i g .9). The modularity of the cascade with
+respect to the electrophile has been demonstrated by the formation of
+anabasine and nornicotine, and suggests the system could form the
+basis of a biocatalytic route towards diverse functionalised pyridines.
+New genetic understanding of nicotine biosynthesis also has the
+potential to inform engineering of Nicotiana sp., including the elim-
+ination or rerouting of alkaloid biosynthesis for new synthetic biology
+chassis. This work resolves a centuries-old puzzle in chemistry, plant
+biology and biochemistry, and will lead to the development of novel
+biotechnological and biocatalytic tools to produce valuable chiral
+chemicals.
+In the period between completing ﬁnal revisions to this manu-
+script and it being accepted, an article from the group of Dapeng Li was
+published describing their independent discovery of enzymes
+involved in nicotine biosynthesis
+63.
+FAD
+N
+N
+H
+H
+Glc
+N
+N
+H
+H
+Glc
+H
+H
+N
+N
+Glc
+N
+N
+H
+H H
+N
+N
+H
+H
+H
+H
+N
+HN
+N
+N
+GlcGlc
+Glc Glc
+N
+N
+H
+H
+Glc
+H
+H
+[O]
+NicGS
+or [O]
+N
+N
+H
+H H
+Glc
+4b
+(S)-13
+Glc-11
+(R)-13
+(R)-5b
+(S)-5b
+3
+N
+N
+(S)-1
+N
+N
+(R)-1
+N
+HN
+11N
+N
+Glc
+10
+3
+OH
+O
+NH
+H
+Glc
+4b
+N
+Glc
+12
+NaGR
+NADPH NADP+
+CO2
+[O]
+or NicGS
+O2 +H +
+H2O2
+O2 H2O2
++H +
+NicGH
+NicGH
+GlcH
+GlcH
+GlcH
+NicGH?
+Fig. 9 | Putative activities of NicGS (BBL).Possible mechanistic routes towards (S)
+−1 from 10. The blue background shows key NaGR and NicGH reactions and major
+products. The grey background shows possible reactions that are either non-
+enzymatically or catalysed by NicGS. Only compounds with blue or white back-
+ground have been directly detected. To induce the stereoselective outcome, NicGS
+may operate through: dynamic kinetic resolution (catalysing just purple arrows and
+allowing other intermediates to non-enzymatically equilibrate), epimerisation of5b
+via a ring opened intermediate (catalysing red and purple arrows), catalysis of the
+stereoselective Mannich reaction between3 and 10 prior to oxidation, reversal of
+the non-desired Mannich reaction (opening (R)-5b into 3 and 10). Blue arrows show
+the predicted mechanism of Glc−11 formation.
+Article https://doi.org/10.1038/s41467-026-72705-0
+Nature Communications|         (2026) 17:4221 10
+
+Methods
+Expression analysis
+Genes of interest were deﬁned by assessment of the literature related
+to nicotine biosynthesis (Supplementary Data 1). Protein sequences
+were obtained via GenBank or UniProt accession numbers and used as
+tblastn queries against the coding sequences from the 2017N. tabacum
+genome37 to obtain gene names and sequences. Biosynthetic gene
+clusters were identi ﬁed using functional annotations and RNA-seq
+proﬁles of genes neighbouring genes of interest, using JBrowse hosted
+on the SolGenomics64,q u e r y i n gt h e2 0 1 7N. tabacum genome37.G e n e
+names were used as queries for the Plant Gene Expression Omnibus
+(PEO) (https://peo.ku.dk/)
+40.T h eP E O N. tabacum dataset consists of
+TPMs for 824 samples over twelve tissue types. Precomputed Pearson
+Correlation Coef ﬁcient (PCC) values were used to identify top-
+correlating genes.
+For gene co-expression analysis, TPMs of genes of interest were
+extracted from PEO and analysed in R-Studio (tidyverse and pheatmap
+packages). For plotting gene expression from N. tabacum across tis-
+sues, log
+2(TPM + 1) values were grouped by Plant Ontology (i.e. tissue
+type), averaged, and plotted as a heatmap, with Z-score normalisation
+across tissue types. For expression correlation, an all-by-all PCC matrix
+was computed (824 samples, log
+2(TPM + 1)), depicted as a heatmap,
+with genes grouped with complete-linkage hierarchical clustering on
+Euclidean distance. Nicotiana benthamiana nicotine biosynthesis
+genes homologs were identiﬁed by top BLASTN hit using N. tabacum
+genes as queries of the N. benthamiana v1.0.1 genome
+64. Gene names
+were used as queries for PEO and TPM values were extracted
+(476 samples), grouped by Plant Ontology and plotted as boxplots
+(log
+2(TPM + 1))40.
+For assessment of gene expressions after topping, we extracted a
+list of differentially expressed genes (DEGs) in tobacco roots after
+topping, from Qin et al 2020
+41. Using the mean FPKM value at t =0w e
+converted log2 fold change values to FPKM values across the time
+course and then calculated PCCs with A622 (Nitab4.5_0000884g0010)
+expression. Genes were ﬁltered by annotation ‘UDP-glucosyltransfer-
+ase’ and PCC
+A622 > 0 . 8 5 .T o ph i t sw e r ea s s e s s e df o rt h e i ro v e r a l l
+expression level and used as a query in PEO.
+Protein puriﬁcation
+Codon-optimised NaGR (A622, UniProt Accession: IFRH_TOBAC),
+NaGT (UGT1, 2017 N. tabacum genome: Nitab4.5_0006222g002037)
+were expressed using the pET28a(+) vector as C-terminal (NaGR) or
+N-terminal (NaGT) His-tagged proteins, usingE. coli B834 or SoluBL21,
+respectively. NaGR was expressed as a Δ5 N-terminal truncated form.
+Proteins were puriﬁed using nickel afﬁnity chromatography followed
+by size-exclusion chromatography. NicGS (BBLa, 2017 N. tabacum
+genome: Nitab4.5_ 0006307g0010) and NicGH (β-GD1, 2017 N. taba-
+cum genome: Nitab4.5_0000884g0020) were expressed as N-terminal
+His-tagged proteins using a Komagataella phafﬁi secretion system
+based on the pPICZ α vector. Proteins were puri ﬁed from the media
+using tangential ﬂow ﬁltration, followed by nickel af ﬁnity chromato-
+graphy and size-exclusion chromatography. OLADO (UniProt Acces-
+sion: A0A1S3ZKS9_TOBAC) was expressed using the pET28a(+) vector
+as an N-terminal His-tagged protein usingE. coli SoluBL21 and puriﬁed
+using nickel af ﬁnity chromatography followed by buffer exchange
+using a PD10 column
+42. Protein concentration was estimated using a
+Nanodrop spectrophotometer with predicted extinction coefﬁcients
+derived from Expasy ProtParam, and then stored at -70 °C. Details of
+sequences are available in Supplementary Data 1 and 4), further
+methodological details are available in the Supplementary
+Information.
+In vitro assays
+In vitro enzyme assays and multi-enzyme cascades were carried out in
+50 μL reactions, in 50 mM phosphate buffer, pH 7.4, 100 mM NaCl.
+Reactions contained 1 mM nicotinic acid, 1 mM N-methylpyrrolinium,
+0.5 mg mL– 1 NaGT (UGT), 0.5 mg mL– 1 NaGR (A622), 50 μgm L– 1 NicGS
+(BBLa) and 5μgm L– 1 NicGH (β-GD). Other combinations were tested by
+removing component(s) of this mix to make different combinations
+of enzymes/substrates. The reactions were incubated for 16 hours at
+37 °C, then quenched (200 μL, 90:10 acetonitrile: water, 20 mM
+ammonium formate, pH 3), centrifuged (21,000 × g,1 0 m i n )a n d
+the supernatant was transferred to vials for LC-MS analysis. The
+N-methylpyrrolinium was prepared by incubation of 1 μL γ-
+methylaminobutyraldehyded i e t h y la c e t a lw i t h4 9μL1 MH C la t
+70 °C for 1 h before neutralisation with 40μL 1 M NaOH, incubated on
+ice until adding to the assay on the same day. 1-Pyrroline for norni-
+cotine assays was prepared in the same way from aminobutyraldehyde
+diethyl acetal. Enzyme assays were analysed by LC-MS, with Hydro-
+philic Interaction Liquid Chromatography (HILIC) separation using a
+Waters XBridge BEH Amide column (5μm, 2.1 × 100 mm) on a Thermo
+Scientiﬁc Vanquish UHPLC. Detection was performed on a Thermo
+Scientiﬁc LTQ XL Linear Ion Trap Mass Spectrometer. Details on LC-MS
+analytical procedures can be found in the Supplementary Information.
+Chiral nicotine analysis of an in vitro reaction
+In vitro enzyme assays for chiral analysis were carried out in 3 × 50μL
+reactions for each condition, in 50 mM phosphate buffer, pH 7.4,
+100 mM NaCl. Reactions contained 5 mM nicotinic acid, 5 mM N-
+methylpyrrolinium, 10 mM UDP-Glc, 2 U Glucose-6-phosphate dehy-
+drogenase (Merck), 5 mM NADP and 10 mM glucose-6-phosphate, with
+0.5 mg mL
+– 1 NaGT (UGT), 0.5 mg mL– 1 NaGR (A622), 50 μgm L– 1 NicGS
+(BBLa) and 5 μgm L– 1 NicGH (β-GD). Samples for chiral HPLC analysis
+were basi ﬁed with 1 μL 1 M NaOH, then protein precipitated with
+500 μL cold EtOH. After centrifugation (21,000 × g, 10 min), the pro-
+tein pellet was washed with a further 500μL EtOH, the EtOH was then
+combined, evaporated to dryness and resuspended in 50μLp r o p a n - 2 -
+ol and then loaded into vials for analysis. Assays with NicGS were
+diluted 10-fold further. Nicotine chiral analysis was carried out on an
+Agilent 1200 HPLC by normal phase isocratic elution using a CHIR-
+ALPAK® AD-H 250 ×4.6 mm column using 99:1 hexane: IPA at
+1m Lm i n
+– 1. Nicotine peaks were detected by UV absorbance at 260 nm.
+In vitro assay statistics
+Statistical analysis of in vitro reaction product formation was per-
+formed using a one-way ANOVA (R-studio, function: aov) to determine
+EIC peak area differences across unique reactions, followed by a
+Tukey’s HSD post-hoc test (function: TukeyHSD), with peak area
+grouping assigned letters (function: multcompLetters) based on sig-
+niﬁcant differences ( p < 0.05) in pairwise comparisons. Reactions
+were performed in triplicate (n = 3). For analysis of isotopologue ratios,
+d
+3/d4 isotopologue ratios were calculated per chemical and per sample
+through integration and division of EIC peak areas. Samples with zero
+p e a ka r e af o re i t h e ri s o t o p o l o g u ew e r er e m o v e df r o mt h ea n a l y s i s .
+Then isotopologue ratios ( n = 3) for each chemical were compared
+across unique in vitro reactions, analysed by analysis of variance and
+Tukey’s HSD as described above. To calculate the nicotine con-
+centration of the complete cascade, a standard curve of known con-
+centrations was run in the same batch as the samples and ﬁtted using
+log-log linear regression. Model parameters were used to convert
+sample peak areas into concentrations. To accurately estimate the
+mean and standard error, we ﬁrst estimated the uncertainty of indivi-
+dual concentrations through the regression parameter errors and
+residual variability, before combining these using inverse-variance
+weighting of the triplicates to yield a pooled mean and standard error.
+Protein crystallization
+Initial screening of crystallization conditions was performed using
+commercially available INDEX (Hampton Research), PACT premier and
+CSSI/II (Molecular Dimensions) screens in 96-well sitting drop trays,
+Article https://doi.org/10.1038/s41467-026-72705-0
+Nature Communications|         (2026) 17:4221 11
+
+which were stored at 4 °C. Drops (300 nL) were set up with a 1:1 mix-
+ture of 12 mg/mL NaGR (A622) with precipitant mother liquor. Ligand
+complexes of A622 were obtained by co-crystallisation with 5 mM
+nicotinic acid N-glucoside 1, derived from a 100 mM stock solution in
+H
+2O, which was added to the NaGR (A622) solution and incubated on
+ice for 30 min before the trays were set up. Crystals were obtained in
+0.1 M HEPES, pH 7.5 and 25 % (w/v) PEG 3350. NicGS (BBLa) protein was
+enzymatically deglycosylated before setting up crystallization screens.
+53 μL2 0m gm L
+– 1 NicGS (BBLa) was incubated overnight at 37 °C with
+7 μLE n d o Ha n d7 μL GlycoBuffer 3 (New England Biolabs). After
+incubation, the deglycosylated BBL was used for crystallisation at
+15 mg/mL. Initial screening of crystallization conditions was performed
+as for NaGR but at 16 °C. Initial apo-crystals of NicGS (BBLa) were
+obtained in drops containing 0.14 M LiSO
+4, 0.1 M Bis-Tris pH 5.5, 21%
+PEG 3350, by co-crystallisation with 10 mM ( S)-nicotine glucoside 13,
+derived from a 100 mM stock solution in H 2O. Ligand-bound crystals
+were obtained by co-crystallisation as described, but with 50 mM (S)-
+nicotine glucoside, derived from a 1 M aqueous solution of (S)-nicotine
+glucoside. Crystals were harvested directly into liquid nitrogen with
+nylon CryoLoops
+TM (Hampton Research), using the mother liquor
+without any further cryoprotectant (NaGR and NicGS apo)o rb y
+addition of 10% ethylene glycol (NicGS ligand-bound) to the drop prior
+to ﬁshing.
+X-ray structure elucidation
+The datasets described in this report were collected at the Diamond
+Light Source, Didcot, Oxfordshire, U.K., on beamline I03. Data were
+processed and integrated using XDS 65 a n ds c a l e du s i n gS C A L A66
+included in the Xia267 processing system. Data collection statistics are
+provided in Supplementary Data 7. The crystals of NaGR (A622) were
+obtained in space groupP1 ,w i t ho n em o l e c u l ei nt h ea s y m m e t r i cu n i t ;
+the crystals of NicGS (BBLa) were obtained in space groupP2
+12121,w i t h
+two molecules in the asymmetric unit. The structures were solved by
+molecular replacement using MOLREP
+68 with the AlphaFold structures
+AF-P52579-F1-v4 and AF-F1T160-F1-v4 used as the models for NaGR and
+NicGS, respectively ( https://alphafold.ebi.ac.uk/)
+69. The structures
+were built and re ﬁned using iterative cycles in Coot 70 and REFMAC71
+employing local NCS restraints in the re ﬁnement cycles where rele-
+vant. The ﬁnal structure of NaGR (A622) ligand complex exhibited %
+Rcryst /Rfree values of 17.1/21.0; theﬁnal structures of apo-NicGS (BBLa)
+and the NicGS (BBLa) ligand complex exhibited %Rcryst /Rfree values of
+29.3/32.4 and 21.5/26.9, respectively. Re ﬁnement statistics for the
+structures are presented in Supplementary Data 7. The structures of
+NaGR (A622)-NADP+nicotinic acid N-glucoside, NicGS (BBLa)-FAD
+nicotineN-glucoside and NicGS (BBLa)-FAD have been deposited in the
+Protein Databank (PDB) with accession codes 9RDD, 9RDR and 9RUW,
+respectively.
+In planta pathway reconstruction
+The genes for transient overexpression were synthesized and cloned
+into a pHREAC vector (Addgene plasmid #134908) 72 by Twist
+Bioscience (South San Francisco, USA). Coding sequences of the genes
+of interest were obtained from the N. tabacum v1.0 Edwards 2017
+genome (scaffold)
+37 and con ﬁrmed/reﬁned by examining mapped
+RNAseq data in the genome browser on the website of the Sol geno-
+mics Network
+64. A list of gene identiﬁers and coding sequences can be
+found in Supplementary Data 8. The cloned sequences of all pHREAC
+gene inserts were checked by Sanger sequencing and the plasmids
+were separately transformed into the electrocompetent Agrobacter-
+ium tumefaciens strain AGL1. Transient expression was performed in
+leaves of 4-week-old greenhouse-grown wild-type N. benthamiana
+plants according to Chuang and Franke 2022
+73. pHREAC-GFP (kindly
+provided by Hadrien Peyret and George Lomonossoff) was used as a
+control and as a placeholder in the drop-out experiment. Four days
+post-inﬁltration, leaves were reinﬁltrated with 400µM nicotinamide-d
+4
+(D4 98%; Cambridge Isotope Laboratories, Tewksbury, MA, USA) dis-
+solved in in ﬁltration buffer without acetosyringone. Leaf disks were
+harvested after an additional 2 days (6 disks/plant: 3 disks/leaf x 2
+leaves per plant). The harvested samples were ﬂash-frozen in liquid
+nitrogen and were stored at – 70 °C until tissue homogenization using
+chrome balls and a TissueLyzer (Qiagen). The homogenized samples
+were stored at -70 °C until metabolite extraction.
+Metabolite analysis of in planta pathway reconstruction
+Metabolites were extracted from homogenized ﬂash-frozen plant tis-
+sue (n = 8) as described by Vollheyde and Dudley et al. 202331.F o rt h e
+analysis, 75 ppm (386.2µM) caffeine was used as the internal standard
+in the extraction solution and the proportion of tissue to extractant
+(µL) was 40 mg/100 µL. After the incubation step, samples were spun
+down for 5 min at 16200 × g ( m a xs p e e dt a b l et o pc e n t r i f u g e )a n d
+supernatants were diluted in ultrapure water at a proportion of 1:15.
+Samples were stored at -70 °C after extraction untilﬁltering and after
+ﬁltering until further analysis. The methanolic plant extracts were
+analysed via reversed-phase LC-MS according to Vollheyde and Dudley
+et al. 2023
+31 with an injection volume of 10 µL. Compounds were
+identiﬁed by comparison to commercial and synthesized standards.
+The chiral LC-MS analysis of methanolic plant extracts was performed
+according to Vollheyde and Dudley et al. 2023
+31 with an injection
+volume of 10 µL.
+Statistical analysis was performed in R Studio. For each iso-
+topologue (D0, D3, D4), a one-way ANOVA was conducted to test for
+differences between gene combinations (groups = 7, n =8 ) . F o r t h e
+dropout, the construct containing all genes was set as the reference.
+For the step-wise reconstruction, the construct containing GFP only
+was set as the reference. Post-hoc comparisons were carried out using
+two-tailed Dunnett’s test (multcomp package) to compare each con-
+struct directly against the reference group.
+Nicotiana benthaminametabolite analysis
+N. benthamiana WT and quintuple bbla-d´ knock-out seeds (ΔNicGS)
+were kindly provided by Nicola Patron31.S e e d so fN. benthamiana a622
+knock-out line 3-3-1 (ΔNaGR) were kindly provided by Boaz Negin and
+Georg Jander29. Prior to germination, seeds of each line were surface
+sterilized according to Florentine et al. 201674. Several seeds per line
+were incubated in 500 µL 1% sodium hypochlorite solution for 2 min
+and afterward the seeds were washed three times with 500 µL ultra-
+pure water. The seeds were germinated in petri dishes on three layers
+of ﬁlter paper wetted with ultra-pure water. The plates were sealed
+with Leucopore and kept in a growth cabinet under long-day condi-
+tions (16 h light, 8 h dark) at day: night temperatures of 22 °C: 21 °C,
+60% humidity and 200 µmol light intensity. The germinated seedlings
+were transferred to soil and the plants were grown in a growth cabinet
+under long day conditions (16 h light, 8 h dark) at day: night tem-
+peratures of 22 °C: 21 °C, 60% humidity and 200 µmol light intensity.
+Leaf and root samples were harvested from about 2-month-old plants.
+The root material was mostly collected from the soil-pot interface. To
+clean the roots, the soil was washed off with water, and excess water
+was removed by taping the roots on tissue paper. The harvested
+samples wereﬂash-frozen in liquid nitrogen and were stored at– 70 °C
+until tissue homogenization using chrome balls and a TissueLyzer
+(Qiagen). The homogenized samples were stored at – 70 °C until fur-
+ther use. The samples were extracted and analysed by LC-MS as
+described above.
+Nicotiana tabacummetabolite analysis
+Nicotiana tabacum var. Samsun was grown in a temperature-
+controlled glasshouse with 21/18 (SD ± 3)°C Day/Night and 16 h pho-
+toperiod. Further details of growing conditions are in the Supple-
+mentary Information. Plants ’ apical and axillary growing tips were
+removed as soon as ﬂower buds appeared (after about 1 month) and
+Article https://doi.org/10.1038/s41467-026-72705-0
+Nature Communications|         (2026) 17:4221 12
+
+these were regularly removed (monthly) until roots were harvested
+from 3-month-old plants and freeze-dried. 10 mg of freeze-dried root
+tissue was extracted into 1 mL MeOH, centrifuged (21,000×g ,1 0m i n )
+and loaded into LCMS vials for analysis. LC-MS analysis was carried out
+with Hydrophilic Interaction Liquid Chromatography (HILIC) separa-
+tion on a Waters ACQUITY UPLC I-Class with detection performed on a
+Thermo Scienti ﬁc Orbitrap Fusion ™ Tribrid™ mass spectrometer.
+Details on LC-MS analytical procedures can be found in the Supple-
+mentary Information.
+Synthetic methods
+Generally, glucoside intermediates were synthesised by glucosylation
+of the pyridine nitrogen using acetobromo- α-
+D-glucose, followed by
+deacetylation with aqueous HBr. Detailed synthetic methods and
+compound characterisation are available in the Supplementary
+Information.
+Reporting summary
+Further information on research design is available in the Nature
+Portfolio Reporting Summary linked to this article.
+Data availability
+Crystal structure ﬁles have been deposited on the RCSB Protein Data
+Bank under the accessions: NaGR holo (nicotinic acid-N glucoside)
+9RDD NicGS holo (nicotine N-glucoside) 9RDR NicGS apo 9RUW.A l l
+other data are available in the main text, the supplementary informa-
+tion and from the corresponding author(s) upon request. Source data
+are provided with this paper.
+References
+1. Duke, D. et al. Earliest evidence for human use of tobacco in the
+Pleistocene Americas.Nat. Hum. Behav. 6,1 8 3–192 (2022).
+2. Wip ﬂi, H. & Samet, J. M. One hundred years in the making: The
+global tobacco epidemic.Annu. Rev. Public Health 37,
+149–166 (2016).
+3. Langley, J. N. On the reaction of cells and of nerve-endings to
+certain poisons, chieﬂy as regards the reaction of striated muscle to
+nicotine and to curari. J. Physiol. 33,3 7 4–413 (1905).
+4. Baldwin, I. T. An ecologically motivated analysis of plant-herbivore
+interactions in native tobacco.Plant Physiol.127, 1449–1458 (2001).
+5. Millar, N. S. & Denholm, I. Nicotini c acetylcholine receptors: targets
+for commercially important insecticides.Invert. Neurosci.7,
+53–66 (2007).
+6. Kessler, D. et al. Unpredictabilit y of nectar nicotine promotes out-
+crossing by hummingbirds inNicotiana attenuata. Plant J. 71,
+529–538 (2012).
+7. Shitan, N., Hayashida, M. & Yazak i, K. Translocation and accumu-
+lation of nicotine via distinct spatio-temporal regulation of nicotine
+transporters in Nicotiana tabacum. Plant Signal Behav. 10,
+e1035852 (2015).
+8. Shoji, T., Kajikawa, M. & Hashimoto , T. Clustered transcription factor
+genes regulate nicotine biosynthesis in tobacco.Plant Cell 22,
+3390–3409 (2010).
+9. Elser, D. et al. Evolutionary met abolomics of specialized metabo-
+lism diversiﬁcation in the genus Nicotiana highlightsN-acylnorni-
+cotine innovations.Sci. Adv. 9, eade8984 (2023).
+10. Benvenuto, E. et al. Plant molecular farming in the wake of the
+closure of Medicago Inc. Nat. Biotechnol.41,8 9 3–894 (2023).
+1 1 . G o l u b o v a ,D . ,T a n s l e y ,C . ,S u ,H .&P a t r o n ,N .J .E n g i n e e r i n g
+Nicotiana benthamianaas a platform for natural product biosynth-
+esis. Curr. Opin. Plant Biol. 81, 102611 (2024).
+12. Lichman, B. R. The scaffold-forming steps of plant alkaloid bio-
+synthesis.Nat. Prod. Rep. 38,1 0 3–129 (2021).
+13. Dawson, R. F. et al. Biosynthesis of the pyridine ring of nicotine. J.
+Am. Chem. Soc. 78,2 6 4 5–2646 (1956).
+14. Leete, E. Biosynthesis of the Nicotiana alkaloids. XI. Investiga-
+tion of tautomerism in N-methyl-delta-pyrrolinium chloride and
+its incorporation into nicotine. J. Am. Chem. Soc. 89,
+7081–7084 (1967).
+15. Dawson, R. F. Biosynthesis of the Nicotiana alkaloids.Am. Sci. 48,
+321–340 (1960).
+16. Brent Friesen, J. & Leete, E. Nicotine synthase — an enzyme from
+Nicotianaspecies which catalyzes the formation of (S)-nicotine from
+nicotinic acid and 1-methyl-δ’pyrrolinium chloride.Tetrahedron
+Lett. 31,6 2 9 5–6298 (1990).
+17. Yang, K. S., Gholson, R. K. & Waller, G. R. Studies on nicotine bio-
+synthesis.J. Am. Chem. Soc. 87,4 1 8 4–4188 (1965).
+18. Scott, T. A. & Glynn, J. P. The incorporation of [2,3,7- 14C] nicotinic
+acid into nicotine by Nicotiana tabacum. Phytochemistry6,
+505–510 (1967).
+1 9 . L e e t e ,E .T h ei n c o r p o r a t i o no f[ 5 , 6 -13C2]Nicotinic acid into the
+tobacco alkaloids examined by the use of 13C nuclear magnetic
+resonance.Bioorg. Chem. 6,2 7 3–286 (1977).
+20. Dawson, R. F., Christman, D. R., D’Adamo, A., Solt, M. L. & Wolf, A. P.
+The biosynthesis of nicotine from isotopically labeled nicotinic
+acids. J. Am. Chem. Soc. 82,2 6 2 8–2633 (1960).
+2 1 . L e e t e ,E .&L i u ,Y . - Y .M e t a b o l i s mo f[ 2 -
+3H]- and [6-3H]-nicotinic acid
+in intact Nicotiana tabacumplants. Phytochemistry12,
+593–596 (1973).
+22. Leete, E. Stereochemistry of the reduction of nicotinic acid when it
+serves as a precursor of anatabine.J. Chem. Soc. Chem. Commun.
+610 (1978) https://doi.org/10.1039/c39780000610.
+2 3 . C a i ,B . ,J a c k ,A .M . ,L e w i s ,R .S . ,D e w e y ,R .E .&B u s h ,L .P .(R)-nicotine
+biosynthesis, metabolism and translocation in tobacco as deter-
+mined by nicotine demethylase mutants.Phytochemistry95,
+188–196 (2013).
+24. Leete, E. Biosynthesis of anatabine and anabasine in Nicotiana glu-
+tinosa. J. Chem. Soc. Chem. Commun.9 –10. https://doi.org/10.
+1039/C39750000009(1975).
+2 5 . H i b i ,N . ,H i g a s h i g u c h i ,S . ,H a s h i m o t o ,T .&Y a m a d a ,Y .G e n e
+expression in tobacco low-nicotine mutants.Plant Cell 6,
+723–735 (1994).
+26. Kajikawa, M., Hirai, N. & Hashimoto, T. A PIP-family protein is
+required for biosynthesis of tobacco alkaloids.Plant Mol. Biol. 69,
+287–298 (2009).
+2 7 . D e b o e r ,K .D . ,L y e ,J .C . ,A i t k e n ,C .D . ,S u ,A .K . - K .&H a m i l l ,J .D .T h e
+A622 gene in Nicotiana glauca(tree tobacco): evidence for a func-
+tional role in pyridine alkaloid synthesis.Plant Mol. Biol. 69,
+299–312 (2009).
+2 8 . B u r n e r ,N . ,K e r n o d l e ,S .P . ,S t e e d e ,T .&L e w i s ,R .S .E d i t i n go fA 6 2 2
+genes results in ultra-low nicotine whole tobacco plants at the
+expense of dramatically reduced growth and development.Mol.
+Breed. 42, 20 (2022).
+29. Negin, B., Wang, F., Fischer, H. D. & Jander, G. Acylsugars, nicotine
+and a protease inhibitor provide variable protection for Nicotiana
+benthamiana in a natural setting.Plant Cell Environ. 48,
+1073–1087 (2025).
+30. Kajikawa, M., Shoji, T., Kato, A. & Hashimoto, T. Vacuole-localized
+berberine bridge enzyme-like proteins are required for a late step of
+nicotine biosynthesis in tobacco.Plant Physiol. 155,
+2010–2022 (2011).
+31. Vollheyde, K. et al. An improved Nicotiana benthamiana biopro-
+duction chassis provides novel insights into nicotine biosynthesis.
+N. Phytol. 240,3 0 2–317 (2023).
+32. Shoji, T. et al. Expression patterns of two tobacco iso ﬂavone
+reductase-like genes and their possible roles in secondary meta-
+bolism in tobacco. Plant Mol. Biol. 50,4 2 7–440 (2002).
+33. Daniel, B. et al. The family of berberine bridge enzyme-like
+enzymes: A treasure-trove of oxidative reactions.Arch. Biochem
+Biophys. 632,8 8–103 (2017).
+Article https://doi.org/10.1038/s41467-026-72705-0
+Nature Communications|         (2026) 17:4221 13
+
+34. Allen, Z. et al. BBL enzymes exhibit enantiospeci ﬁcp r e f e r e n c e si n
+the biosynthesis of pyridine alkaloids inNicotiana tabacumL. Phy-
+tochemistry232, 114363 (2025).
+35. Posselt, W. & Reimann, L. Chemische Untersuchung des Tabaks und
+Darstellung eines eigenthümlich wirksamen Prinzips dieser Pﬂanze.
+Mag. f.ür. die neuesten Erfahrungen, Entdeckungen und Ber-
+ichtigungen im. Geb. der Pharm. 6,1 3 8–161 (1828).
+36. Smit, S. J. & Lichman, B. R. Plant biosynthetic gene clusters in the
+context of metabolic evolution. Nat. Prod. Rep. 39,
+1465–1482 (2022).
+37. Edwards, K. D. et al. A reference genome for Nicotiana taba-
+cum enables map-based cloning of homeologous loci impli-
+c a t e di nn i t r o g e nu t i l i z a t i o ne fﬁciency. BMC Genomics 18,
+448 (2017).
+38. Shoji, T. et al. Multidrug and toxic compound extrusion-type
+transporters implicated in vacuolar sequestration of nicotine in
+tobacco roots. Plant Physiol. 149,7 0 8–718 (2009).
+39. Kajikawa, M. et al. Genomic insights into the evolution of the nico-
+tine biosynthesis pathway in tobacco.Plant Physiol. 174,
+999–1011 (2017).
+40. Koh, E., Goh, W., Julca, I., Villanueva, E. & Mutwil, M. PEO: Plant
+Expression Omnibus - a comparative transcriptomic database for
+103 Archaeplastida.Plant J. 117,1 5 9 2–1603 (2024).
+41. Qin, Y. et al. Transcriptome analysis reveals key genes involved in
+the regulation of nicotine biosynthesis at early time points after
+topping in tobacco (Nicotiana tabacumL.). BMC Plant Biol. 20,
+30 (2020).
+42. Wood, C. X. et al. Parallel evolut ion of plant alkaloid biosynthesis
+from bacterial-like decarboxylases.N. Phytol. 249,
+2954–2973 (2026).
+43. Wang, X. et al. Crystal structure of isoﬂavone reductase from alfalfa
+(Medicago sativa L.). J. Mol. Biol. 358,1 3 4 1–1352 (2006).
+44. Winkler, A. et al. A concerted mechanism for berberine bridge
+enzyme. Nat. Chem. Biol. 4,7 3 9–741 (2008).
+45. Carlson, E. D., Rajniak, J. & Sattely, E. S. Multiplicity of the Agro-
+bacterium Infection of Nicotiana benthamianafor Transient DNA
+Delivery. ACS Synth. Biol. 12,2 3 2 9–2338 (2023).
+46. Dawson, R. F. The localization of the nicotine synthetic mechanism
+in the tobacco plant. Science 94,3 9 6–397 (1941).
+47. Xu, B., Sheehan, M. J. & Timko, M. P. Differential induction of orni-
+thine decarboxylase (ODC) gene family members in transgenic
+tobacco (Nicotiana tabacumL. cv. Bright Yellow 2) cell suspensions
+by methyl-jasmonate treatment.Plant Growth Regul. 44,
+101–116 (2004).
+4 8 . J u n k e r ,A . ,F i s c h e r ,J . ,S i c h h a r t ,Y . ,B r a n d t ,W .&D r ä g e r ,B .E v o l u t i o n
+of the key alkaloid enzyme putrescineN-methyltransferase from
+spermidine synthase.Front Plant Sci. 4, 260 (2013).
+49. Naconsie, M., Kato, K., Shoji, T. & Hashimoto, T. Molecular evolution
+of N-methylputrescine oxidase in tobacco.Plant Cell Physiol. 55,
+436–444 (2014).
+50. Jeong, J.-H. et al. Impact of CRISPR/Cas9-induced mutations in
+nicotine biosynthesis core genes A622 and BBL on tobacco:
+reduction in nicotine content and developmental abnormalities.
+Curr. Plant Biol. 38, 100343 (2024).
+51. Liu, J. et al. Systematic genomic characterization of β-glucosidase
+genes in tobacco reveals NtBGLU50 as a multifunctional regulator
+of glycoside metabolism and defense-associated pathways.Ind.
+Crops Prod. 240, 122643 (2026).
+52. Osbourn, A. E. Preformed antimicrobial compounds and plant
+defense against fungal attack.Plant Cell 8, 1821 (1996).
+5 3 . v o nR a d ,U . ,H ü t t l ,R . ,L o t t s p e i c h ,F . ,G i e r l ,A .&F r e y ,M .T w og l u -
+cosyltransferases are involved in detoxiﬁcation of benzoxazinoids
+in maize. Plant J. 28,6 3 3–642 (2001).
+5 4 . C i c e k ,M .&E s e n ,A .S t r u c t u r ea n de x p r e s s i o no fad h u r r i n a s e( b e t a -
+glucosidase) from sorghum.Plant Physiol. 116, 1469–1478 (1998).
+5 5 . H o u ,B .i n g k a i ,L i mG i l l i a n ,E .n g - K .i a t ,H i g g i n sD i a n n a ,S .&B o w l e s ,
+J. N-Glucosylation of cytokinins by glycosyltransferases ofArabi-
+dopsis thaliana. J. Biol. Chem. 279,2 7 8 2 2–47832 (2004).
+5 6 . B o n t p a r t ,T . ,C h e y n i e r ,V . ,A g e o r g e s ,A .&T e r r i e r ,N .B A H Do rS C P L
+acyltransferase? What a dilemma for acylation in the world of plant
+phenolic compounds.N. Phytol. 208, 695–
+707 (2015).
+57. Regenbrecht, J. & Strack, D. Distribution of 1-sinapoylglucose:
+choline sinapoyltransferase activity in the Brassicaceae.Phy-
+tochemistry24,4 0 7–410 (1985).
+58. Michalczuk, L. & Bandurski, R. S. UDP-glucose: indoleacetic acid
+glucosyl transferase and indoleacetyl-glucose: myo-inositol indo-
+leacetyl transferase.Biochem. Biophys. Res. Commun.93,
+588–592 (1980).
+59. Qiu, F. et al. Functional genomics analysis reveals two novel
+genes required for littorine biosynthesis. N. Phytol. 225,
+1906–1914 (2020).
+60. Jozwiak, A. et al. A cellulose synthase-like protein governs the
+biosynthesis of Solanum alkaloids.Science 386, eadq5721 (2024).
+61. Boccia, M. et al. A scaffold protein manages the biosynthesis of
+steroidal defense metabolites in plants.Science 386,
+1366–1372 (2024).
+62. Zheng, X. et al. Biosynthesis of the pyrrolidine protein synthesis
+inhibitor anisomycin involves anovel gene ensemble and cryptic
+biosynthetic steps.Proc. Natl. Acad. Sci. USA114,4 1 3 5–4140 (2017).
+63. Chang, L. et al. Complete biosynthesis of nicotine.Cell. https://doi.
+org/10.1016/j.cell.2026.03.034(2026).
+64. Fernandez-Pozo, N. et al. The Sol Genomics Network (SGN)-from
+genotype to phenotype to breeding.Nucleic Acids Res. 43,
+D1036–41 (2015).
+65. Kabsch, W. XDS. Acta Crystallogr D. Biol. Crystallogr.66,
+125–132 (2010).
+66. Evans, P. Scaling and assessment of data quality.Acta Crystallogr D.
+Biol. Crystallogr62,7 2–82 (2006).
+67. Winter, G. Xia2: An expert system for macromolecular crystal-
+lography data reduction.J. Appl. Crystallogr. 43,1 8 6–190 (2010).
+68. Vagin, A. & Teplyakov, A. Molecular replacement with MOLREP.
+Acta Crystallogr D. Biol. Crystallogr.66,2 2–25 (2010).
+69. Jumper, J. et al. Highly accurate protein structure prediction with
+AlphaFold.Nature 596,5 8 3–589 (2021).
+70. Emsley, P. & Cowtan, K. Coot: model-building tools for mole-
+cular graphics. Acta Crystallogr D. Biol. Crystallogr. 60,
+2126–2132 (2004).
+71. Murshudov, G. N., Vagin, A. A. & Dodson, E. J. Re ﬁnement of mac-
+romolecular structures by the maximum-likelihood method.Acta
+Crystallogr D. Biol. Crystallogr.53,2 4 0–255 (1997).
+7 2 . P e y r e t ,H . ,B r o w n ,J .K .M .&L o m o n o s s o f f ,G .P .I m p r o v i n gp l a n t
+transient expression through the rational design of synthetic 5’and
+3’untranslated regions.Plant Methods 15, 108 (2019).
+73. Chuang, L. & Franke, J. Rapid combinatorial coexpression of bio-
+synthetic genes by transient expression in the plant hostNicotiana
+benthamiana. Methods Mol. Biol. 2489,3 9 5–420 (2022).
+74. Florentine, S. K. et al. In ﬂuence of selected environmental factors
+on seed germination and seedling survival of the arid zone invasive
+species tobacco bush (Nicotiana glaucaR. Graham). Rangel. J. 38,
+417 (2016).
+75. Sierro, N., Auberson, M., Dulize, R. & Ivanov, N. V. Chromosome-
+level genome assemblies ofNicotiana tabacum, Nicotiana sylvestris,
+and Nicotiana tomentosiformis. Sci. Data 11, 135 (2024).
+Acknowledgements
+We thank: Sam Hart and Dr. Johan P. Turkenburg for assistance with
+X-ray data collection; Diamond Light Source Didcot UK for access to
+beamline I03 under grant number mx24948; Jared Cartwright, Tony
+Larson and the Biosciences Technology Facility; Ed Bergstrom, Karl
+Heaton, Mariela González, Jack Olsen and the Centre of Excellence in
+Article https://doi.org/10.1038/s41467-026-72705-0
+Nature Communications|         (2026) 17:4221 14
+
+Mass Spectrometry; Matthew Davy and the NMR facility; Caragh
+Whitehead, Tessa Keenan, Zhouqian Jiang, Inesh Amarnath and Lachlan
+Waddell for preliminary work and materials; Peter Bølge Sørensen, Jason
+Daff and the University of York Horticulture team. We thank Hadrien
+Peyret and George Lomonossoff for the pHREAC-GFP plasmid, Georg
+Jander and Boaz Negin for the gift of the N. benthamiana a622line, and
+Nicola Patron for the N. benthamiana wildtype and quintuplebbla-d´
+knock-out line. B.R.L. acknowledges funding from UKRI [MR/S01862X/1
+and MR/X010260/1]. B.T.W.S. acknowledges funding from BBSRC [BB/
+T007222/1] and F.G-F. acknowledges funding from Independent
+Research Fund Denmark [DFF 2035-00038B, 0136-00410B and 5281-
+00267B].
+Author contributions
+B.T.W.S. performed chemical synthesis; protein expression, puriﬁcation
+and crystallography; and in vitro enzyme assays, pathway reconstruc-
+tion and analysis. I.M.A. performed and analysedNicotiana benthamiana
+transient expression experiments and ran the analysis of mutant plants.
+K.V. designed plant expression constructs and co-supervised I.M.A. Z.I.
+contributed to construct design, protein puriﬁcation and method
+development. J. L. developed methods for chiral analysis. K.S.S. and
+C.D.S. synthesised deuterated substrates. M.A.F. supervised the design
+and execution of chemical synthesis. G.G. supervised protein prepara-
+tion, crystallography and contributed to the X-ray structural analysis.
+F.G-F. supervised thein planta transient expression and metabolic ana-
+lysis. B.R.L. identiﬁed gene candidates, supervised the biocatalytic
+reconstruction and coordinated theproject. All authors contributed to
+data interpretation and writing the manuscript.
+Competing interests
+C.D.S. and K.S.S. are inventors on a pending patent related to the pro-
+duction of deuterated compounds. The remaining authors declare no
+competing interests.
+Additional information
+Supplementary informationThe online version contains
+supplementary material available at
+https://doi.org/10.1038/s41467-026-72705-0.
+Correspondenceand requests for materials should be addressed to
+Benjamin R. Lichman.
+Peer review informationNature Communicationsthanks Yang Qu and
+the other anonymous reviewers for their contribution to the peer review
+of this work. A peer review ﬁle is available.
+Reprints and permissions informationis available at
+http://www.nature.com/reprints
+Publisher’s note Springer Nature remains neutral with regard to jur-
+isdictional claims in published maps and institutional afﬁliations.
+Open Access This article is licensed under a Creative Commons
+Attribution 4.0 International License, which permits use, sharing,
+adaptation, distribution and reproduction in any medium or format, as
+long as you give appropriate credit to the original author(s) and the
+source, provide a link to the Creative Commons licence, and indicate if
+changes were made. The images or other third party material in this
+article are included in the article’s Creative Commons licence, unless
+indicated otherwise in a credit line to the material. If material is not
+included in the article’s Creative Commons licence and your intended
+use is not permitted by statutory regulation or exceeds the permitted
+use, you will need to obtain permission directly from the copyright
+holder. To view a copy of this licence, visithttp://creativecommons.org/
+licenses/by/4.0/.
+© The Author(s) 2026
+Article https://doi.org/10.1038/s41467-026-72705-0
+Nature Communications|         (2026) 17:4221 15

--- a/src/ai_gene_review/validation/module_validator.py
+++ b/src/ai_gene_review/validation/module_validator.py
@@ -1,0 +1,277 @@
+"""Term-label validation for module (``ModuleReview``) YAML files.
+
+The repository delegates gene-review term-label checking to the external
+``linkml-term-validator``, but that tool only inspects slots bound to dynamic
+enums or binding constraints. ``ModuleReview`` has neither, so the ``term``
+descriptors scattered through a module document (``concepts``, ``function``,
+``substrates``/``products``, ``locations``, ``processes``,
+``anatomical_locations``, ...) are otherwise unchecked: a wrong label sails
+through structural validation.
+
+This validator closes that gap. It walks a module YAML, collects every
+``{id, label}`` term, routes each id by prefix through the same
+``conf/oak_config.yaml`` mapping used for gene reviews, resolves the id with
+OAK, and reports:
+
+* an ERROR when the provided label does not match the ontology's primary label
+  or any of its aliases (case-insensitively), and
+* an ERROR when the id cannot be found in the configured ontology.
+
+Prefixes mapped to ``null`` (e.g. ``PMID``, ``UniProtKB``, ``file``) are skipped
+silently; prefixes absent from the config are skipped with a warning, matching
+the documented ``oak_config.yaml`` semantics.
+
+Structural (schema) validation is handled separately by ``linkml-validate``
+(see ``just validate-modules``); this module only adds term-label checking.
+"""
+
+from __future__ import annotations
+
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Callable, Dict, Iterator, List, Optional, Set, Tuple
+
+import yaml
+
+# A resolver answers: given a CURIE, return (status, primary_label, aliases).
+# status is "ok" when the id resolved, "not_found" when the ontology was
+# consulted but the id is absent, and "unavailable" when the ontology itself
+# could not be loaded/queried (e.g. transient download failure) - the latter is
+# advisory so CI does not go red on flaky ontology fetches. Implemented as a
+# plain callable so it can be dependency-injected in tests without mocking.
+Resolver = Callable[[str], Tuple[str, Optional[str], Set[str]]]
+
+
+@dataclass
+class ModuleValidationResult:
+    """Result of validating a single module file's term labels."""
+
+    path: Path
+    errors: List[str] = field(default_factory=list)
+    warnings: List[str] = field(default_factory=list)
+
+    @property
+    def is_valid(self) -> bool:
+        """True when there are no errors (warnings are advisory)."""
+        return not self.errors
+
+
+def iter_terms(obj: object) -> Iterator[Tuple[str, str]]:
+    """Yield every ontology ``(id, label)`` pair from a parsed module document.
+
+    In the schema, ontology grounding only ever appears as the value of a
+    ``term`` key (``Descriptor.term``, range ``Term``). Module *nodes* and
+    *annotons* also carry ``id``/``label`` fields, but those are
+    document-scoped identifiers, not ontology terms, so they must NOT be
+    collected. We therefore yield only dicts reached via a ``term`` key that
+    carry a string ``id`` and ``label``.
+
+    >>> doc = {"term": {"id": "GO:1", "label": "x"}}
+    >>> list(iter_terms(doc))
+    [('GO:1', 'x')]
+    >>> list(iter_terms({"id": "some_node", "label": "a node"}))
+    []
+    """
+    if isinstance(obj, dict):
+        for key, value in obj.items():
+            if (
+                key == "term"
+                and isinstance(value, dict)
+                and isinstance(value.get("id"), str)
+                and isinstance(value.get("label"), str)
+            ):
+                yield (value["id"], value["label"])
+            yield from iter_terms(value)
+    elif isinstance(obj, list):
+        for item in obj:
+            yield from iter_terms(item)
+
+
+def compare_label(
+    curie: str, provided: str, primary: Optional[str], aliases: Set[str]
+) -> Optional[str]:
+    """Return an error message if ``provided`` does not match the ontology.
+
+    A match is exact or case-insensitive against the primary label or any alias.
+
+    >>> compare_label("X:1", "root", "root", set()) is None
+    True
+    >>> compare_label("X:1", "wrong", "root", set()) is not None
+    True
+    """
+    candidates = {c for c in ([primary] if primary else []) + list(aliases)}
+    if provided in candidates:
+        return None
+    lowered = {c.lower() for c in candidates}
+    if provided.lower() in lowered:
+        return None
+    shown = primary if primary is not None else "<no label>"
+    return (
+        f"Label mismatch for {curie}: module says '{provided}' "
+        f"but ontology label is '{shown}'"
+    )
+
+
+def validate_terms(
+    terms: List[Tuple[str, str]],
+    adapter_map: Dict[str, Optional[str]],
+    resolver: Resolver,
+) -> Tuple[List[str], List[str]]:
+    """Validate a list of ``(id, label)`` terms, returning (errors, warnings).
+
+    ``adapter_map`` maps a prefix to an OAK adapter string, to ``None`` (skip
+    silently), or omits it (skip with a warning). ``resolver`` performs the
+    actual ontology lookup for configured prefixes.
+    """
+    errors: List[str] = []
+    warnings: List[str] = []
+    unconfigured_seen: Set[str] = set()
+
+    for curie, label in terms:
+        prefix = curie.split(":", 1)[0] if ":" in curie else curie
+        if prefix not in adapter_map:
+            if prefix not in unconfigured_seen:
+                unconfigured_seen.add(prefix)
+                warnings.append(
+                    f"Prefix '{prefix}' (e.g. {curie}) is not in oak_config.yaml; "
+                    f"term label not validated"
+                )
+            continue
+        if adapter_map[prefix] is None:
+            continue  # explicitly skipped (null), no warning
+        status, primary, aliases = resolver(curie)
+        if status == "unavailable":
+            warnings.append(
+                f"Could not consult ontology for {curie} "
+                f"(ontology unavailable); label not validated"
+            )
+            continue
+        if status == "not_found":
+            errors.append(f"Term id {curie} not found in configured ontology")
+            continue
+        err = compare_label(curie, label, primary, aliases)
+        if err:
+            errors.append(err)
+
+    return errors, warnings
+
+
+def load_oak_adapter_map(config_path: Path) -> Dict[str, Optional[str]]:
+    """Load the prefix -> adapter mapping from an ``oak_config.yaml``."""
+    with open(config_path) as f:
+        data = yaml.safe_load(f) or {}
+    adapters = data.get("ontology_adapters", {})
+    return {str(k): (None if v is None else str(v)) for k, v in adapters.items()}
+
+
+def _build_oak_resolver(adapter_map: Dict[str, Optional[str]]) -> Resolver:
+    """Build a resolver backed by real OAK adapters (lazily created, cached).
+
+    Adapter creation and lookups touch external ontology databases, so failures
+    (network/download issues) degrade to ``not_found`` would be wrong here;
+    instead such terms are treated as resolvable-but-unknown and reported by the
+    caller. We keep one adapter per adapter string.
+    """
+    from oaklib import get_adapter  # imported lazily; heavy dependency
+
+    cache: Dict[str, object] = {}
+    # Adapter strings that failed to load are remembered so we don't retry (and
+    # re-log) them per term.
+    failed: Set[str] = set()
+
+    def get(adapter_string: str):
+        if adapter_string in failed:
+            return None
+        if adapter_string not in cache:
+            # External system (ontology download/db): tolerate failures and
+            # degrade to "unavailable" rather than crashing the whole run.
+            try:
+                cache[adapter_string] = get_adapter(adapter_string)
+            except Exception:  # noqa: BLE001 - external system
+                failed.add(adapter_string)
+                return None
+        return cache[adapter_string]
+
+    def resolve(curie: str) -> Tuple[str, Optional[str], Set[str]]:
+        prefix = curie.split(":", 1)[0]
+        adapter_string = adapter_map[prefix]
+        assert adapter_string is not None  # routed only for configured prefixes
+        adapter = get(adapter_string)
+        if adapter is None:
+            return ("unavailable", None, set())
+        try:  # external system: ontology query may fail transiently
+            primary = adapter.label(curie)
+            if primary is None:
+                return ("not_found", None, set())
+            aliases: Set[str] = set()
+            # entity_aliases includes synonyms; tolerate adapters lacking it.
+            alias_fn = getattr(adapter, "entity_aliases", None)
+            if callable(alias_fn):
+                aliases = {a for a in alias_fn(curie) if isinstance(a, str)}
+            return ("ok", primary, aliases)
+        except Exception:  # noqa: BLE001 - external system
+            return ("unavailable", None, set())
+
+    return resolve
+
+
+def validate_module_file(
+    path: Path,
+    config_path: Optional[Path] = None,
+    resolver: Optional[Resolver] = None,
+) -> ModuleValidationResult:
+    """Validate term labels in a single module YAML file.
+
+    ``resolver`` may be injected for testing; otherwise a real OAK-backed
+    resolver is built from ``config_path`` (defaults to ``conf/oak_config.yaml``
+    relative to the repository root).
+    """
+    path = Path(path)
+    if config_path is None:
+        config_path = Path(__file__).resolve().parents[3] / "conf" / "oak_config.yaml"
+    adapter_map = load_oak_adapter_map(config_path)
+
+    with open(path) as f:
+        doc = yaml.safe_load(f)
+
+    terms = list(iter_terms(doc))
+    if resolver is None:
+        resolver = _build_oak_resolver(adapter_map)
+    errors, warnings = validate_terms(terms, adapter_map, resolver)
+    return ModuleValidationResult(path=path, errors=errors, warnings=warnings)
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    """CLI entry point: validate one or more module files. Returns exit code."""
+    import argparse
+
+    parser = argparse.ArgumentParser(
+        description="Validate term labels in module (ModuleReview) YAML files."
+    )
+    parser.add_argument("files", nargs="+", type=Path, help="Module YAML files")
+    parser.add_argument(
+        "-c",
+        "--config",
+        type=Path,
+        default=None,
+        help="Path to oak_config.yaml (default: conf/oak_config.yaml)",
+    )
+    args = parser.parse_args(argv)
+
+    exit_code = 0
+    for path in args.files:
+        result = validate_module_file(path, config_path=args.config)
+        for w in result.warnings:
+            print(f"⚠️  WARN  {path}: {w}")
+        for e in result.errors:
+            print(f"❌ ERROR {path}: {e}")
+        if result.is_valid:
+            print(f"✅ {path}: term labels OK ({len(result.warnings)} warnings)")
+        else:
+            exit_code = 1
+    return exit_code
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_module_validator.py
+++ b/tests/test_module_validator.py
@@ -1,0 +1,200 @@
+"""Tests for the module (ModuleReview) term-label validator.
+
+The unit tests exercise the pure logic (term discovery, prefix routing, label
+comparison) using an in-memory resolver function so they run offline. An
+integration test exercises the real oaklib-backed resolver against the
+committed nicotine module.
+"""
+
+from pathlib import Path
+
+import pytest
+
+from ai_gene_review.validation.module_validator import (
+    compare_label,
+    iter_terms,
+    validate_terms,
+    validate_module_file,
+    load_oak_adapter_map,
+)
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+MODULES_DIR = PROJECT_ROOT / "modules"
+
+
+# --------------------------------------------------------------------------- #
+# iter_terms
+# --------------------------------------------------------------------------- #
+
+
+def test_iter_terms_finds_nested_terms():
+    doc = {
+        "module": {
+            "concepts": [{"preferred_term": "x", "term": {"id": "GO:1", "label": "a"}}],
+            "parts": [
+                {
+                    "node": {
+                        "annotons": [
+                            {
+                                "function": {
+                                    "term": {"id": "GO:2", "label": "b"},
+                                    "substrates": [
+                                        {"term": {"id": "CHEBI:1", "label": "c"}}
+                                    ],
+                                }
+                            }
+                        ]
+                    }
+                }
+            ],
+        }
+    }
+    found = set(iter_terms(doc))
+    assert found == {("GO:1", "a"), ("GO:2", "b"), ("CHEBI:1", "c")}
+
+
+def test_iter_terms_requires_string_id_and_label():
+    # A term under `term:` whose id/label are not both strings is ignored.
+    doc = {"term": {"id": 5, "label": "n"}, "other": {"id": "GO:1"}}
+    assert list(iter_terms(doc)) == []
+
+
+def test_iter_terms_ignores_node_and_annoton_ids():
+    # Module nodes/annotons carry id+label that are NOT ontology terms; only
+    # values under a `term:` key are real terms.
+    doc = {
+        "id": "odc_step",
+        "label": "a reaction node",
+        "annotons": [
+            {
+                "id": "odc_activity",
+                "label": "an annoton",
+                "function": {"term": {"id": "GO:0004586", "label": "ODC activity"}},
+            }
+        ],
+    }
+    assert list(iter_terms(doc)) == [("GO:0004586", "ODC activity")]
+
+
+# --------------------------------------------------------------------------- #
+# compare_label
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.parametrize(
+    "provided,primary,aliases,expect_ok",
+    [
+        ("root", "root", set(), True),  # exact
+        ("Root", "root", set(), True),  # case-insensitive
+        ("vacuole", "vacuolar membrane", {"vacuole"}, True),  # alias match
+        ("WRONG", "root", {"radix"}, False),  # genuine mismatch
+    ],
+)
+def test_compare_label(provided, primary, aliases, expect_ok):
+    err = compare_label("X:1", provided, primary, aliases)
+    assert (err is None) == expect_ok
+
+
+# --------------------------------------------------------------------------- #
+# validate_terms (pure, injected resolver)
+# --------------------------------------------------------------------------- #
+
+
+def _resolver_factory(known):
+    """Build a real resolver function backed by an in-memory dict.
+
+    known: {curie: (primary_label, aliases) or None-if-not-found}
+    Returns (status, primary, aliases) where status is 'ok'|'not_found'.
+    """
+
+    def resolve(curie):
+        entry = known.get(curie, "missing")
+        if entry == "missing":
+            return ("not_found", None, set())
+        return ("ok", entry[0], entry[1])
+
+    return resolve
+
+
+def test_validate_terms_passes_on_correct_labels():
+    terms = [("GO:0005774", "vacuolar membrane"), ("PO:0009005", "root")]
+    resolver = _resolver_factory(
+        {
+            "GO:0005774": ("vacuolar membrane", set()),
+            "PO:0009005": ("root", set()),
+        }
+    )
+    adapters = {"GO": "real", "PO": "real"}
+    errors, warnings = validate_terms(terms, adapters, resolver)
+    assert errors == []
+
+
+def test_validate_terms_flags_wrong_label():
+    terms = [("GO:0005774", "WRONG LABEL")]
+    resolver = _resolver_factory({"GO:0005774": ("vacuolar membrane", set())})
+    errors, warnings = validate_terms(terms, {"GO": "real"}, resolver)
+    assert len(errors) == 1
+    assert "GO:0005774" in errors[0]
+
+
+def test_validate_terms_flags_unresolvable_id():
+    terms = [("GO:9999999", "nonexistent")]
+    resolver = _resolver_factory({})  # nothing known -> not_found
+    errors, warnings = validate_terms(terms, {"GO": "real"}, resolver)
+    assert len(errors) == 1
+    assert "not found" in errors[0].lower()
+
+
+def test_validate_terms_treats_unavailable_as_warning():
+    terms = [("GO:0005774", "vacuolar membrane")]
+
+    def resolver(curie):
+        return ("unavailable", None, set())
+
+    errors, warnings = validate_terms(terms, {"GO": "real"}, resolver)
+    assert errors == []
+    assert len(warnings) == 1
+    assert "unavailable" in warnings[0].lower()
+
+
+def test_validate_terms_skips_null_prefix_silently():
+    terms = [("UniProtKB:P12345", "some protein")]
+    resolver = _resolver_factory({})
+    # UniProtKB mapped to None (null) -> skipped, no error, no warning
+    errors, warnings = validate_terms(terms, {"UniProtKB": None}, resolver)
+    assert errors == []
+    assert warnings == []
+
+
+def test_validate_terms_warns_on_unconfigured_prefix():
+    terms = [("FOO:1", "bar")]
+    resolver = _resolver_factory({})
+    errors, warnings = validate_terms(terms, {}, resolver)
+    assert errors == []
+    assert any("FOO" in w for w in warnings)
+
+
+# --------------------------------------------------------------------------- #
+# config loading
+# --------------------------------------------------------------------------- #
+
+
+def test_load_oak_adapter_map():
+    cfg = load_oak_adapter_map(PROJECT_ROOT / "conf" / "oak_config.yaml")
+    assert cfg["GO"] == "sqlite:obo:go"
+    assert cfg["PMID"] is None
+    # PO and SBO must be configured so module terms get validated.
+    assert "PO" in cfg
+    assert "SBO" in cfg
+
+
+# --------------------------------------------------------------------------- #
+# Integration: real oaklib against the committed modules
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.integration
+def test_nicotine_module_terms_resolve_for_real():
+    path = MODULES_DIR / "nicotine_biosynthesis.yaml"
+    result = validate_module_file(path)
+    assert result.errors == [], "\n".join(result.errors)


### PR DESCRIPTION
Add modules/nicotine_biosynthesis.yaml, a pathway-level decomposition of
nicotine biosynthesis in Nicotiana/Solanaceae. Complements the existing
NICOTINE_BIOSYNTHESIS project (which is gene-by-gene) by capturing the
pathway shape that per-gene GO annotation cannot: the two independently
synthesized rings (pyridine via the NAD/quinolinate branch, pyrrolidine
via the polyamine/ornithine branch) converging at condensation, the
revised cryptic activating-glucosylation late relay (UGT1 -> A622 -> BBL ->
beta-GD1), and the co-clustered MATE1 vacuolar transport metabolon.

GO molecular-function/process ids are reused from the verified per-gene
NICAT reviews; representative UniProt members are the project's
sequence-backed candidate accessions. Validates clean against ModuleReview.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01TNRVhLECFT7sX3vnUaj7mg