### PR TITLE
Warm reference cache

### DIFF
--- a/publications/DOI_10.1248_bpbreports.6.6_193.md
+++ b/publications/DOI_10.1248_bpbreports.6.6_193.md
@@ -8,7 +8,13 @@ authors:
 journal: BPB Reports
 year: '2023'
 doi: 10.1248/bpbreports.6.6_193
-content_type: unavailable
+content_type: full_text_pdf
+full_text_attempted: true
+full_text_provider: openalex
+full_text_url: "https://www.jstage.jst.go.jp/article/bpbreports/6/6/6_193/_pdf"
+oa_status: diamond
+license: cc-by
+local_pdf_path: files/DOI_10.1248_bpbreports.6.6_193.pdf
 ---
 
 # Regulation of the ER-Resident Mannosidase EDEM2 in HEK293 Cells
@@ -17,3 +23,504 @@ content_type: unavailable
 **DOI:** [10.1248/bpbreports.6.6_193](https://doi.org/10.1248/bpbreports.6.6_193)
 
 ## Content
+
+*To whom correspondence should be addressed.   e-mail: oh-hashi.kentaro.u7@f.gifu-u.ac.jp
+INTRODUCTION
+Approximately one-third of newly synthesized proteins 
+are processed within the endoplasmic reticulum (ER). Under 
+normal conditions, correctly folded proteins are transport-
+ed to their final destinations via the ER–Golgi pathway. Dur -
+ing this process, specific asparagine residues in some proteins 
+are labeled with Glc 3Man9GlcNAc 2. Following the remov-
+al of two glucose residues by glycosidase I/II, the monogly-
+cosylated form associates with calnexin/calreticulin; this pro-
+motes proper folding of the protein, and its terminal glucose 
+is then released. On the other hand, misfolded proteins, even 
+those that have passed through the calnexin/calreticulin cycle, 
+are subjected to selective degradation. 1,2) It has been report-
+ed that several ubiquitin (Ub) ligases are embedded in the ER 
+membrane 3) and that ER-associated degradation (ERAD) via 
+these Ub ligases is responsible for the degradation of unfolded 
+or misfolded proteins under normal/ER stress states and serves 
+as a protein turnover process within the ER. 4,5) Degradation of 
+incompletely folded N-glycosylated proteins via the SEL1L/
+Hrd1 complex, N-glycosylated protein recognition, retro-trans-
+location, ubiquitination and degradation are the most studied 
+parts of this process. During the recognition step, target N-gly-
+cosylated proteins are subjected to mannose trimming by ER 
+mannosidase I or ER degradation-enhancing α-mannosidase-
+like protein (EDEM) family (EDEM1/2/3). ER mannosidase 
+eliminates some mannose residues at the terminal of N-Gly -
+can.6) Following these events, lectin chaperones such as OS9 
+and XTP3-B recognize and bind to the 1,6-α-mannosyl link-
+age that is exposed after trimming of the mannose residues. 4,5,7) 
+The target proteins, together with the lectin chaperones, are 
+transferred to the ERAD complex and move from the ER to 
+the cytosol in coordination with specialized proteins, includ-
+ing SEL1L, Hrd1 and the Derlin family. SL1L acts as a scaf-
+fold for the Hrd1-containing ERAD complex on the ER mem-
+brane, where Hrd1 ubiquitinates substrate proteins. In parallel, 
+polyubiquitin chains are added to the target proteins by E3 
+Ub ligases (e.g., Hrd1 and gp78) in the same ERAD complex, 
+resulting in discarding of the target proteins at the 26S pro-
+teasome at the degradation step. 3,4,5,8)  EDEM2 is an important 
+enzyme in ERAD; it functions at the earliest mannose trim-
+ming step, and it has recently been reported that disulfide 
+bonding of EDEM to TXNDC11 is important for maintain-
+ing its activity. 9,10) Although many studies involving EDEM2 
+overexpression or knockdown have been conducted in an 
+attempt to elucidate the ERAD mechanism, 11,12,13)  little has 
+been learned about the mechanism that regulates endogenous 
+ERAD2 protein expression. We recently used genome editing 
+of SEL1L and TXNDC11 in HEK293 cells to study the regu-
+latory mechanisms of the ATF6/CREB3 family as ERAD sub-
+strates. 14,15,16)  Based on these findings, in the present work we 
+examined changes in endogenous EDEM2 expression under 
+various conditions, including ER stress and ERAD dysfunc-
+tion.
+Report
+Regulation of the ER-Resident Mannosidase EDEM2 in HEK293 Cells
+Ryoichi Murase,a  Genki Kato,a  and Kentaro Oh-hashia,b,c,d,*
+ 
+aGraduate School of Natural Science and Technology, Gifu University, 1-1 Yanagido, Gifu 501-1193, Japan; bDepartment 
+of Chemistry and Biomolecular Science, Faculty of Engineering, Gifu University, 1-1 Yanagido, Gifu 501-1193, Japan; 
+cUnited Graduate School of Drug Discovery and Medical Information Sciences, Gifu University, 1-1 Yanagido, Gifu 501-
+1193, Japan; dCenter for One Medicine Innovative Translational Research (COMIT), Gifu University, 1-1 Yanagido, Gifu 
+501-1193, Japan
+Received October 6, 2023; Accepted November 9, 2023
+EDEM2 plays an important role as the first enzyme that acts during mannose trimming of N-glycosylated 
+proteins in the ERAD machinery. Although EDEM2 expression has been reported to be transcriptionally reg-
+ulated by the IRE1-sXBP1 pathway, very little is known about how endogenous EDEM2 protein expression is 
+regulated. In this work, three different ER stress inducers were used to treat HEK293 cells. Thapsigargan slight-
+ly increased both EDEM2 mRNA and protein levels in the cells. Treatment with MG132 did not increase the lev-
+el of mature EDEM2 protein, and a truncated form of the protein appeared. In SEL1L-deficient cells, there was 
+a slight increase in EDEM2 protein as well as in TXNDC11, a protein that has been reported to form disulfide 
+bonds with EDEM2. On the other hand, EDEM2 protein level decreased in TXNDC11-deficient cells. DTT treat-
+ment decreased EDEM2 and TXNDC11 protein levels in a time-dependent manner. The decrease in EDEM2 
+protein after DTT treatment was attenuated by treatment of the cells with MG132 and by SEL1L deficiency. 
+These findings demonstrate that endogenous EDEM2 protein is regulated posttranscriptionally and that it is in 
+part an SEL1L-mediated ERAD substrate.
+Key words   EDEM2, ERAD, ER stress, SEL1L, TXNDC11
+193
+V ol. 6, No. 6BPB Reports 6, 193-199 (2023)
+
+MATERIALS AND METHODS
+Materials   Thapsigargin (Tg), tunicamycin (Tm), brefel-
+din A (BFA), cycloheximide (CHX), dithiothreitol (DTT) were 
+obtained from Sigma–Aldrich (St. Louis, MO, USA). MG132 
+(MG) and concanamycin A (CMA) were obtained from  
+Peptide Institute (Osaka, Japan) and from Wako (Osaka, 
+Japan), respectively.
+Construction of Plasmids   gRNAs against human EDEM2 
+(5’-TTCCGGCTGCTCATCCCGCT-3’ and 5’-GCTGAG-
+GCAGCAGCGCGCAC-3’ (EDEM2 KD)), human SEL1L 
+(5’-GAGCTTGGCCTCGGCGTCCT-3’ (SEL1L KD#1)) and 
+(5′-GCAGCAGCGTCAGCCCTATC-3′ (SEL1L KD#2)) and 
+human TXNDC11 (5’-CCGGCCGCTGGCGCGCCATG-3’  
+and 5’-CAGCGCGCAGCCGAGCGCCA-3’ (TXNDC11 KD)) 
+aligned with tracer RNA were inserted into a pcDNA3.1-
+derived vector containing a U6 promoter. 16,17) To prepare donor 
+genes, a DNA fragment encoding the N-terminal region of 
+human EDEM2 (107 bp from the translation start site), SEL1L 
+(70 bp from the translation start site) or TXNDC11 (124 bp 
+from 131 bp to 254 bp for TXNDC11 KD) was fused with a 
+puromycin-resistance gene via IRES and inserted into a pGL3-
+derived vector. The hCas9 construct (#41815) used in this 
+study was obtained from Addgene. 18)
+Establishment of EDEM2-, SEL1L- and TXNDC11-
+Deficient HEK293 Cells   EDEM2-, SEL1L- and TXNDC11-
+deficient HEK293 cells were established using the CRISPR/
+Cas9 system as described previously. 14,16,17)  In brief, donor 
+genes encoding human EDEM2, SEL1L or TXNDC11 N-ter -
+minus in a pGL3-derived vector, together with constructs for 
+each gRNA and hCas9, were transfected into HEK293 cells, 
+and cells were selected with the appropriate concentrations 
+of puromycin. To establish EDEM2- and TXNDC11-deficient 
+cells, two different constructs for guide RNAs were cotrans-
+fected together with the donor gene and hCas9 constructs.
+Cell Culture and Treatment   HEK293 cells were main-
+tained in Dulbecco’s modified Eagle’s minimum essential 
+medium containing 5% fetal bovine serum. The cells were 
+seeded in 12-well plates and treated with Tg (0.01 µM), 
+Tm (2 µg/mL), BFA (0.5 µg/mL), CMA (50 nM), MG132  
+(10 µM), CHX (20 µg/mL) or vehicle for the indicated times; 
+the expression of the indicated genes and proteins was then 
+measured using RT–PCR and western blot analysis.
+Western Blot Analysis   Cells were lysed in homogeni-
+zation buffer (20 mM Tris-HCl (pH 8.0) containing 137 mM 
+NaCl, 0.2 mM EDTA (pH 8.0), 10% (v/v) glycerol, 1% (v/v) 
+Triton X-100, 1 mM PMSF, 10 µg/mL leupeptin, and 10 µg/
+mL pepstatin A) as described previously. 14-17) The protein con-
+centrations of the lysates were determined using the Brad -
+ford assay, and equal amounts of lysate protein from differ -
+ent samples were separated by SDS–PAGE and transferred 
+to polyvinylidene difluoride (PVDF) membranes (Millipore, 
+Burlington, MA, USA). The membranes were incubated with 
+the indicated antibodies, and the target proteins were detect-
+ed by enhanced chemiluminescence (ECL) (GE Healthcare,  
+Buckingghamshire, UK) or enhanced chemiluminescence 
+plus (ECL-plus) reagents (Life Technologies, Waltham, 
+MA, USA). We used the following antibodies at the indicat-
+ed dilutions: ATF6α (1:1200) (Proteintech, Rosemont, IL, 
+USA); EDEM2 (1:1500) (Novus Biological, Centennial, CO, 
+USA); GADD153 (1:1000) (Santa Cruz Biotech, Dallas, TX, 
+USA); G3PDH (1:12000) (Proteintech); Herp (1:1000) (Cell  
+Signaling Technology, Beverly, MA, USA); LC3 (1:3000) 
+(MBL, Nagoya, Japan); OS9 (1:1000) (Cell Signaling  
+Technology); SEL1L (1:1500) (Abcam, Cambridge, UK); 
+and TXNDC11 (1:1200) (Abcam). The level of expression of 
+each protein was analyzed using ImageJ software (National  
+Institutes of Health, USA), 19) and the relative amount of each 
+protein was calculated based on the G3PDH value obtained 
+from an identical sample of cell lysate. Protein expression was 
+normalized to the value obtained from untreated control cells.
+Reverse Transcription-Polymerase Chain Reaction  
+(RT–PCR)   To estimate the mRNA expression level of each 
+gene, we used RT–PCR as described previously. 14-17)  Total 
+RNA was extracted using TRI Reagent (Molecular Research 
+Center, Cincinnati, OH, USA). The extracted RNA was con-
+verted to cDNA by reverse transcription using a mixture con-
+taining DTT, dNTPs, random ninemers, RNaseOUT (Life 
+Technologies), and Prime Superscript III RNase reverse tran-
+scriptase (Life Technologies) as was done previously in our 
+laboratory. 14-17) Each cDNA sample was added to a PCR mix-
+ture containing primers, dNTPs, and Taq DNA polymerase 
+(Taq PCR kit, Takara, Shiga, Japan) for amplification. The RT–
+PCR primers used in this study were as follows: EDEM2 sense 
+primer, 5’-TGTCTGCTCATCTGCTCTCCAA-3’; EDEM2 
+antisense primer, 5’-CAACAATGAAGGTCCCAATCCC-3’; 
+GADD153 sense primer, 5’-CGGAAACAGAGTGGT -
+CATTC-3’; GADD153 antisense primer, 5’-TGCGTATGTGG-
+GATTGAGGGTC-3’; G3PDH sense primer, 5’-ACCA -
+CAGTCCATGCCATCAC-3’; G3PDH antisense primer, 
+5’-TCCACCACCCTGTTGCTGTA-3’; TXNDC11 sense 
+primer, 5’-GTGATAATACCAGCAAAGCC-3’; TXNDC11 
+antisense primer, 5’-TTTCTGCATTTCCCCTGGTT-3’; 
+XBP1 sense primer, 5’-CGGCCTTGTGGTTGAGAA-3’; and 
+XBP1 antisense primer, 5’-ACTTGTCCAGAATGCCCA-3’. 
+The typical reaction cycling conditions were 30 sec at 96°C,  
+30 sec at 58°C, and 30 sec at 72°C. The reactions were ter -
+minated after 21–28 cycles of amplification, and the products 
+were separated by electrophoresis on 1.5% agarose gels and 
+visualized using ethidium bromide. The level of expression of 
+each mRNA was analyzed using ImageJ software (National  
+Institutes of Health), 19) and the relative amount of each mRNA 
+was calculated based on the G3PDH value obtained from an 
+identical sample of cDNA. Each mRNA expression was nor -
+malized to the value obtained from untreated control cells.
+RESULTS AND DISCUSSION
+EDEM2 plays an important role as the first enzyme in 
+mannose trimming of N-glycosylated proteins in the ERAD 
+machinery. 4,5,6)  It has also been reported that transcription of 
+the EDEM2 gene is upregulated by ER stress, 12) but few stud-
+ies of endogenous EDEM2 mRNA and protein expression have 
+been reported. 12,20,21)  Thus, we first evaluated EDEM2 mRNA 
+and protein expression in HEK293 cells after treatment with 
+three different ER stress inducers: Tg, Tm and BFA (Fig. 1).  
+As reported previously, 12) increases in EDEM2 mRNA were 
+observed after stimulus with each individual ER stress induc -
+er (Fig. 1A). TXNDC11 has been reported to form a disulfide 
+bond with EDEM2 and to be involved in the mannosidase 
+activity of EDEM2. 10) We recently reported that transcription 
+of the TXNDC11 gene is regulated by the IRE1-sXBP1 path-
+way via the unfolded protein response element (UPRE) near 
+the transcription start site. 16) The levels of TXNDC11, sXBP1 
+194
+V ol. 6, No. 6 (2023)BPB Reports
+
+and GADD153 mRNA were also increased after treatment 
+with each individual ER stress inducer in this study. On the 
+other hand, the effects of the individual ER stress inducers on 
+EDEM2 protein expression were quite different. As shown 
+in Fig. 1B, treatment of the cells with Tg for 24 h slightly 
+induced EDEM2 protein expression in HEK293 cells. After 
+treatment with Tm, low-molecular-weight EDEM2, which is 
+thought to represent the unglycosylated form, was detected, 
+and the level of expression of mature EDEM2 protein was cor -
+respondingly decreased. BFA treatment also reduced the level 
+of mature EDEM2 protein in HEK293 cells, although the pre-
+cise mechanism through which this occurred is unclear. On the 
+other hand, the amount of TXNDC11 protein did not clearly 
+decrease after stimulation with Tm or BFA. GADD153 mRNA 
+and protein was respectively induced by each treatment  
+(Fig. 1).
+We then investigated the degradation and stability of the 
+EDEM2 protein in HEK293 cells. After 6 h of treatment with 
+the proteasome inhibitor MG132 (MG), the lysosome inhibi-
+tor concanamycin A (CMA), or the protein synthesis inhib-
+itor cycloheximide (CHX), the level of EDEM2 mRNA was 
+reduced by approximately 30% (Fig. 2A). These results differ 
+from the reported effects of these agents on TXNDC11 mRNA 
+expression; 16) the level of TXNDC11 mRNA was unchanged 
+after treatment with MG or CMA and slightly increased after 
+CHX treatment (Fig. 2A). On the other hand, TXNDC11 pro-
+tein expression was slightly downregulated by 24 h of CHX 
+treatment (Fig. 2B). Regarding EDEM2 protein expression, a 
+low-molecular-weight band was observed after treatment of 
+the cells with MG132 for 24 h (Fig. 2B). Since the bands about 
+50 kDa was observed in untreated EDEM2-deficient HEK293 
+cells (Fig. 3), it is likely that after MG132 treatment, the 
+cleaved EDEM2 overlaps with nonspecific bands. CMA treat -
+ment increased LC3 expression but had no effect on EDEM2 
+protein expression (Fig. 2B). Our previous study showed that 
+CHX treatment almost completely abolished ATF6/CREB3 
+family expression in HEK293 cells within 4 h, 15,16) but EDEM2 
+protein was reduced by about 50% even after 24 h of CHX 
+treatment compared to that in untreated control cells (Fig. 2B). 
+These findings suggest that the EDEM2 protein is a relative-
+ly stable protein, although it is partly subject to cleavage and 
+degradation through a proteasome pathway. Since the anti-
+EDEM2 antibody used in this study recognizes the C-terminal 
+100 amino acid residues of human EDEM2, the low-molecu-
+lar-weight EDEM2 that appeared in the MG132 treatment was 
+deduced to be its C-terminal fragment.
+We recently established HEK293 cells that are deficient in 
+SEL1L, Herp, and TXNDC11 and analyzed the proteins pre-
+Fig. 1.   Effects of ER Stress-Inducing Reagents on EDEM2 Expression in HEK293 Cells
+Wild-type HEK293 cells were treated with Tg (0.01 μM), Tm (2 μg/ml), BFA (0.5 μg/ml) or vehicle (Con) for 6 h (A) or 24 h (B). The expression of the indicated mRNAs (A) 
+and proteins (B) was measured as described in Materials and Methods. Representative results obtained for four independent cultures are shown. The amount of EDEM2 mRNA and 
+protein in untreated cells was set at 1. An open arrowhead indicates the unglycosylated form.
+195
+V ol. 6, No. 6 (2023) BPB Reports
+
+sent in the ER of those cells, including members of the ATF6/
+CREB3 family. 14-16)  As shown in Fig. 3, ERAD-related fac-
+tors such as Herp, OS9, and TXNDC11 are highly expressed 
+in SEL1L-deficient cells even under unstimulated conditions. 
+Therefore, we examined changes in EDEM2 protein expres-
+sion in SEL1L- and TXNDC11-deficient cells. EDEM2 pro-
+tein expression was slightly increased in SEL1L-deficient cells 
+compared to wild-type cells. In particular, EDEM2 mRNA 
+was present in SEL1L-deficient clone #1 at levels slight-
+ly higher than those observed in the wild-type cells, but this 
+did not occur in clone #2 (Supplementary Fig. 1A). In our pre-
+vious study, the TXNDC11 protein level in SEL1L-deficient 
+cells increased approximately 1.5-fold. 16) Both EDEM2 and 
+TXNDC11 are thought to be regulated by the IRE1-sXBP1 
+pathway; however, there may be other regulatory mecha-
+nisms, such as posttranscriptional mechanisms. On the oth-
+er hand, EDEM2 protein levels were markedly decreased in 
+the TXNDC11-deficient cells (Fig. 3B) and did not correlate 
+with the EDEM2 mRNA levels in the cells (Supplementary  
+Fig. 1B). A decrease in the amount of EDEM2 protein was 
+also observed in TXNDC11-deficient cells established using 
+other gRNAs (data not shown).
+George et al. reported that EDEM2 and TXNDC11 asso-
+ciate with each other via disulfide bonds. 10) Therefore, we 
+attempted to determine whether the reducing agent DTT 
+affects EDEM2 protein expression. As shown in Fig. 4A, treat-
+ment of wild-type HEK293 cells with 1 mM DTT decreased 
+EDEM2 and TXNDC11 protein levels in a time-dependent 
+manner. Since DTT, like Tg, Tm and BFA, is also used as an 
+ER stress inducer, 22) we examined the mRNA levels of EDEM 
+and TXNDC11 and found that both increased remarkably 
+after DTT treatment (Supplementary Fig. 2). DTT treatment 
+also induced GADD153 protein expression. The results sug-
+gest that DTT decreases EDEM2 protein expression in a post-
+transcriptional manner. Finally, we used our SEL1L-deficient 
+cells (#2) to examine changes in EDEM2 protein levels after 
+DTT treatment in the presence or absence of MG132 (Fig. 4B) 
+and CMA (Fig. 4C). Interestingly, in wild-type HEK293 cells, 
+the decrease in EDEM2 protein that normally occurred after 
+DTT treatment was partially suppressed by MG132 treatment 
+(Fig. 4B). On the other hand, in SEL1L-deficient cells, there 
+was almost no decrease in EDEM2 after DTT treatment. The 
+expression of c-Myc protein, a cytoplasmic/nuclear protein 
+that is degraded by proteasome, 23) was markedly increased by 
+MG132 treatment (Fig. 4B). This c-Myc expression was also 
+decreased by DTT treatment. In addition to ERAD, a lysoso-
+Fig. 2.   Evaluation of the Stability of EDEM2 in HEK293 Cells
+Wild-type HEK293 cells were treated with MG132 (MG) (10 μM), CMA (50 nM), CHX (20 μg/ml) or vehicle (Con) for 6 (A) or 24 (B) h. The expression of the indicated mR-
+NAs (A) and proteins (B) was measured as described in Materials and Methods. Representative results obtained for four independent cultures are shown. The amount of EDEM2 
+mRNA and protein without treatment was set at 1. The bands indicated by an open arrowhead are considered truncated EDEM2 containing nonspecific bands.
+196
+V ol. 6, No. 6 (2023)BPB Reports
+
+mal degradation mechanism called ER-phagy also contributes 
+to protein quality control in the ER. 24,25) However, CMA treat -
+ment did not affect EDEM2 protein expression in either wild-
+type or SEL1L-deficient cells although CMA treatment appar -
+ently increased LC3 expression (Fig. 4C).
+EDEM2 plays an important role in mannose trimming, the 
+first step in the degradation of N-glycosylated proteins in the 
+ER.4-6) This is also demonstrated by the increased expression 
+of full-length ATF6 protein in our EDEM2-deficient HEK293 
+cells (Fig. 3B). The amount of full-length ATF6 protein in 
+SEL1L- and EDEM2-deficient cells was comparable and high-
+er than in wild-type HEK293 cells (Fig. 3), suggesting that 
+the EDEM2-SEL1L pathway is important for the regulation 
+of ATF6 protein within the ER. Our study and others show 
+that ATF6 levels also increase under conditions of TXNDC11 
+deficiency. 10,16)  On the other hand, SEL1L deficiency, but not 
+EDEM2 deficiency, increased the levels of Herp, OS9 and 
+TXNDC11 proteins under resting conditions (Fig. 3AB), sug-
+gesting that failure of ERAD substrates to be removed from 
+the ER and ubiquitinated due to SEL1L deficiency has a great-
+er impact on cells than does EDEM2 deficiency. Further stud-
+ies are needed to determine the details surrounding the regu-
+lation of endogenous substrates by SEL1L and/or EDEM2 
+and the mechanisms by which the levels of these proteins are 
+regulated. Interestingly, the amount of EDEM2 protein was 
+reduced in our TXNDC11-deficient cells, and the molecular 
+weights of EDEM2 and TXNDC11 appeared to shift slight-
+ly upward in the TXNDC11- and EDEM2-deficient cells  
+(Fig. 3B). This indicates that the TXNDC11-EDEM2 complex 
+affects the mannose trimming within the ER. A detailed anal-
+ysis of the complex containing TXNDC11 and EDEM1/2/3 is 
+necessary, since George et al. recently reported that TXNDC11 
+also interacts with EDEM1/3. 26)
+The results of our experiments in which cells were treat-
+ed with CHX indicate that the EDEM2 protein is relatively 
+stable; although the results obtained in MG132-treated cells 
+showed that EDEM2 is partially degraded via the proteasome 
+after its cleavage, it is unclear where and how cleavage occurs 
+(Fig. 2). We consider that further characterization is needed, 
+as the truncated EDEM2 appeared to overlap with a nonspe-
+cific band in our experiments. On the other hand, DTT treat-
+ment decreased the expression of full-length EDEM2 and 
+TXNDC11 protein in a time-dependent manner (Fig. 4A). 
+DTT may have destabilized both proteins by affecting their 
+disulfide bonds, but DTT treatment also reduces c-Myc pro -
+tein (Fig. 4B). Therefore, the results obtained with DTT are 
+not specific, and further studies are needed.
+In this study, we used several reagents and ERAD-defi-
+cient cell lines to elucidate the posttranscriptional regulation 
+of the EDEM2 protein. In particular, DTT treatment caused a 
+Fig. 3.   Effect of SEL1L and TXNDC11 Deficiency on EDEM2 Protein Expression in HEK293 Cells
+Expression of the indicated proteins in wild-type (WT), SEL1L (SEL1L KD)- (A) and in EDEM2 (E2 KD)- and TXNDC11 (TXN11 KD)-deficient HEK293 cells (B) was 
+measured as described in Materials and Methods. Representative results obtained for 3 independent cultures are shown. The bands indicated by open arrowheads are considered 
+truncated EDEM2 containing nonspecific bands.
+197
+V ol. 6, No. 6 (2023) BPB Reports
+
+Fig. 4.   Degradation of EDEM2 Protein Caused by DTT Treatment Is Dependent on SEL1L
+(A) Wild-type (WT) HEK293 cells were treated with DTT (1 mM) for the indicated times. (B and C) Wild-type and SEL1L-deficient 
+(SEL1L KD) HEK293 cells were treated with or without DTT (1 mM), MG132 (MG, 10 μM), CMA (50 nM) or vehicle (Con) for 8 h. The 
+expression of the indicated proteins was measured as described in Materials and Methods. Representative results obtained for four independent 
+cultures are shown. The amount of EDEM2 protein without treatment was set at 1.
+198
+V ol. 6, No. 6 (2023)BPB Reports
+
+decrease in EDEM2 protein expression, which was suppressed 
+by MG132 treatment and SEL1L deficiency. According to Uni-
+prot, EDEM2 does not have intramolecular disulfide bonds. 
+Therefore, the downregulation of EDEM2 protein that occurs 
+after DTT treatment may be the cleavage of the disulfide 
+bond with TXNDC11. Future analysis of the effect of reduc-
+ing reagents, including DTT, on the association of EDEM2 
+and TXNDC11 and the stability of unbound EDEM2 is need-
+ed. Recently, high expression of EDEM2 in several cancer cell 
+lines, including glioma, 27,28,29)  has been reported, although it is 
+unclear whether high EDEM2 expression is related to cancer 
+cell proliferation and poor prognosis via ERAD enhancement. 
+Further investigations of this finding will contribute not only 
+to the regulation of the basic molecular mechanisms of ERAD 
+but also to tumor control.
+Acknowledgments   This study was partially supported by 
+the OGAWA Science and Technology Foundation, Koshiyama 
+Science and Technology foundation, and Grants-in-aid from 
+the Japan Society for the Promotion of Science (JSPS, Japan, 
+KAKENHI, Nos. 19H04030 and 20K21751 to K.O.).
+Conflict of interest   The authors declare no conflict of 
+interest.
+REFERENCES
+1)  Ellgaard L, Helenius A. Quality control in the endoplasmic reticulum. 
+Nat. Rev. Mol. Cell Biol., 4, 181–191 (2003).
+2)  Vembar SS, Brodsky JL. One step at a time: endoplasmic reticulum-
+associated degradation. Nat. Rev. Mol. Cell Biol., 9, 944–957 (2008).
+3)  Ninagawa, S., George, G., & Mori, K. (2021). Mechanisms of pro-
+ductive folding and endoplasmic reticulum-associated degradation of 
+glycoproteins and non-glycoproteins. Biochimica et biophysica acta.  
+General subjects, 1865(3), 129812.
+4)  Hoseki J, Ushioda R, Nagata K. Mechanism and components of endo-
+plasmic reticulum-associated degradation. J. Biochem., 147, 19–25 
+(2010).
+5)  Christianson JC, Ye Y . Cleaning up in the endoplasmic reticulum: 
+ubiquitin in charge. Nat. Struct. Mol. Biol., 21, 325–335 (2014).
+6)  Ninagawa S, Okada T, Sumitomo Y , Kamiya Y , Kato K, Horimoto S, 
+Ishikawa T, Takeda S, Sakuma T, Yamamoto T, Mori K. EDEM2 ini -
+tiates mammalian glycoprotein ERAD by catalyzing the first mannose 
+trimming step. J. Cell Biol., 206, 347–356 (2014).
+7)  van der Goot AT, Pearce MMP, Leto DE, Shaler TA, Kopito RR. 
+Redundant and Antagonistic Roles of XTP3B and OS9 in Decoding 
+Glycan and Non-glycan Degrons in ER-Associated Degradation. Mol. 
+Cell, 70, 516–530.e6 (2018).
+8)  Nakatsukasa K, Brodsky JL. The recognition and retrotranslocation of 
+misfolded proteins from the endoplasmic reticulum. Traffic, 9, 861–
+870 (2008).
+9)  Timms RT, Menzies SA, Tchasovnikarova IA, Christensen LC,  
+Williamson JC, Antrobus R, Dougan G, Ellgaard L, Lehner PJ. Genet-
+ic dissection of mammalian ERAD through comparative haploid and 
+CRISPR forward genetic screens. Nat. Commun., 7, 11786 (2016).
+10)  George G, Ninagawa S, Yagi H, Saito T, Ishikawa T, Sakuma T,  
+Yamamoto T, Imami K, Ishihama Y , Kato K, Okada T, Mori K. 
+EDEM2 stably disulfide-bonded to TXNDC11 catalyzes the first 
+mannose trimming step in mammalian glycoprotein ERAD. eLife, 9, 
+e53455 (2020).
+11)  Tang HY , Huang CH, Zhuang YH, Christianson JC, Chen X. EDEM2 
+and OS-9 are required for ER-associated degradation of non-glyco-
+sylated sonic hedgehog. PLoS One, 9, e92164 (2014).
+12)  Olivari S, Galli C, Alanen H, Ruddock L, Molinari M. A novel stress-
+induced EDEM variant regulating endoplasmic reticulum-associated 
+glycoprotein degradation. J. Biol. Chem., 280, 2424–2428 (2005).
+13)  Mast SW, Diekman K, Karaveg K, Davis A, Sifers RN, Moremen 
+KW. Human EDEM2, a novel homolog of family 47 glycosidases, is 
+involved in ER-associated degradation of glycoproteins. Glycobiology, 
+15, 421–436 (2005).
+14)  Oh-Hashi K, Takahashi K, Hirata Y . Regulation of the ER-bound tran-
+scription factor Luman/CREB3 in HEK293 cells. FEBS Lett., 593, 
+2771–2778 (2019).
+15)  Oh-Hashi K, Yamamoto A, Murase R, Hirata Y . Comparative Analysis 
+of CREB3 and CREB3L2 Protein Expression in HEK293 Cells. Int. J. 
+Mol. Sci., 22, 2767 (2021).
+16)  Murase R, Yamamoto A, Hirata Y , Oh-Hashi K. Expression analysis 
+and functional characterization of thioredoxin domain-containing pro-
+tein 11. Mol. Biol. Rep., 49, 10541–10556 (2022).
+17)  Oh-Hashi K, Sugiura N, Amaya F, Isobe KI, Hirata Y . Functional val-
+idation of ATF4 and GADD34 in Neuro2a cells by CRISPR/Cas9-
+mediated genome editing. Mol. Cell. Biochem., 440, 65–75 (2018).
+18)  Mali P, Yang L, Esvelt KM, Aach J, Guell M, DiCarlo JE, Norville 
+JE, Church GM. RNA-guided human genome engineering via Cas9.  
+Science, 339, 823–826 (2013).
+19)  Schneider, C.A., Rasband, W.S., & Eliceiri, K.W. NIH Image to 
+ImageJ: 25 years of image analysis. Nat. Methods, 9, 671–675 (2012).
+20)  Badiola N, Penas C, Miñano-Molina A, Barneda-Zahonero B, Fadó R, 
+Sánchez-Opazo G, Comella JX, Sabriá J, Zhu C, Blomgren K, Casas 
+C, Rodríguez-Alvarez J. Induction of ER stress in response to oxy-
+gen-glucose deprivation of cortical cultures involves the activation of 
+the PERK and IRE-1 pathways and of caspase-12. Cell Death Dis., 2, 
+e149 (2011).
+21)  Wu Y , Wang H, Xiang W, Yi D. EDEM2 is a diagnostic and prognostic 
+biomarker and associated with immune infiltration in glioma: A com-
+prehensive analysis. Front. Oncol., 12, 1054012 (2023).
+22)  Shen J, Prywes R. Dependence of site-2 protease cleavage of ATF6 on 
+prior site-1 protease digestion is determined by the size of the luminal 
+domain of ATF6. J. Biol. Chem., 279, 43046–43051 (2004).
+23)  Gregory MA, Hann SR. c-Myc proteolysis by the ubiquitin-proteas-
+ome pathway: stabilization of c-Myc in Burkitt’s lymphoma cells. Mol. 
+Cell. Biol., 20, 2423–2435 (2000).
+24)  Mochida K, Nakatogawa H. ER-phagy: selective autophagy of the 
+endoplasmic reticulum. EMBO Rep., 23, e55192 (2022).
+25)  Chiritoiu M, Chiritoiu GN, Munteanu CV A, Pastrama F, Ivessa NE, 
+Petrescu SM. EDEM1 Drives Misfolded Protein Degradation via 
+ERAD and Exploits ER-Phagy as Back-Up Mechanism When ERAD 
+Is Impaired. Int. J. Mol. Sci., 21, 3468 (2020).
+26)  George G, Ninagawa S, Yagi H, Furukawa JI, Hashii N, Ishii-Watabe 
+A, Deng Y , Matsushita K, Ishikawa T, Mamahit YP, Maki Y , Kajihara 
+Y , Kato K, Okada T, Mori K. Purified EDEM3 or EDEM1 alone pro-
+duces determinant oligosaccharide structures from M8B in mammalian 
+glycoprotein ERAD. eLife, 10, e70357 (2021).
+27)  Sun Q, Zhu E. Molecular mechanism and diagnostic marker inves-
+tigation of endoplasmic reticulum stress on periodontitis. BMC Oral 
+Health, 23, 135 (2023).
+28)  Wu Y , Wang H, Xiang W, Yi D. EDEM2 is a diagnostic and prognostic 
+biomarker and associated with immune infiltration in glioma: A com-
+prehensive analysis. Front. Oncol., 12, 1054012 (2023).
+29)   Li M, Keshavarz-Rahaghi F, Ladua G, Swanson L, Speers C, 
+Renouf DJ, Lim HJ, Davies JM, Gill S, Stuart HC, Yip S, Loree JM.  
+Characterizing the KRAS G12C mutation in metastatic colorectal 
+cancer: a population-based cohort and assessment of expression dif-
+ferences in The Cancer Genome Atlas. Ther. Adv. Med. Oncol., 14, 
+17588359221097940 (2022).
+199
+V ol. 6, No. 6 (2023) BPB Reports


### PR DESCRIPTION
## Summary

Automated weekly warm of the reference cache (`publications/`).
Fetches references that are new or lack full text so the full
`just validate-all` reference phase stays cache-bound (no re-fetching).

- **1** cache entries added/updated this run
- **21325** references cached total

Cache data only — no functional review needed; merge when convenient.
(Raw fetched PDFs in `publications/files/` are gitignored.)
