### PR TITLE
Add derived QC stats to module pages

### DIFF
--- a/modules/README.md
+++ b/modules/README.md
@@ -17,6 +17,34 @@ just module-deep-research-perplexity peroxisome-lifecycle
 just module-deep-research-openai modules/gluconeogenesis.yaml
 ```
 
+Render module pages (to `pages/modules/`) with:
+
+```bash
+uv run ai-gene-review render-modules --all
+uv run ai-gene-review render-modules modules/bbsome.yaml
+```
+
+Each rendered module page carries a **Derived QC** panel (computed by
+`ai_gene_review.module_qc`) with:
+
+- **Recommended-field compliance** — `linkml-data-qc` analysis of the
+  `ModuleReview` document, listing any recommended slots populated below 100%.
+- **Module deep research** — whether a `<module>-deep-research-*.md` report
+  exists alongside the module YAML, and from which provider(s).
+- **Leaf nodes lacking representative members** — terminal nodes (no `parts`,
+  no `variant_sets`) whose participants do not ground to a concrete protein
+  (a `gene_product`/`gene`/`active_unit` with a `UniProtKB` term, or a `family`
+  with `representative_members` / PTN exemplars). These are the abstract leaves
+  that still need a concrete UniProt/PTN exemplar.
+- **Gene-review completeness** — for every `UniProtKB` grounding in the module,
+  joined against `genes/**/*-ai-review.yaml`: whether the gene has a review,
+  whether that review is complete (no PENDING/UNDECIDED annotations), and
+  whether it has its own deep research.
+
+The module index (`pages/modules/index.html`) surfaces the headline figures
+(reviewed-gene count, leaf-grounding gaps, module deep-research presence) as
+sortable columns.
+
 Design notes:
 
 - Use `parts` for required or optional submodules.

--- a/src/ai_gene_review/module_qc.py
+++ b/src/ai_gene_review/module_qc.py
@@ -1,0 +1,473 @@
+#!/usr/bin/env python
+"""Derived quality-control statistics for module documents.
+
+This module computes the derived stats surfaced on rendered module pages:
+
+1. ``run_data_qc`` -- LinkML recommended-field compliance (via ``linkml-data-qc``)
+2. ``leaf_nodes_missing_representatives`` -- terminal nodes that do not ground to
+   any concrete protein (a "representative member")
+3. ``module_gene_review_summary`` -- for every ``UniProtKB`` grounding in a module,
+   whether the gene has a review, whether that review is complete, and whether it
+   has deep research
+4. ``module_deep_research`` -- whether the module document as a whole has an
+   associated deep-research report
+
+The functions are deliberately pure (apart from the filesystem-scanning helpers)
+so they can be unit-tested directly against the YAML documents in ``modules/``.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from typing import Any, Optional
+
+import yaml
+
+DEFAULT_SCHEMA_PATH = (
+    Path(__file__).parent / "schema" / "gene_review.yaml"
+)
+
+# Selector types whose participant can ground to a concrete protein.
+_GROUNDED_TERM_PREFIXES = ("UniProtKB:",)
+
+# Action values that mean an annotation has not actually been adjudicated yet.
+_UNREVIEWED_ACTIONS = {"PENDING", "UNDECIDED", "", None}
+
+
+def as_list(value: Any) -> list[Any]:
+    """Return a value as a list, treating null and missing values as empty.
+
+    >>> as_list(None)
+    []
+    >>> as_list([1, 2])
+    [1, 2]
+    >>> as_list("x")
+    ['x']
+    """
+    if value is None:
+        return []
+    if isinstance(value, list):
+        return value
+    return [value]
+
+
+def base_accession(curie_or_id: Any) -> Optional[str]:
+    """Return the bare UniProt accession for a curie or id, dropping isoform suffix.
+
+    >>> base_accession("UniProtKB:Q9NPJ1")
+    'Q9NPJ1'
+    >>> base_accession("UniProtKB:P19544-1")
+    'P19544'
+    >>> base_accession("Q9NPJ1")
+    'Q9NPJ1'
+    >>> base_accession(None) is None
+    True
+    """
+    if not curie_or_id:
+        return None
+    text = str(curie_or_id)
+    if ":" in text:
+        text = text.split(":", 1)[1]
+    # Drop a UniProt isoform suffix (e.g. P19544-1 -> P19544).
+    return text.split("-", 1)[0] or None
+
+
+# ---------------------------------------------------------------------------
+# Module tree traversal
+# ---------------------------------------------------------------------------
+
+def iter_nodes(data: dict[str, Any]) -> list[dict[str, Any]]:
+    """Return every module node, including the root and all nested descendants.
+
+    Nodes are reachable via ``parts[].node`` and ``variant_sets[].variants[]``.
+    """
+    nodes: list[dict[str, Any]] = []
+
+    def walk(node: Any) -> None:
+        if not isinstance(node, dict):
+            return
+        nodes.append(node)
+        for part in as_list(node.get("parts")):
+            if isinstance(part, dict):
+                walk(part.get("node"))
+        for variant_set in as_list(node.get("variant_sets")):
+            if isinstance(variant_set, dict):
+                for variant in as_list(variant_set.get("variants")):
+                    walk(variant)
+
+    walk(data.get("module"))
+    return nodes
+
+
+def is_leaf_node(node: dict[str, Any]) -> bool:
+    """Return True when a node has no child parts and no variant sets.
+
+    >>> is_leaf_node({"id": "a"})
+    True
+    >>> is_leaf_node({"id": "a", "parts": [{"node": {"id": "b"}}]})
+    False
+    """
+    return not as_list(node.get("parts")) and not as_list(node.get("variant_sets"))
+
+
+def _selector_representative_groundings(selector: Any) -> list[dict[str, Any]]:
+    """Return concrete protein groundings (representative members) for a selector.
+
+    A grounding is a concrete protein example: a ``gene``/``gene_product`` carrying
+    a ``UniProtKB`` term, a ``protein_complex`` active unit that resolves the same
+    way, or a ``family``'s ``representative_members``. Abstract selectors
+    (``FAMILY`` with no representatives, ``ANY_WITH_FUNCTION``, etc.) return [].
+    """
+    if not isinstance(selector, dict):
+        return []
+
+    groundings: list[dict[str, Any]] = []
+
+    def add_descriptor(descriptor: Any) -> None:
+        if not isinstance(descriptor, dict):
+            return
+        term = descriptor.get("term")
+        term_id = term.get("id") if isinstance(term, dict) else None
+        label = (
+            descriptor.get("preferred_term")
+            or (term.get("label") if isinstance(term, dict) else None)
+            or term_id
+        )
+        groundings.append({"id": term_id, "label": label})
+
+    # Concrete gene / gene product participants.
+    for slot in ("gene", "gene_product"):
+        descriptor = selector.get(slot)
+        if isinstance(descriptor, dict):
+            add_descriptor(descriptor)
+
+    # Protein complex: drill into active units.
+    complex_descriptor = selector.get("protein_complex")
+    if isinstance(complex_descriptor, dict):
+        for unit in as_list(complex_descriptor.get("active_units")):
+            if isinstance(unit, dict):
+                groundings.extend(
+                    _selector_representative_groundings(unit.get("participant"))
+                )
+
+    # Family: representative members are the concrete examples.
+    family = selector.get("family")
+    if isinstance(family, dict):
+        for member in as_list(family.get("representative_members")):
+            add_descriptor(member)
+
+    return groundings
+
+
+def node_representative_groundings(node: dict[str, Any]) -> list[dict[str, Any]]:
+    """Return all concrete protein groundings declared by a node's annotons."""
+    groundings: list[dict[str, Any]] = []
+    for annoton in as_list(node.get("annotons")):
+        if isinstance(annoton, dict):
+            groundings.extend(
+                _selector_representative_groundings(annoton.get("participant"))
+            )
+    return groundings
+
+
+def leaf_nodes_missing_representatives(
+    data: dict[str, Any],
+) -> list[dict[str, Any]]:
+    """Return leaf nodes that do not ground to any representative protein member.
+
+    A leaf node (no parts, no variant sets) is flagged when none of its annotons'
+    participants resolve to a concrete protein -- e.g. abstract ``FAMILY`` or
+    ``ANY_WITH_FUNCTION`` selectors with no ``representative_members``.
+    """
+    flagged: list[dict[str, Any]] = []
+    for node in iter_nodes(data):
+        if not is_leaf_node(node):
+            continue
+        groundings = node_representative_groundings(node)
+        if not groundings:
+            selector_types = sorted(
+                {
+                    str(annoton.get("participant", {}).get("selector_type"))
+                    for annoton in as_list(node.get("annotons"))
+                    if isinstance(annoton, dict)
+                    and isinstance(annoton.get("participant"), dict)
+                }
+            )
+            flagged.append(
+                {
+                    "id": node.get("id"),
+                    "label": node.get("label") or node.get("id"),
+                    "annoton_count": len(as_list(node.get("annotons"))),
+                    "selector_types": selector_types,
+                }
+            )
+    return flagged
+
+
+def collect_uniprot_groundings(data: dict[str, Any]) -> list[dict[str, Any]]:
+    """Return unique ``UniProtKB`` groundings (base accession) referenced anywhere.
+
+    Recursively scans the whole document for ``term`` dicts whose id is a
+    ``UniProtKB`` curie, so it captures concrete subunits, representative members,
+    and active units alike. Deduplicated on base accession.
+    """
+    found: dict[str, dict[str, Any]] = {}
+
+    def walk(obj: Any, label_hint: Optional[str] = None) -> None:
+        if isinstance(obj, dict):
+            term = obj.get("term")
+            term_id = term.get("id") if isinstance(term, dict) else None
+            if isinstance(term_id, str) and term_id.startswith(
+                _GROUNDED_TERM_PREFIXES
+            ):
+                acc = base_accession(term_id)
+                if acc and acc not in found:
+                    found[acc] = {
+                        "accession": acc,
+                        "curie": term_id,
+                        "label": (
+                            obj.get("preferred_term")
+                            or (term.get("label") if isinstance(term, dict) else None)
+                            or term_id
+                        ),
+                    }
+            for value in obj.values():
+                walk(value)
+        elif isinstance(obj, list):
+            for item in obj:
+                walk(item)
+
+    walk(data.get("module"))
+    return [found[key] for key in sorted(found)]
+
+
+# ---------------------------------------------------------------------------
+# Gene-review index and join
+# ---------------------------------------------------------------------------
+
+_ID_RE = re.compile(r"^id:\s*(\S+)\s*$")
+_SYMBOL_RE = re.compile(r"^gene_symbol:\s*(\S+)\s*$")
+
+
+def _read_review_header(path: Path) -> tuple[Optional[str], Optional[str]]:
+    """Cheaply read the top-level ``id`` and ``gene_symbol`` of a review file."""
+    review_id: Optional[str] = None
+    symbol: Optional[str] = None
+    with path.open(encoding="utf-8") as handle:
+        for _, line in zip(range(40), handle):
+            if review_id is None:
+                match = _ID_RE.match(line)
+                if match:
+                    review_id = match.group(1)
+            if symbol is None:
+                match = _SYMBOL_RE.match(line)
+                if match:
+                    symbol = match.group(1)
+            if review_id is not None and symbol is not None:
+                break
+    return review_id, symbol
+
+
+def index_gene_reviews(genes_dir: Path = Path("genes")) -> dict[str, Path]:
+    """Map base UniProt accession -> gene review YAML path.
+
+    Scans ``genes/<org>/<gene>/<gene>-ai-review.yaml`` and reads only each file's
+    header, so the index is cheap to build even across thousands of genes.
+    """
+    index: dict[str, Path] = {}
+    if not genes_dir.exists():
+        return index
+    for path in genes_dir.glob("*/*/*-ai-review.yaml"):
+        review_id, _ = _read_review_header(path)
+        acc = base_accession(review_id)
+        if acc:
+            index.setdefault(acc, path)
+    return index
+
+
+def review_completeness(review_path: Path) -> dict[str, Any]:
+    """Summarize annotation-review completeness and deep-research presence."""
+    data = yaml.safe_load(review_path.read_text(encoding="utf-8")) or {}
+    annotations = as_list(data.get("existing_annotations"))
+    total = len(annotations)
+    reviewed = 0
+    for annotation in annotations:
+        if not isinstance(annotation, dict):
+            continue
+        review = annotation.get("review")
+        if isinstance(review, dict):
+            action = review.get("action")
+        else:
+            action = annotation.get("action")
+        if action not in _UNREVIEWED_ACTIONS:
+            reviewed += 1
+
+    gene_dir = review_path.parent
+    deep_research = sorted(
+        md.name
+        for md in gene_dir.glob("*-deep-research*.md")
+        if md.is_file()
+        and not md.name.endswith("-citations.md")
+        and not md.name.endswith(".citations.md")
+    )
+
+    return {
+        "symbol": data.get("gene_symbol"),
+        "total_annotations": total,
+        "reviewed_annotations": reviewed,
+        "complete": total > 0 and reviewed == total,
+        "has_deep_research": bool(deep_research),
+        "deep_research_files": deep_research,
+    }
+
+
+def module_gene_review_summary(
+    data: dict[str, Any],
+    gene_index: Optional[dict[str, Path]] = None,
+    genes_dir: Path = Path("genes"),
+) -> dict[str, Any]:
+    """Join a module's UniProt groundings against the gene-review corpus.
+
+    Returns per-gene rows (review present? complete? deep research?) plus
+    aggregate counts used by the module page.
+    """
+    if gene_index is None:
+        gene_index = index_gene_reviews(genes_dir)
+
+    rows: list[dict[str, Any]] = []
+    for grounding in collect_uniprot_groundings(data):
+        acc = grounding["accession"]
+        review_path = gene_index.get(acc)
+        row: dict[str, Any] = {
+            "accession": acc,
+            "curie": grounding["curie"],
+            "label": grounding["label"],
+            "has_review": review_path is not None,
+            "symbol": None,
+            "complete": False,
+            "has_deep_research": False,
+            "total_annotations": 0,
+            "reviewed_annotations": 0,
+            "review_href": None,
+        }
+        if review_path is not None:
+            completeness = review_completeness(review_path)
+            row.update(
+                {
+                    "symbol": completeness["symbol"],
+                    "complete": completeness["complete"],
+                    "has_deep_research": completeness["has_deep_research"],
+                    "total_annotations": completeness["total_annotations"],
+                    "reviewed_annotations": completeness["reviewed_annotations"],
+                    "review_path": review_path.as_posix(),
+                }
+            )
+        rows.append(row)
+
+    rows.sort(key=lambda item: (item["symbol"] or item["accession"]).lower())
+    total = len(rows)
+    return {
+        "genes": rows,
+        "total_genes": total,
+        "with_review": sum(1 for row in rows if row["has_review"]),
+        "without_review": sum(1 for row in rows if not row["has_review"]),
+        "complete_reviews": sum(1 for row in rows if row["complete"]),
+        "with_deep_research": sum(1 for row in rows if row["has_deep_research"]),
+        "without_deep_research": sum(
+            1 for row in rows if row["has_review"] and not row["has_deep_research"]
+        ),
+    }
+
+
+# ---------------------------------------------------------------------------
+# Module-level deep research
+# ---------------------------------------------------------------------------
+
+def module_deep_research(yaml_path: Path) -> dict[str, Any]:
+    """Detect a module-level deep-research report next to the module YAML.
+
+    Looks for ``<stem>-deep-research*.md`` siblings (e.g.
+    ``photosynthesis-deep-research-falcon.md``) and infers their providers.
+    """
+    stem = yaml_path.stem
+    parent = yaml_path.parent
+    files = sorted(
+        md
+        for md in parent.glob(f"{stem}-deep-research*.md")
+        if md.is_file()
+        and not md.name.endswith("-citations.md")
+        and not md.name.endswith(".citations.md")
+    )
+    providers: list[dict[str, Any]] = []
+    marker = "-deep-research-"
+    for md in files:
+        report_stem = md.name.removesuffix(".md")
+        provider = (
+            report_stem.rsplit(marker, 1)[-1] if marker in report_stem else None
+        )
+        providers.append({"file": md.name, "provider": provider or None})
+    return {"has_deep_research": bool(files), "reports": providers}
+
+
+# ---------------------------------------------------------------------------
+# linkml-data-qc compliance
+# ---------------------------------------------------------------------------
+
+def run_data_qc(
+    yaml_path: Path,
+    schema_path: Path = DEFAULT_SCHEMA_PATH,
+    target_class: str = "ModuleReview",
+) -> dict[str, Any]:
+    """Run ``linkml-data-qc`` recommended-field analysis for a module document.
+
+    Returns the global/weighted compliance percentages plus a list of recommended
+    slots that are populated below 100% (``missing``).
+    """
+    from linkml_data_qc.analyzer import ComplianceAnalyzer  # type: ignore[import-untyped]
+
+    analyzer = ComplianceAnalyzer(str(schema_path))
+    report = analyzer.analyze_file(str(yaml_path), target_class)
+
+    missing: list[dict[str, Any]] = []
+    for path_score in report.path_scores:
+        for slot_score in path_score.slot_scores:
+            if slot_score.populated < slot_score.total:
+                missing.append(
+                    {
+                        "path": path_score.path,
+                        "slot": slot_score.slot_name,
+                        "populated": slot_score.populated,
+                        "total": slot_score.total,
+                        "percentage": round(slot_score.percentage, 1),
+                    }
+                )
+    return {
+        "global_compliance": round(report.global_compliance, 1),
+        "weighted_compliance": round(report.weighted_compliance, 1),
+        "recommended_slots": sorted(report.recommended_slots),
+        "missing": missing,
+    }
+
+
+def collect_module_qc(
+    yaml_path: Path,
+    data: dict[str, Any],
+    schema_path: Path = DEFAULT_SCHEMA_PATH,
+    gene_index: Optional[dict[str, Path]] = None,
+    genes_dir: Path = Path("genes"),
+) -> dict[str, Any]:
+    """Collect all derived QC stats for a module document in one structure."""
+    try:
+        data_qc = run_data_qc(yaml_path, schema_path=schema_path)
+    except Exception as error:  # external tool: degrade gracefully, never crash render
+        data_qc = {"error": str(error)}
+
+    return {
+        "data_qc": data_qc,
+        "leaf_nodes_missing_representatives": leaf_nodes_missing_representatives(data),
+        "gene_reviews": module_gene_review_summary(
+            data, gene_index=gene_index, genes_dir=genes_dir
+        ),
+        "module_deep_research": module_deep_research(yaml_path),
+    }

--- a/src/ai_gene_review/render_modules.py
+++ b/src/ai_gene_review/render_modules.py
@@ -12,6 +12,8 @@ from urllib.parse import quote
 import yaml
 from jinja2 import Environment, FileSystemLoader, select_autoescape
 
+from ai_gene_review.module_qc import collect_module_qc, index_gene_reviews
+
 
 def as_list(value: Any) -> list[Any]:
     """Return a value as a list, treating null and missing values as empty."""
@@ -292,6 +294,7 @@ def make_summary(
     yaml_path: Path,
     output_path: Path,
     index_path: Path,
+    qc: Optional[dict[str, Any]] = None,
 ) -> dict[str, Any]:
     """Build a compact summary used by the module index page."""
     module_value = data.get("module")
@@ -311,6 +314,7 @@ def make_summary(
         "module_type": module.get("module_type"),
         "concepts": concepts,
         "stats": collect_module_stats(data),
+        "qc": qc,
     }
 
 
@@ -368,8 +372,15 @@ def render_module(
     output_dir: Path = Path("pages/modules"),
     modules_dir: Path = Path("modules"),
     template_path: Optional[Path] = None,
+    gene_index: Optional[dict[str, Path]] = None,
+    genes_dir: Path = Path("genes"),
 ) -> tuple[Path, list[str]]:
-    """Render a single module YAML file to HTML."""
+    """Render a single module YAML file to HTML.
+
+    ``gene_index`` (base UniProt accession -> review path) may be supplied to
+    avoid re-scanning the gene corpus when rendering many modules; it is built
+    lazily inside the QC step when omitted.
+    """
     data = load_module_yaml(yaml_path)
 
     if template_path is None:
@@ -381,6 +392,9 @@ def render_module(
     index_path = output_dir / "index.html"
     stats = collect_module_stats(data)
     anchor_map = collect_anchor_map(data)
+    qc = collect_module_qc(
+        yaml_path, data, gene_index=gene_index, genes_dir=genes_dir
+    )
     warnings = [
         f"Duplicate module element id: {duplicate_id}"
         for duplicate_id in collect_duplicate_ids(data)
@@ -391,6 +405,7 @@ def render_module(
         data=data,
         module=data.get("module", {}),
         stats=stats,
+        qc=qc,
         source_file=yaml_path.as_posix(),
         output_path=output_path.as_posix(),
         index_href=relative_href(output_path, index_path),
@@ -447,6 +462,7 @@ def render_all_modules(
     modules_dir: Path = Path("modules"),
     output_dir: Path = Path("pages/modules"),
     template_path: Optional[Path] = None,
+    genes_dir: Path = Path("genes"),
 ) -> tuple[list[Path], list[str]]:
     """Render all module YAML files to HTML and create an index page."""
     output_paths: list[Path] = []
@@ -459,6 +475,9 @@ def render_all_modules(
         print(f"No module YAML files found in {modules_dir}")
         return output_paths, all_warnings
 
+    # Build the gene-review index once and reuse it across all modules.
+    gene_index = index_gene_reviews(genes_dir)
+
     clean_module_html(output_dir)
     print(f"Found {len(yaml_files)} module files to render")
     for yaml_file in yaml_files:
@@ -468,9 +487,16 @@ def render_all_modules(
                 output_dir=output_dir,
                 modules_dir=modules_dir,
                 template_path=template_path,
+                gene_index=gene_index,
+                genes_dir=genes_dir,
             )
             data = load_module_yaml(yaml_file)
-            summaries.append(make_summary(data, yaml_file, output_path, index_path))
+            qc = collect_module_qc(
+                yaml_file, data, gene_index=gene_index, genes_dir=genes_dir
+            )
+            summaries.append(
+                make_summary(data, yaml_file, output_path, index_path, qc=qc)
+            )
             output_paths.append(output_path)
 
             if warnings:

--- a/src/ai_gene_review/templates/module.html.j2
+++ b/src/ai_gene_review/templates/module.html.j2
@@ -432,6 +432,81 @@
             margin-bottom: 18px;
         }
 
+        .qc-panel {
+            margin-bottom: 18px;
+        }
+
+        .qc-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+            gap: 12px;
+        }
+
+        .qc-card {
+            border: 1px solid var(--border);
+            border-radius: 8px;
+            background: #fbfcfd;
+            padding: 12px 14px;
+        }
+
+        .qc-card-wide {
+            grid-column: 1 / -1;
+        }
+
+        .qc-card h3 {
+            font-size: 0.98rem;
+            margin-bottom: 8px;
+        }
+
+        .qc-headline {
+            font-size: 1.5rem;
+            font-weight: 700;
+        }
+
+        .qc-list {
+            margin: 6px 0 0;
+            padding-left: 18px;
+        }
+
+        .qc-list li {
+            margin: 3px 0;
+        }
+
+        .qc-table {
+            width: 100%;
+            border-collapse: collapse;
+            margin-top: 8px;
+        }
+
+        .qc-table th,
+        .qc-table td {
+            text-align: left;
+            padding: 5px 8px;
+            border-bottom: 1px solid var(--border);
+            vertical-align: top;
+        }
+
+        .qc-table th {
+            color: var(--muted);
+            font-size: 0.78rem;
+            text-transform: uppercase;
+        }
+
+        .qc-table td.center,
+        .qc-table th.center {
+            text-align: center;
+        }
+
+        .ok {
+            color: var(--green);
+            font-weight: 700;
+        }
+
+        .warn {
+            color: var(--red);
+            font-weight: 700;
+        }
+
         @media (max-width: 960px) {
             .page {
                 padding: 14px;
@@ -828,6 +903,114 @@
         <div class="stat"><span class="stat-value">{{ stats.annotons }}</span><span class="stat-label">Annotons</span></div>
         <div class="stat"><span class="stat-value">{{ stats.connections }}</span><span class="stat-label">Connections</span></div>
     </section>
+
+    {%- if qc %}
+    <section class="qc-panel panel" aria-label="Derived QC">
+        <div class="panel-header">
+            <h2>Derived QC</h2>
+        </div>
+        <div class="panel-body qc-grid">
+            <div class="qc-card">
+                <h3>Recommended-field compliance</h3>
+                {%- if qc.data_qc.get('error') %}
+                    <p class="muted small">Unavailable: {{ qc.data_qc.get('error') }}</p>
+                {%- else %}
+                    <div><span class="qc-headline">{{ qc.data_qc.global_compliance }}%</span>
+                        <span class="muted small">recommended fields populated</span></div>
+                    {%- if qc.data_qc.missing %}
+                        <ul class="qc-list small">
+                            {%- for item in qc.data_qc.missing %}
+                                <li><code>{{ item.path }}</code> &middot; {{ item.slot }}
+                                    <span class="muted">({{ item.populated }}/{{ item.total }})</span></li>
+                            {%- endfor %}
+                        </ul>
+                    {%- else %}
+                        <p class="muted small">All recommended fields populated.</p>
+                    {%- endif %}
+                {%- endif %}
+            </div>
+
+            <div class="qc-card">
+                <h3>Module deep research</h3>
+                {%- if qc.module_deep_research.has_deep_research %}
+                    <p><span class="ok">&#10003; present</span></p>
+                    <ul class="qc-list small">
+                        {%- for report in qc.module_deep_research.reports %}
+                            <li>{{ report.file }}{% if report.provider %} <span class="muted">({{ report.provider }})</span>{% endif %}</li>
+                        {%- endfor %}
+                    </ul>
+                {%- else %}
+                    <p><span class="warn">&#10007; none found</span></p>
+                    <p class="muted small">No <code>{{ data.get('id', 'module') }}</code> deep-research report alongside the module YAML.</p>
+                {%- endif %}
+            </div>
+
+            <div class="qc-card">
+                <h3>Leaf nodes lacking representative members</h3>
+                {%- if qc.leaf_nodes_missing_representatives %}
+                    <p class="small">{{ qc.leaf_nodes_missing_representatives | length }} leaf node(s) with no concrete protein grounding:</p>
+                    <ul class="qc-list small">
+                        {%- for node in qc.leaf_nodes_missing_representatives %}
+                            <li><a href="#node-{{ anchor_id(node.id) }}">{{ node.label }}</a>
+                                {%- if node.selector_types %} <span class="muted">{{ node.selector_types | join(', ') }}</span>{% endif -%}
+                            </li>
+                        {%- endfor %}
+                    </ul>
+                {%- else %}
+                    <p><span class="ok">&#10003;</span> <span class="small">every leaf node grounds to a representative protein.</span></p>
+                {%- endif %}
+            </div>
+
+            <div class="qc-card qc-card-wide">
+                <h3>Gene-review completeness
+                    <span class="muted small">({{ qc.gene_reviews.with_review }}/{{ qc.gene_reviews.total_genes }} grounded genes reviewed)</span>
+                </h3>
+                {%- if qc.gene_reviews.genes %}
+                    <p class="small muted">
+                        {{ qc.gene_reviews.complete_reviews }} complete review(s) &middot;
+                        {{ qc.gene_reviews.with_deep_research }} with deep research &middot;
+                        {{ qc.gene_reviews.without_review }} missing review &middot;
+                        {{ qc.gene_reviews.without_deep_research }} reviewed but lacking deep research
+                    </p>
+                    <table class="qc-table small">
+                        <thead>
+                            <tr>
+                                <th>Gene</th>
+                                <th class="center">Review</th>
+                                <th class="center">Complete</th>
+                                <th class="center">Deep research</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            {%- for gene in qc.gene_reviews.genes %}
+                                <tr>
+                                    <td>{{ gene.symbol or gene.label or gene.accession }}
+                                        <span class="muted term-id">{{ gene.accession }}</span></td>
+                                    <td class="center">
+                                        {%- if gene.has_review %}<span class="ok">&#10003;</span>{% else %}<span class="warn">&#10007;</span>{% endif -%}
+                                    </td>
+                                    <td class="center">
+                                        {%- if gene.has_review %}
+                                            {%- if gene.complete %}<span class="ok">&#10003;</span>
+                                            {%- else %}<span class="warn">{{ gene.reviewed_annotations }}/{{ gene.total_annotations }}</span>{% endif -%}
+                                        {%- else %}&mdash;{% endif -%}
+                                    </td>
+                                    <td class="center">
+                                        {%- if gene.has_review %}
+                                            {%- if gene.has_deep_research %}<span class="ok">&#10003;</span>{% else %}<span class="warn">&#10007;</span>{% endif -%}
+                                        {%- else %}&mdash;{% endif -%}
+                                    </td>
+                                </tr>
+                            {%- endfor %}
+                        </tbody>
+                    </table>
+                {%- else %}
+                    <p class="muted small">No concrete UniProt-grounded genes in this module.</p>
+                {%- endif %}
+            </div>
+        </div>
+    </section>
+    {%- endif %}
 
     <section class="browser">
         <aside class="panel tree-panel">

--- a/src/ai_gene_review/templates/module_index.html.j2
+++ b/src/ai_gene_review/templates/module_index.html.j2
@@ -244,6 +244,9 @@
                     <th class="num" data-sort="num">Variant&nbsp;sets <span class="arrow"></span></th>
                     <th class="num" data-sort="num">Variants <span class="arrow"></span></th>
                     <th class="num" data-sort="num">Connections <span class="arrow"></span></th>
+                    <th class="num" data-sort="num">Genes&nbsp;rev. <span class="arrow"></span></th>
+                    <th class="num" data-sort="num">Leaf&nbsp;gaps <span class="arrow"></span></th>
+                    <th data-sort="text">Module&nbsp;DR <span class="arrow"></span></th>
                     <th data-sort="text">Source <span class="arrow"></span></th>
                 </tr>
             </thead>
@@ -276,6 +279,21 @@
                     <td class="num">{{ module.stats.variant_sets }}</td>
                     <td class="num">{{ module.stats.variants }}</td>
                     <td class="num">{{ module.stats.connections }}</td>
+                    {%- if module.qc %}
+                    <td class="num" data-sort-value="{{ module.qc.gene_reviews.with_review }}">
+                        {{ module.qc.gene_reviews.with_review }}/{{ module.qc.gene_reviews.total_genes }}
+                    </td>
+                    <td class="num" data-sort-value="{{ module.qc.leaf_nodes_missing_representatives | length }}">
+                        {{ module.qc.leaf_nodes_missing_representatives | length }}
+                    </td>
+                    <td data-sort-value="{{ 'yes' if module.qc.module_deep_research.has_deep_research else 'no' }}">
+                        {%- if module.qc.module_deep_research.has_deep_research %}&#10003;{% else %}&#10007;{% endif %}
+                    </td>
+                    {%- else %}
+                    <td class="num" data-sort-value="0"></td>
+                    <td class="num" data-sort-value="0"></td>
+                    <td data-sort-value="no"></td>
+                    {%- endif %}
                     <td><span class="source">{{ module.source_path }}</span></td>
                 </tr>
                 {%- endfor %}

--- a/tests/test_module_qc.py
+++ b/tests/test_module_qc.py
@@ -1,0 +1,328 @@
+"""Tests for derived module QC statistics (ai_gene_review.module_qc)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+from ai_gene_review.module_qc import (
+    base_accession,
+    collect_module_qc,
+    collect_uniprot_groundings,
+    index_gene_reviews,
+    is_leaf_node,
+    iter_nodes,
+    leaf_nodes_missing_representatives,
+    module_deep_research,
+    module_gene_review_summary,
+    node_representative_groundings,
+    review_completeness,
+    run_data_qc,
+)
+
+MODULES_DIR = Path("modules")
+SCHEMA_PATH = Path("src/ai_gene_review/schema/gene_review.yaml")
+
+
+def load_module(name: str) -> dict:
+    return yaml.safe_load((MODULES_DIR / name).read_text())
+
+
+# ---------------------------------------------------------------------------
+# Small helpers
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize(
+    "value,expected",
+    [
+        ("UniProtKB:Q9NPJ1", "Q9NPJ1"),
+        ("UniProtKB:P19544-1", "P19544"),
+        ("Q9NPJ1", "Q9NPJ1"),
+        (None, None),
+        ("", None),
+    ],
+)
+def test_base_accession(value, expected):
+    assert base_accession(value) == expected
+
+
+def test_is_leaf_node():
+    assert is_leaf_node({"id": "a"})
+    assert not is_leaf_node({"id": "a", "parts": [{"node": {"id": "b"}}]})
+    assert not is_leaf_node(
+        {"id": "a", "variant_sets": [{"id": "v", "variants": [{"id": "b"}]}]}
+    )
+
+
+# ---------------------------------------------------------------------------
+# Tree traversal
+# ---------------------------------------------------------------------------
+
+def test_iter_nodes_visits_nested_parts():
+    data = {
+        "module": {
+            "id": "root",
+            "parts": [
+                {"node": {"id": "child1"}},
+                {
+                    "node": {
+                        "id": "child2",
+                        "variant_sets": [
+                            {"id": "vs", "variants": [{"id": "grandchild"}]}
+                        ],
+                    }
+                },
+            ],
+        }
+    }
+    ids = {node["id"] for node in iter_nodes(data)}
+    assert ids == {"root", "child1", "child2", "grandchild"}
+
+
+# ---------------------------------------------------------------------------
+# Representative-member / leaf grounding
+# ---------------------------------------------------------------------------
+
+def test_node_representative_groundings_concrete_gene_product():
+    node = {
+        "id": "n",
+        "annotons": [
+            {
+                "participant": {
+                    "selector_type": "GENE_PRODUCT",
+                    "gene_product": {
+                        "preferred_term": "BBS1",
+                        "term": {"id": "UniProtKB:Q8NFJ9", "label": "BBS1"},
+                    },
+                }
+            }
+        ],
+    }
+    groundings = node_representative_groundings(node)
+    assert groundings == [{"id": "UniProtKB:Q8NFJ9", "label": "BBS1"}]
+
+
+def test_node_representative_groundings_family_with_members():
+    node = {
+        "id": "n",
+        "annotons": [
+            {
+                "participant": {
+                    "selector_type": "FAMILY",
+                    "family": {
+                        "preferred_term": "Ras GTPases",
+                        "representative_members": [
+                            {
+                                "preferred_term": "HRAS",
+                                "term": {"id": "UniProtKB:P01112"},
+                            }
+                        ],
+                    },
+                }
+            }
+        ],
+    }
+    groundings = node_representative_groundings(node)
+    assert groundings == [{"id": "UniProtKB:P01112", "label": "HRAS"}]
+
+
+def test_family_without_representatives_is_not_grounded():
+    node = {
+        "id": "n",
+        "annotons": [
+            {
+                "participant": {
+                    "selector_type": "FAMILY",
+                    "family": {"preferred_term": "SOS Ras GEFs"},
+                }
+            }
+        ],
+    }
+    assert node_representative_groundings(node) == []
+
+
+def test_protein_complex_active_units_grounded():
+    node = {
+        "id": "n",
+        "annotons": [
+            {
+                "participant": {
+                    "selector_type": "PROTEIN_COMPLEX",
+                    "protein_complex": {
+                        "preferred_term": "BBSome",
+                        "active_units": [
+                            {
+                                "participant": {
+                                    "selector_type": "GENE_PRODUCT",
+                                    "gene_product": {
+                                        "preferred_term": "BBS1",
+                                        "term": {"id": "UniProtKB:Q8NFJ9"},
+                                    },
+                                }
+                            }
+                        ],
+                    },
+                }
+            }
+        ],
+    }
+    groundings = node_representative_groundings(node)
+    assert groundings == [{"id": "UniProtKB:Q8NFJ9", "label": "BBS1"}]
+
+
+def test_bbsome_leaf_grounding():
+    # bbsome.yaml grounds most subunits to concrete UniProt accessions, but the
+    # cargo-trafficking leaf references the BBSome only by its GO complex term
+    # (no active_units / representative members), so it is correctly flagged.
+    data = load_module("bbsome.yaml")
+    flagged = leaf_nodes_missing_representatives(data)
+    flagged_ids = {item["id"] for item in flagged}
+    assert "bbsome_cargo_trafficking" in flagged_ids
+    # The octamer leaf lists concrete subunits, so it must not be flagged.
+    assert "bbsome_core_octamer" not in flagged_ids
+
+
+def test_ras_mapk_flags_abstract_family_leaves():
+    # ras_mapk_cascade.yaml uses some FAMILY selectors without representatives.
+    data = load_module("ras_mapk_cascade.yaml")
+    flagged = leaf_nodes_missing_representatives(data)
+    # At least one leaf (e.g. the SOS GEF step) lacks representative members.
+    assert any(
+        "FAMILY" in item["selector_types"] for item in flagged
+    ), flagged
+
+
+# ---------------------------------------------------------------------------
+# UniProt grounding collection
+# ---------------------------------------------------------------------------
+
+def test_collect_uniprot_groundings_dedupes_on_base_accession():
+    data = {
+        "module": {
+            "id": "root",
+            "annotons": [
+                {
+                    "participant": {
+                        "gene_product": {"term": {"id": "UniProtKB:Q8NFJ9"}}
+                    }
+                },
+                {
+                    "participant": {
+                        "gene_product": {"term": {"id": "UniProtKB:Q8NFJ9-2"}}
+                    }
+                },
+            ],
+        }
+    }
+    groundings = collect_uniprot_groundings(data)
+    assert [g["accession"] for g in groundings] == ["Q8NFJ9"]
+
+
+def test_collect_uniprot_groundings_bbsome():
+    data = load_module("bbsome.yaml")
+    accessions = {g["accession"] for g in collect_uniprot_groundings(data)}
+    assert "Q8NFJ9" in accessions  # BBS1
+    assert "Q9NPJ1" in accessions  # MKKS/BBS6
+
+
+# ---------------------------------------------------------------------------
+# Gene-review index and join
+# ---------------------------------------------------------------------------
+
+def test_index_gene_reviews_and_completeness(tmp_path):
+    genes = tmp_path / "genes"
+    gene_dir = genes / "human" / "FOO"
+    gene_dir.mkdir(parents=True)
+    review = gene_dir / "FOO-ai-review.yaml"
+    review.write_text(
+        "id: Q12345\n"
+        "gene_symbol: FOO\n"
+        "existing_annotations:\n"
+        "  - term: {id: 'GO:0001', label: x}\n"
+        "    review: {action: ACCEPT}\n"
+        "  - term: {id: 'GO:0002', label: y}\n"
+        "    review: {action: PENDING}\n"
+    )
+    (gene_dir / "FOO-deep-research-openai.md").write_text("# research\n")
+
+    index = index_gene_reviews(genes)
+    assert index == {"Q12345": review}
+
+    completeness = review_completeness(review)
+    assert completeness["total_annotations"] == 2
+    assert completeness["reviewed_annotations"] == 1
+    assert completeness["complete"] is False
+    assert completeness["has_deep_research"] is True
+
+
+def test_module_gene_review_summary_join(tmp_path):
+    genes = tmp_path / "genes"
+    gene_dir = genes / "human" / "FOO"
+    gene_dir.mkdir(parents=True)
+    (gene_dir / "FOO-ai-review.yaml").write_text(
+        "id: Q12345\n"
+        "gene_symbol: FOO\n"
+        "existing_annotations:\n"
+        "  - term: {id: 'GO:0001', label: x}\n"
+        "    review: {action: ACCEPT}\n"
+    )
+
+    data = {
+        "module": {
+            "id": "root",
+            "annotons": [
+                {"participant": {"gene_product": {"term": {"id": "UniProtKB:Q12345"}}}},
+                {"participant": {"gene_product": {"term": {"id": "UniProtKB:Q99999"}}}},
+            ],
+        }
+    }
+    summary = module_gene_review_summary(data, genes_dir=genes)
+    assert summary["total_genes"] == 2
+    assert summary["with_review"] == 1
+    assert summary["without_review"] == 1
+    assert summary["complete_reviews"] == 1
+    # Q99999 has no review; Q12345 has a review but no deep research file.
+    assert summary["without_deep_research"] == 1
+
+
+# ---------------------------------------------------------------------------
+# Module-level deep research
+# ---------------------------------------------------------------------------
+
+def test_module_deep_research_present():
+    result = module_deep_research(MODULES_DIR / "photosynthesis.yaml")
+    assert result["has_deep_research"] is True
+    assert any(r["provider"] == "falcon" for r in result["reports"])
+
+
+def test_module_deep_research_absent():
+    result = module_deep_research(MODULES_DIR / "bbsome.yaml")
+    assert result["has_deep_research"] is False
+    assert result["reports"] == []
+
+
+# ---------------------------------------------------------------------------
+# linkml-data-qc
+# ---------------------------------------------------------------------------
+
+def test_run_data_qc_returns_compliance():
+    result = run_data_qc(MODULES_DIR / "bbsome.yaml", schema_path=SCHEMA_PATH)
+    assert "global_compliance" in result
+    assert isinstance(result["global_compliance"], float)
+    assert isinstance(result["missing"], list)
+    assert "status" in result["recommended_slots"]
+
+
+def test_collect_module_qc_smoke():
+    yaml_path = MODULES_DIR / "bbsome.yaml"
+    data = load_module("bbsome.yaml")
+    qc = collect_module_qc(yaml_path, data, schema_path=SCHEMA_PATH)
+    assert set(qc) == {
+        "data_qc",
+        "leaf_nodes_missing_representatives",
+        "gene_reviews",
+        "module_deep_research",
+    }
+    assert qc["module_deep_research"]["has_deep_research"] is False


### PR DESCRIPTION
Surface four derived statistics on each rendered module page (and headline
columns on the module index), computed by a new tested `module_qc` module:

- linkml-data-qc recommended-field compliance for the ModuleReview document
- leaf nodes lacking representative members (abstract leaves with no concrete
  UniProt/PTN protein grounding)
- gene-review completeness for every UniProtKB grounding in the module (has
  review? complete? has deep research?)
- whether the module as a whole has a deep-research report

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Hg4NrzBz7qi8nG1Cn7DULj