### PR TITLE
Fix browser payload size and table view

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -212,6 +212,7 @@
 
         .results-area {
             flex: 1;
+            min-width: 0;
             padding: 24px;
             background: white;
         }
@@ -302,14 +303,16 @@
 
         .results-table-wrap {
             width: 100%;
-            overflow-x: visible;
+            overflow-x: auto;
             border: 1px solid #e5e7eb;
             border-radius: 6px;
             background: white;
+            scrollbar-gutter: stable;
         }
 
         .results-table {
             width: 100%;
+            min-width: 1220px;
             border-collapse: collapse;
             table-layout: fixed;
             font-size: 11px;
@@ -347,15 +350,14 @@
         }
 
         .table-cell-gene { width: 13%; }
-        .table-cell-go_term { width: 21%; }
-        .table-cell-term_ontology { width: 7%; }
+        .table-cell-go_term { width: 23%; }
         .table-cell-evidence_type { width: 6%; }
-        .table-cell-reference { width: 12%; }
-        .table-cell-review_action { width: 9%; }
-        .table-cell-review_summary { width: 11%; }
-        .table-cell-review_reason { width: 11%; }
-        .table-cell-review_proposed_replacement_terms { width: 6%; }
-        .table-cell-status { width: 4%; }
+        .table-cell-reference { width: 16%; }
+        .table-cell-review_action { width: 8%; }
+        .table-cell-review_summary { width: 12%; }
+        .table-cell-review_reason { width: 12%; }
+        .table-cell-review_proposed_replacement_terms { width: 5%; }
+        .table-cell-status { width: 5%; }
 
         .cell-content {
             display: block;
@@ -1237,8 +1239,14 @@
 
                 if (fieldConfig.type === 'curie' && String(value).includes(':')) {
                     const escapedValue = this.escapeHtml(value);
+                    const labelValue = fieldConfig.linkTextField && item
+                        ? item[fieldConfig.linkTextField]
+                        : value;
+                    const label = labelValue === undefined || labelValue === null
+                        ? value
+                        : labelValue;
                     const curieUrl = `https://bioregistry.io/${escapedValue}`;
-                    return `<a href="${curieUrl}" target="_blank" style="color: #10b981; text-decoration: none; border-bottom: 1px dashed #10b981;">${escapedValue}</a>`;
+                    return `<a href="${curieUrl}" target="_blank" style="color: #10b981; text-decoration: none; border-bottom: 1px dashed #10b981;">${this.escapeHtml(label)}</a>`;
                 }
 
                 if (fieldConfig.type === 'url' && value) {

--- a/app/index.html
+++ b/app/index.html
@@ -70,6 +70,7 @@
             display: flex;
             gap: 12px;
             align-items: center;
+            flex-wrap: wrap;
         }
 
         .search-box {
@@ -93,6 +94,7 @@
             color: #6b7280;
             font-weight: 500;
             font-family: 'SF Mono', 'Monaco', monospace;
+            white-space: nowrap;
         }
 
         .main-content {
@@ -218,6 +220,7 @@
             display: flex;
             justify-content: space-between;
             align-items: center;
+            gap: 16px;
             margin-bottom: 20px;
             padding-bottom: 12px;
             border-bottom: 1px solid #e5e7eb;
@@ -227,6 +230,47 @@
             font-size: 1rem;
             color: #374151;
             font-weight: 500;
+        }
+
+        .results-controls {
+            display: flex;
+            align-items: center;
+            gap: 10px;
+            flex-wrap: wrap;
+            justify-content: flex-end;
+        }
+
+        .view-toggle {
+            display: inline-flex;
+            border: 1px solid #d1d5db;
+            border-radius: 6px;
+            overflow: hidden;
+            background: white;
+        }
+
+        .view-toggle-btn {
+            border: 0;
+            background: white;
+            color: #374151;
+            padding: 7px 12px;
+            font-size: 13px;
+            font-weight: 600;
+            cursor: pointer;
+            border-right: 1px solid #d1d5db;
+        }
+
+        .view-toggle-btn:last-child {
+            border-right: 0;
+        }
+
+        .view-toggle-btn.active {
+            background: #10b981;
+            color: white;
+        }
+
+        .view-toggle-btn:focus-visible {
+            outline: 2px solid #10b981;
+            outline-offset: 2px;
         }
 
         .clear-filters {
@@ -250,6 +294,159 @@
             display: grid;
             grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
             gap: 20px;
+        }
+
+        .results-grid.table-view {
+            display: block;
+        }
+
+        .results-table-wrap {
+            width: 100%;
+            overflow-x: visible;
+            border: 1px solid #e5e7eb;
+            border-radius: 6px;
+            background: white;
+        }
+
+        .results-table {
+            width: 100%;
+            border-collapse: collapse;
+            table-layout: fixed;
+            font-size: 11px;
+        }
+
+        .results-table th,
+        .results-table td {
+            border-bottom: 1px solid #e5e7eb;
+            padding: 5px 6px;
+            text-align: left;
+            vertical-align: middle;
+        }
+
+        .results-table th {
+            position: sticky;
+            top: 0;
+            z-index: 1;
+            background: #f9fafb;
+            color: #374151;
+            font-size: 11px;
+            font-weight: 700;
+            text-transform: uppercase;
+            letter-spacing: 0.02em;
+            white-space: nowrap;
+            overflow: hidden;
+            text-overflow: ellipsis;
+        }
+
+        .results-table tbody tr:hover {
+            background: #f9fafb;
+        }
+
+        .results-table tbody tr:last-child td {
+            border-bottom: 0;
+        }
+
+        .table-cell-gene { width: 13%; }
+        .table-cell-go_term { width: 21%; }
+        .table-cell-term_ontology { width: 7%; }
+        .table-cell-evidence_type { width: 6%; }
+        .table-cell-reference { width: 12%; }
+        .table-cell-review_action { width: 9%; }
+        .table-cell-review_summary { width: 11%; }
+        .table-cell-review_reason { width: 11%; }
+        .table-cell-review_proposed_replacement_terms { width: 6%; }
+        .table-cell-status { width: 4%; }
+
+        .cell-content {
+            display: block;
+            max-width: 100%;
+            overflow: hidden;
+            text-overflow: ellipsis;
+            white-space: nowrap;
+        }
+
+        .compound-cell {
+            display: flex;
+            align-items: baseline;
+            gap: 6px;
+            min-width: 0;
+        }
+
+        .compound-primary {
+            flex: 1 1 auto;
+            font-weight: 700;
+            color: #111827;
+            min-width: 0;
+            overflow: hidden;
+            text-overflow: ellipsis;
+            white-space: nowrap;
+        }
+
+        .compound-secondary {
+            flex: 0 1 auto;
+            color: #6b7280;
+            min-width: 0;
+            overflow: hidden;
+            text-overflow: ellipsis;
+            white-space: nowrap;
+        }
+
+        .compound-link {
+            flex: 0 0 auto;
+        }
+
+        .empty-cell {
+            color: #9ca3af;
+        }
+
+        .action-badge {
+            display: inline-block;
+            max-width: 100%;
+            padding: 2px 6px;
+            border-radius: 4px;
+            font-size: 11px;
+            line-height: 1.3;
+            font-weight: 700;
+            overflow: hidden;
+            text-overflow: ellipsis;
+            white-space: nowrap;
+            vertical-align: middle;
+        }
+
+        .action-accept {
+            background: #d1fae5;
+            color: #065f46;
+        }
+
+        .action-keep-as-non-core {
+            background: #dbeafe;
+            color: #1e40af;
+        }
+
+        .action-remove {
+            background: #fee2e2;
+            color: #991b1b;
+        }
+
+        .action-modify {
+            background: #fef3c7;
+            color: #92400e;
+        }
+
+        .action-mark-as-over-annotated {
+            background: #ffedd5;
+            color: #9a3412;
+        }
+
+        .action-undecided,
+        .action-pending {
+            background: #e5e7eb;
+            color: #374151;
+        }
+
+        .action-new {
+            background: #ccfbf1;
+            color: #115e59;
         }
 
         .result-card {
@@ -316,6 +513,10 @@
             grid-column: 1 / -1;
             text-align: center;
             padding: 20px;
+        }
+
+        .results-grid.table-view .load-more-container {
+            padding-bottom: 0;
         }
 
         .load-more-btn {
@@ -403,12 +604,38 @@
         }
 
         @media (max-width: 768px) {
+            .search-container {
+                align-items: stretch;
+            }
+
+            .search-box {
+                flex-basis: 100%;
+            }
+
             .main-content {
                 flex-direction: column;
             }
             
             .sidebar {
                 width: 100%;
+            }
+
+            .results-header {
+                align-items: flex-start;
+                flex-direction: column;
+            }
+
+            .results-controls {
+                width: 100%;
+                justify-content: space-between;
+            }
+
+            .results-table-wrap {
+                overflow-x: auto;
+            }
+
+            .results-table {
+                min-width: 980px;
             }
         }
     </style>
@@ -422,6 +649,10 @@
 
         <div class="search-container">
             <input type="text" id="searchBox" class="search-box" placeholder="Search products...">
+            <div class="view-toggle" role="group" aria-label="Results view">
+                <button type="button" class="view-toggle-btn active" data-view="table" aria-pressed="true">Table</button>
+                <button type="button" class="view-toggle-btn" data-view="card" aria-pressed="false">Cards</button>
+            </div>
             <div class="performance-info" id="performanceInfo">Ready</div>
         </div>
 
@@ -433,7 +664,9 @@
             <div class="results-area">
                 <div class="results-header">
                     <div class="results-count" id="resultsCount">Loading...</div>
-                    <button class="clear-filters" id="clearFilters">Clear All Filters</button>
+                    <div class="results-controls">
+                        <button class="clear-filters" id="clearFilters">Clear All Filters</button>
+                    </div>
                 </div>
                 <div class="results-grid" id="resultsGrid"></div>
             </div>
@@ -455,6 +688,7 @@
                 this.schema = schema;
                 this.currentFilters = {};
                 this.currentQuery = '';
+                this.currentView = schema.defaultView || 'table';
 
                 // Track collapsed facets
                 this.collapsedFacets = new Set();
@@ -623,6 +857,15 @@
                     this.clearAllFilters();
                 });
 
+                document.querySelectorAll('.view-toggle-btn').forEach(button => {
+                    button.addEventListener('click', () => {
+                        this.currentView = button.dataset.view;
+                        this.updateViewToggle();
+                        this.renderResults();
+                    });
+                });
+                this.updateViewToggle();
+
                 // Load more button (delegated since it's dynamically created)
                 document.addEventListener('click', (e) => {
                     if (e.target.id === 'loadMoreBtn') {
@@ -641,6 +884,14 @@
                             this.renderFacets(this.currentFacetCounts);
                         }
                     }
+                });
+            }
+
+            updateViewToggle() {
+                document.querySelectorAll('.view-toggle-btn').forEach(button => {
+                    const isActive = button.dataset.view === this.currentView;
+                    button.classList.toggle('active', isActive);
+                    button.setAttribute('aria-pressed', String(isActive));
                 });
             }
             
@@ -904,6 +1155,7 @@
                 const totalCount = items.length;
                 const showingCount = Math.min(this.displayedCount, totalCount);
                 resultsCount.textContent = `Showing ${showingCount} of ${totalCount} items`;
+                resultsGrid.className = `results-grid ${this.currentView === 'table' ? 'table-view' : 'card-view'}`;
 
                 if (totalCount === 0) {
                     resultsGrid.innerHTML = `
@@ -918,81 +1170,200 @@
 
                 // Only render up to displayedCount items
                 const itemsToRender = items.slice(0, this.displayedCount);
+                const html = this.currentView === 'table'
+                    ? this.renderTableResults(itemsToRender, totalCount)
+                    : this.renderCardResults(itemsToRender, totalCount);
 
-                // Generic rendering based on schema displayFields
+                resultsGrid.innerHTML = html;
+            }
+
+            getCardFields() {
+                return this.schema.displayFields || this.schema.tableFields || [];
+            }
+
+            getTableFields() {
+                return this.schema.tableFields || this.schema.displayFields || [];
+            }
+
+            escapeHtml(value) {
+                return String(value)
+                    .replace(/&/g, '&amp;')
+                    .replace(/</g, '&lt;')
+                    .replace(/>/g, '&gt;')
+                    .replace(/"/g, '&quot;')
+                    .replace(/'/g, '&#039;');
+            }
+
+            fieldClass(fieldName) {
+                return fieldName.replace(/[^a-zA-Z0-9_-]/g, '_');
+            }
+
+            columnClass(fieldConfig) {
+                return this.fieldClass(fieldConfig.key || fieldConfig.field || fieldConfig.label);
+            }
+
+            plainValue(value) {
+                if (Array.isArray(value)) {
+                    return value.join('; ');
+                }
+                return String(value);
+            }
+
+            actionClass(value) {
+                return `action-${String(value).toLowerCase().replace(/_/g, '-').replace(/[^a-z0-9-]/g, '')}`;
+            }
+
+            renderValue(fieldConfig, value, mode, item = null) {
+                if (value === undefined || value === null) {
+                    return mode === 'table' ? '<span class="empty-cell"></span>' : '';
+                }
+
+                if (fieldConfig.type === 'array') {
+                    if (mode === 'card') {
+                        const values = Array.isArray(value) ? value : [value];
+                        return `
+                            <div class="array-values">
+                                ${values.map(v => `<span class="array-item">${this.escapeHtml(v)}</span>`).join('')}
+                            </div>
+                        `;
+                    }
+                    return this.escapeHtml(this.plainValue(value));
+                }
+
+                if (fieldConfig.field === 'review.action') {
+                    const escapedValue = this.escapeHtml(value);
+                    return `<span class="action-badge ${this.actionClass(value)}">${escapedValue}</span>`;
+                }
+
+                if (fieldConfig.type === 'curie' && String(value).includes(':')) {
+                    const escapedValue = this.escapeHtml(value);
+                    const curieUrl = `https://bioregistry.io/${escapedValue}`;
+                    return `<a href="${curieUrl}" target="_blank" style="color: #10b981; text-decoration: none; border-bottom: 1px dashed #10b981;">${escapedValue}</a>`;
+                }
+
+                if (fieldConfig.type === 'url' && value) {
+                    const escapedUrl = this.escapeHtml(value);
+                    const labelValue = fieldConfig.linkTextField && item
+                        ? item[fieldConfig.linkTextField]
+                        : fieldConfig.label;
+                    const label = labelValue === undefined || labelValue === null
+                        ? fieldConfig.label
+                        : labelValue;
+                    return `<a href="${escapedUrl}" target="_blank" style="color: #10b981; text-decoration: none; border-bottom: 1px dashed #10b981;">${this.escapeHtml(label)}</a>`;
+                }
+
+                return this.escapeHtml(value);
+            }
+
+            renderCompoundValue(fieldConfig, item, mode) {
+                const parts = (fieldConfig.parts || [])
+                    .map((partConfig, index) => {
+                        const value = item[partConfig.field];
+                        if (value === undefined || value === null) {
+                            return '';
+                        }
+
+                        const role = partConfig.role || (index === 0 ? 'primary' : 'secondary');
+                        const displayValue = this.renderValue(partConfig, value, mode, item);
+                        return `<span class="compound-${role}">${displayValue}</span>`;
+                    })
+                    .filter(Boolean)
+                    .join('');
+
+                return parts ? `<span class="compound-cell">${parts}</span>` : '<span class="empty-cell"></span>';
+            }
+
+            renderFieldValue(fieldConfig, item, mode) {
+                if (fieldConfig.type === 'compound') {
+                    return this.renderCompoundValue(fieldConfig, item, mode);
+                }
+                return this.renderValue(fieldConfig, item[fieldConfig.field], mode, item);
+            }
+
+            tableCellTitle(fieldConfig, item) {
+                if (fieldConfig.type === 'compound') {
+                    return (fieldConfig.parts || [])
+                        .map(partConfig => {
+                            if (partConfig.linkTextField && item[partConfig.linkTextField] !== undefined) {
+                                return item[partConfig.linkTextField];
+                            }
+                            return item[partConfig.field];
+                        })
+                        .filter(value => value !== undefined && value !== null)
+                        .map(value => this.plainValue(value))
+                        .join(' ');
+                }
+                const value = item[fieldConfig.field];
+                return value === undefined || value === null ? '' : this.plainValue(value);
+            }
+
+            renderLoadMore(totalCount) {
+                if (this.displayedCount >= totalCount) {
+                    return '';
+                }
+
+                const remaining = totalCount - this.displayedCount;
+                return `
+                    <div class="load-more-container">
+                        <button class="load-more-btn" id="loadMoreBtn">
+                            Load More Results
+                        </button>
+                        <div class="load-more-info">${remaining.toLocaleString()} more items available</div>
+                    </div>
+                `;
+            }
+
+            renderTableResults(itemsToRender, totalCount) {
+                const fields = this.getTableFields();
+                const headers = fields.map(fieldConfig => {
+                    const className = this.columnClass(fieldConfig);
+                    return `<th class="table-cell-${className}">${this.escapeHtml(fieldConfig.label)}</th>`;
+                }).join('');
+
+                const rows = itemsToRender.map(item => {
+                    const cells = fields.map(fieldConfig => {
+                        const className = this.columnClass(fieldConfig);
+                        const title = this.escapeHtml(this.tableCellTitle(fieldConfig, item));
+                        const displayValue = this.renderFieldValue(fieldConfig, item, 'table');
+                        return `<td class="table-cell-${className}"><span class="cell-content" title="${title}">${displayValue}</span></td>`;
+                    }).join('');
+                    return `<tr>${cells}</tr>`;
+                }).join('');
+
+                return `
+                    <div class="results-table-wrap">
+                        <table class="results-table">
+                            <thead><tr>${headers}</tr></thead>
+                            <tbody>${rows}</tbody>
+                        </table>
+                    </div>
+                    ${this.renderLoadMore(totalCount)}
+                `;
+            }
+
+            renderCardResults(itemsToRender, totalCount) {
                 let html = itemsToRender.map(item => {
-                    const fieldsHtml = this.schema.displayFields.map(fieldConfig => {
+                    const fieldsHtml = this.getCardFields().map(fieldConfig => {
                         const value = item[fieldConfig.field];
 
                         if (value === undefined || value === null) {
                             return '';
                         }
 
-                        if (fieldConfig.type === 'array') {
-                            if (Array.isArray(value)) {
-                                return `
-                                    <div class="field-display">
-                                        <span class="field-label">${fieldConfig.label}:</span>
-                                        <div class="array-values">
-                                            ${value.map(v => `<span class="array-item">${v}</span>`).join('')}
-                                        </div>
-                                    </div>
-                                `;
-                            } else {
-                                return `
-                                    <div class="field-display">
-                                        <span class="field-label">${fieldConfig.label}:</span>
-                                        <span class="array-item">${value}</span>
-                                    </div>
-                                `;
-                            }
-                        } else {
-                            let displayValue = value;
-                            if (fieldConfig.format === 'currency') {
-                                displayValue = `${value}`;
-                            }
+                        const displayValue = this.renderValue(fieldConfig, value, 'card', item);
 
-                            // Generic handling for CURIE type fields
-                            if (fieldConfig.type === 'curie' && value.includes(':')) {
-                                // Create hyperlink for any CURIE (Compact URI)
-                                const curieUrl = `https://bioregistry.io/${value}`;
-                                displayValue = `<a href="${curieUrl}" target="_blank" style="color: #10b981; text-decoration: none; border-bottom: 1px dashed #10b981;">${displayValue}</a>`;
-                            }
-
-                            // Generic handling for URL type fields
-                            if (fieldConfig.type === 'url' && value) {
-                                // Handle local URLs (starting with ../) or full URLs
-                                const isLocalUrl = value.startsWith('../');
-                                const target = isLocalUrl ? '_blank' : '_blank';  // Open both in new tab
-                                displayValue = `<a href="${value}" target="${target}" style="color: #10b981; text-decoration: none; border-bottom: 1px dashed #10b981;">${fieldConfig.label}</a>`;
-                            }
-
-                            return `
-                                <div class="field-display">
-                                    <span class="field-label">${fieldConfig.label}:</span>
-                                    <span class="field-value">${displayValue}</span>
-                                </div>
-                            `;
-                        }
+                        return `
+                            <div class="field-display">
+                                <span class="field-label">${this.escapeHtml(fieldConfig.label)}:</span>
+                                <span class="field-value">${displayValue}</span>
+                            </div>
+                        `;
                     }).join('');
 
                     return `<div class="result-card">${fieldsHtml}</div>`;
                 }).join('');
 
-                // Add "Load More" button if there are more items
-                if (this.displayedCount < totalCount) {
-                    const remaining = totalCount - this.displayedCount;
-                    html += `
-                        <div class="load-more-container">
-                            <button class="load-more-btn" id="loadMoreBtn">
-                                Load More Results
-                            </button>
-                            <div class="load-more-info">${remaining.toLocaleString()} more items available</div>
-                        </div>
-                    `;
-                }
-
-                resultsGrid.innerHTML = html;
+                return html + this.renderLoadMore(totalCount);
             }
             
             renderFacets(facetCounts) {

--- a/app/index.html
+++ b/app/index.html
@@ -105,12 +105,74 @@
         .sidebar {
             width: 280px;
             background: #f9fafb;
-            padding: 24px;
+            padding: 16px;
             border-right: 1px solid #e5e7eb;
+            transition: width 0.18s ease, padding 0.18s ease;
+            flex: 0 0 auto;
+        }
+
+        .sidebar.collapsed {
+            width: 64px !important;
+            min-width: 64px !important;
+            padding: 12px 8px;
+        }
+
+        .sidebar.collapsed #facetsSidebar {
+            display: none;
+        }
+
+        .sidebar.collapsed .sidebar-title {
+            display: none;
+        }
+
+        .sidebar-toolbar {
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+            gap: 8px;
+            margin-bottom: 12px;
+        }
+
+        .sidebar-title {
+            color: #374151;
+            font-size: 0.78rem;
+            font-weight: 700;
+            letter-spacing: 0.03em;
+            text-transform: uppercase;
+        }
+
+        .sidebar-toggle-btn {
+            border: 1px solid #d1d5db;
+            background: white;
+            color: #374151;
+            padding: 5px 8px;
+            border-radius: 5px;
+            cursor: pointer;
+            font-size: 12px;
+            font-weight: 700;
+            line-height: 1.2;
+            white-space: nowrap;
+        }
+
+        .sidebar-toggle-btn:hover {
+            background: #f3f4f6;
+        }
+
+        .sidebar-toggle-btn:focus-visible {
+            outline: 2px solid #10b981;
+            outline-offset: 2px;
+        }
+
+        .sidebar.collapsed .sidebar-toolbar {
+            justify-content: center;
+        }
+
+        .sidebar.collapsed .sidebar-toggle-btn {
+            padding: 6px 7px;
         }
 
         .facet-group {
-            margin-bottom: 16px;
+            margin-bottom: 10px;
             border: 1px solid #e5e7eb;
             border-radius: 6px;
             overflow: hidden;
@@ -121,7 +183,7 @@
             display: flex;
             align-items: center;
             justify-content: space-between;
-            padding: 12px 16px;
+            padding: 9px 11px;
             background: white;
             cursor: pointer;
             user-select: none;
@@ -134,15 +196,15 @@
         }
 
         .facet-title {
-            font-size: 0.95rem;
+            font-size: 0.8rem;
             font-weight: 600;
             color: #111827;
             margin: 0;
-            letter-spacing: -0.2px;
+            letter-spacing: 0;
         }
 
         .facet-toggle {
-            font-size: 0.9rem;
+            font-size: 0.75rem;
             color: #10b981;
             transition: transform 0.2s ease;
             font-weight: 600;
@@ -153,7 +215,7 @@
         }
 
         .facet-content {
-            padding: 15px 20px;
+            padding: 10px 12px;
             max-height: 400px;
             overflow-y: auto;
             transition: all 0.3s ease;
@@ -168,12 +230,12 @@
         .facet-item {
             display: flex;
             align-items: center;
-            margin-bottom: 6px;
-            padding: 7px 12px;
+            margin-bottom: 4px;
+            padding: 5px 8px;
             border-radius: 4px;
             transition: all 0.15s ease;
             cursor: pointer;
-            font-size: 0.9rem;
+            font-size: 0.78rem;
         }
 
         .facet-item:hover {
@@ -186,9 +248,9 @@
         }
 
         .facet-checkbox {
-            margin-right: 10px;
-            width: 16px;
-            height: 16px;
+            margin-right: 7px;
+            width: 14px;
+            height: 14px;
             accent-color: #10b981;
             cursor: pointer;
         }
@@ -197,9 +259,9 @@
             margin-left: auto;
             background: #f3f4f6;
             color: #6b7280;
-            padding: 2px 7px;
+            padding: 1px 6px;
             border-radius: 10px;
-            font-size: 11px;
+            font-size: 10px;
             font-weight: 600;
             min-width: 24px;
             text-align: center;
@@ -284,6 +346,22 @@
             font-size: 13px;
             font-weight: 500;
             transition: all 0.15s ease;
+        }
+
+        .export-tsv {
+            background: #f3f4f6;
+            color: #374151;
+            border: 1px solid #d1d5db;
+            padding: 7px 14px;
+            border-radius: 4px;
+            cursor: pointer;
+            font-size: 13px;
+            font-weight: 500;
+            transition: all 0.15s ease;
+        }
+
+        .export-tsv:hover {
+            background: #e5e7eb;
         }
 
         .clear-filters:hover {
@@ -517,8 +595,24 @@
             padding: 20px;
         }
 
-        .results-grid.table-view .load-more-container {
-            padding-bottom: 0;
+        .load-more-container.top-load-more {
+            display: flex;
+            align-items: center;
+            justify-content: flex-end;
+            gap: 12px;
+            padding: 0 0 12px;
+            text-align: right;
+        }
+
+        .top-load-more .load-more-info {
+            margin-top: 0;
+            order: -1;
+            white-space: nowrap;
+        }
+
+        .top-load-more .load-more-btn {
+            padding: 8px 16px;
+            font-size: 13px;
         }
 
         .load-more-btn {
@@ -622,6 +716,11 @@
                 width: 100%;
             }
 
+            .sidebar.collapsed {
+                width: 100% !important;
+                min-width: 0 !important;
+            }
+
             .results-header {
                 align-items: flex-start;
                 flex-direction: column;
@@ -659,14 +758,21 @@
         </div>
 
         <div class="main-content">
-            <div class="sidebar" id="facetsSidebar">
-                <!-- Facets will be generated here -->
+            <div class="sidebar" id="facetsPanel">
+                <div class="sidebar-toolbar">
+                    <span class="sidebar-title">Filters</span>
+                    <button type="button" class="sidebar-toggle-btn" id="toggleFacets" aria-expanded="true">Hide</button>
+                </div>
+                <div id="facetsSidebar">
+                    <!-- Facets will be generated here -->
+                </div>
             </div>
 
             <div class="results-area">
                 <div class="results-header">
                     <div class="results-count" id="resultsCount">Loading...</div>
                     <div class="results-controls">
+                        <button class="export-tsv" id="exportTsv">Export TSV</button>
                         <button class="clear-filters" id="clearFilters">Clear All Filters</button>
                     </div>
                 </div>
@@ -691,6 +797,7 @@
                 this.currentFilters = {};
                 this.currentQuery = '';
                 this.currentView = schema.defaultView || 'table';
+                this.sidebarCollapsed = false;
 
                 // Track collapsed facets
                 this.collapsedFacets = new Set();
@@ -859,6 +966,14 @@
                     this.clearAllFilters();
                 });
 
+                document.getElementById('exportTsv').addEventListener('click', () => {
+                    this.exportCurrentResultsToTsv();
+                });
+
+                document.getElementById('toggleFacets').addEventListener('click', () => {
+                    this.toggleSidebar();
+                });
+
                 document.querySelectorAll('.view-toggle-btn').forEach(button => {
                     button.addEventListener('click', () => {
                         this.currentView = button.dataset.view;
@@ -887,6 +1002,15 @@
                         }
                     }
                 });
+            }
+
+            toggleSidebar() {
+                this.sidebarCollapsed = !this.sidebarCollapsed;
+                const sidebar = document.getElementById('facetsPanel');
+                const button = document.getElementById('toggleFacets');
+                sidebar.classList.toggle('collapsed', this.sidebarCollapsed);
+                button.setAttribute('aria-expanded', String(!this.sidebarCollapsed));
+                button.textContent = this.sidebarCollapsed ? 'Show' : 'Hide';
             }
 
             updateViewToggle() {
@@ -1211,6 +1335,76 @@
                 return String(value);
             }
 
+            tsvCell(value) {
+                if (value === undefined || value === null) {
+                    return '';
+                }
+                const text = this.plainValue(value)
+                    .replace(/\r?\n|\r/g, ' ')
+                    .replace(/\t/g, ' ')
+                    .trim();
+                return /^[=+\-@]/.test(text) ? `'${text}` : text;
+            }
+
+            exportPartText(partConfig, item) {
+                const value = item[partConfig.field];
+                if (value === undefined || value === null) {
+                    return '';
+                }
+
+                if (partConfig.linkTextField && item[partConfig.linkTextField] !== undefined && item[partConfig.linkTextField] !== null) {
+                    const label = this.plainValue(item[partConfig.linkTextField]);
+                    if (partConfig.type === 'curie') {
+                        return `${label} (${this.plainValue(value)})`;
+                    }
+                    return label;
+                }
+
+                return this.plainValue(value);
+            }
+
+            exportFieldText(fieldConfig, item) {
+                if (fieldConfig.type === 'compound') {
+                    return (fieldConfig.parts || [])
+                        .map(partConfig => this.exportPartText(partConfig, item))
+                        .filter(Boolean)
+                        .join(' | ');
+                }
+
+                if (fieldConfig.linkTextField && item[fieldConfig.linkTextField] !== undefined && item[fieldConfig.linkTextField] !== null) {
+                    const label = this.plainValue(item[fieldConfig.linkTextField]);
+                    const value = item[fieldConfig.field];
+                    if (fieldConfig.type === 'curie') {
+                        return `${label} (${this.plainValue(value)})`;
+                    }
+                    return label;
+                }
+
+                const value = item[fieldConfig.field];
+                return value === undefined || value === null ? '' : this.plainValue(value);
+            }
+
+            exportCurrentResultsToTsv() {
+                const fields = this.getTableFields();
+                const rows = this.currentFilteredData || [];
+                const header = fields.map(fieldConfig => this.tsvCell(fieldConfig.label)).join('\t');
+                const body = rows.map(item => fields
+                    .map(fieldConfig => this.tsvCell(this.exportFieldText(fieldConfig, item)))
+                    .join('\t')
+                );
+                const tsv = [header, ...body].join('\n') + '\n';
+                const blob = new Blob([tsv], { type: 'text/tab-separated-values;charset=utf-8' });
+                const url = URL.createObjectURL(blob);
+                const link = document.createElement('a');
+                const date = new Date().toISOString().slice(0, 10);
+                link.href = url;
+                link.download = `gene-annotation-review-${date}.tsv`;
+                document.body.appendChild(link);
+                link.click();
+                link.remove();
+                URL.revokeObjectURL(url);
+            }
+
             actionClass(value) {
                 return `action-${String(value).toLowerCase().replace(/_/g, '-').replace(/[^a-z0-9-]/g, '')}`;
             }
@@ -1305,14 +1499,15 @@
                 return value === undefined || value === null ? '' : this.plainValue(value);
             }
 
-            renderLoadMore(totalCount) {
+            renderLoadMore(totalCount, placement = 'bottom') {
                 if (this.displayedCount >= totalCount) {
                     return '';
                 }
 
                 const remaining = totalCount - this.displayedCount;
+                const placementClass = placement === 'top' ? ' top-load-more' : '';
                 return `
-                    <div class="load-more-container">
+                    <div class="load-more-container${placementClass}">
                         <button class="load-more-btn" id="loadMoreBtn">
                             Load More Results
                         </button>
@@ -1339,13 +1534,13 @@
                 }).join('');
 
                 return `
+                    ${this.renderLoadMore(totalCount, 'top')}
                     <div class="results-table-wrap">
                         <table class="results-table">
                             <thead><tr>${headers}</tr></thead>
                             <tbody>${rows}</tbody>
                         </table>
                     </div>
-                    ${this.renderLoadMore(totalCount)}
                 `;
             }
 

--- a/app/schema.js
+++ b/app/schema.js
@@ -135,20 +135,10 @@ window.searchSchema = {
           "field": "term_id",
           "label": "GO ID",
           "type": "curie",
+          "linkTextField": "term_label",
           "role": "primary"
-        },
-        {
-          "field": "term_label",
-          "label": "GO Term",
-          "type": "string",
-          "role": "secondary"
         }
       ]
-    },
-    {
-      "field": "term_ontology",
-      "label": "Aspect",
-      "type": "string"
     },
     {
       "field": "evidence_type",
@@ -164,13 +154,8 @@ window.searchSchema = {
           "field": "original_reference_id",
           "label": "Orig Ref",
           "type": "curie",
+          "linkTextField": "original_reference_title",
           "role": "primary"
-        },
-        {
-          "field": "original_reference_title",
-          "label": "Orig Title",
-          "type": "string",
-          "role": "secondary"
         }
       ]
     },

--- a/app/schema.js
+++ b/app/schema.js
@@ -5,6 +5,7 @@ window.searchSchema = {
   "id": "https://example.org/gene-annotation-review",
   "itemsPerPage": 50,
   "facetItemsToShow": 15,
+  "defaultView": "table",
   "customCss": ".sidebar { width: 340px; min-width: 340px; } .results-grid { grid-template-columns: 1fr; }",
   "searchableFields": [
     "gene_symbol",
@@ -102,6 +103,101 @@ window.searchSchema = {
       "label": "Tags",
       "type": "array",
       "sortBy": "count"
+    }
+  ],
+  "tableFields": [
+    {
+      "label": "Gene",
+      "type": "compound",
+      "key": "gene",
+      "parts": [
+        {
+          "field": "review_html_link",
+          "label": "Gene",
+          "type": "url",
+          "linkTextField": "gene_symbol",
+          "role": "primary"
+        },
+        {
+          "field": "protein_id",
+          "label": "ID",
+          "type": "string",
+          "role": "secondary"
+        }
+      ]
+    },
+    {
+      "label": "GO Term",
+      "type": "compound",
+      "key": "go_term",
+      "parts": [
+        {
+          "field": "term_id",
+          "label": "GO ID",
+          "type": "curie",
+          "role": "primary"
+        },
+        {
+          "field": "term_label",
+          "label": "GO Term",
+          "type": "string",
+          "role": "secondary"
+        }
+      ]
+    },
+    {
+      "field": "term_ontology",
+      "label": "Aspect",
+      "type": "string"
+    },
+    {
+      "field": "evidence_type",
+      "label": "Evidence",
+      "type": "string"
+    },
+    {
+      "label": "Reference",
+      "type": "compound",
+      "key": "reference",
+      "parts": [
+        {
+          "field": "original_reference_id",
+          "label": "Orig Ref",
+          "type": "curie",
+          "role": "primary"
+        },
+        {
+          "field": "original_reference_title",
+          "label": "Orig Title",
+          "type": "string",
+          "role": "secondary"
+        }
+      ]
+    },
+    {
+      "field": "review.action",
+      "label": "Action",
+      "type": "string"
+    },
+    {
+      "field": "review.summary",
+      "label": "Summary",
+      "type": "string"
+    },
+    {
+      "field": "review.reason",
+      "label": "Reason",
+      "type": "string"
+    },
+    {
+      "field": "review.proposed_replacement_terms",
+      "label": "Replacements",
+      "type": "string"
+    },
+    {
+      "field": "status",
+      "label": "Status",
+      "type": "string"
     }
   ],
   "displayFields": [

--- a/project.justfile
+++ b/project.justfile
@@ -1592,19 +1592,25 @@ gen-all: gen-project pydantic
 
 # Deploy linkml-browser app for viewing exported annotations
 deploy-browser: export-annotations-json
-    @echo "Deploying linkml-browser to app/ directory..."
-    @rm -rf app
+    #!/usr/bin/env bash
+    set -euo pipefail
+    echo "Deploying linkml-browser to app/ directory..."
+    tmp_dir="$(mktemp -d)"
+    trap 'rm -rf "$tmp_dir"' EXIT
     uv run linkml-browser deploy \
         exports/exported_annotations.json \
-        app \
+        "$tmp_dir" \
         --schema src/ai_gene_review/schema/display_schema.json \
         --title "Gene Annotation Review Browser" \
         --description "Browse and filter gene annotation reviews" \
         --force
-    uv run python src/ai_gene_review/tools/minify_linkml_browser_data.py app/data.js
-    @cp src/ai_gene_review/browser/index.html app/
-    @echo "Browser deployed to app/ directory"
-    @echo "To view: open app/index.html or run 'just serve-browser'"
+    uv run python src/ai_gene_review/tools/minify_linkml_browser_data.py "$tmp_dir/data.js"
+    mkdir -p app
+    cp "$tmp_dir/data.js" app/data.js
+    cp "$tmp_dir/schema.js" app/schema.js
+    cp src/ai_gene_review/browser/index.html app/
+    echo "Browser deployed to app/ directory"
+    echo "To view: open app/index.html or run 'just serve-browser'"
 
 # Serve the linkml-browser app locally  
 serve-browser:
@@ -1613,17 +1619,24 @@ serve-browser:
 
 # Update browser data without regenerating HTML
 update-browser-data: export-annotations-json
-    @echo "Updating browser data..."
+    #!/usr/bin/env bash
+    set -euo pipefail
+    echo "Updating browser data..."
+    tmp_dir="$(mktemp -d)"
+    trap 'rm -rf "$tmp_dir"' EXIT
     uv run linkml-browser deploy \
         exports/exported_annotations.json \
-        app \
+        "$tmp_dir" \
         --schema src/ai_gene_review/schema/display_schema.json \
         --title "Gene Annotation Review Browser" \
         --description "Browse and filter gene annotation reviews" \
         --force
-    uv run python src/ai_gene_review/tools/minify_linkml_browser_data.py app/data.js
-    @cp src/ai_gene_review/browser/index.html app/
-    @echo "Data updated in app/"
+    uv run python src/ai_gene_review/tools/minify_linkml_browser_data.py "$tmp_dir/data.js"
+    mkdir -p app
+    cp "$tmp_dir/data.js" app/data.js
+    cp "$tmp_dir/schema.js" app/schema.js
+    cp src/ai_gene_review/browser/index.html app/
+    echo "Data updated in app/"
 
 # ============== Markdown and Documentation Tools ==============
 

--- a/src/ai_gene_review/browser/index.html
+++ b/src/ai_gene_review/browser/index.html
@@ -212,6 +212,7 @@
 
         .results-area {
             flex: 1;
+            min-width: 0;
             padding: 24px;
             background: white;
         }
@@ -302,14 +303,16 @@
 
         .results-table-wrap {
             width: 100%;
-            overflow-x: visible;
+            overflow-x: auto;
             border: 1px solid #e5e7eb;
             border-radius: 6px;
             background: white;
+            scrollbar-gutter: stable;
         }
 
         .results-table {
             width: 100%;
+            min-width: 1220px;
             border-collapse: collapse;
             table-layout: fixed;
             font-size: 11px;
@@ -347,15 +350,14 @@
         }
 
         .table-cell-gene { width: 13%; }
-        .table-cell-go_term { width: 21%; }
-        .table-cell-term_ontology { width: 7%; }
+        .table-cell-go_term { width: 23%; }
         .table-cell-evidence_type { width: 6%; }
-        .table-cell-reference { width: 12%; }
-        .table-cell-review_action { width: 9%; }
-        .table-cell-review_summary { width: 11%; }
-        .table-cell-review_reason { width: 11%; }
-        .table-cell-review_proposed_replacement_terms { width: 6%; }
-        .table-cell-status { width: 4%; }
+        .table-cell-reference { width: 16%; }
+        .table-cell-review_action { width: 8%; }
+        .table-cell-review_summary { width: 12%; }
+        .table-cell-review_reason { width: 12%; }
+        .table-cell-review_proposed_replacement_terms { width: 5%; }
+        .table-cell-status { width: 5%; }
 
         .cell-content {
             display: block;
@@ -1237,8 +1239,14 @@
 
                 if (fieldConfig.type === 'curie' && String(value).includes(':')) {
                     const escapedValue = this.escapeHtml(value);
+                    const labelValue = fieldConfig.linkTextField && item
+                        ? item[fieldConfig.linkTextField]
+                        : value;
+                    const label = labelValue === undefined || labelValue === null
+                        ? value
+                        : labelValue;
                     const curieUrl = `https://bioregistry.io/${escapedValue}`;
-                    return `<a href="${curieUrl}" target="_blank" style="color: #10b981; text-decoration: none; border-bottom: 1px dashed #10b981;">${escapedValue}</a>`;
+                    return `<a href="${curieUrl}" target="_blank" style="color: #10b981; text-decoration: none; border-bottom: 1px dashed #10b981;">${this.escapeHtml(label)}</a>`;
                 }
 
                 if (fieldConfig.type === 'url' && value) {

--- a/src/ai_gene_review/browser/index.html
+++ b/src/ai_gene_review/browser/index.html
@@ -70,6 +70,7 @@
             display: flex;
             gap: 12px;
             align-items: center;
+            flex-wrap: wrap;
         }
 
         .search-box {
@@ -93,6 +94,7 @@
             color: #6b7280;
             font-weight: 500;
             font-family: 'SF Mono', 'Monaco', monospace;
+            white-space: nowrap;
         }
 
         .main-content {
@@ -218,6 +220,7 @@
             display: flex;
             justify-content: space-between;
             align-items: center;
+            gap: 16px;
             margin-bottom: 20px;
             padding-bottom: 12px;
             border-bottom: 1px solid #e5e7eb;
@@ -227,6 +230,47 @@
             font-size: 1rem;
             color: #374151;
             font-weight: 500;
+        }
+
+        .results-controls {
+            display: flex;
+            align-items: center;
+            gap: 10px;
+            flex-wrap: wrap;
+            justify-content: flex-end;
+        }
+
+        .view-toggle {
+            display: inline-flex;
+            border: 1px solid #d1d5db;
+            border-radius: 6px;
+            overflow: hidden;
+            background: white;
+        }
+
+        .view-toggle-btn {
+            border: 0;
+            background: white;
+            color: #374151;
+            padding: 7px 12px;
+            font-size: 13px;
+            font-weight: 600;
+            cursor: pointer;
+            border-right: 1px solid #d1d5db;
+        }
+
+        .view-toggle-btn:last-child {
+            border-right: 0;
+        }
+
+        .view-toggle-btn.active {
+            background: #10b981;
+            color: white;
+        }
+
+        .view-toggle-btn:focus-visible {
+            outline: 2px solid #10b981;
+            outline-offset: 2px;
         }
 
         .clear-filters {
@@ -250,6 +294,159 @@
             display: grid;
             grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
             gap: 20px;
+        }
+
+        .results-grid.table-view {
+            display: block;
+        }
+
+        .results-table-wrap {
+            width: 100%;
+            overflow-x: visible;
+            border: 1px solid #e5e7eb;
+            border-radius: 6px;
+            background: white;
+        }
+
+        .results-table {
+            width: 100%;
+            border-collapse: collapse;
+            table-layout: fixed;
+            font-size: 11px;
+        }
+
+        .results-table th,
+        .results-table td {
+            border-bottom: 1px solid #e5e7eb;
+            padding: 5px 6px;
+            text-align: left;
+            vertical-align: middle;
+        }
+
+        .results-table th {
+            position: sticky;
+            top: 0;
+            z-index: 1;
+            background: #f9fafb;
+            color: #374151;
+            font-size: 11px;
+            font-weight: 700;
+            text-transform: uppercase;
+            letter-spacing: 0.02em;
+            white-space: nowrap;
+            overflow: hidden;
+            text-overflow: ellipsis;
+        }
+
+        .results-table tbody tr:hover {
+            background: #f9fafb;
+        }
+
+        .results-table tbody tr:last-child td {
+            border-bottom: 0;
+        }
+
+        .table-cell-gene { width: 13%; }
+        .table-cell-go_term { width: 21%; }
+        .table-cell-term_ontology { width: 7%; }
+        .table-cell-evidence_type { width: 6%; }
+        .table-cell-reference { width: 12%; }
+        .table-cell-review_action { width: 9%; }
+        .table-cell-review_summary { width: 11%; }
+        .table-cell-review_reason { width: 11%; }
+        .table-cell-review_proposed_replacement_terms { width: 6%; }
+        .table-cell-status { width: 4%; }
+
+        .cell-content {
+            display: block;
+            max-width: 100%;
+            overflow: hidden;
+            text-overflow: ellipsis;
+            white-space: nowrap;
+        }
+
+        .compound-cell {
+            display: flex;
+            align-items: baseline;
+            gap: 6px;
+            min-width: 0;
+        }
+
+        .compound-primary {
+            flex: 1 1 auto;
+            font-weight: 700;
+            color: #111827;
+            min-width: 0;
+            overflow: hidden;
+            text-overflow: ellipsis;
+            white-space: nowrap;
+        }
+
+        .compound-secondary {
+            flex: 0 1 auto;
+            color: #6b7280;
+            min-width: 0;
+            overflow: hidden;
+            text-overflow: ellipsis;
+            white-space: nowrap;
+        }
+
+        .compound-link {
+            flex: 0 0 auto;
+        }
+
+        .empty-cell {
+            color: #9ca3af;
+        }
+
+        .action-badge {
+            display: inline-block;
+            max-width: 100%;
+            padding: 2px 6px;
+            border-radius: 4px;
+            font-size: 11px;
+            line-height: 1.3;
+            font-weight: 700;
+            overflow: hidden;
+            text-overflow: ellipsis;
+            white-space: nowrap;
+            vertical-align: middle;
+        }
+
+        .action-accept {
+            background: #d1fae5;
+            color: #065f46;
+        }
+
+        .action-keep-as-non-core {
+            background: #dbeafe;
+            color: #1e40af;
+        }
+
+        .action-remove {
+            background: #fee2e2;
+            color: #991b1b;
+        }
+
+        .action-modify {
+            background: #fef3c7;
+            color: #92400e;
+        }
+
+        .action-mark-as-over-annotated {
+            background: #ffedd5;
+            color: #9a3412;
+        }
+
+        .action-undecided,
+        .action-pending {
+            background: #e5e7eb;
+            color: #374151;
+        }
+
+        .action-new {
+            background: #ccfbf1;
+            color: #115e59;
         }
 
         .result-card {
@@ -316,6 +513,10 @@
             grid-column: 1 / -1;
             text-align: center;
             padding: 20px;
+        }
+
+        .results-grid.table-view .load-more-container {
+            padding-bottom: 0;
         }
 
         .load-more-btn {
@@ -403,12 +604,38 @@
         }
 
         @media (max-width: 768px) {
+            .search-container {
+                align-items: stretch;
+            }
+
+            .search-box {
+                flex-basis: 100%;
+            }
+
             .main-content {
                 flex-direction: column;
             }
             
             .sidebar {
                 width: 100%;
+            }
+
+            .results-header {
+                align-items: flex-start;
+                flex-direction: column;
+            }
+
+            .results-controls {
+                width: 100%;
+                justify-content: space-between;
+            }
+
+            .results-table-wrap {
+                overflow-x: auto;
+            }
+
+            .results-table {
+                min-width: 980px;
             }
         }
     </style>
@@ -422,6 +649,10 @@
 
         <div class="search-container">
             <input type="text" id="searchBox" class="search-box" placeholder="Search products...">
+            <div class="view-toggle" role="group" aria-label="Results view">
+                <button type="button" class="view-toggle-btn active" data-view="table" aria-pressed="true">Table</button>
+                <button type="button" class="view-toggle-btn" data-view="card" aria-pressed="false">Cards</button>
+            </div>
             <div class="performance-info" id="performanceInfo">Ready</div>
         </div>
 
@@ -433,7 +664,9 @@
             <div class="results-area">
                 <div class="results-header">
                     <div class="results-count" id="resultsCount">Loading...</div>
-                    <button class="clear-filters" id="clearFilters">Clear All Filters</button>
+                    <div class="results-controls">
+                        <button class="clear-filters" id="clearFilters">Clear All Filters</button>
+                    </div>
                 </div>
                 <div class="results-grid" id="resultsGrid"></div>
             </div>
@@ -455,6 +688,7 @@
                 this.schema = schema;
                 this.currentFilters = {};
                 this.currentQuery = '';
+                this.currentView = schema.defaultView || 'table';
 
                 // Track collapsed facets
                 this.collapsedFacets = new Set();
@@ -623,6 +857,15 @@
                     this.clearAllFilters();
                 });
 
+                document.querySelectorAll('.view-toggle-btn').forEach(button => {
+                    button.addEventListener('click', () => {
+                        this.currentView = button.dataset.view;
+                        this.updateViewToggle();
+                        this.renderResults();
+                    });
+                });
+                this.updateViewToggle();
+
                 // Load more button (delegated since it's dynamically created)
                 document.addEventListener('click', (e) => {
                     if (e.target.id === 'loadMoreBtn') {
@@ -641,6 +884,14 @@
                             this.renderFacets(this.currentFacetCounts);
                         }
                     }
+                });
+            }
+
+            updateViewToggle() {
+                document.querySelectorAll('.view-toggle-btn').forEach(button => {
+                    const isActive = button.dataset.view === this.currentView;
+                    button.classList.toggle('active', isActive);
+                    button.setAttribute('aria-pressed', String(isActive));
                 });
             }
             
@@ -904,6 +1155,7 @@
                 const totalCount = items.length;
                 const showingCount = Math.min(this.displayedCount, totalCount);
                 resultsCount.textContent = `Showing ${showingCount} of ${totalCount} items`;
+                resultsGrid.className = `results-grid ${this.currentView === 'table' ? 'table-view' : 'card-view'}`;
 
                 if (totalCount === 0) {
                     resultsGrid.innerHTML = `
@@ -918,81 +1170,200 @@
 
                 // Only render up to displayedCount items
                 const itemsToRender = items.slice(0, this.displayedCount);
+                const html = this.currentView === 'table'
+                    ? this.renderTableResults(itemsToRender, totalCount)
+                    : this.renderCardResults(itemsToRender, totalCount);
 
-                // Generic rendering based on schema displayFields
+                resultsGrid.innerHTML = html;
+            }
+
+            getCardFields() {
+                return this.schema.displayFields || this.schema.tableFields || [];
+            }
+
+            getTableFields() {
+                return this.schema.tableFields || this.schema.displayFields || [];
+            }
+
+            escapeHtml(value) {
+                return String(value)
+                    .replace(/&/g, '&amp;')
+                    .replace(/</g, '&lt;')
+                    .replace(/>/g, '&gt;')
+                    .replace(/"/g, '&quot;')
+                    .replace(/'/g, '&#039;');
+            }
+
+            fieldClass(fieldName) {
+                return fieldName.replace(/[^a-zA-Z0-9_-]/g, '_');
+            }
+
+            columnClass(fieldConfig) {
+                return this.fieldClass(fieldConfig.key || fieldConfig.field || fieldConfig.label);
+            }
+
+            plainValue(value) {
+                if (Array.isArray(value)) {
+                    return value.join('; ');
+                }
+                return String(value);
+            }
+
+            actionClass(value) {
+                return `action-${String(value).toLowerCase().replace(/_/g, '-').replace(/[^a-z0-9-]/g, '')}`;
+            }
+
+            renderValue(fieldConfig, value, mode, item = null) {
+                if (value === undefined || value === null) {
+                    return mode === 'table' ? '<span class="empty-cell"></span>' : '';
+                }
+
+                if (fieldConfig.type === 'array') {
+                    if (mode === 'card') {
+                        const values = Array.isArray(value) ? value : [value];
+                        return `
+                            <div class="array-values">
+                                ${values.map(v => `<span class="array-item">${this.escapeHtml(v)}</span>`).join('')}
+                            </div>
+                        `;
+                    }
+                    return this.escapeHtml(this.plainValue(value));
+                }
+
+                if (fieldConfig.field === 'review.action') {
+                    const escapedValue = this.escapeHtml(value);
+                    return `<span class="action-badge ${this.actionClass(value)}">${escapedValue}</span>`;
+                }
+
+                if (fieldConfig.type === 'curie' && String(value).includes(':')) {
+                    const escapedValue = this.escapeHtml(value);
+                    const curieUrl = `https://bioregistry.io/${escapedValue}`;
+                    return `<a href="${curieUrl}" target="_blank" style="color: #10b981; text-decoration: none; border-bottom: 1px dashed #10b981;">${escapedValue}</a>`;
+                }
+
+                if (fieldConfig.type === 'url' && value) {
+                    const escapedUrl = this.escapeHtml(value);
+                    const labelValue = fieldConfig.linkTextField && item
+                        ? item[fieldConfig.linkTextField]
+                        : fieldConfig.label;
+                    const label = labelValue === undefined || labelValue === null
+                        ? fieldConfig.label
+                        : labelValue;
+                    return `<a href="${escapedUrl}" target="_blank" style="color: #10b981; text-decoration: none; border-bottom: 1px dashed #10b981;">${this.escapeHtml(label)}</a>`;
+                }
+
+                return this.escapeHtml(value);
+            }
+
+            renderCompoundValue(fieldConfig, item, mode) {
+                const parts = (fieldConfig.parts || [])
+                    .map((partConfig, index) => {
+                        const value = item[partConfig.field];
+                        if (value === undefined || value === null) {
+                            return '';
+                        }
+
+                        const role = partConfig.role || (index === 0 ? 'primary' : 'secondary');
+                        const displayValue = this.renderValue(partConfig, value, mode, item);
+                        return `<span class="compound-${role}">${displayValue}</span>`;
+                    })
+                    .filter(Boolean)
+                    .join('');
+
+                return parts ? `<span class="compound-cell">${parts}</span>` : '<span class="empty-cell"></span>';
+            }
+
+            renderFieldValue(fieldConfig, item, mode) {
+                if (fieldConfig.type === 'compound') {
+                    return this.renderCompoundValue(fieldConfig, item, mode);
+                }
+                return this.renderValue(fieldConfig, item[fieldConfig.field], mode, item);
+            }
+
+            tableCellTitle(fieldConfig, item) {
+                if (fieldConfig.type === 'compound') {
+                    return (fieldConfig.parts || [])
+                        .map(partConfig => {
+                            if (partConfig.linkTextField && item[partConfig.linkTextField] !== undefined) {
+                                return item[partConfig.linkTextField];
+                            }
+                            return item[partConfig.field];
+                        })
+                        .filter(value => value !== undefined && value !== null)
+                        .map(value => this.plainValue(value))
+                        .join(' ');
+                }
+                const value = item[fieldConfig.field];
+                return value === undefined || value === null ? '' : this.plainValue(value);
+            }
+
+            renderLoadMore(totalCount) {
+                if (this.displayedCount >= totalCount) {
+                    return '';
+                }
+
+                const remaining = totalCount - this.displayedCount;
+                return `
+                    <div class="load-more-container">
+                        <button class="load-more-btn" id="loadMoreBtn">
+                            Load More Results
+                        </button>
+                        <div class="load-more-info">${remaining.toLocaleString()} more items available</div>
+                    </div>
+                `;
+            }
+
+            renderTableResults(itemsToRender, totalCount) {
+                const fields = this.getTableFields();
+                const headers = fields.map(fieldConfig => {
+                    const className = this.columnClass(fieldConfig);
+                    return `<th class="table-cell-${className}">${this.escapeHtml(fieldConfig.label)}</th>`;
+                }).join('');
+
+                const rows = itemsToRender.map(item => {
+                    const cells = fields.map(fieldConfig => {
+                        const className = this.columnClass(fieldConfig);
+                        const title = this.escapeHtml(this.tableCellTitle(fieldConfig, item));
+                        const displayValue = this.renderFieldValue(fieldConfig, item, 'table');
+                        return `<td class="table-cell-${className}"><span class="cell-content" title="${title}">${displayValue}</span></td>`;
+                    }).join('');
+                    return `<tr>${cells}</tr>`;
+                }).join('');
+
+                return `
+                    <div class="results-table-wrap">
+                        <table class="results-table">
+                            <thead><tr>${headers}</tr></thead>
+                            <tbody>${rows}</tbody>
+                        </table>
+                    </div>
+                    ${this.renderLoadMore(totalCount)}
+                `;
+            }
+
+            renderCardResults(itemsToRender, totalCount) {
                 let html = itemsToRender.map(item => {
-                    const fieldsHtml = this.schema.displayFields.map(fieldConfig => {
+                    const fieldsHtml = this.getCardFields().map(fieldConfig => {
                         const value = item[fieldConfig.field];
 
                         if (value === undefined || value === null) {
                             return '';
                         }
 
-                        if (fieldConfig.type === 'array') {
-                            if (Array.isArray(value)) {
-                                return `
-                                    <div class="field-display">
-                                        <span class="field-label">${fieldConfig.label}:</span>
-                                        <div class="array-values">
-                                            ${value.map(v => `<span class="array-item">${v}</span>`).join('')}
-                                        </div>
-                                    </div>
-                                `;
-                            } else {
-                                return `
-                                    <div class="field-display">
-                                        <span class="field-label">${fieldConfig.label}:</span>
-                                        <span class="array-item">${value}</span>
-                                    </div>
-                                `;
-                            }
-                        } else {
-                            let displayValue = value;
-                            if (fieldConfig.format === 'currency') {
-                                displayValue = `${value}`;
-                            }
+                        const displayValue = this.renderValue(fieldConfig, value, 'card', item);
 
-                            // Generic handling for CURIE type fields
-                            if (fieldConfig.type === 'curie' && value.includes(':')) {
-                                // Create hyperlink for any CURIE (Compact URI)
-                                const curieUrl = `https://bioregistry.io/${value}`;
-                                displayValue = `<a href="${curieUrl}" target="_blank" style="color: #10b981; text-decoration: none; border-bottom: 1px dashed #10b981;">${displayValue}</a>`;
-                            }
-
-                            // Generic handling for URL type fields
-                            if (fieldConfig.type === 'url' && value) {
-                                // Handle local URLs (starting with ../) or full URLs
-                                const isLocalUrl = value.startsWith('../');
-                                const target = isLocalUrl ? '_blank' : '_blank';  // Open both in new tab
-                                displayValue = `<a href="${value}" target="${target}" style="color: #10b981; text-decoration: none; border-bottom: 1px dashed #10b981;">${fieldConfig.label}</a>`;
-                            }
-
-                            return `
-                                <div class="field-display">
-                                    <span class="field-label">${fieldConfig.label}:</span>
-                                    <span class="field-value">${displayValue}</span>
-                                </div>
-                            `;
-                        }
+                        return `
+                            <div class="field-display">
+                                <span class="field-label">${this.escapeHtml(fieldConfig.label)}:</span>
+                                <span class="field-value">${displayValue}</span>
+                            </div>
+                        `;
                     }).join('');
 
                     return `<div class="result-card">${fieldsHtml}</div>`;
                 }).join('');
 
-                // Add "Load More" button if there are more items
-                if (this.displayedCount < totalCount) {
-                    const remaining = totalCount - this.displayedCount;
-                    html += `
-                        <div class="load-more-container">
-                            <button class="load-more-btn" id="loadMoreBtn">
-                                Load More Results
-                            </button>
-                            <div class="load-more-info">${remaining.toLocaleString()} more items available</div>
-                        </div>
-                    `;
-                }
-
-                resultsGrid.innerHTML = html;
+                return html + this.renderLoadMore(totalCount);
             }
             
             renderFacets(facetCounts) {

--- a/src/ai_gene_review/browser/index.html
+++ b/src/ai_gene_review/browser/index.html
@@ -105,12 +105,74 @@
         .sidebar {
             width: 280px;
             background: #f9fafb;
-            padding: 24px;
+            padding: 16px;
             border-right: 1px solid #e5e7eb;
+            transition: width 0.18s ease, padding 0.18s ease;
+            flex: 0 0 auto;
+        }
+
+        .sidebar.collapsed {
+            width: 64px !important;
+            min-width: 64px !important;
+            padding: 12px 8px;
+        }
+
+        .sidebar.collapsed #facetsSidebar {
+            display: none;
+        }
+
+        .sidebar.collapsed .sidebar-title {
+            display: none;
+        }
+
+        .sidebar-toolbar {
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+            gap: 8px;
+            margin-bottom: 12px;
+        }
+
+        .sidebar-title {
+            color: #374151;
+            font-size: 0.78rem;
+            font-weight: 700;
+            letter-spacing: 0.03em;
+            text-transform: uppercase;
+        }
+
+        .sidebar-toggle-btn {
+            border: 1px solid #d1d5db;
+            background: white;
+            color: #374151;
+            padding: 5px 8px;
+            border-radius: 5px;
+            cursor: pointer;
+            font-size: 12px;
+            font-weight: 700;
+            line-height: 1.2;
+            white-space: nowrap;
+        }
+
+        .sidebar-toggle-btn:hover {
+            background: #f3f4f6;
+        }
+
+        .sidebar-toggle-btn:focus-visible {
+            outline: 2px solid #10b981;
+            outline-offset: 2px;
+        }
+
+        .sidebar.collapsed .sidebar-toolbar {
+            justify-content: center;
+        }
+
+        .sidebar.collapsed .sidebar-toggle-btn {
+            padding: 6px 7px;
         }
 
         .facet-group {
-            margin-bottom: 16px;
+            margin-bottom: 10px;
             border: 1px solid #e5e7eb;
             border-radius: 6px;
             overflow: hidden;
@@ -121,7 +183,7 @@
             display: flex;
             align-items: center;
             justify-content: space-between;
-            padding: 12px 16px;
+            padding: 9px 11px;
             background: white;
             cursor: pointer;
             user-select: none;
@@ -134,15 +196,15 @@
         }
 
         .facet-title {
-            font-size: 0.95rem;
+            font-size: 0.8rem;
             font-weight: 600;
             color: #111827;
             margin: 0;
-            letter-spacing: -0.2px;
+            letter-spacing: 0;
         }
 
         .facet-toggle {
-            font-size: 0.9rem;
+            font-size: 0.75rem;
             color: #10b981;
             transition: transform 0.2s ease;
             font-weight: 600;
@@ -153,7 +215,7 @@
         }
 
         .facet-content {
-            padding: 15px 20px;
+            padding: 10px 12px;
             max-height: 400px;
             overflow-y: auto;
             transition: all 0.3s ease;
@@ -168,12 +230,12 @@
         .facet-item {
             display: flex;
             align-items: center;
-            margin-bottom: 6px;
-            padding: 7px 12px;
+            margin-bottom: 4px;
+            padding: 5px 8px;
             border-radius: 4px;
             transition: all 0.15s ease;
             cursor: pointer;
-            font-size: 0.9rem;
+            font-size: 0.78rem;
         }
 
         .facet-item:hover {
@@ -186,9 +248,9 @@
         }
 
         .facet-checkbox {
-            margin-right: 10px;
-            width: 16px;
-            height: 16px;
+            margin-right: 7px;
+            width: 14px;
+            height: 14px;
             accent-color: #10b981;
             cursor: pointer;
         }
@@ -197,9 +259,9 @@
             margin-left: auto;
             background: #f3f4f6;
             color: #6b7280;
-            padding: 2px 7px;
+            padding: 1px 6px;
             border-radius: 10px;
-            font-size: 11px;
+            font-size: 10px;
             font-weight: 600;
             min-width: 24px;
             text-align: center;
@@ -284,6 +346,22 @@
             font-size: 13px;
             font-weight: 500;
             transition: all 0.15s ease;
+        }
+
+        .export-tsv {
+            background: #f3f4f6;
+            color: #374151;
+            border: 1px solid #d1d5db;
+            padding: 7px 14px;
+            border-radius: 4px;
+            cursor: pointer;
+            font-size: 13px;
+            font-weight: 500;
+            transition: all 0.15s ease;
+        }
+
+        .export-tsv:hover {
+            background: #e5e7eb;
         }
 
         .clear-filters:hover {
@@ -517,8 +595,24 @@
             padding: 20px;
         }
 
-        .results-grid.table-view .load-more-container {
-            padding-bottom: 0;
+        .load-more-container.top-load-more {
+            display: flex;
+            align-items: center;
+            justify-content: flex-end;
+            gap: 12px;
+            padding: 0 0 12px;
+            text-align: right;
+        }
+
+        .top-load-more .load-more-info {
+            margin-top: 0;
+            order: -1;
+            white-space: nowrap;
+        }
+
+        .top-load-more .load-more-btn {
+            padding: 8px 16px;
+            font-size: 13px;
         }
 
         .load-more-btn {
@@ -622,6 +716,11 @@
                 width: 100%;
             }
 
+            .sidebar.collapsed {
+                width: 100% !important;
+                min-width: 0 !important;
+            }
+
             .results-header {
                 align-items: flex-start;
                 flex-direction: column;
@@ -659,14 +758,21 @@
         </div>
 
         <div class="main-content">
-            <div class="sidebar" id="facetsSidebar">
-                <!-- Facets will be generated here -->
+            <div class="sidebar" id="facetsPanel">
+                <div class="sidebar-toolbar">
+                    <span class="sidebar-title">Filters</span>
+                    <button type="button" class="sidebar-toggle-btn" id="toggleFacets" aria-expanded="true">Hide</button>
+                </div>
+                <div id="facetsSidebar">
+                    <!-- Facets will be generated here -->
+                </div>
             </div>
 
             <div class="results-area">
                 <div class="results-header">
                     <div class="results-count" id="resultsCount">Loading...</div>
                     <div class="results-controls">
+                        <button class="export-tsv" id="exportTsv">Export TSV</button>
                         <button class="clear-filters" id="clearFilters">Clear All Filters</button>
                     </div>
                 </div>
@@ -691,6 +797,7 @@
                 this.currentFilters = {};
                 this.currentQuery = '';
                 this.currentView = schema.defaultView || 'table';
+                this.sidebarCollapsed = false;
 
                 // Track collapsed facets
                 this.collapsedFacets = new Set();
@@ -859,6 +966,14 @@
                     this.clearAllFilters();
                 });
 
+                document.getElementById('exportTsv').addEventListener('click', () => {
+                    this.exportCurrentResultsToTsv();
+                });
+
+                document.getElementById('toggleFacets').addEventListener('click', () => {
+                    this.toggleSidebar();
+                });
+
                 document.querySelectorAll('.view-toggle-btn').forEach(button => {
                     button.addEventListener('click', () => {
                         this.currentView = button.dataset.view;
@@ -887,6 +1002,15 @@
                         }
                     }
                 });
+            }
+
+            toggleSidebar() {
+                this.sidebarCollapsed = !this.sidebarCollapsed;
+                const sidebar = document.getElementById('facetsPanel');
+                const button = document.getElementById('toggleFacets');
+                sidebar.classList.toggle('collapsed', this.sidebarCollapsed);
+                button.setAttribute('aria-expanded', String(!this.sidebarCollapsed));
+                button.textContent = this.sidebarCollapsed ? 'Show' : 'Hide';
             }
 
             updateViewToggle() {
@@ -1211,6 +1335,76 @@
                 return String(value);
             }
 
+            tsvCell(value) {
+                if (value === undefined || value === null) {
+                    return '';
+                }
+                const text = this.plainValue(value)
+                    .replace(/\r?\n|\r/g, ' ')
+                    .replace(/\t/g, ' ')
+                    .trim();
+                return /^[=+\-@]/.test(text) ? `'${text}` : text;
+            }
+
+            exportPartText(partConfig, item) {
+                const value = item[partConfig.field];
+                if (value === undefined || value === null) {
+                    return '';
+                }
+
+                if (partConfig.linkTextField && item[partConfig.linkTextField] !== undefined && item[partConfig.linkTextField] !== null) {
+                    const label = this.plainValue(item[partConfig.linkTextField]);
+                    if (partConfig.type === 'curie') {
+                        return `${label} (${this.plainValue(value)})`;
+                    }
+                    return label;
+                }
+
+                return this.plainValue(value);
+            }
+
+            exportFieldText(fieldConfig, item) {
+                if (fieldConfig.type === 'compound') {
+                    return (fieldConfig.parts || [])
+                        .map(partConfig => this.exportPartText(partConfig, item))
+                        .filter(Boolean)
+                        .join(' | ');
+                }
+
+                if (fieldConfig.linkTextField && item[fieldConfig.linkTextField] !== undefined && item[fieldConfig.linkTextField] !== null) {
+                    const label = this.plainValue(item[fieldConfig.linkTextField]);
+                    const value = item[fieldConfig.field];
+                    if (fieldConfig.type === 'curie') {
+                        return `${label} (${this.plainValue(value)})`;
+                    }
+                    return label;
+                }
+
+                const value = item[fieldConfig.field];
+                return value === undefined || value === null ? '' : this.plainValue(value);
+            }
+
+            exportCurrentResultsToTsv() {
+                const fields = this.getTableFields();
+                const rows = this.currentFilteredData || [];
+                const header = fields.map(fieldConfig => this.tsvCell(fieldConfig.label)).join('\t');
+                const body = rows.map(item => fields
+                    .map(fieldConfig => this.tsvCell(this.exportFieldText(fieldConfig, item)))
+                    .join('\t')
+                );
+                const tsv = [header, ...body].join('\n') + '\n';
+                const blob = new Blob([tsv], { type: 'text/tab-separated-values;charset=utf-8' });
+                const url = URL.createObjectURL(blob);
+                const link = document.createElement('a');
+                const date = new Date().toISOString().slice(0, 10);
+                link.href = url;
+                link.download = `gene-annotation-review-${date}.tsv`;
+                document.body.appendChild(link);
+                link.click();
+                link.remove();
+                URL.revokeObjectURL(url);
+            }
+
             actionClass(value) {
                 return `action-${String(value).toLowerCase().replace(/_/g, '-').replace(/[^a-z0-9-]/g, '')}`;
             }
@@ -1305,14 +1499,15 @@
                 return value === undefined || value === null ? '' : this.plainValue(value);
             }
 
-            renderLoadMore(totalCount) {
+            renderLoadMore(totalCount, placement = 'bottom') {
                 if (this.displayedCount >= totalCount) {
                     return '';
                 }
 
                 const remaining = totalCount - this.displayedCount;
+                const placementClass = placement === 'top' ? ' top-load-more' : '';
                 return `
-                    <div class="load-more-container">
+                    <div class="load-more-container${placementClass}">
                         <button class="load-more-btn" id="loadMoreBtn">
                             Load More Results
                         </button>
@@ -1339,13 +1534,13 @@
                 }).join('');
 
                 return `
+                    ${this.renderLoadMore(totalCount, 'top')}
                     <div class="results-table-wrap">
                         <table class="results-table">
                             <thead><tr>${headers}</tr></thead>
                             <tbody>${rows}</tbody>
                         </table>
                     </div>
-                    ${this.renderLoadMore(totalCount)}
                 `;
             }
 

--- a/src/ai_gene_review/export/annotation_export.py
+++ b/src/ai_gene_review/export/annotation_export.py
@@ -27,6 +27,7 @@ from pathlib import Path
 from typing import Dict, List, Any, Union, Optional
 
 from ai_gene_review.datamodel.gene_review_model import GeneReview, ExistingAnnotation
+from ai_gene_review.export.browser_payload import compact_browser_rows
 
 
 class _AttrDict:
@@ -458,16 +459,11 @@ class AnnotationExporter:
         output_path = Path(output_path)
         output_path.parent.mkdir(parents=True, exist_ok=True)
 
-        # Strip null/None values and empty lists to reduce file size.
-        # In JS, accessing a missing key returns undefined (falsy, same as null).
-        compact = [
-            {k: v for k, v in ann.items() if v is not None and v != []}
-            for ann in annotations
-        ]
+        compact = compact_browser_rows(annotations)
 
         with open(output_path, "w") as f:
             f.write("window.searchData = ")
-            json.dump(compact, f, separators=(",", ":"), default=str)
+            json.dump(compact, f, separators=(",", ":"), default=str, ensure_ascii=False)
             f.write(";\n")
             f.write("window.dispatchEvent(new Event('searchDataReady'));\n")
 

--- a/src/ai_gene_review/export/browser_payload.py
+++ b/src/ai_gene_review/export/browser_payload.py
@@ -1,0 +1,89 @@
+"""Browser payload compaction helpers."""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+GO_REF_CODENAMES = {
+    "GO_REF:0000002": "InterPro2GO",
+    "GO_REF:0000003": "EC2GO",
+    "GO_REF:0000004": "Keyword2GO",
+    "GO_REF:0000008": "MGI orthology",
+    "GO_REF:0000015": "InterPro2GO",
+    "GO_REF:0000024": "Curated orthology",
+    "GO_REF:0000033": "Phylogenetic trees",
+    "GO_REF:0000036": "Multi-source manual",
+    "GO_REF:0000041": "UniPathway2GO",
+    "GO_REF:0000043": "UniProtKB-KW",
+    "GO_REF:0000044": "UniProtKB-SubCell",
+    "GO_REF:0000050": "Seq-model transfer",
+    "GO_REF:0000051": "PomBase keyword",
+    "GO_REF:0000052": "IF localization",
+    "GO_REF:0000054": "Fusion localization",
+    "GO_REF:0000096": "Mouse-rat ortholog",
+    "GO_REF:0000104": "UniRule",
+    "GO_REF:0000107": "Ensembl Compara",
+    "GO_REF:0000108": "Logical inference",
+    "GO_REF:0000109": "SubCellular2GO",
+    "GO_REF:0000110": "FlyBase",
+    "GO_REF:0000111": "IC+ISS inference",
+    "GO_REF:0000113": "TFClass2GO",
+    "GO_REF:0000114": "Source pipeline 114",
+    "GO_REF:0000115": "Rfam2GO",
+    "GO_REF:0000116": "Rhea2GO",
+    "GO_REF:0000117": "ARBA",
+    "GO_REF:0000118": "TreeGrafter2GO",
+    "GO_REF:0000119": "Mouse-human orth",
+    "GO_REF:0000120": "Combined IEA",
+    "GO_REF:0000121": "Source pipeline 121",
+    "GO_REF:0000122": "AtSubP",
+    "GO_REF:0000123": "YeastPathways2GO",
+}
+
+BROWSER_TEXT_LIMITS = {
+    "original_reference_title": 20,
+    "review.reason": 50,
+    "review.summary": 50,
+}
+
+
+def truncate_text(value: str, max_chars: int) -> str:
+    """Truncate text to at most max_chars, using an ellipsis when shortened."""
+    if len(value) <= max_chars:
+        return value
+    if max_chars <= 3:
+        return value[:max_chars]
+    return value[: max_chars - 3].rstrip() + "..."
+
+
+def compact_browser_row(row: dict[str, Any]) -> dict[str, Any]:
+    """Drop inert values and shorten text-heavy browser fields."""
+    compact: dict[str, Any] = {}
+    reference_id = row.get("original_reference_id")
+
+    for key, value in row.items():
+        if value is None or value == []:
+            continue
+
+        if key == "original_reference_title":
+            if isinstance(reference_id, str) and reference_id.startswith("GO_REF:"):
+                value = GO_REF_CODENAMES.get(reference_id, reference_id)
+            elif isinstance(value, str):
+                value = truncate_text(value, BROWSER_TEXT_LIMITS[key])
+        elif key in BROWSER_TEXT_LIMITS and isinstance(value, str):
+            value = truncate_text(value, BROWSER_TEXT_LIMITS[key])
+
+        compact[key] = value
+
+    return compact
+
+
+def compact_browser_rows(data: object) -> object:
+    """Compact row-oriented linkml-browser data without changing its JS contract."""
+    if not isinstance(data, list):
+        return data
+    return [
+        compact_browser_row(row) if isinstance(row, dict) else row
+        for row in data
+    ]

--- a/src/ai_gene_review/schema/display_schema.json
+++ b/src/ai_gene_review/schema/display_schema.json
@@ -135,20 +135,10 @@
             "field": "term_id",
             "label": "GO ID",
             "type": "curie",
+            "linkTextField": "term_label",
             "role": "primary"
-          },
-          {
-            "field": "term_label",
-            "label": "GO Term",
-            "type": "string",
-            "role": "secondary"
           }
         ]
-      },
-      {
-        "field": "term_ontology",
-        "label": "Aspect",
-        "type": "string"
       },
       {
         "field": "evidence_type",
@@ -164,13 +154,8 @@
             "field": "original_reference_id",
             "label": "Orig Ref",
             "type": "curie",
+            "linkTextField": "original_reference_title",
             "role": "primary"
-          },
-          {
-            "field": "original_reference_title",
-            "label": "Orig Title",
-            "type": "string",
-            "role": "secondary"
           }
         ]
       },

--- a/src/ai_gene_review/schema/display_schema.json
+++ b/src/ai_gene_review/schema/display_schema.json
@@ -5,6 +5,7 @@
     "id": "https://example.org/gene-annotation-review",
     "itemsPerPage": 50,
     "facetItemsToShow": 15,
+    "defaultView": "table",
     "customCss": ".sidebar { width: 340px; min-width: 340px; } .results-grid { grid-template-columns: 1fr; }",
     "searchableFields": [
       "gene_symbol",
@@ -102,6 +103,101 @@
         "label": "Tags",
         "type": "array",
         "sortBy": "count"
+      }
+    ],
+    "tableFields": [
+      {
+        "label": "Gene",
+        "type": "compound",
+        "key": "gene",
+        "parts": [
+          {
+            "field": "review_html_link",
+            "label": "Gene",
+            "type": "url",
+            "linkTextField": "gene_symbol",
+            "role": "primary"
+          },
+          {
+            "field": "protein_id",
+            "label": "ID",
+            "type": "string",
+            "role": "secondary"
+          }
+        ]
+      },
+      {
+        "label": "GO Term",
+        "type": "compound",
+        "key": "go_term",
+        "parts": [
+          {
+            "field": "term_id",
+            "label": "GO ID",
+            "type": "curie",
+            "role": "primary"
+          },
+          {
+            "field": "term_label",
+            "label": "GO Term",
+            "type": "string",
+            "role": "secondary"
+          }
+        ]
+      },
+      {
+        "field": "term_ontology",
+        "label": "Aspect",
+        "type": "string"
+      },
+      {
+        "field": "evidence_type",
+        "label": "Evidence",
+        "type": "string"
+      },
+      {
+        "label": "Reference",
+        "type": "compound",
+        "key": "reference",
+        "parts": [
+          {
+            "field": "original_reference_id",
+            "label": "Orig Ref",
+            "type": "curie",
+            "role": "primary"
+          },
+          {
+            "field": "original_reference_title",
+            "label": "Orig Title",
+            "type": "string",
+            "role": "secondary"
+          }
+        ]
+      },
+      {
+        "field": "review.action",
+        "label": "Action",
+        "type": "string"
+      },
+      {
+        "field": "review.summary",
+        "label": "Summary",
+        "type": "string"
+      },
+      {
+        "field": "review.reason",
+        "label": "Reason",
+        "type": "string"
+      },
+      {
+        "field": "review.proposed_replacement_terms",
+        "label": "Replacements",
+        "type": "string"
+      },
+      {
+        "field": "status",
+        "label": "Status",
+        "type": "string"
       }
     ],
     "displayFields": [

--- a/src/ai_gene_review/tools/minify_linkml_browser_data.py
+++ b/src/ai_gene_review/tools/minify_linkml_browser_data.py
@@ -7,22 +7,16 @@ import argparse
 import json
 from pathlib import Path
 
+from ai_gene_review.export.browser_payload import compact_browser_rows
+
 
 PREFIX = "window.searchData = "
 READY_EVENT = "window.dispatchEvent(new Event('searchDataReady'));"
 
 
 def compact_rows(data: object) -> object:
-    """Drop inert top-level values from row-oriented linkml-browser data."""
-    if not isinstance(data, list):
-        return data
-
-    return [
-        {key: value for key, value in row.items() if value is not None and value != []}
-        if isinstance(row, dict)
-        else row
-        for row in data
-    ]
+    """Compact row-oriented linkml-browser data."""
+    return compact_browser_rows(data)
 
 
 def minify_data_js(path: Path) -> int:

--- a/tests/test_browser_payload.py
+++ b/tests/test_browser_payload.py
@@ -1,0 +1,34 @@
+from ai_gene_review.export.browser_payload import compact_browser_row
+
+
+def test_browser_payload_uses_goref_codename_and_truncates_review_text():
+    row = {
+        "original_reference_id": "GO_REF:0000117",
+        "original_reference_title": "Electronic Gene Ontology annotations created by ARBA machine learning models",
+        "review.summary": "S" * 80,
+        "review.reason": "R" * 80,
+        "review.supporting_text": "kept intact",
+        "empty": None,
+        "empty_list": [],
+    }
+
+    compact = compact_browser_row(row)
+
+    assert compact["original_reference_title"] == "ARBA"
+    assert compact["review.summary"] == ("S" * 47) + "..."
+    assert compact["review.reason"] == ("R" * 47) + "..."
+    assert compact["review.supporting_text"] == "kept intact"
+    assert "empty" not in compact
+    assert "empty_list" not in compact
+
+
+def test_browser_payload_truncates_non_goref_reference_titles_to_20_chars():
+    row = {
+        "original_reference_id": "PMID:12345",
+        "original_reference_title": "A very informative publication title",
+    }
+
+    compact = compact_browser_row(row)
+
+    assert compact["original_reference_title"] == "A very informativ..."
+    assert len(compact["original_reference_title"]) == 20


### PR DESCRIPTION
## Summary

Fixes the generated browser payload that caused issue #1524 by compacting the static `app/data.js` output and improving the annotation browser for the larger review set.

Changes:
- Compact browser payload text fields:
  - GO_REF reference titles become short codenames such as `ARBA`, `InterPro2GO`, and `TreeGrafter2GO`.
  - Non-GO_REF reference titles are truncated for browser faceting/display.
  - Review summaries and reasons are truncated in the browser payload.
- Keep the global annotation browser, rather than switching to a per-gene-only route.
- Add a table-first browser view with a card/table toggle.
- Combine dense table columns for gene, GO term, and reference.
- Add horizontal table scrolling, top-positioned Load More for table mode, collapsible filters, and TSV export for the currently filtered result set.
- Make `deploy-browser` build in a temporary directory so it does not delete unrelated files under `app/`.

## Issue note

Closes #1524.

This PR does not take the per-gene-browser route discussed in the issue. It keeps the global browser viable for now by reducing the generated payload and making the annotation-heavy view more table-oriented. The existing per-gene pages remain the detailed annotation view.

## Validation

- `just deploy-browser`
- `uv run pytest tests/test_browser_payload.py`
- `uv run ruff check src/ai_gene_review/export/browser_payload.py src/ai_gene_review/export/annotation_export.py src/ai_gene_review/tools/minify_linkml_browser_data.py tests/test_browser_payload.py`
- `jq empty src/ai_gene_review/schema/display_schema.json`
- `node --check` on the generated browser inline script
- Playwright smoke checks for table/card toggling, horizontal scroll, collapsible filters, top Load More, and TSV export

## Size

Fresh generated `app/data.js`: `89,877,012` bytes (`85.71 MiB`).

This is still above GitHub's 50 MB warning threshold, but below the 100 MB hard limit that caused the failed generated-pages push.
