### PR TITLE
Cellulose module follow-ups: UniProt mnemonic labels + apoplast COBRA location

### DIFF
--- a/modules/cellulose_biosynthesis.yaml
+++ b/modules/cellulose_biosynthesis.yaml
@@ -407,10 +407,14 @@ module:
                       id: GO:0010215
                       label: cellulose microfibril organization
                   locations:
-                    - preferred_term: plasma membrane / apoplast (GPI-anchored)
+                    - preferred_term: plasma membrane (GPI-anchored)
                       term:
                         id: GO:0005886
                         label: plasma membrane
+                    - preferred_term: apoplast
+                      term:
+                        id: GO:0048046
+                        label: apoplast
                   role_description: >-
                     GPI-anchored protein influencing microfibril orientation and
                     crystallinity; cob mutants have reduced, disorganized cellulose.

--- a/modules/cellulose_biosynthesis.yaml
+++ b/modules/cellulose_biosynthesis.yaml
@@ -234,15 +234,15 @@ module:
                           - preferred_term: Arabidopsis CESA1 (RSW1)
                             term:
                               id: UniProtKB:O48946
-                              label: Cellulose synthase A catalytic subunit 1 [UDP-forming]
+                              label: CESA1_ARATH
                           - preferred_term: Arabidopsis CESA3 (IXR1)
                             term:
                               id: UniProtKB:Q941L0
-                              label: Cellulose synthase A catalytic subunit 3 [UDP-forming]
+                              label: CESA3_ARATH
                           - preferred_term: Arabidopsis CESA6
                             term:
                               id: UniProtKB:Q94JQ6
-                              label: Cellulose synthase A catalytic subunit 6 [UDP-forming]
+                              label: CESA6_ARATH
                     function:
                       preferred_term: cellulose synthase (UDP-forming) activity
                       term:
@@ -278,15 +278,15 @@ module:
                           - preferred_term: Arabidopsis CESA8 (IRX1)
                             term:
                               id: UniProtKB:Q8LPK5
-                              label: Cellulose synthase A catalytic subunit 8 [UDP-forming]
+                              label: CESA8_ARATH
                           - preferred_term: Arabidopsis CESA7 (IRX3)
                             term:
                               id: UniProtKB:Q9SWW6
-                              label: Cellulose synthase A catalytic subunit 7 [UDP-forming]
+                              label: CESA7_ARATH
                           - preferred_term: Arabidopsis CESA4 (IRX5)
                             term:
                               id: UniProtKB:Q84JA6
-                              label: Cellulose synthase A catalytic subunit 4 [UDP-forming]
+                              label: CESA4_ARATH
                     function:
                       preferred_term: cellulose synthase (UDP-forming) activity
                       term:
@@ -324,7 +324,7 @@ module:
                   - preferred_term: Arabidopsis CSI1 (POM2)
                     term:
                       id: UniProtKB:F4IIM1
-                      label: Protein CELLULOSE SYNTHASE INTERACTIVE 1
+                      label: CSI1_ARATH
             function:
               preferred_term: scaffold linking the CSC to cortical microtubules
               description: >-
@@ -366,7 +366,7 @@ module:
                         - preferred_term: Arabidopsis KOR1 (KORRIGAN / RSW2)
                           term:
                             id: UniProtKB:Q38890
-                            label: Endoglucanase 25
+                            label: GUN25_ARATH
                   function:
                     preferred_term: cellulase activity
                     term:
@@ -400,7 +400,7 @@ module:
                         - preferred_term: Arabidopsis COBRA (COB)
                           term:
                             id: UniProtKB:Q94KT8
-                            label: Protein COBRA
+                            label: COBRA_ARATH
                   function:
                     preferred_term: cellulose microfibril organization
                     term:


### PR DESCRIPTION
## Summary

Two follow-up improvements to `modules/cellulose_biosynthesis.yaml` (the module merged in #1566). These were prepared after #1566 was squash-merged, so they need a separate PR. The net diff against `main` is exactly these two changes.

1. **UniProt `term.label` → entry-name mnemonics.** Set `representative_members` term labels to the UniProt entry name (`CESA1_ARATH`, `CESA3_ARATH`, `CESA6_ARATH`, `CESA8_ARATH`, `CESA7_ARATH`, `CESA4_ARATH`, `GUN25_ARATH`, `CSI1_ARATH`, `COBRA_ARATH`). The human-readable descriptive names remain in `preferred_term`. This aligns `term.label` with the database's own canonical label and is the convention we settled on while investigating UniProt term validation (see #1576).

2. **COBRA gains apoplast as a second location.** Adds `GO:0048046` (apoplast) alongside `GO:0005886` (plasma membrane), since COBRA is GPI-anchored on the outer face and acts in the apoplastic space. Addresses a review suggestion on #1566.

## Validation

- `linkml-validate -s src/ai_gene_review/schema/gene_review.yaml -C ModuleReview modules/cellulose_biosynthesis.yaml` → **No issues found**.
- All GO ids/labels verified against the local GO cache; all UniProt accessions and mnemonics verified against UniProt.

## Notes

- UniProt term-label validation itself is **not** enabled (the `sqlite:obo:uniprot` adapter indexes under the `UP:` prefix with mnemonic labels, and module descriptor slots are unbound). That investigation and the decision to defer it are tracked in **#1576**.
- The review bot's other suggestions on #1566 were verified and not actioned: the three suggested reference PMIDs were hallucinated (unrelated papers), and `F4IIM1` is a reviewed SwissProt entry (not TrEMBL).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GKsCFAAFJ3w3XDNjkFKJdC

---
_Generated by [Claude Code](https://claude.ai/code/session_01GKsCFAAFJ3w3XDNjkFKJdC)_