### PR TITLE
[codex] Bypass review for generated pages PRs

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -22,7 +22,8 @@ jobs:
       ${{
         (
           github.event_name == 'pull_request' &&
-          github.event.pull_request.head.repo.full_name == github.repository
+          github.event.pull_request.head.repo.full_name == github.repository &&
+          github.event.pull_request.head.ref != 'auto/generate-pages'
         ) ||
         github.event_name == 'workflow_dispatch' ||
         (

--- a/.github/workflows/generate-pages.yaml
+++ b/.github/workflows/generate-pages.yaml
@@ -286,14 +286,26 @@ jobs:
             echo "Created regeneration PR #$PR_NUMBER."
           fi
 
-          # Publish automatically: enable auto-merge so the regeneration PR
-          # lands on main once required checks (if any) pass, instead of sitting
-          # unmerged until it expires. The PR only contains generated artifacts
-          # (enforced by the safety guard above), so merging it cannot clobber
-          # source files. Non-fatal if the repo does not allow auto-merge -- in
-          # that case the PR simply stays open for a maintainer to merge.
-          gh pr merge "$PR_NUMBER" \
+          merge_state="$(gh pr view "$PR_NUMBER" \
             --repo "$GITHUB_REPOSITORY" \
-            --auto \
-            --squash \
-            || echo "Auto-merge could not be enabled; PR #$PR_NUMBER left open for manual merge."
+            --json mergeStateStatus \
+            --jq '.mergeStateStatus')"
+
+          if [ "$merge_state" = "CLEAN" ]; then
+            echo "Regeneration PR #$PR_NUMBER is clean; merging generated artifacts directly."
+            gh pr merge "$PR_NUMBER" \
+              --repo "$GITHUB_REPOSITORY" \
+              --squash
+          else
+            # Publish automatically: enable auto-merge so the regeneration PR
+            # lands on main once required checks or reviews pass, instead of
+            # sitting unmerged. The PR only contains generated artifacts
+            # (enforced by the safety guard above), so merging it cannot clobber
+            # source files. Non-fatal if the repo does not allow auto-merge -- in
+            # that case the PR simply stays open for a maintainer to merge.
+            gh pr merge "$PR_NUMBER" \
+              --repo "$GITHUB_REPOSITORY" \
+              --auto \
+              --squash \
+              || echo "Auto-merge could not be enabled; PR #$PR_NUMBER left open for manual merge."
+          fi


### PR DESCRIPTION
## Summary

- Skip automatic Claude Code Review on `auto/generate-pages` regeneration PRs.
- Let the generated-pages workflow direct-merge artifact-only PRs when GitHub reports them as `CLEAN`; keep `--auto` for non-clean states that are waiting on required checks or reviews.

## Root Cause

PR #1592 is an artifact-only regeneration PR with 2,843 changed generated files. The Claude review action tried to fetch PR file metadata and failed inside `pullRequest.files.nodes`, while the normal build/test check passed.

The generated-pages workflow also tried `gh pr merge --auto`, but GitHub rejected it because the PR was already in `CLEAN` status at creation time. In that state `--auto` cannot be enabled; the workflow needs to merge directly or leave the PR for a human.

## Dismech Comparison

Dismech's weekly-compliance path uses a separate auto-merge workflow for a narrowly eligible class of bot PRs. Its generated-pages PRs are not a clean bypass model; recent generated-pages/grouping-pages PRs still show `REVIEW_REQUIRED` and are often closed as stale rather than merged automatically.

## Validation

- Parsed both modified workflow YAML files with Ruby/Psych.
- Inspected PR #1592 checks and the Generate Pages run logs with `gh`.

