### PR TITLE
Regenerate pages and browser app

### DIFF
--- a/genes/yeast/TOM22/TOM22-ai-review.html
+++ b/genes/yeast/TOM22/TOM22-ai-review.html
@@ -1,0 +1,5076 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>TOM22 - AI Gene Review</title>
+    <style>
+        :root {
+            --color-accept: #22c55e;
+            --color-remove: #ef4444;
+            --color-modify: #f97316;
+            --color-keep-non-core: #3b82f6;
+            --color-undecided: #6b7280;
+            --color-new: #8b5cf6;
+            --color-mark-over: #eab308;
+            --bg-light: #f9fafb;
+            --border-color: #e5e7eb;
+            --text-muted: #6b7280;
+            --text-primary: #111827;
+        }
+
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+            line-height: 1.6;
+            color: var(--text-primary);
+            background-color: #ffffff;
+            padding: 2rem;
+            max-width: 1400px;
+            margin: 0 auto;
+        }
+
+        .header {
+            border-bottom: 2px solid var(--border-color);
+            padding-bottom: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        h1 {
+            font-size: 2.5rem;
+            font-weight: 700;
+            margin-bottom: 0.5rem;
+            color: #1f2937;
+        }
+
+        .gene-info {
+            display: flex;
+            gap: 2rem;
+            flex-wrap: wrap;
+            margin-top: 1rem;
+        }
+
+        .info-item {
+            display: flex;
+            gap: 0.5rem;
+        }
+
+        .info-label {
+            font-weight: 600;
+            color: var(--text-muted);
+        }
+
+        .aliases {
+            display: flex;
+            gap: 0.5rem;
+            flex-wrap: wrap;
+        }
+
+        .badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.875rem;
+            font-weight: 500;
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+        }
+
+        .status-badge {
+            padding: 0.375rem 0.875rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .status-initialized {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fde68a;
+        }
+
+        .status-in-progress {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+        }
+
+        .status-draft {
+            background-color: #fce7f3;
+            color: #831843;
+            border: 1px solid #fbcfe8;
+        }
+
+        .status-complete {
+            background-color: #d1fae5;
+            color: #065f46;
+            border: 1px solid #a7f3d0;
+        }
+
+        .description-card {
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        .description-card h2 {
+            font-size: 1.25rem;
+            margin-bottom: 1rem;
+            color: #374151;
+        }
+
+        .section {
+            margin-bottom: 2.5rem;
+        }
+
+        .section-title {
+            font-size: 1.5rem;
+            font-weight: 600;
+            margin-bottom: 1.5rem;
+            color: #1f2937;
+            border-bottom: 1px solid var(--border-color);
+            padding-bottom: 0.5rem;
+        }
+
+        .annotations-table {
+            width: 100%;
+            border-collapse: collapse;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            overflow: hidden;
+        }
+
+        .annotations-table thead {
+            background-color: var(--bg-light);
+        }
+
+        .annotations-table th {
+            text-align: left;
+            padding: 1rem;
+            font-weight: 600;
+            border-bottom: 2px solid var(--border-color);
+            font-size: 0.875rem;
+            text-transform: uppercase;
+            letter-spacing: 0.05em;
+            color: var(--text-muted);
+        }
+
+        .annotations-table td {
+            padding: 1rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .annotations-table tbody tr:hover {
+            background-color: #f9fafb;
+        }
+
+        .action-badge {
+            display: inline-block;
+            padding: 0.375rem 0.75rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .action-accept {
+            background-color: var(--color-accept);
+            color: white;
+        }
+
+        .action-remove {
+            background-color: var(--color-remove);
+            color: white;
+        }
+
+        .action-modify {
+            background-color: var(--color-modify);
+            color: white;
+        }
+
+        .action-keep_as_non_core {
+            background-color: var(--color-keep-non-core);
+            color: white;
+        }
+
+        .action-undecided {
+            background-color: var(--color-undecided);
+            color: white;
+        }
+
+        .action-new {
+            background-color: var(--color-new);
+            color: white;
+        }
+
+        .action-mark_as_over_annotated {
+            background-color: var(--color-mark-over);
+            color: white;
+        }
+
+        .term-info {
+            display: flex;
+            flex-direction: column;
+            gap: 0.25rem;
+        }
+
+        .term-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .term-label {
+            font-weight: 500;
+        }
+
+        .evidence-code {
+            font-family: monospace;
+            background-color: var(--bg-light);
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .not-badge {
+            display: inline-block;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-weight: 600;
+            margin-left: 0.25rem;
+        }
+
+        .isoform-badge {
+            display: inline-block;
+            background-color: #eff6ff;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            margin-top: 0.25rem;
+        }
+
+        .core-function-card {
+            background-color: white;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 1rem;
+        }
+
+        .core-function-card h3 {
+            font-size: 1.125rem;
+            margin-bottom: 1rem;
+            color: #1f2937;
+        }
+
+        .core-function-statement {
+            margin-bottom: 1rem;
+            padding: 0.75rem;
+            background-color: var(--bg-light);
+            border-left: 4px solid var(--color-accept);
+            border-radius: 0.25rem;
+        }
+
+        .function-annotations {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin-top: 1rem;
+        }
+
+        .reference-item {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+        }
+
+        .reference-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: start;
+            margin-bottom: 0.75rem;
+        }
+
+        .reference-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #2563eb;
+        }
+
+        .supported-by {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f3f4f6;
+            border-left: 3px solid #3b82f6;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .supported-by-title {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .support-item {
+            margin-bottom: 0.5rem;
+        }
+
+        .support-ref {
+            font-weight: 500;
+            color: #2563eb;
+        }
+
+        .support-text {
+            color: #6b7280;
+            font-style: italic;
+            margin-left: 1rem;
+        }
+
+        a.term-link {
+            color: #2563eb;
+            text-decoration: none;
+        }
+
+        a.term-link:hover {
+            text-decoration: underline;
+        }
+
+        .core-function-terms {
+            margin-top: 1rem;
+        }
+
+        .function-term-group {
+            margin-bottom: 1rem;
+        }
+
+        .function-term-label {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .reference-title {
+            font-weight: 500;
+            margin-bottom: 0.5rem;
+        }
+
+        .findings-list {
+            margin-top: 1rem;
+            padding-left: 1.5rem;
+        }
+
+        .finding-item {
+            margin-bottom: 0.75rem;
+        }
+
+        .finding-statement {
+            font-weight: 500;
+            margin-bottom: 0.25rem;
+        }
+
+        .finding-text {
+            color: var(--text-muted);
+            font-size: 0.95rem;
+            font-style: italic;
+        }
+
+        .proposed-term {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #fef3c7;
+        }
+
+        .question-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #dbeafe;
+        }
+
+        .experiment-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #f3e8ff;
+        }
+
+        .prediction-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: white;
+        }
+
+        .prediction-card .prediction-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+        }
+
+        .prediction-source {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+        }
+
+        .assessment-badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.8rem;
+            font-weight: 600;
+            text-transform: uppercase;
+        }
+
+        .assessment-cor { background-color: #dcfce7; color: #166534; }
+        .assessment-cnn { background-color: #dbeafe; color: #1e40af; }
+        .assessment-lsp { background-color: #fef9c3; color: #854d0e; }
+        .assessment-unc { background-color: #f3f4f6; color: #374151; }
+        .assessment-pli { background-color: #fee2e2; color: #991b1b; }
+        .assessment-npi { background-color: #fecaca; color: #7f1d1d; }
+        .assessment-rep { background-color: #fde68a; color: #92400e; }
+
+        .confidence-score {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+            margin-left: 0.5rem;
+        }
+
+        .error-type-badge {
+            font-size: 0.75rem;
+            padding: 0.125rem 0.5rem;
+            border-radius: 0.25rem;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+        }
+
+        .isoforms-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fill, minmax(400px, 1fr));
+            gap: 1rem;
+        }
+
+        .isoform-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            background-color: white;
+            transition: box-shadow 0.2s;
+        }
+
+        .isoform-card:hover {
+            box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+        }
+
+        .functional-isoform-type {
+            display: inline-block;
+            padding: 0.2rem 0.5rem;
+            border-radius: 0.25rem;
+            font-size: 0.7rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.03em;
+        }
+
+        .type-SPLICE_VARIANT, .type-SPLICE_CLASS {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #93c5fd;
+        }
+
+        .type-CLEAVAGE_PRODUCT {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fcd34d;
+        }
+
+        .type-MODIFICATION_STATE {
+            background-color: #f3e8ff;
+            color: #6b21a8;
+            border: 1px solid #c4b5fd;
+        }
+
+        .type-CONFORMATIONAL_STATE {
+            background-color: #dcfce7;
+            color: #166534;
+            border: 1px solid #86efac;
+        }
+
+        .functional-isoform-mappings {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+            font-size: 0.85rem;
+        }
+
+        .functional-isoform-mappings .mapping-type {
+            font-weight: 600;
+            color: var(--text-muted);
+            font-size: 0.75rem;
+        }
+
+        .functional-isoform-go {
+            margin-top: 0.5rem;
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.25rem;
+        }
+
+        .go-chip {
+            display: inline-block;
+            padding: 0.15rem 0.4rem;
+            background-color: #ecfdf5;
+            color: #047857;
+            border: 1px solid #a7f3d0;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-family: monospace;
+        }
+
+        .isoform-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+            padding-bottom: 0.5rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .isoform-name {
+            font-weight: 600;
+            font-size: 1.1rem;
+            color: #1f2937;
+        }
+
+        .isoform-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .isoform-sequence-note {
+            font-size: 0.875rem;
+            color: var(--text-muted);
+            margin-bottom: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+        }
+
+        .isoform-description {
+            font-size: 0.95rem;
+            line-height: 1.5;
+        }
+
+        .collapsible {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .collapsible:after {
+            content: ' ▼';
+            font-size: 0.75rem;
+        }
+
+        .collapsible.collapsed:after {
+            content: ' ►';
+        }
+
+        .collapse-content {
+            transition: max-height 0.3s ease;
+            overflow: hidden;
+        }
+
+        .collapsed + .collapse-content {
+            max-height: 0;
+        }
+
+        .no-data {
+            color: var(--text-muted);
+            font-style: italic;
+            padding: 1rem;
+            text-align: center;
+            background-color: var(--bg-light);
+            border-radius: 0.5rem;
+        }
+
+        /* Styling for markdown section summaries with voting */
+        .markdown-section summary {
+            padding: 0.75rem;
+            background: var(--bg-light);
+            border-radius: 0.5rem;
+            margin-bottom: 0.5rem;
+        }
+
+        .markdown-section summary:hover {
+            background: #e5e7eb;
+        }
+
+        .markdown-section summary .vote-buttons {
+            margin-left: auto;
+        }
+
+        .deep-research-section {
+            margin-bottom: 1rem;
+            border: 1px solid #c7d2fe;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8faff;
+        }
+
+        .deep-research-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .deep-research-section summary h3 {
+            margin: 0;
+            color: #3730a3;
+            font-size: 1.1rem;
+        }
+
+        .report-meta {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin: 0.75rem 0 1rem;
+            align-items: center;
+        }
+
+        .report-badge {
+            display: inline-flex;
+            align-items: center;
+            border: 1px solid #c7d2fe;
+            border-radius: 999px;
+            background: #eef2ff;
+            color: #4338ca;
+            font-size: 0.78rem;
+            font-weight: 600;
+            padding: 0.2rem 0.6rem;
+        }
+
+        .report-meta-text {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+        }
+
+        .artifact-list {
+            display: grid;
+            gap: 0.75rem;
+            margin: 0.75rem 0 1rem;
+        }
+
+        .artifact-link {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+            margin-top: 0.5rem;
+            word-break: break-word;
+        }
+
+        @media print {
+            body {
+                padding: 1rem;
+            }
+
+            .collapsible:after {
+                display: none;
+            }
+
+            .collapsed + .collapse-content {
+                max-height: none !important;
+            }
+        }
+
+        @media (max-width: 768px) {
+            body {
+                padding: 1rem;
+            }
+
+            h1 {
+                font-size: 2rem;
+            }
+
+            .annotations-table {
+                font-size: 0.875rem;
+            }
+
+            .annotations-table th,
+            .annotations-table td {
+                padding: 0.5rem;
+            }
+        }
+    </style>
+</head>
+<body>
+    <div class="header">
+        <h1>TOM22</h1>
+        <div class="gene-info">
+            
+            <div class="info-item">
+                
+                <span class="info-label">UniProt ID:</span>
+                <span>
+                    <a href="https://www.uniprot.org/uniprotkb/P49334" target="_blank" class="term-link">
+                        P49334
+                    </a>
+                </span>
+                
+            </div>
+            
+            
+            <div class="info-item">
+                <span class="info-label">Organism:</span>
+                <span>Saccharomyces cerevisiae</span>
+            </div>
+            
+            
+            <div class="info-item">
+                <span class="info-label">Review Status:</span>
+                <span class="status-badge status-in-progress">
+                    IN PROGRESS
+                </span>
+            </div>
+            
+            
+        </div>
+        <div style="margin-top: 1rem; text-align: center;">
+            <a id="feedback-form-link"
+               href="#"
+               target="_blank"
+               style="display: inline-block; padding: 10px 20px; background-color: #4CAF50; color: white; text-decoration: none; border-radius: 5px; font-weight: 600;">
+                📝 Provide Detailed Feedback
+            </a>
+            <script>
+                // Construct the form URL with proper encoding
+                // Extract organism code from the current page path (e.g., /genes/ARATH/APO1/ -> ARATH)
+                const pathParts = window.location.pathname.split('/');
+                const genesIndex = pathParts.indexOf('genes');
+                let organism = '';
+                if (genesIndex !== -1 && pathParts[genesIndex + 1]) {
+                    organism = pathParts[genesIndex + 1].toUpperCase();
+                }
+                const geneSymbol = "TOM22";
+                const speciesGene = organism + ' ' + geneSymbol;
+                const formBaseUrl = 'https://docs.google.com/forms/d/e/1FAIpQLSdTot9L6GVkkZYgLQT0E8ZdAJv8RiN5ZgOVkgWNcKSbYvxxzQ/viewform';
+                const entryId = '1226477767'; // Correct entry ID for Species/Gene field
+                const formUrl = formBaseUrl + '?entry.' + entryId + '=' + encodeURIComponent(speciesGene);
+                const feedbackLink = document.getElementById('feedback-form-link');
+                feedbackLink.href = formUrl;
+                // Add tooltip showing the pre-filled value
+                feedbackLink.title = 'Opens form with pre-filled: ' + speciesGene;
+            </script>
+        </div>
+    </div>
+
+    
+    <div class="description-card">
+        <div style="display: flex; justify-content: space-between; align-items: center;">
+            <h2>Gene Description</h2>
+            <span class="vote-buttons" data-g="P49334" data-a="DESCRIPTION: Yeast TOM22 (Mom22/Mas17/Mas22) encodes Tom22, a s..." data-r="" data-act="DESCRIPTION">
+                <button class="vote-btn" data-v="up" title="Agree with this description">👍</button>
+                <button class="vote-btn" data-v="down" title="Disagree with this description">👎</button>
+            </span>
+        </div>
+        <p>Yeast TOM22 (Mom22/Mas17/Mas22) encodes Tom22, a single-pass type II outer mitochondrial membrane protein that serves as the central receptor and organizing scaffold of the translocase of the outer mitochondrial membrane (TOM) complex. Together with Tom20 and Tom70, it forms the transit peptide receptor at the outer membrane surface, recognizes cytosolically synthesized mitochondrial preproteins, and transfers them toward the Tom40 translocation pore. Its cytosolic domain docks Tom20 and Tom70 to the general import pore (GIP) complex, its intermembrane space domain provides a trans binding site for presequences, and its transmembrane anchor is required to stabilize the higher-order TOM machinery and to control Tom40 channel gating. Tom22 also contributes to Tom40 biogenesis and Tom40 β-barrel insertion into the outer membrane through TOM–SAM handoff.</p>
+    </div>
+    
+
+    
+
+    
+
+    
+    <div class="section">
+        <h2 class="section-title">Existing Annotations Review</h2>
+        <table class="annotations-table">
+            <thead>
+                <tr>
+                    <th>GO Term</th>
+                    <th>Evidence</th>
+                    <th>Action</th>
+                    <th>Reason</th>
+                </tr>
+            </thead>
+            <tbody>
+                
+                <tr>
+                    <td>
+                        <div class="term-info">
+                            
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005742" target="_blank" class="term-link">
+                                    GO:0005742
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrial outer membrane translocase complex</span>
+                            
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+                        
+                        
+                        
+                        <br>
+                        <span style="font-size: 0.75rem;">
+                            
+                            GO_REF:0000033
+                            
+                        </span>
+                        
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P49334" data-a="GO:0005742" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+                        
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Correct. Tom22 is a core receptor/scaffold subunit of the TOM (translocase of outer mitochondrial membrane) complex.
+                        </div>
+                        
+                        
+                        
+                        
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+                            
+                            <div class="support-item">
+                                <span class="support-ref">
+                                    
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/9774667" target="_blank" class="term-link">
+                                        PMID:9774667
+                                    </a>
+                                    
+                                </span>
+                                
+                                <div class="support-text">The receptor Tom22 stably associates with Tom40, the main component of the GIP, in a complex with a molecular weight of approximately 400,000 ( approximately 400K), while the other receptors, Tom20 and Tom70, are more loosely associated with this GIP complex and can be found in distinct subcomplexes.</div>
+                                
+                            </div>
+                            
+                            <div class="support-item">
+                                <span class="support-ref">
+                                    
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/9774667" target="_blank" class="term-link">
+                                        PMID:9774667
+                                    </a>
+                                    
+                                </span>
+                                
+                                <div class="support-text">The GIP complex, containing Tom40, Tom22, and three small Tom proteins, forms the central unit of the outer membrane import machinery.</div>
+                                
+                            </div>
+                            
+                        </div>
+                        
+                        
+                    </td>
+                </tr>
+                
+                <tr>
+                    <td>
+                        <div class="term-info">
+                            
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0030150" target="_blank" class="term-link">
+                                    GO:0030150
+                                </a>
+                            </span>
+                            <span class="term-label">protein import into mitochondrial matrix</span>
+                            
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+                        
+                        
+                        
+                        <br>
+                        <span style="font-size: 0.75rem;">
+                            
+                            GO_REF:0000033
+                            
+                        </span>
+                        
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P49334" data-a="GO:0030150" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+                        
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Correct as a TOM-entry step for matrix-destined mitochondrial preproteins. Tom22 is a receptor/scaffold that recognizes preproteins and transfers them toward the Tom40 pore for downstream TIM23/PAM-mediated matrix import. Tom22 also participates in non-matrix import routes, so this BP captures one of several TOM-mediated pathways.
+                        </div>
+                        
+                        
+                        
+                        
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+                            
+                            <div class="support-item">
+                                <span class="support-ref">
+                                    
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/10519552" target="_blank" class="term-link">
+                                        PMID:10519552
+                                    </a>
+                                    
+                                </span>
+                                
+                                <div class="support-text">The central receptor Tom22 binds preproteins through both its cytosolic domain and its intermembrane space domain and is stably associated with the channel protein Tom40</div>
+                                
+                            </div>
+                            
+                            <div class="support-item">
+                                <span class="support-ref">
+                                    
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/10519552" target="_blank" class="term-link">
+                                        PMID:10519552
+                                    </a>
+                                    
+                                </span>
+                                
+                                <div class="support-text">Here we report the unexpected observation that a yeast strain can survive without Tom22, although it is strongly reduced in growth and the import of mitochondrial proteins.</div>
+                                
+                            </div>
+                            
+                        </div>
+                        
+                        
+                    </td>
+                </tr>
+                
+                <tr>
+                    <td>
+                        <div class="term-info">
+                            
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0008320" target="_blank" class="term-link">
+                                    GO:0008320
+                                </a>
+                            </span>
+                            <span class="term-label">protein transmembrane transporter activity</span>
+                            
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+                        
+                        
+                        
+                        <br>
+                        <span style="font-size: 0.75rem;">
+                            
+                            GO_REF:0000033
+                            
+                        </span>
+                        
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P49334" data-a="GO:0008320" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+                        
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Accepted as a contribution to TOM complex protein transmembrane transporter activity. Tom22 is the central receptor/scaffold that recognizes preproteins and transfers them to the Tom40 pore; the `contributes_to` qualifier is the appropriate semantic for a complex subunit that does not independently carry out transmembrane transport but is required for the activity of the complex that does.
+                        </div>
+                        
+                        
+                        <div>
+                            <strong>Reason:</strong> Upstream go-annotation issue #6466 raised the concern that &#34;tom40 is the channel, we don&#39;t know the MF of tom22&#34; and suggested removing this IBA propagation. The annotation is retained because (a) it carries the `contributes_to` qualifier, which by GO semantics indicates a subunit-level contribution to a complex-level activity (not a claim that Tom22 independently translocates substrate); (b) the same propagation is annotated by SGD as an experimental IMP (PMID:10519552) — Tom22 is required for tight control of channel gating and the higher-order organisation that sustains import; and (c) the parallel human TOMM22 review (genes/human/TOMM22/TOMM22-ai-review.yaml) reaches the same conclusion. Tom40 should retain `enables GO:0008320` while Tom22 retains `contributes_to GO:0008320`.
+                        </div>
+                        
+                        
+                        
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+                            
+                            <div class="support-item">
+                                <span class="support-ref">
+                                    
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/10519552" target="_blank" class="term-link">
+                                        PMID:10519552
+                                    </a>
+                                    
+                                </span>
+                                
+                                <div class="support-text">In the absence of Tom22, the translocase dissociates into core complexes, representing the basic import units, but lacks a tight control of channel gating.</div>
+                                
+                            </div>
+                            
+                            <div class="support-item">
+                                <span class="support-ref">
+                                    
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/10519552" target="_blank" class="term-link">
+                                        PMID:10519552
+                                    </a>
+                                    
+                                </span>
+                                
+                                <div class="support-text">Tom22 is a multifunctional protein that is required for the higher-level organization of the TOM machinery.</div>
+                                
+                            </div>
+                            
+                            <div class="support-item">
+                                <span class="support-ref">
+                                    
+                                    file:human/TOMM22/TOMM22-deep-research-falcon.md
+                                    
+                                </span>
+                                
+                                <div class="support-text">TOMM22 functions as a **major preprotein-binding site** and **organizational scaffold** for the TOM complex, helping recognize mitochondrial precursor proteins and transfer them toward the **Tom40 import pore**.</div>
+                                
+                            </div>
+                            
+                        </div>
+                        
+                        
+                    </td>
+                </tr>
+                
+                <tr>
+                    <td>
+                        <div class="term-info">
+                            
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005741" target="_blank" class="term-link">
+                                    GO:0005741
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrial outer membrane</span>
+                            
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+                        
+                        
+                        
+                        <br>
+                        <span style="font-size: 0.75rem;">
+                            
+                            GO_REF:0000120
+                            
+                        </span>
+                        
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P49334" data-a="GO:0005741" data-r="GO_REF:0000120" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+                        
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Correct. Tom22 is a single-pass type II mitochondrial outer membrane protein.
+                        </div>
+                        
+                        
+                        
+                        
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+                            
+                            <div class="support-item">
+                                <span class="support-ref">
+                                    
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/9774667" target="_blank" class="term-link">
+                                        PMID:9774667
+                                    </a>
+                                    
+                                </span>
+                                
+                                <div class="support-text">The preprotein translocase of the outer mitochondrial membrane (Tom) is a multisubunit machinery containing receptors and a general import pore (GIP).</div>
+                                
+                            </div>
+                            
+                        </div>
+                        
+                        
+                    </td>
+                </tr>
+                
+                <tr>
+                    <td>
+                        <div class="term-info">
+                            
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005742" target="_blank" class="term-link">
+                                    GO:0005742
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrial outer membrane translocase complex</span>
+                            
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+                        
+                        
+                        
+                        <br>
+                        <span style="font-size: 0.75rem;">
+                            
+                            GO_REF:0000002
+                            
+                        </span>
+                        
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P49334" data-a="GO:0005742" data-r="GO_REF:0000002" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+                        
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Correct. Tom22 is a core subunit of the TOM/translocase complex.
+                        </div>
+                        
+                        
+                        
+                        
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+                            
+                            <div class="support-item">
+                                <span class="support-ref">
+                                    
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/9774667" target="_blank" class="term-link">
+                                        PMID:9774667
+                                    </a>
+                                    
+                                </span>
+                                
+                                <div class="support-text">The GIP complex, containing Tom40, Tom22, and three small Tom proteins, forms the central unit of the outer membrane import machinery.</div>
+                                
+                            </div>
+                            
+                        </div>
+                        
+                        
+                    </td>
+                </tr>
+                
+                <tr>
+                    <td>
+                        <div class="term-info">
+                            
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006886" target="_blank" class="term-link">
+                                    GO:0006886
+                                </a>
+                            </span>
+                            <span class="term-label">intracellular protein transport</span>
+                            
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+                        
+                        
+                        
+                        <br>
+                        <span style="font-size: 0.75rem;">
+                            
+                            GO_REF:0000002
+                            
+                        </span>
+                        
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="P49334" data-a="GO:0006886" data-r="GO_REF:0000002" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+                        
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Correct pathway family but too broad. Tom22 specifically functions in TOM-complex mitochondrial protein import, and more specific TOM/mitochondrial-import BPs are already annotated.
+                        </div>
+                        
+                        
+                        <div>
+                            <strong>Reason:</strong> Generic intracellular protein transport is far less informative than the existing TOM-mediated import annotations.
+                        </div>
+                        
+                        
+                        
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+                            
+                            <div class="support-item">
+                                <span class="support-ref">
+                                    
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/10519552" target="_blank" class="term-link">
+                                        PMID:10519552
+                                    </a>
+                                    
+                                </span>
+                                
+                                <div class="support-text">Mitochondrial preproteins are imported by a multisubunit translocase of the outer membrane (TOM), including receptor proteins and a general import pore.</div>
+                                
+                            </div>
+                            
+                        </div>
+                        
+                        
+                    </td>
+                </tr>
+                
+                <tr>
+                    <td>
+                        <div class="term-info">
+                            
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0030150" target="_blank" class="term-link">
+                                    GO:0030150
+                                </a>
+                            </span>
+                            <span class="term-label">protein import into mitochondrial matrix</span>
+                            
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+                        
+                        
+                        
+                        <br>
+                        <span style="font-size: 0.75rem;">
+                            
+                            GO_REF:0000002
+                            
+                        </span>
+                        
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P49334" data-a="GO:0030150" data-r="GO_REF:0000002" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+                        
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Correct as a TOM-entry step for matrix-destined preproteins (duplicates the IBA/IMP annotations for the same term).
+                        </div>
+                        
+                        
+                        
+                        
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+                            
+                            <div class="support-item">
+                                <span class="support-ref">
+                                    
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/10519552" target="_blank" class="term-link">
+                                        PMID:10519552
+                                    </a>
+                                    
+                                </span>
+                                
+                                <div class="support-text">The central receptor Tom22 binds preproteins through both its cytosolic domain and its intermembrane space domain and is stably associated with the channel protein Tom40</div>
+                                
+                            </div>
+                            
+                        </div>
+                        
+                        
+                    </td>
+                </tr>
+                
+                <tr>
+                    <td>
+                        <div class="term-info">
+                            
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
+                                    GO:0005515
+                                </a>
+                            </span>
+                            <span class="term-label">protein binding</span>
+                            
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+                        
+                        
+                        
+                        <br>
+                        <span style="font-size: 0.75rem;">
+                            
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/11276259" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:11276259
+                            </a>
+                            
+                                
+                                
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Multistep assembly of the protein import channel of the mito...
+                                </span>
+                                
+                            
+                            
+                        </span>
+                        
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="P49334" data-a="GO:0005515" data-r="PMID:11276259" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+                        
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Protein binding is too generic for Tom22. The biologically informative role here (Tom22 as the receptor that initiates Tom40 targeting/assembly) is already captured by mitochondrial outer membrane translocase complex and protein insertion into mitochondrial outer membrane annotations.
+                        </div>
+                        
+                        
+                        <div>
+                            <strong>Reason:</strong> Per project curation guidance, avoid generic `protein binding`; specific complex membership and assembly roles are informative.
+                        </div>
+                        
+                        
+                        
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+                            
+                            <div class="support-item">
+                                <span class="support-ref">
+                                    
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/11276259" target="_blank" class="term-link">
+                                        PMID:11276259
+                                    </a>
+                                    
+                                </span>
+                                
+                                <div class="support-text">the channel-lining Tom40 is first targeted to the membrane via the receptor proteins Tom20 and Tom22; it then assembles with Tom5 to form the 250 kDa intermediate exposed to the intermembrane space.</div>
+                                
+                            </div>
+                            
+                        </div>
+                        
+                        
+                    </td>
+                </tr>
+                
+                <tr>
+                    <td>
+                        <div class="term-info">
+                            
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
+                                    GO:0005515
+                                </a>
+                            </span>
+                            <span class="term-label">protein binding</span>
+                            
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+                        
+                        
+                        
+                        <br>
+                        <span style="font-size: 0.75rem;">
+                            
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/15797382" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:15797382
+                            </a>
+                            
+                                
+                                
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Mitochondrial presequence translocase: switching between TOM...
+                                </span>
+                                
+                            
+                            
+                        </span>
+                        
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="P49334" data-a="GO:0005515" data-r="PMID:15797382" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+                        
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Protein binding is too generic. The Tom22–Tim21 interaction documented in this paper is captured at the level of TOM-complex membership and PAM/presequence-translocase coupling annotations rather than generic protein binding.
+                        </div>
+                        
+                        
+                        <div>
+                            <strong>Reason:</strong> Generic `protein binding` does not convey the biological role; the Tim21–Tom22 interaction is a downstream coupling event better captured by complex/process annotations.
+                        </div>
+                        
+                        
+                        
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+                            
+                            <div class="support-item">
+                                <span class="support-ref">
+                                    
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/10519552" target="_blank" class="term-link">
+                                        PMID:10519552
+                                    </a>
+                                    
+                                </span>
+                                
+                                <div class="support-text">Tom22 is a multifunctional protein that is required for the higher-level organization of the TOM machinery.</div>
+                                
+                            </div>
+                            
+                        </div>
+                        
+                        
+                    </td>
+                </tr>
+                
+                <tr>
+                    <td>
+                        <div class="term-info">
+                            
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
+                                    GO:0005515
+                                </a>
+                            </span>
+                            <span class="term-label">protein binding</span>
+                            
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+                        
+                        
+                        
+                        <br>
+                        <span style="font-size: 0.75rem;">
+                            
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/16093310" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:16093310
+                            </a>
+                            
+                                
+                                
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Large-scale identification of yeast integral membrane protei...
+                                </span>
+                                
+                            
+                            
+                        </span>
+                        
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="P49334" data-a="GO:0005515" data-r="PMID:16093310" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+                        
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Protein binding is too generic for Tom22. The Tom22–Tom40 interaction is informatively captured by TOM-complex part_of annotations.
+                        </div>
+                        
+                        
+                        <div>
+                            <strong>Reason:</strong> Use TOM complex / outer-membrane translocase membership instead of generic protein binding.
+                        </div>
+                        
+                        
+                        
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+                            
+                            <div class="support-item">
+                                <span class="support-ref">
+                                    
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/9774667" target="_blank" class="term-link">
+                                        PMID:9774667
+                                    </a>
+                                    
+                                </span>
+                                
+                                <div class="support-text">The receptor Tom22 stably associates with Tom40, the main component of the GIP, in a complex with a molecular weight of approximately 400,000 ( approximately 400K), while the other receptors, Tom20 and Tom70, are more loosely associated with this GIP complex and can be found in distinct subcomplexes.</div>
+                                
+                            </div>
+                            
+                        </div>
+                        
+                        
+                    </td>
+                </tr>
+                
+                <tr>
+                    <td>
+                        <div class="term-info">
+                            
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
+                                    GO:0005515
+                                </a>
+                            </span>
+                            <span class="term-label">protein binding</span>
+                            
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+                        
+                        
+                        
+                        <br>
+                        <span style="font-size: 0.75rem;">
+                            
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/17635912" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:17635912
+                            </a>
+                            
+                                
+                                
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    The mitochondrial TOM complex is required for tBid/Bax-induc...
+                                </span>
+                                
+                            
+                            
+                        </span>
+                        
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="P49334" data-a="GO:0005515" data-r="PMID:17635912" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+                        
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Protein binding is too generic. The relevant interactions (Tom22 with Tom40 and with apoptotic regulators such as Bax in cross-species systems) are better captured by complex membership and process-level annotations.
+                        </div>
+                        
+                        
+                        <div>
+                            <strong>Reason:</strong> Generic `protein binding` does not convey the functional contribution; TOM-complex and import-process annotations already capture the informative role.
+                        </div>
+                        
+                        
+                        
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+                            
+                            <div class="support-item">
+                                <span class="support-ref">
+                                    
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/9774667" target="_blank" class="term-link">
+                                        PMID:9774667
+                                    </a>
+                                    
+                                </span>
+                                
+                                <div class="support-text">The receptor Tom22 stably associates with Tom40, the main component of the GIP, in a complex with a molecular weight of approximately 400,000 ( approximately 400K), while the other receptors, Tom20 and Tom70, are more loosely associated with this GIP complex and can be found in distinct subcomplexes.</div>
+                                
+                            </div>
+                            
+                        </div>
+                        
+                        
+                    </td>
+                </tr>
+                
+                <tr>
+                    <td>
+                        <div class="term-info">
+                            
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
+                                    GO:0005515
+                                </a>
+                            </span>
+                            <span class="term-label">protein binding</span>
+                            
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+                        
+                        
+                        
+                        <br>
+                        <span style="font-size: 0.75rem;">
+                            
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/22009199" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:22009199
+                            </a>
+                            
+                                
+                                
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    The mitochondrial contact site complex, a determinant of mit...
+                                </span>
+                                
+                            
+                            
+                        </span>
+                        
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="P49334" data-a="GO:0005515" data-r="PMID:22009199" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+                        
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Protein binding is too generic. The Tom22 interaction with the MICOS/mitofilin (Fcj1) machinery reported in this paper is better captured by the mitochondrial-membrane organisation and TOM/MICOS coupling annotations than by generic protein binding.
+                        </div>
+                        
+                        
+                        <div>
+                            <strong>Reason:</strong> Per project guidance, avoid `protein binding`; use informative complex/process terms.
+                        </div>
+                        
+                        
+                        
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+                            
+                            <div class="support-item">
+                                <span class="support-ref">
+                                    
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/10519552" target="_blank" class="term-link">
+                                        PMID:10519552
+                                    </a>
+                                    
+                                </span>
+                                
+                                <div class="support-text">Tom22 is a multifunctional protein that is required for the higher-level organization of the TOM machinery.</div>
+                                
+                            </div>
+                            
+                        </div>
+                        
+                        
+                    </td>
+                </tr>
+                
+                <tr>
+                    <td>
+                        <div class="term-info">
+                            
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
+                                    GO:0005515
+                                </a>
+                            </span>
+                            <span class="term-label">protein binding</span>
+                            
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+                        
+                        
+                        
+                        <br>
+                        <span style="font-size: 0.75rem;">
+                            
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/22198199" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:22198199
+                            </a>
+                            
+                                
+                                
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    The cytosolic domain of human Tom22 modulates human Bax mito...
+                                </span>
+                                
+                            
+                            
+                        </span>
+                        
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="P49334" data-a="GO:0005515" data-r="PMID:22198199" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+                        
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Protein binding is too generic for Tom22. Cross-species Tom22–Bax interactions documented in this paper are captured at the level of TOM-complex membership and outer-membrane process annotations.
+                        </div>
+                        
+                        
+                        <div>
+                            <strong>Reason:</strong> Generic `protein binding` is uninformative; use TOM complex / OMM-process annotations.
+                        </div>
+                        
+                        
+                        
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+                            
+                            <div class="support-item">
+                                <span class="support-ref">
+                                    
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/9774667" target="_blank" class="term-link">
+                                        PMID:9774667
+                                    </a>
+                                    
+                                </span>
+                                
+                                <div class="support-text">The receptor Tom22 stably associates with Tom40, the main component of the GIP, in a complex with a molecular weight of approximately 400,000 ( approximately 400K), while the other receptors, Tom20 and Tom70, are more loosely associated with this GIP complex and can be found in distinct subcomplexes.</div>
+                                
+                            </div>
+                            
+                        </div>
+                        
+                        
+                    </td>
+                </tr>
+                
+                <tr>
+                    <td>
+                        <div class="term-info">
+                            
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
+                                    GO:0005515
+                                </a>
+                            </span>
+                            <span class="term-label">protein binding</span>
+                            
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+                        
+                        
+                        
+                        <br>
+                        <span style="font-size: 0.75rem;">
+                            
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/23911324" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:23911324
+                            </a>
+                            
+                                
+                                
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Coupling of mitochondrial import and export translocases by ...
+                                </span>
+                                
+                            
+                            
+                        </span>
+                        
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="P49334" data-a="GO:0005515" data-r="PMID:23911324" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+                        
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Protein binding is too generic. Tom22 interactions with Tom40, Tom20, and Sam50 captured here represent TOM/TOM-SAM supercomplex relationships best annotated at the complex-membership level.
+                        </div>
+                        
+                        
+                        <div>
+                            <strong>Reason:</strong> TOM and SAM/TOM-SAM coupling annotations are more informative than generic protein binding.
+                        </div>
+                        
+                        
+                        
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+                            
+                            <div class="support-item">
+                                <span class="support-ref">
+                                    
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/9774667" target="_blank" class="term-link">
+                                        PMID:9774667
+                                    </a>
+                                    
+                                </span>
+                                
+                                <div class="support-text">The GIP complex, containing Tom40, Tom22, and three small Tom proteins, forms the central unit of the outer membrane import machinery.</div>
+                                
+                            </div>
+                            
+                        </div>
+                        
+                        
+                    </td>
+                </tr>
+                
+                <tr>
+                    <td>
+                        <div class="term-info">
+                            
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
+                                    GO:0005515
+                                </a>
+                            </span>
+                            <span class="term-label">protein binding</span>
+                            
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+                        
+                        
+                        
+                        <br>
+                        <span style="font-size: 0.75rem;">
+                            
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/37968396" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:37968396
+                            </a>
+                            
+                                
+                                
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    The social and structural architecture of the yeast protein ...
+                                </span>
+                                
+                            
+                            
+                        </span>
+                        
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="P49334" data-a="GO:0005515" data-r="PMID:37968396" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+                        
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Protein binding is too generic. Large-scale interactome data implicating Tom22 with Tom40 and Tom20 corroborate TOM-complex membership annotations rather than supporting an independent informative MF.
+                        </div>
+                        
+                        
+                        <div>
+                            <strong>Reason:</strong> Generic `protein binding` is uninformative; use TOM-complex annotations.
+                        </div>
+                        
+                        
+                        
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+                            
+                            <div class="support-item">
+                                <span class="support-ref">
+                                    
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/9774667" target="_blank" class="term-link">
+                                        PMID:9774667
+                                    </a>
+                                    
+                                </span>
+                                
+                                <div class="support-text">The receptor Tom22 stably associates with Tom40, the main component of the GIP, in a complex with a molecular weight of approximately 400,000 ( approximately 400K), while the other receptors, Tom20 and Tom70, are more loosely associated with this GIP complex and can be found in distinct subcomplexes.</div>
+                                
+                            </div>
+                            
+                        </div>
+                        
+                        
+                    </td>
+                </tr>
+                
+                <tr>
+                    <td>
+                        <div class="term-info">
+                            
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
+                                    GO:0005515
+                                </a>
+                            </span>
+                            <span class="term-label">protein binding</span>
+                            
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+                        
+                        
+                        
+                        <br>
+                        <span style="font-size: 0.75rem;">
+                            
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/9774667" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:9774667
+                            </a>
+                            
+                                
+                                
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Preprotein translocase of the outer mitochondrial membrane: ...
+                                </span>
+                                
+                            
+                            
+                        </span>
+                        
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="P49334" data-a="GO:0005515" data-r="PMID:9774667" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+                        
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Protein binding is too generic for Tom22. The Tom22–Tom40 and Tom22–Tom20 interactions documented in this study are already captured by TOM-complex membership annotations.
+                        </div>
+                        
+                        
+                        <div>
+                            <strong>Reason:</strong> Generic `protein binding` is uninformative; TOM-complex annotations carry the same information with more specificity.
+                        </div>
+                        
+                        
+                        
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+                            
+                            <div class="support-item">
+                                <span class="support-ref">
+                                    
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/9774667" target="_blank" class="term-link">
+                                        PMID:9774667
+                                    </a>
+                                    
+                                </span>
+                                
+                                <div class="support-text">The GIP complex, containing Tom40, Tom22, and three small Tom proteins, forms the central unit of the outer membrane import machinery.</div>
+                                
+                            </div>
+                            
+                        </div>
+                        
+                        
+                    </td>
+                </tr>
+                
+                <tr>
+                    <td>
+                        <div class="term-info">
+                            
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005741" target="_blank" class="term-link">
+                                    GO:0005741
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrial outer membrane</span>
+                            
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+                        
+                        
+                        
+                        <br>
+                        <span style="font-size: 0.75rem;">
+                            
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/9774667" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:9774667
+                            </a>
+                            
+                                
+                                
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Preprotein translocase of the outer mitochondrial membrane: ...
+                                </span>
+                                
+                            
+                            
+                        </span>
+                        
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P49334" data-a="GO:0005741" data-r="PMID:9774667" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+                        
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Correct. Tom22 is an integral outer mitochondrial membrane component of the TOM complex.
+                        </div>
+                        
+                        
+                        
+                        
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+                            
+                            <div class="support-item">
+                                <span class="support-ref">
+                                    
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/9774667" target="_blank" class="term-link">
+                                        PMID:9774667
+                                    </a>
+                                    
+                                </span>
+                                
+                                <div class="support-text">The preprotein translocase of the outer mitochondrial membrane (Tom) is a multisubunit machinery containing receptors and a general import pore (GIP).</div>
+                                
+                            </div>
+                            
+                        </div>
+                        
+                        
+                    </td>
+                </tr>
+                
+                <tr>
+                    <td>
+                        <div class="term-info">
+                            
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005742" target="_blank" class="term-link">
+                                    GO:0005742
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrial outer membrane translocase complex</span>
+                            
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+                        
+                        
+                        
+                        <br>
+                        <span style="font-size: 0.75rem;">
+                            
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/9774667" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:9774667
+                            </a>
+                            
+                                
+                                
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Preprotein translocase of the outer mitochondrial membrane: ...
+                                </span>
+                                
+                            
+                            
+                        </span>
+                        
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P49334" data-a="GO:0005742" data-r="PMID:9774667" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+                        
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Correct. Tom22 is a core subunit of the TOM/GIP complex as demonstrated by this study.
+                        </div>
+                        
+                        
+                        
+                        
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+                            
+                            <div class="support-item">
+                                <span class="support-ref">
+                                    
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/9774667" target="_blank" class="term-link">
+                                        PMID:9774667
+                                    </a>
+                                    
+                                </span>
+                                
+                                <div class="support-text">The GIP complex, containing Tom40, Tom22, and three small Tom proteins, forms the central unit of the outer membrane import machinery.</div>
+                                
+                            </div>
+                            
+                        </div>
+                        
+                        
+                    </td>
+                </tr>
+                
+                <tr>
+                    <td>
+                        <div class="term-info">
+                            
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0045040" target="_blank" class="term-link">
+                                    GO:0045040
+                                </a>
+                            </span>
+                            <span class="term-label">protein insertion into mitochondrial outer membrane</span>
+                            
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+                        
+                        
+                        
+                        <br>
+                        <span style="font-size: 0.75rem;">
+                            
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/9774667" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:9774667
+                            </a>
+                            
+                                
+                                
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Preprotein translocase of the outer mitochondrial membrane: ...
+                                </span>
+                                
+                            
+                            
+                        </span>
+                        
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P49334" data-a="GO:0045040" data-r="PMID:9774667" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+                        
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Correct. Tom22 acts as a receptor required for targeting and assembly of Tom40 and other outer membrane import-machinery substrates into the OMM.
+                        </div>
+                        
+                        
+                        
+                        
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+                            
+                            <div class="support-item">
+                                <span class="support-ref">
+                                    
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/11276259" target="_blank" class="term-link">
+                                        PMID:11276259
+                                    </a>
+                                    
+                                </span>
+                                
+                                <div class="support-text">the channel-lining Tom40 is first targeted to the membrane via the receptor proteins Tom20 and Tom22; it then assembles with Tom5 to form the 250 kDa intermediate exposed to the intermembrane space.</div>
+                                
+                            </div>
+                            
+                        </div>
+                        
+                        
+                    </td>
+                </tr>
+                
+                <tr>
+                    <td>
+                        <div class="term-info">
+                            
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0045040" target="_blank" class="term-link">
+                                    GO:0045040
+                                </a>
+                            </span>
+                            <span class="term-label">protein insertion into mitochondrial outer membrane</span>
+                            
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">NAS</span>
+                        
+                        
+                        
+                        <br>
+                        <span style="font-size: 0.75rem;">
+                            
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/9774667" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:9774667
+                            </a>
+                            
+                                
+                                
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Preprotein translocase of the outer mitochondrial membrane: ...
+                                </span>
+                                
+                            
+                            
+                        </span>
+                        
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P49334" data-a="GO:0045040" data-r="PMID:9774667" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+                        
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Correct (duplicate of the IDA call from the same paper).
+                        </div>
+                        
+                        
+                        
+                        
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+                            
+                            <div class="support-item">
+                                <span class="support-ref">
+                                    
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/9774667" target="_blank" class="term-link">
+                                        PMID:9774667
+                                    </a>
+                                    
+                                </span>
+                                
+                                <div class="support-text">In mutant mitochondria lacking Tom6, the interaction between Tom22 and Tom40 is destabilized, leading to the dissociation of Tom22 and the generation of a subcomplex of approximately 100K containing Tom40, Tom7, and Tom5.</div>
+                                
+                            </div>
+                            
+                        </div>
+                        
+                        
+                    </td>
+                </tr>
+                
+                <tr>
+                    <td>
+                        <div class="term-info">
+                            
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005741" target="_blank" class="term-link">
+                                    GO:0005741
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrial outer membrane</span>
+                            
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+                        
+                        
+                        
+                        <br>
+                        <span style="font-size: 0.75rem;">
+                            
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/16689936" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:16689936
+                            </a>
+                            
+                                
+                                
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Integral membrane proteins in the mitochondrial outer membra...
+                                </span>
+                                
+                            
+                            
+                        </span>
+                        
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P49334" data-a="GO:0005741" data-r="PMID:16689936" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+                        
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Correct. Confirms Tom22 as an integral mitochondrial outer membrane protein in yeast.
+                        </div>
+                        
+                        
+                        
+                        
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+                            
+                            <div class="support-item">
+                                <span class="support-ref">
+                                    
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/9774667" target="_blank" class="term-link">
+                                        PMID:9774667
+                                    </a>
+                                    
+                                </span>
+                                
+                                <div class="support-text">The preprotein translocase of the outer mitochondrial membrane (Tom) is a multisubunit machinery containing receptors and a general import pore (GIP).</div>
+                                
+                            </div>
+                            
+                        </div>
+                        
+                        
+                    </td>
+                </tr>
+                
+                <tr>
+                    <td>
+                        <div class="term-info">
+                            
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005739" target="_blank" class="term-link">
+                                    GO:0005739
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrion</span>
+                            
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">HDA</span>
+                        
+                        
+                        
+                        <br>
+                        <span style="font-size: 0.75rem;">
+                            
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/24769239" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:24769239
+                            </a>
+                            
+                                
+                                
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Quantitative variations of the mitochondrial proteome and ph...
+                                </span>
+                                
+                            
+                            
+                        </span>
+                        
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="P49334" data-a="GO:0005739" data-r="PMID:24769239" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+                        
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Correct but very broad. More specific mitochondrial outer membrane annotations are present.
+                        </div>
+                        
+                        
+                        <div>
+                            <strong>Reason:</strong> Tom22 is a single-pass outer-membrane protein; the specific GO:0005741 (mitochondrial outer membrane) annotations are more informative.
+                        </div>
+                        
+                        
+                        
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+                            
+                            <div class="support-item">
+                                <span class="support-ref">
+                                    
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/9774667" target="_blank" class="term-link">
+                                        PMID:9774667
+                                    </a>
+                                    
+                                </span>
+                                
+                                <div class="support-text">The preprotein translocase of the outer mitochondrial membrane (Tom) is a multisubunit machinery containing receptors and a general import pore (GIP).</div>
+                                
+                            </div>
+                            
+                        </div>
+                        
+                        
+                    </td>
+                </tr>
+                
+                <tr>
+                    <td>
+                        <div class="term-info">
+                            
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005739" target="_blank" class="term-link">
+                                    GO:0005739
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrion</span>
+                            
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">HDA</span>
+                        
+                        
+                        
+                        <br>
+                        <span style="font-size: 0.75rem;">
+                            
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/16823961" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:16823961
+                            </a>
+                            
+                                
+                                
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Toward the complete yeast mitochondrial proteome: multidimen...
+                                </span>
+                                
+                            
+                            
+                        </span>
+                        
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="P49334" data-a="GO:0005739" data-r="PMID:16823961" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+                        
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Correct but very broad; more specific outer-membrane annotations exist.
+                        </div>
+                        
+                        
+                        <div>
+                            <strong>Reason:</strong> Prefer GO:0005741 mitochondrial outer membrane.
+                        </div>
+                        
+                        
+                        
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+                            
+                            <div class="support-item">
+                                <span class="support-ref">
+                                    
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/9774667" target="_blank" class="term-link">
+                                        PMID:9774667
+                                    </a>
+                                    
+                                </span>
+                                
+                                <div class="support-text">The preprotein translocase of the outer mitochondrial membrane (Tom) is a multisubunit machinery containing receptors and a general import pore (GIP).</div>
+                                
+                            </div>
+                            
+                        </div>
+                        
+                        
+                    </td>
+                </tr>
+                
+                <tr>
+                    <td>
+                        <div class="term-info">
+                            
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005741" target="_blank" class="term-link">
+                                    GO:0005741
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrial outer membrane</span>
+                            
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">HDA</span>
+                        
+                        
+                        
+                        <br>
+                        <span style="font-size: 0.75rem;">
+                            
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/16407407" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:16407407
+                            </a>
+                            
+                                
+                                
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Proteomic analysis of the yeast mitochondrial outer membrane...
+                                </span>
+                                
+                            
+                            
+                        </span>
+                        
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P49334" data-a="GO:0005741" data-r="PMID:16407407" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+                        
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Correct. Tom22 is an integral outer mitochondrial membrane protein.
+                        </div>
+                        
+                        
+                        
+                        
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+                            
+                            <div class="support-item">
+                                <span class="support-ref">
+                                    
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/9774667" target="_blank" class="term-link">
+                                        PMID:9774667
+                                    </a>
+                                    
+                                </span>
+                                
+                                <div class="support-text">The preprotein translocase of the outer mitochondrial membrane (Tom) is a multisubunit machinery containing receptors and a general import pore (GIP).</div>
+                                
+                            </div>
+                            
+                        </div>
+                        
+                        
+                    </td>
+                </tr>
+                
+                <tr>
+                    <td>
+                        <div class="term-info">
+                            
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0008320" target="_blank" class="term-link">
+                                    GO:0008320
+                                </a>
+                            </span>
+                            <span class="term-label">protein transmembrane transporter activity</span>
+                            
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IMP</span>
+                        
+                        
+                        
+                        <br>
+                        <span style="font-size: 0.75rem;">
+                            
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/10519552" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:10519552
+                            </a>
+                            
+                                
+                                
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Tom22 is a multifunctional organizer of the mitochondrial pr...
+                                </span>
+                                
+                            
+                            
+                        </span>
+                        
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P49334" data-a="GO:0008320" data-r="PMID:10519552" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+                        
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Accepted as contribution to the TOM complex protein translocation activity. The IMP rests on tom22Δ growth/import phenotypes plus a tight control of channel gating, demonstrating that Tom22 is required for the TOM complex to perform transmembrane protein translocation even though Tom40 is the conducting pore.
+                        </div>
+                        
+                        
+                        <div>
+                            <strong>Reason:</strong> Experimental annotation by SGD curator with the `contributes_to` qualifier, which is the correct semantic for a complex subunit that does not independently translocate substrate but is required for the activity of the complex that does. Upstream go-annotation issue #6466 raised concern about the IBA propagation of this term; this IMP is the source of the experimental support and aligns with that semantic.
+                        </div>
+                        
+                        
+                        
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+                            
+                            <div class="support-item">
+                                <span class="support-ref">
+                                    
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/10519552" target="_blank" class="term-link">
+                                        PMID:10519552
+                                    </a>
+                                    
+                                </span>
+                                
+                                <div class="support-text">The central receptor Tom22 binds preproteins through both its cytosolic domain and its intermembrane space domain and is stably associated with the channel protein Tom40</div>
+                                
+                            </div>
+                            
+                            <div class="support-item">
+                                <span class="support-ref">
+                                    
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/10519552" target="_blank" class="term-link">
+                                        PMID:10519552
+                                    </a>
+                                    
+                                </span>
+                                
+                                <div class="support-text">In the absence of Tom22, the translocase dissociates into core complexes, representing the basic import units, but lacks a tight control of channel gating.</div>
+                                
+                            </div>
+                            
+                        </div>
+                        
+                        
+                    </td>
+                </tr>
+                
+                <tr>
+                    <td>
+                        <div class="term-info">
+                            
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005742" target="_blank" class="term-link">
+                                    GO:0005742
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrial outer membrane translocase complex</span>
+                            
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+                        
+                        
+                        
+                        <br>
+                        <span style="font-size: 0.75rem;">
+                            
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/9774667" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:9774667
+                            </a>
+                            
+                                
+                                
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Preprotein translocase of the outer mitochondrial membrane: ...
+                                </span>
+                                
+                            
+                            
+                        </span>
+                        
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P49334" data-a="GO:0005742" data-r="PMID:9774667" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+                        
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Correct. Direct demonstration that Tom22 is a core member of the TOM/GIP complex.
+                        </div>
+                        
+                        
+                        
+                        
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+                            
+                            <div class="support-item">
+                                <span class="support-ref">
+                                    
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/9774667" target="_blank" class="term-link">
+                                        PMID:9774667
+                                    </a>
+                                    
+                                </span>
+                                
+                                <div class="support-text">The receptor Tom22 stably associates with Tom40, the main component of the GIP, in a complex with a molecular weight of approximately 400,000 ( approximately 400K), while the other receptors, Tom20 and Tom70, are more loosely associated with this GIP complex and can be found in distinct subcomplexes.</div>
+                                
+                            </div>
+                            
+                        </div>
+                        
+                        
+                    </td>
+                </tr>
+                
+                <tr>
+                    <td>
+                        <div class="term-info">
+                            
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0030150" target="_blank" class="term-link">
+                                    GO:0030150
+                                </a>
+                            </span>
+                            <span class="term-label">protein import into mitochondrial matrix</span>
+                            
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IMP</span>
+                        
+                        
+                        
+                        <br>
+                        <span style="font-size: 0.75rem;">
+                            
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/10519552" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:10519552
+                            </a>
+                            
+                                
+                                
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Tom22 is a multifunctional organizer of the mitochondrial pr...
+                                </span>
+                                
+                            
+                            
+                        </span>
+                        
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P49334" data-a="GO:0030150" data-r="PMID:10519552" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+                        
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Correct. tom22Δ mitochondria are strongly defective for preprotein import; matrix-destined preproteins use the TOM complex at the entry step, with Tom22 acting as the central receptor.
+                        </div>
+                        
+                        
+                        
+                        
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+                            
+                            <div class="support-item">
+                                <span class="support-ref">
+                                    
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/10519552" target="_blank" class="term-link">
+                                        PMID:10519552
+                                    </a>
+                                    
+                                </span>
+                                
+                                <div class="support-text">Here we report the unexpected observation that a yeast strain can survive without Tom22, although it is strongly reduced in growth and the import of mitochondrial proteins.</div>
+                                
+                            </div>
+                            
+                        </div>
+                        
+                        
+                    </td>
+                </tr>
+                
+                <tr>
+                    <td>
+                        <div class="term-info">
+                            
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0030150" target="_blank" class="term-link">
+                                    GO:0030150
+                                </a>
+                            </span>
+                            <span class="term-label">protein import into mitochondrial matrix</span>
+                            
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IMP</span>
+                        
+                        
+                        
+                        <br>
+                        <span style="font-size: 0.75rem;">
+                            
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/9774667" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:9774667
+                            </a>
+                            
+                                
+                                
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Preprotein translocase of the outer mitochondrial membrane: ...
+                                </span>
+                                
+                            
+                            
+                        </span>
+                        
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P49334" data-a="GO:0030150" data-r="PMID:9774667" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+                        
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Correct. The TOM complex is the entry step for matrix-destined preproteins; Tom22 is one of two essential subunits of the GIP complex.
+                        </div>
+                        
+                        
+                        
+                        
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+                            
+                            <div class="support-item">
+                                <span class="support-ref">
+                                    
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/9774667" target="_blank" class="term-link">
+                                        PMID:9774667
+                                    </a>
+                                    
+                                </span>
+                                
+                                <div class="support-text">Besides the essential proteins Tom22 and Tom40, the GIP complex contains three small subunits, Tom5, Tom6, and Tom7.</div>
+                                
+                            </div>
+                            
+                        </div>
+                        
+                        
+                    </td>
+                </tr>
+                
+                <tr>
+                    <td>
+                        <div class="term-info">
+                            
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0045040" target="_blank" class="term-link">
+                                    GO:0045040
+                                </a>
+                            </span>
+                            <span class="term-label">protein insertion into mitochondrial outer membrane</span>
+                            
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IMP</span>
+                        
+                        
+                        
+                        <br>
+                        <span style="font-size: 0.75rem;">
+                            
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/12628251" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:12628251
+                            </a>
+                            
+                                
+                                
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Biogenesis of yeast mitochondrial cytochrome c: a unique rel...
+                                </span>
+                                
+                            
+                            
+                        </span>
+                        
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P49334" data-a="GO:0045040" data-r="PMID:12628251" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+                        
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Correct. Tom22 is required for biogenesis of OMM/IMS substrates routed through the TOM machinery; cytochrome c levels are greatly reduced in tom22 mutants.
+                        </div>
+                        
+                        
+                        
+                        
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+                            
+                            <div class="support-item">
+                                <span class="support-ref">
+                                    
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/12628251" target="_blank" class="term-link">
+                                        PMID:12628251
+                                    </a>
+                                    
+                                </span>
+                                
+                                <div class="support-text">Mitochondria lacking the central receptor and organizing protein Tom22 contain greatly reduced levels of cytochrome c.</div>
+                                
+                            </div>
+                            
+                        </div>
+                        
+                        
+                    </td>
+                </tr>
+                
+                <tr>
+                    <td>
+                        <div class="term-info">
+                            
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005741" target="_blank" class="term-link">
+                                    GO:0005741
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrial outer membrane</span>
+                            
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+                        
+                        
+                        
+                        <br>
+                        <span style="font-size: 0.75rem;">
+                            
+                            Reactome:R-SCE-1252255
+                            
+                        </span>
+                        
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P49334" data-a="GO:0005741" data-r="Reactome:R-SCE-1252255" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+                        
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Correct. Tom22 is an outer mitochondrial membrane component of the TOM complex.
+                        </div>
+                        
+                        
+                        
+                        
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+                            
+                            <div class="support-item">
+                                <span class="support-ref">
+                                    
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/9774667" target="_blank" class="term-link">
+                                        PMID:9774667
+                                    </a>
+                                    
+                                </span>
+                                
+                                <div class="support-text">The preprotein translocase of the outer mitochondrial membrane (Tom) is a multisubunit machinery containing receptors and a general import pore (GIP).</div>
+                                
+                            </div>
+                            
+                        </div>
+                        
+                        
+                    </td>
+                </tr>
+                
+                <tr>
+                    <td>
+                        <div class="term-info">
+                            
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005741" target="_blank" class="term-link">
+                                    GO:0005741
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrial outer membrane</span>
+                            
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+                        
+                        
+                        
+                        <br>
+                        <span style="font-size: 0.75rem;">
+                            
+                            Reactome:R-SCE-8953627
+                            
+                        </span>
+                        
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P49334" data-a="GO:0005741" data-r="Reactome:R-SCE-8953627" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+                        
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Correct. Tom22 in the MIB context is still anchored in the mitochondrial outer membrane.
+                        </div>
+                        
+                        
+                        
+                        
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+                            
+                            <div class="support-item">
+                                <span class="support-ref">
+                                    
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/9774667" target="_blank" class="term-link">
+                                        PMID:9774667
+                                    </a>
+                                    
+                                </span>
+                                
+                                <div class="support-text">The preprotein translocase of the outer mitochondrial membrane (Tom) is a multisubunit machinery containing receptors and a general import pore (GIP).</div>
+                                
+                            </div>
+                            
+                        </div>
+                        
+                        
+                    </td>
+                </tr>
+                
+            </tbody>
+        </table>
+    </div>
+    
+
+    
+    <div class="section">
+        <h2 class="section-title">Core Functions</h2>
+        
+        <div class="core-function-card">
+            
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+                <h3>Tom22 is the central preprotein receptor and organizing scaffold of the TOM complex, recognizing presequence-bearing and internal-signal mitochondrial precursors via its cytosolic and IMS domains and transferring them toward the Tom40 translocation pore.</h3>
+                <span class="vote-buttons" data-g="P49334" data-a="FUNCTION: Tom22 is the central preprotein receptor and organ..." data-r="" data-act="CORE_FUNCTION">
+                    <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
+                    <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
+                </span>
+            </div>
+            
+
+            <div class="core-function-terms">
+                
+                <div class="function-term-group">
+                    <div class="function-term-label">Molecular Function:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0030943" target="_blank" class="term-link">
+                            mitochondrion targeting sequence binding
+                        </a>
+                    </span>
+                </div>
+                
+
+                
+                <div class="function-term-group">
+                    <div class="function-term-label">Directly Involved In:</div>
+                    <div class="function-annotations">
+                        
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0030150" target="_blank" class="term-link">
+                                protein import into mitochondrial matrix
+                            </a>
+                        </span>
+                        
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0045040" target="_blank" class="term-link">
+                                protein insertion into mitochondrial outer membrane
+                            </a>
+                        </span>
+                        
+                    </div>
+                </div>
+                
+
+                
+                <div class="function-term-group">
+                    <div class="function-term-label">Cellular Locations:</div>
+                    <div class="function-annotations">
+                        
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005741" target="_blank" class="term-link">
+                                mitochondrial outer membrane
+                            </a>
+                        </span>
+                        
+                    </div>
+                </div>
+                
+
+                
+                <div class="function-term-group">
+                    <div class="function-term-label">In Complex:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005742" target="_blank" class="term-link">
+                            mitochondrial outer membrane translocase complex
+                        </a>
+                    </span>
+                </div>
+                
+
+                
+            </div>
+
+            
+            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
+                <strong>Supporting Evidence:</strong>
+                <ul class="findings-list">
+                    
+                    <li class="finding-item">
+                        <span class="reference-id">
+                            
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/10519552" target="_blank" class="term-link">
+                                PMID:10519552
+                            </a>
+                            
+                        </span>
+                        
+                        <div class="finding-text">The central receptor Tom22 binds preproteins through both its cytosolic domain and its intermembrane space domain and is stably associated with the channel protein Tom40</div>
+                        
+                    </li>
+                    
+                    <li class="finding-item">
+                        <span class="reference-id">
+                            
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/10519552" target="_blank" class="term-link">
+                                PMID:10519552
+                            </a>
+                            
+                        </span>
+                        
+                        <div class="finding-text">Tom22 is a multifunctional protein that is required for the higher-level organization of the TOM machinery.</div>
+                        
+                    </li>
+                    
+                    <li class="finding-item">
+                        <span class="reference-id">
+                            
+                            file:human/TOMM22/TOMM22-deep-research-falcon.md
+                            
+                        </span>
+                        
+                        <div class="finding-text">TOMM22 functions as a **major preprotein-binding site** and **organizational scaffold** for the TOM complex, helping recognize mitochondrial precursor proteins and transfer them toward the **Tom40 import pore**.</div>
+                        
+                    </li>
+                    
+                </ul>
+            </div>
+            
+        </div>
+        
+        <div class="core-function-card">
+            
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+                <h3>Tom22 contributes to TOM complex protein transmembrane transport activity. Tom40 is the conducting pore; Tom22 is the receptor/scaffold required for preprotein delivery to that pore and for tight control of channel gating, so the `contributes_to` qualifier on GO:0008320 is the appropriate semantic.</h3>
+                <span class="vote-buttons" data-g="P49334" data-a="FUNCTION: Tom22 contributes to TOM complex protein transmemb..." data-r="" data-act="CORE_FUNCTION">
+                    <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
+                    <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
+                </span>
+            </div>
+            
+
+            <div class="core-function-terms">
+                
+
+                
+
+                
+                <div class="function-term-group">
+                    <div class="function-term-label">Cellular Locations:</div>
+                    <div class="function-annotations">
+                        
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005741" target="_blank" class="term-link">
+                                mitochondrial outer membrane
+                            </a>
+                        </span>
+                        
+                    </div>
+                </div>
+                
+
+                
+                <div class="function-term-group">
+                    <div class="function-term-label">In Complex:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005742" target="_blank" class="term-link">
+                            mitochondrial outer membrane translocase complex
+                        </a>
+                    </span>
+                </div>
+                
+
+                
+            </div>
+
+            
+            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
+                <strong>Supporting Evidence:</strong>
+                <ul class="findings-list">
+                    
+                    <li class="finding-item">
+                        <span class="reference-id">
+                            
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/10519552" target="_blank" class="term-link">
+                                PMID:10519552
+                            </a>
+                            
+                        </span>
+                        
+                        <div class="finding-text">In the absence of Tom22, the translocase dissociates into core complexes, representing the basic import units, but lacks a tight control of channel gating.</div>
+                        
+                    </li>
+                    
+                    <li class="finding-item">
+                        <span class="reference-id">
+                            
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/9774667" target="_blank" class="term-link">
+                                PMID:9774667
+                            </a>
+                            
+                        </span>
+                        
+                        <div class="finding-text">The GIP complex, containing Tom40, Tom22, and three small Tom proteins, forms the central unit of the outer membrane import machinery.</div>
+                        
+                    </li>
+                    
+                </ul>
+            </div>
+            
+        </div>
+        
+        <div class="core-function-card">
+            
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+                <h3>Tom22 is required for TOM complex assembly and stability, docking Tom20 and Tom70 onto the TOM core and supporting Tom40 biogenesis/outer-membrane insertion through the TOM-SAM pathway.</h3>
+                <span class="vote-buttons" data-g="P49334" data-a="FUNCTION: Tom22 is required for TOM complex assembly and sta..." data-r="" data-act="CORE_FUNCTION">
+                    <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
+                    <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
+                </span>
+            </div>
+            
+
+            <div class="core-function-terms">
+                
+
+                
+                <div class="function-term-group">
+                    <div class="function-term-label">Directly Involved In:</div>
+                    <div class="function-annotations">
+                        
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0045040" target="_blank" class="term-link">
+                                protein insertion into mitochondrial outer membrane
+                            </a>
+                        </span>
+                        
+                    </div>
+                </div>
+                
+
+                
+                <div class="function-term-group">
+                    <div class="function-term-label">Cellular Locations:</div>
+                    <div class="function-annotations">
+                        
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005741" target="_blank" class="term-link">
+                                mitochondrial outer membrane
+                            </a>
+                        </span>
+                        
+                    </div>
+                </div>
+                
+
+                
+                <div class="function-term-group">
+                    <div class="function-term-label">In Complex:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005742" target="_blank" class="term-link">
+                            mitochondrial outer membrane translocase complex
+                        </a>
+                    </span>
+                </div>
+                
+
+                
+            </div>
+
+            
+            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
+                <strong>Supporting Evidence:</strong>
+                <ul class="findings-list">
+                    
+                    <li class="finding-item">
+                        <span class="reference-id">
+                            
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/9774667" target="_blank" class="term-link">
+                                PMID:9774667
+                            </a>
+                            
+                        </span>
+                        
+                        <div class="finding-text">The receptor Tom22 stably associates with Tom40, the main component of the GIP, in a complex with a molecular weight of approximately 400,000 ( approximately 400K), while the other receptors, Tom20 and Tom70, are more loosely associated with this GIP complex and can be found in distinct subcomplexes.</div>
+                        
+                    </li>
+                    
+                    <li class="finding-item">
+                        <span class="reference-id">
+                            
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/11276259" target="_blank" class="term-link">
+                                PMID:11276259
+                            </a>
+                            
+                        </span>
+                        
+                        <div class="finding-text">the channel-lining Tom40 is first targeted to the membrane via the receptor proteins Tom20 and Tom22; it then assembles with Tom5 to form the 250 kDa intermediate exposed to the intermembrane space.</div>
+                        
+                    </li>
+                    
+                </ul>
+            </div>
+            
+        </div>
+        
+    </div>
+    
+
+    
+    <div class="section">
+        <h2 class="section-title collapsible">References</h2>
+        <div class="collapse-content">
+            
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+                        
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000002.md" target="_blank" class="term-link">
+                            GO_REF:0000002
+                        </a>
+                        
+                    </span>
+                </div>
+                
+                <div class="reference-title">Gene Ontology annotation through association of InterPro records with GO terms</div>
+                
+                
+            </div>
+            
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+                        
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000033.md" target="_blank" class="term-link">
+                            GO_REF:0000033
+                        </a>
+                        
+                    </span>
+                </div>
+                
+                <div class="reference-title">Annotation inferences using phylogenetic trees</div>
+                
+                
+            </div>
+            
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+                        
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000120.md" target="_blank" class="term-link">
+                            GO_REF:0000120
+                        </a>
+                        
+                    </span>
+                </div>
+                
+                <div class="reference-title">Combined Automated Annotation using Multiple IEA Methods</div>
+                
+                
+            </div>
+            
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+                        
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/10519552" target="_blank" class="term-link">
+                            PMID:10519552
+                        </a>
+                        
+                    </span>
+                </div>
+                
+                <div class="reference-title">Tom22 is a multifunctional organizer of the mitochondrial preprotein translocase.</div>
+                
+                
+                <ul class="findings-list">
+                    
+                    <li class="finding-item">
+                        <div class="finding-statement">Tom22 is the central preprotein receptor of the TOM complex, binding preproteins through both its cytosolic and intermembrane space domains and stably associated with the Tom40 channel.</div>
+                        
+                        <div class="finding-text">"The central receptor Tom22 binds preproteins through both its cytosolic domain and its intermembrane space domain and is stably associated with the channel protein Tom40"</div>
+                        
+                    </li>
+                    
+                    <li class="finding-item">
+                        <div class="finding-statement">Tom22 is required for the higher-level organization of the TOM machinery and for tight control of Tom40 channel gating.</div>
+                        
+                        <div class="finding-text">"In the absence of Tom22, the translocase dissociates into core complexes, representing the basic import units, but lacks a tight control of channel gating."</div>
+                        
+                    </li>
+                    
+                    <li class="finding-item">
+                        <div class="finding-statement">Tom22&#39;s cytosolic domain serves as the docking point for the peripheral receptors Tom20 and Tom70 onto the TOM/GIP core.</div>
+                        
+                        <div class="finding-text">"its cytosolic domain serves as docking point for the peripheral receptors Tom20 and Tom70."</div>
+                        
+                    </li>
+                    
+                </ul>
+                
+            </div>
+            
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+                        
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/11276259" target="_blank" class="term-link">
+                            PMID:11276259
+                        </a>
+                        
+                    </span>
+                </div>
+                
+                <div class="reference-title">Multistep assembly of the protein import channel of the mitochondrial outer membrane.</div>
+                
+                
+                <ul class="findings-list">
+                    
+                    <li class="finding-item">
+                        <div class="finding-statement">Tom40 is first targeted to the OMM via the receptor proteins Tom20 and Tom22, supporting Tom22&#39;s role in protein insertion into the outer membrane.</div>
+                        
+                        <div class="finding-text">"the channel-lining Tom40 is first targeted to the membrane via the receptor proteins Tom20 and Tom22; it then assembles with Tom5 to form the 250 kDa intermediate exposed to the intermembrane space."</div>
+                        
+                    </li>
+                    
+                </ul>
+                
+            </div>
+            
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+                        
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/12628251" target="_blank" class="term-link">
+                            PMID:12628251
+                        </a>
+                        
+                    </span>
+                </div>
+                
+                <div class="reference-title">Biogenesis of yeast mitochondrial cytochrome c: a unique relationship to the TOM machinery.</div>
+                
+                
+                <ul class="findings-list">
+                    
+                    <li class="finding-item">
+                        <div class="finding-statement">tom22 mutants have greatly reduced cytochrome c levels, supporting Tom22&#39;s role in TOM-mediated import beyond canonical matrix presequence routes.</div>
+                        
+                        <div class="finding-text">"Mitochondria lacking the central receptor and organizing protein Tom22 contain greatly reduced levels of cytochrome c."</div>
+                        
+                    </li>
+                    
+                </ul>
+                
+            </div>
+            
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+                        
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/15797382" target="_blank" class="term-link">
+                            PMID:15797382
+                        </a>
+                        
+                    </span>
+                </div>
+                
+                <div class="reference-title">Mitochondrial presequence translocase: switching between TOM tethering and motor recruitment involves Tim21 and Tim17.</div>
+                
+                
+            </div>
+            
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+                        
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/16093310" target="_blank" class="term-link">
+                            PMID:16093310
+                        </a>
+                        
+                    </span>
+                </div>
+                
+                <div class="reference-title">Large-scale identification of yeast integral membrane protein interactions.</div>
+                
+                
+            </div>
+            
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+                        
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/16407407" target="_blank" class="term-link">
+                            PMID:16407407
+                        </a>
+                        
+                    </span>
+                </div>
+                
+                <div class="reference-title">Proteomic analysis of the yeast mitochondrial outer membrane reveals accumulation of a subclass of preproteins.</div>
+                
+                
+            </div>
+            
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+                        
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/16689936" target="_blank" class="term-link">
+                            PMID:16689936
+                        </a>
+                        
+                    </span>
+                </div>
+                
+                <div class="reference-title">Integral membrane proteins in the mitochondrial outer membrane of Saccharomyces cerevisiae.</div>
+                
+                
+            </div>
+            
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+                        
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/16823961" target="_blank" class="term-link">
+                            PMID:16823961
+                        </a>
+                        
+                    </span>
+                </div>
+                
+                <div class="reference-title">Toward the complete yeast mitochondrial proteome: multidimensional separation techniques for mitochondrial proteomics.</div>
+                
+                
+            </div>
+            
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+                        
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/17635912" target="_blank" class="term-link">
+                            PMID:17635912
+                        </a>
+                        
+                    </span>
+                </div>
+                
+                <div class="reference-title">The mitochondrial TOM complex is required for tBid/Bax-induced cytochrome c release.</div>
+                
+                
+            </div>
+            
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+                        
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/22009199" target="_blank" class="term-link">
+                            PMID:22009199
+                        </a>
+                        
+                    </span>
+                </div>
+                
+                <div class="reference-title">The mitochondrial contact site complex, a determinant of mitochondrial architecture.</div>
+                
+                
+            </div>
+            
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+                        
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/22198199" target="_blank" class="term-link">
+                            PMID:22198199
+                        </a>
+                        
+                    </span>
+                </div>
+                
+                <div class="reference-title">The cytosolic domain of human Tom22 modulates human Bax mitochondrial translocation and conformation in yeast.</div>
+                
+                
+            </div>
+            
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+                        
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/23911324" target="_blank" class="term-link">
+                            PMID:23911324
+                        </a>
+                        
+                    </span>
+                </div>
+                
+                <div class="reference-title">Coupling of mitochondrial import and export translocases by receptor-mediated supercomplex formation.</div>
+                
+                
+            </div>
+            
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+                        
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/24769239" target="_blank" class="term-link">
+                            PMID:24769239
+                        </a>
+                        
+                    </span>
+                </div>
+                
+                <div class="reference-title">Quantitative variations of the mitochondrial proteome and phosphoproteome during fermentative and respiratory growth in Saccharomyces cerevisiae.</div>
+                
+                
+            </div>
+            
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+                        
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/37968396" target="_blank" class="term-link">
+                            PMID:37968396
+                        </a>
+                        
+                    </span>
+                </div>
+                
+                <div class="reference-title">The social and structural architecture of the yeast protein interactome.</div>
+                
+                
+            </div>
+            
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+                        
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/9774667" target="_blank" class="term-link">
+                            PMID:9774667
+                        </a>
+                        
+                    </span>
+                </div>
+                
+                <div class="reference-title">Preprotein translocase of the outer mitochondrial membrane: molecular dissection and assembly of the general import pore complex.</div>
+                
+                
+                <ul class="findings-list">
+                    
+                    <li class="finding-item">
+                        <div class="finding-statement">Tom22 is a core, essential subunit of the GIP complex stably associated with Tom40.</div>
+                        
+                        <div class="finding-text">"The receptor Tom22 stably associates with Tom40, the main component of the GIP, in a complex with a molecular weight of approximately 400,000 ( approximately 400K), while the other receptors, Tom20 and Tom70, are more loosely associated with this GIP complex and can be found in distinct subcomplexes."</div>
+                        
+                    </li>
+                    
+                    <li class="finding-item">
+                        <div class="finding-statement">The TOM/GIP complex containing Tom40, Tom22, and three small Tom proteins forms the central unit of the OMM import machinery.</div>
+                        
+                        <div class="finding-text">"The GIP complex, containing Tom40, Tom22, and three small Tom proteins, forms the central unit of the outer membrane import machinery."</div>
+                        
+                    </li>
+                    
+                </ul>
+                
+            </div>
+            
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+                        
+                        Reactome:R-SCE-1252255
+                        
+                    </span>
+                </div>
+                
+                <div class="reference-title">TOM40:TOM70 complex translocates proteins from the cytosol to the mitochondrial intermembrane space</div>
+                
+                
+            </div>
+            
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+                        
+                        Reactome:R-SCE-8953627
+                        
+                    </span>
+                </div>
+                
+                <div class="reference-title">Formation of MIB complex containing the MICOS complex</div>
+                
+                
+            </div>
+            
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+                        
+                        file:human/TOMM22/TOMM22-deep-research-falcon.md
+                        
+                    </span>
+                </div>
+                
+                <div class="reference-title">Falcon deep research report for human TOMM22 (used as ortholog reference for yeast Tom22)</div>
+                
+                
+                <ul class="findings-list">
+                    
+                    <li class="finding-item">
+                        <div class="finding-statement">TOMM22 functions as the central receptor of the TOM complex, recognizing mitochondrial precursor proteins and transferring them toward the Tom40 import pore.</div>
+                        
+                        <div class="finding-text">"TOMM22 functions as a **major preprotein-binding site** and **organizational scaffold** for the TOM complex, helping recognize mitochondrial precursor proteins and transfer them toward the **Tom40 import pore**."</div>
+                        
+                    </li>
+                    
+                </ul>
+                
+            </div>
+            
+        </div>
+    </div>
+    
+
+
+    
+    <div class="section">
+        <h2 class="section-title">Suggested Questions for Experts</h2>
+        
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> How separable are Tom22&#39;s preprotein-receptor and TOM-complex scaffold functions in yeast, and does the IMS domain alone account for the trans presequence binding step?</p>
+                    
+                </div>
+                <span class="vote-buttons" data-g="P49334" data-a="Q: How separable are Tom22&#39;s preprotein-receptor and ..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+        
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> For the TOM-SAM handoff that inserts Tom40 β-barrels, which Tom22 surface is required, and is this distinct from the cytosolic Tom20/Tom70 docking surface?</p>
+                    
+                </div>
+                <span class="vote-buttons" data-g="P49334" data-a="Q: For the TOM-SAM handoff that inserts Tom40 β-barre..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+        
+    </div>
+    
+
+    
+    <div class="section">
+        <h2 class="section-title">Suggested Experiments</h2>
+        
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    
+                    <p><strong>Experiment:</strong> In purified reconstituted TOM proteoliposomes, compare preprotein translocation rates of Tom40-only vs. Tom22+Tom40 (and full TOM minus Tom22) at varying preprotein concentrations to quantify Tom22&#39;s kinetic contribution beyond gating.</p>
+                    
+                    
+                    <p style="margin-top: 0.5rem;"><em>Hypothesis: The `contributes_to` semantic on GO:0008320 reflects a genuine functional dependence of TOM-mediated transport on Tom22, not just a complex-membership artifact.</em></p>
+                    
+                    
+                </div>
+                <span class="vote-buttons" data-g="P49334" data-a="EXPERIMENT: In purified reconstituted TOM proteoliposomes, com..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+        
+    </div>
+    
+
+    
+
+    
+
+    <!-- Computational Predictions Section -->
+    
+
+    <!-- Deep Research Sections -->
+    
+
+    <!-- Additional Documentation Sections -->
+    
+    <div class="section">
+        <h2 class="section-title">📚 Additional Documentation</h2>
+        
+        <details class="markdown-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; cursor: pointer;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Notes</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(TOM22-notes.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="P49334" data-a="DOC: Notes" data-r="" data-act="DOCUMENTATION" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This documentation is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This documentation needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+                <h1 id="tom22-yeast-review-notes">TOM22 (yeast) — review notes</h1>
+<h2 id="trigger">Trigger</h2>
+<p>This review was created to address upstream issue<br />
+<a href="https://github.com/geneontology/go-annotation/issues/6466">geneontology/go-annotation#6466</a>,<br />
+"PAINT issue: PTN004364609 GO:0008320 | transmembrane protein transporter<br />
+activity for Tom40", which states:</p>
+<blockquote>
+<p>tom40 is the channel, we don't know the MF of tom22</p>
+</blockquote>
+<p>The PANTHER family <code>PTN004364609</code> IBA propagation reaches yeast Tom22 via<br />
+<code>SGD:S000005075</code>. The upstream curator's concern is whether GO:0008320<br />
+"transmembrane protein transporter activity" should propagate to Tom22 at all,<br />
+since Tom40 is the conducting pore.</p>
+<h2 id="decision">Decision</h2>
+<p>Retain both GO:0008320 annotations on yeast Tom22 with the <code>contributes_to</code><br />
+qualifier:</p>
+<ol>
+<li><code>contributes_to GO:0008320</code> — IBA from PTN004364609 (GO_REF:0000033) — ACCEPT.</li>
+<li><code>contributes_to GO:0008320</code> — IMP from PMID:10519552 (SGD assignment) — ACCEPT.</li>
+</ol>
+<p>Reasoning:</p>
+<ul>
+<li>The <code>contributes_to</code> qualifier in GO semantics encodes exactly the case the<br />
+  upstream curator is concerned about: a subunit that does not independently<br />
+  perform the MF but is required for the activity of the complex that does.<br />
+  Tom22 fits that pattern — it is a receptor/scaffold for the TOM complex, the<br />
+  complex as a whole performs transmembrane protein transport, and Tom40 is the<br />
+  conducting pore.</li>
+<li>The IBA is not the only source of this annotation. SGD already has an<br />
+  experimental <strong>IMP</strong> annotation with <code>contributes_to</code> from PMID:10519552<br />
+  (van Wilpe et al. 1999, "Tom22 is a multifunctional organizer of the<br />
+  mitochondrial preprotein translocase", Nature). Per CLAUDE.md curation<br />
+  guidance, an experimental annotation by a real curator should not be removed<br />
+  on the basis of an abstract-only read.</li>
+<li>PMID:10519552 establishes that "the translocase dissociates into core<br />
+  complexes ... but lacks a tight control of channel gating" in the absence of<br />
+  Tom22, i.e. Tom22 is required for the activity of the TOM transmembrane<br />
+  protein translocase even though Tom40 is the pore.</li>
+<li>The human ortholog review (<code>genes/human/TOMM22/TOMM22-ai-review.yaml</code>) reaches<br />
+  the same conclusion: ACCEPT <code>contributes_to GO:0008320</code> rather than remove.</li>
+</ul>
+<p>The biologically appropriate response to the upstream concern is to keep<br />
+<code>contributes_to</code> on Tom22 and reserve <code>enables GO:0008320</code> for Tom40.</p>
+<h2 id="other-key-calls">Other key calls</h2>
+<ul>
+<li>All <code>enables GO:0005515 protein binding</code> IPIs — MARK_AS_OVER_ANNOTATED. Per<br />
+  CLAUDE.md guidance, generic <code>protein binding</code> is uninformative; the TOM and<br />
+  TOM-SAM complex membership annotations capture the same information with more<br />
+  specificity.</li>
+<li><code>GO:0006886 intracellular protein transport</code> IEA — MARK_AS_OVER_ANNOTATED.<br />
+  Generic; specific TOM-mediated import BPs are already present.</li>
+<li><code>GO:0005739 mitochondrion</code> HDA × 2 — MARK_AS_OVER_ANNOTATED. Parent of the<br />
+  more specific GO:0005741 mitochondrial outer membrane annotations that are<br />
+  also present.</li>
+<li>All <code>GO:0005742 mitochondrial outer membrane translocase complex</code>,<br />
+<code>GO:0005741 mitochondrial outer membrane</code>, and <code>GO:0045040 protein insertion
+  into mitochondrial outer membrane</code> annotations — ACCEPT.</li>
+<li><code>GO:0030150 protein import into mitochondrial matrix</code> IBA/IEA/IMP — ACCEPT<br />
+  with the understanding that matrix import is one of several TOM-mediated<br />
+  routes through Tom22; the matrix term is well-supported by the experimental<br />
+  IMPs in tom22Δ.</li>
+</ul>
+<h2 id="data-provenance">Data provenance</h2>
+<ul>
+<li>Cached publications used (verbatim supporting_text):<br />
+  PMID:9774667, PMID:10519552, PMID:11276259, PMID:12628251.</li>
+<li>Cross-reference: <code>genes/human/TOMM22/TOMM22-ai-review.yaml</code> (ortholog review)<br />
+  and <code>genes/human/TOMM22/TOMM22-deep-research-falcon.md</code> (used for orthologue<br />
+  context; quoted verbatim).</li>
+<li>Deep research providers (falcon, perplexity-lite) returned no result for<br />
+  yeast TOM22 due to missing API keys. Per CLAUDE.md, no<br />
+<code>*-deep-research-{provider}.md</code> file was authored.</li>
+</ul>
+<h2 id="open-questions-for-the-upstream-curator">Open questions for the upstream curator</h2>
+<ul>
+<li>Should the PTN004364609 IBA for GO:0008320 be left in place with<br />
+<code>contributes_to</code> on all non-Tom40 subunits (the conservative interpretation<br />
+  consistent with the SGD IMP and the human TOMM22 review), or only on<br />
+  receptors that have direct experimental support? If the latter, Tom22 should<br />
+  still keep the term because PMID:10519552 is a direct IMP.</li>
+<li>For the related <code>GO:0030943 mitochondrion targeting sequence binding</code><br />
+  proposed obsoletion (go-annotation#6437 → go-ontology#32108), once the NTR<br />
+  replacement term is minted, Tom22 will need a MODIFY pass on the<br />
+<code>core_functions.molecular_function</code> slot.</li>
+</ul>
+            </div>
+        </details>
+        
+    </div>
+    
+
+    <!-- YAML Preview Section -->
+    <div class="section">
+        <details class="yaml-preview">
+            <summary>
+                <h2 style="display: inline;">📄 View Raw YAML</h2>
+            </summary>
+            <div class="yaml-content">
+                <pre><code>id: P49334
+gene_symbol: TOM22
+product_type: PROTEIN
+status: IN_PROGRESS
+taxon:
+  id: NCBITaxon:559292
+  label: Saccharomyces cerevisiae
+description: Yeast TOM22 (Mom22/Mas17/Mas22) encodes Tom22, a single-pass type II outer mitochondrial membrane protein that serves as the central receptor and organizing scaffold of the translocase of the outer mitochondrial membrane (TOM) complex. Together with Tom20 and Tom70, it forms the transit peptide receptor at the outer membrane surface, recognizes cytosolically synthesized mitochondrial preproteins, and transfers them toward the Tom40 translocation pore. Its cytosolic domain docks Tom20 and Tom70 to the general import pore (GIP) complex, its intermembrane space domain provides a trans binding site for presequences, and its transmembrane anchor is required to stabilize the higher-order TOM machinery and to control Tom40 channel gating. Tom22 also contributes to Tom40 biogenesis and Tom40 β-barrel insertion into the outer membrane through TOM–SAM handoff.
+existing_annotations:
+- term:
+    id: GO:0005742
+    label: mitochondrial outer membrane translocase complex
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  review:
+    summary: Correct. Tom22 is a core receptor/scaffold subunit of the TOM (translocase of outer mitochondrial membrane) complex.
+    action: ACCEPT
+    supported_by:
+    - reference_id: PMID:9774667
+      supporting_text: The receptor Tom22 stably associates with Tom40, the main component of the GIP, in a complex with a molecular weight of approximately 400,000 ( approximately 400K), while the other receptors, Tom20 and Tom70, are more loosely associated with this GIP complex and can be found in distinct subcomplexes.
+    - reference_id: PMID:9774667
+      supporting_text: The GIP complex, containing Tom40, Tom22, and three small Tom proteins, forms the central unit of the outer membrane import machinery.
+- term:
+    id: GO:0030150
+    label: protein import into mitochondrial matrix
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  review:
+    summary: Correct as a TOM-entry step for matrix-destined mitochondrial preproteins. Tom22 is a receptor/scaffold that recognizes preproteins and transfers them toward the Tom40 pore for downstream TIM23/PAM-mediated matrix import. Tom22 also participates in non-matrix import routes, so this BP captures one of several TOM-mediated pathways.
+    action: ACCEPT
+    supported_by:
+    - reference_id: PMID:10519552
+      supporting_text: The central receptor Tom22 binds preproteins through both its cytosolic domain and its intermembrane space domain and is stably associated with the channel protein Tom40
+    - reference_id: PMID:10519552
+      supporting_text: Here we report the unexpected observation that a yeast strain can survive without Tom22, although it is strongly reduced in growth and the import of mitochondrial proteins.
+- term:
+    id: GO:0008320
+    label: protein transmembrane transporter activity
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: contributes_to
+  review:
+    summary: Accepted as a contribution to TOM complex protein transmembrane transporter activity. Tom22 is the central receptor/scaffold that recognizes preproteins and transfers them to the Tom40 pore; the `contributes_to` qualifier is the appropriate semantic for a complex subunit that does not independently carry out transmembrane transport but is required for the activity of the complex that does.
+    action: ACCEPT
+    reason: &#39;Upstream go-annotation issue #6466 raised the concern that &#34;tom40 is the channel, we don&#39;&#39;t know the MF of tom22&#34; and suggested removing this IBA propagation. The annotation is retained because (a) it carries the `contributes_to` qualifier, which by GO semantics indicates a subunit-level contribution to a complex-level activity (not a claim that Tom22 independently translocates substrate); (b) the same propagation is annotated by SGD as an experimental IMP (PMID:10519552) — Tom22 is required for tight control of channel gating and the higher-order organisation that sustains import; and (c) the parallel human TOMM22 review (genes/human/TOMM22/TOMM22-ai-review.yaml) reaches the same conclusion. Tom40 should retain `enables GO:0008320` while Tom22 retains `contributes_to GO:0008320`.&#39;
+    additional_reference_ids:
+    - file:human/TOMM22/TOMM22-deep-research-falcon.md
+    - PMID:10519552
+    supported_by:
+    - reference_id: PMID:10519552
+      supporting_text: In the absence of Tom22, the translocase dissociates into core complexes, representing the basic import units, but lacks a tight control of channel gating.
+    - reference_id: PMID:10519552
+      supporting_text: Tom22 is a multifunctional protein that is required for the higher-level organization of the TOM machinery.
+    - reference_id: file:human/TOMM22/TOMM22-deep-research-falcon.md
+      supporting_text: TOMM22 functions as a **major preprotein-binding site** and **organizational scaffold** for the TOM complex, helping recognize mitochondrial precursor proteins and transfer them toward the **Tom40 import pore**.
+- term:
+    id: GO:0005741
+    label: mitochondrial outer membrane
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000120
+  review:
+    summary: Correct. Tom22 is a single-pass type II mitochondrial outer membrane protein.
+    action: ACCEPT
+    supported_by:
+    - reference_id: PMID:9774667
+      supporting_text: The preprotein translocase of the outer mitochondrial membrane (Tom) is a multisubunit machinery containing receptors and a general import pore (GIP).
+- term:
+    id: GO:0005742
+    label: mitochondrial outer membrane translocase complex
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000002
+  review:
+    summary: Correct. Tom22 is a core subunit of the TOM/translocase complex.
+    action: ACCEPT
+    supported_by:
+    - reference_id: PMID:9774667
+      supporting_text: The GIP complex, containing Tom40, Tom22, and three small Tom proteins, forms the central unit of the outer membrane import machinery.
+- term:
+    id: GO:0006886
+    label: intracellular protein transport
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000002
+  review:
+    summary: Correct pathway family but too broad. Tom22 specifically functions in TOM-complex mitochondrial protein import, and more specific TOM/mitochondrial-import BPs are already annotated.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: Generic intracellular protein transport is far less informative than the existing TOM-mediated import annotations.
+    supported_by:
+    - reference_id: PMID:10519552
+      supporting_text: Mitochondrial preproteins are imported by a multisubunit translocase of the outer membrane (TOM), including receptor proteins and a general import pore.
+- term:
+    id: GO:0030150
+    label: protein import into mitochondrial matrix
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000002
+  review:
+    summary: Correct as a TOM-entry step for matrix-destined preproteins (duplicates the IBA/IMP annotations for the same term).
+    action: ACCEPT
+    supported_by:
+    - reference_id: PMID:10519552
+      supporting_text: The central receptor Tom22 binds preproteins through both its cytosolic domain and its intermembrane space domain and is stably associated with the channel protein Tom40
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:11276259
+  qualifier: enables
+  review:
+    summary: Protein binding is too generic for Tom22. The biologically informative role here (Tom22 as the receptor that initiates Tom40 targeting/assembly) is already captured by mitochondrial outer membrane translocase complex and protein insertion into mitochondrial outer membrane annotations.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: Per project curation guidance, avoid generic `protein binding`; specific complex membership and assembly roles are informative.
+    supported_by:
+    - reference_id: PMID:11276259
+      supporting_text: the channel-lining Tom40 is first targeted to the membrane via the receptor proteins Tom20 and Tom22; it then assembles with Tom5 to form the 250 kDa intermediate exposed to the intermembrane space.
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:15797382
+  qualifier: enables
+  review:
+    summary: Protein binding is too generic. The Tom22–Tim21 interaction documented in this paper is captured at the level of TOM-complex membership and PAM/presequence-translocase coupling annotations rather than generic protein binding.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: Generic `protein binding` does not convey the biological role; the Tim21–Tom22 interaction is a downstream coupling event better captured by complex/process annotations.
+    supported_by:
+    - reference_id: PMID:10519552
+      supporting_text: Tom22 is a multifunctional protein that is required for the higher-level organization of the TOM machinery.
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:16093310
+  qualifier: enables
+  review:
+    summary: Protein binding is too generic for Tom22. The Tom22–Tom40 interaction is informatively captured by TOM-complex part_of annotations.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: Use TOM complex / outer-membrane translocase membership instead of generic protein binding.
+    supported_by:
+    - reference_id: PMID:9774667
+      supporting_text: The receptor Tom22 stably associates with Tom40, the main component of the GIP, in a complex with a molecular weight of approximately 400,000 ( approximately 400K), while the other receptors, Tom20 and Tom70, are more loosely associated with this GIP complex and can be found in distinct subcomplexes.
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:17635912
+  qualifier: enables
+  review:
+    summary: Protein binding is too generic. The relevant interactions (Tom22 with Tom40 and with apoptotic regulators such as Bax in cross-species systems) are better captured by complex membership and process-level annotations.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: Generic `protein binding` does not convey the functional contribution; TOM-complex and import-process annotations already capture the informative role.
+    supported_by:
+    - reference_id: PMID:9774667
+      supporting_text: The receptor Tom22 stably associates with Tom40, the main component of the GIP, in a complex with a molecular weight of approximately 400,000 ( approximately 400K), while the other receptors, Tom20 and Tom70, are more loosely associated with this GIP complex and can be found in distinct subcomplexes.
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:22009199
+  qualifier: enables
+  review:
+    summary: Protein binding is too generic. The Tom22 interaction with the MICOS/mitofilin (Fcj1) machinery reported in this paper is better captured by the mitochondrial-membrane organisation and TOM/MICOS coupling annotations than by generic protein binding.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: Per project guidance, avoid `protein binding`; use informative complex/process terms.
+    supported_by:
+    - reference_id: PMID:10519552
+      supporting_text: Tom22 is a multifunctional protein that is required for the higher-level organization of the TOM machinery.
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:22198199
+  qualifier: enables
+  review:
+    summary: Protein binding is too generic for Tom22. Cross-species Tom22–Bax interactions documented in this paper are captured at the level of TOM-complex membership and outer-membrane process annotations.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: Generic `protein binding` is uninformative; use TOM complex / OMM-process annotations.
+    supported_by:
+    - reference_id: PMID:9774667
+      supporting_text: The receptor Tom22 stably associates with Tom40, the main component of the GIP, in a complex with a molecular weight of approximately 400,000 ( approximately 400K), while the other receptors, Tom20 and Tom70, are more loosely associated with this GIP complex and can be found in distinct subcomplexes.
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:23911324
+  qualifier: enables
+  review:
+    summary: Protein binding is too generic. Tom22 interactions with Tom40, Tom20, and Sam50 captured here represent TOM/TOM-SAM supercomplex relationships best annotated at the complex-membership level.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: TOM and SAM/TOM-SAM coupling annotations are more informative than generic protein binding.
+    supported_by:
+    - reference_id: PMID:9774667
+      supporting_text: The GIP complex, containing Tom40, Tom22, and three small Tom proteins, forms the central unit of the outer membrane import machinery.
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:37968396
+  qualifier: enables
+  review:
+    summary: Protein binding is too generic. Large-scale interactome data implicating Tom22 with Tom40 and Tom20 corroborate TOM-complex membership annotations rather than supporting an independent informative MF.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: Generic `protein binding` is uninformative; use TOM-complex annotations.
+    supported_by:
+    - reference_id: PMID:9774667
+      supporting_text: The receptor Tom22 stably associates with Tom40, the main component of the GIP, in a complex with a molecular weight of approximately 400,000 ( approximately 400K), while the other receptors, Tom20 and Tom70, are more loosely associated with this GIP complex and can be found in distinct subcomplexes.
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:9774667
+  qualifier: enables
+  review:
+    summary: Protein binding is too generic for Tom22. The Tom22–Tom40 and Tom22–Tom20 interactions documented in this study are already captured by TOM-complex membership annotations.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: Generic `protein binding` is uninformative; TOM-complex annotations carry the same information with more specificity.
+    supported_by:
+    - reference_id: PMID:9774667
+      supporting_text: The GIP complex, containing Tom40, Tom22, and three small Tom proteins, forms the central unit of the outer membrane import machinery.
+- term:
+    id: GO:0005741
+    label: mitochondrial outer membrane
+  evidence_type: IDA
+  original_reference_id: PMID:9774667
+  qualifier: located_in
+  review:
+    summary: Correct. Tom22 is an integral outer mitochondrial membrane component of the TOM complex.
+    action: ACCEPT
+    supported_by:
+    - reference_id: PMID:9774667
+      supporting_text: The preprotein translocase of the outer mitochondrial membrane (Tom) is a multisubunit machinery containing receptors and a general import pore (GIP).
+- term:
+    id: GO:0005742
+    label: mitochondrial outer membrane translocase complex
+  evidence_type: IPI
+  original_reference_id: PMID:9774667
+  qualifier: part_of
+  review:
+    summary: Correct. Tom22 is a core subunit of the TOM/GIP complex as demonstrated by this study.
+    action: ACCEPT
+    supported_by:
+    - reference_id: PMID:9774667
+      supporting_text: The GIP complex, containing Tom40, Tom22, and three small Tom proteins, forms the central unit of the outer membrane import machinery.
+- term:
+    id: GO:0045040
+    label: protein insertion into mitochondrial outer membrane
+  evidence_type: IDA
+  original_reference_id: PMID:9774667
+  qualifier: involved_in
+  review:
+    summary: Correct. Tom22 acts as a receptor required for targeting and assembly of Tom40 and other outer membrane import-machinery substrates into the OMM.
+    action: ACCEPT
+    supported_by:
+    - reference_id: PMID:11276259
+      supporting_text: the channel-lining Tom40 is first targeted to the membrane via the receptor proteins Tom20 and Tom22; it then assembles with Tom5 to form the 250 kDa intermediate exposed to the intermembrane space.
+- term:
+    id: GO:0045040
+    label: protein insertion into mitochondrial outer membrane
+  evidence_type: NAS
+  original_reference_id: PMID:9774667
+  qualifier: involved_in
+  review:
+    summary: Correct (duplicate of the IDA call from the same paper).
+    action: ACCEPT
+    supported_by:
+    - reference_id: PMID:9774667
+      supporting_text: In mutant mitochondria lacking Tom6, the interaction between Tom22 and Tom40 is destabilized, leading to the dissociation of Tom22 and the generation of a subcomplex of approximately 100K containing Tom40, Tom7, and Tom5.
+- term:
+    id: GO:0005741
+    label: mitochondrial outer membrane
+  evidence_type: IDA
+  original_reference_id: PMID:16689936
+  qualifier: located_in
+  review:
+    summary: Correct. Confirms Tom22 as an integral mitochondrial outer membrane protein in yeast.
+    action: ACCEPT
+    supported_by:
+    - reference_id: PMID:9774667
+      supporting_text: The preprotein translocase of the outer mitochondrial membrane (Tom) is a multisubunit machinery containing receptors and a general import pore (GIP).
+- term:
+    id: GO:0005739
+    label: mitochondrion
+  evidence_type: HDA
+  original_reference_id: PMID:24769239
+  qualifier: located_in
+  review:
+    summary: Correct but very broad. More specific mitochondrial outer membrane annotations are present.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: Tom22 is a single-pass outer-membrane protein; the specific GO:0005741 (mitochondrial outer membrane) annotations are more informative.
+    supported_by:
+    - reference_id: PMID:9774667
+      supporting_text: The preprotein translocase of the outer mitochondrial membrane (Tom) is a multisubunit machinery containing receptors and a general import pore (GIP).
+- term:
+    id: GO:0005739
+    label: mitochondrion
+  evidence_type: HDA
+  original_reference_id: PMID:16823961
+  qualifier: located_in
+  review:
+    summary: Correct but very broad; more specific outer-membrane annotations exist.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: Prefer GO:0005741 mitochondrial outer membrane.
+    supported_by:
+    - reference_id: PMID:9774667
+      supporting_text: The preprotein translocase of the outer mitochondrial membrane (Tom) is a multisubunit machinery containing receptors and a general import pore (GIP).
+- term:
+    id: GO:0005741
+    label: mitochondrial outer membrane
+  evidence_type: HDA
+  original_reference_id: PMID:16407407
+  qualifier: located_in
+  review:
+    summary: Correct. Tom22 is an integral outer mitochondrial membrane protein.
+    action: ACCEPT
+    supported_by:
+    - reference_id: PMID:9774667
+      supporting_text: The preprotein translocase of the outer mitochondrial membrane (Tom) is a multisubunit machinery containing receptors and a general import pore (GIP).
+- term:
+    id: GO:0008320
+    label: protein transmembrane transporter activity
+  evidence_type: IMP
+  original_reference_id: PMID:10519552
+  qualifier: contributes_to
+  review:
+    summary: Accepted as contribution to the TOM complex protein translocation activity. The IMP rests on tom22Δ growth/import phenotypes plus a tight control of channel gating, demonstrating that Tom22 is required for the TOM complex to perform transmembrane protein translocation even though Tom40 is the conducting pore.
+    action: ACCEPT
+    reason: &#39;Experimental annotation by SGD curator with the `contributes_to` qualifier, which is the correct semantic for a complex subunit that does not independently translocate substrate but is required for the activity of the complex that does. Upstream go-annotation issue #6466 raised concern about the IBA propagation of this term; this IMP is the source of the experimental support and aligns with that semantic.&#39;
+    supported_by:
+    - reference_id: PMID:10519552
+      supporting_text: The central receptor Tom22 binds preproteins through both its cytosolic domain and its intermembrane space domain and is stably associated with the channel protein Tom40
+    - reference_id: PMID:10519552
+      supporting_text: In the absence of Tom22, the translocase dissociates into core complexes, representing the basic import units, but lacks a tight control of channel gating.
+- term:
+    id: GO:0005742
+    label: mitochondrial outer membrane translocase complex
+  evidence_type: IDA
+  original_reference_id: PMID:9774667
+  qualifier: part_of
+  review:
+    summary: Correct. Direct demonstration that Tom22 is a core member of the TOM/GIP complex.
+    action: ACCEPT
+    supported_by:
+    - reference_id: PMID:9774667
+      supporting_text: The receptor Tom22 stably associates with Tom40, the main component of the GIP, in a complex with a molecular weight of approximately 400,000 ( approximately 400K), while the other receptors, Tom20 and Tom70, are more loosely associated with this GIP complex and can be found in distinct subcomplexes.
+- term:
+    id: GO:0030150
+    label: protein import into mitochondrial matrix
+  evidence_type: IMP
+  original_reference_id: PMID:10519552
+  qualifier: involved_in
+  review:
+    summary: Correct. tom22Δ mitochondria are strongly defective for preprotein import; matrix-destined preproteins use the TOM complex at the entry step, with Tom22 acting as the central receptor.
+    action: ACCEPT
+    supported_by:
+    - reference_id: PMID:10519552
+      supporting_text: Here we report the unexpected observation that a yeast strain can survive without Tom22, although it is strongly reduced in growth and the import of mitochondrial proteins.
+- term:
+    id: GO:0030150
+    label: protein import into mitochondrial matrix
+  evidence_type: IMP
+  original_reference_id: PMID:9774667
+  qualifier: involved_in
+  review:
+    summary: Correct. The TOM complex is the entry step for matrix-destined preproteins; Tom22 is one of two essential subunits of the GIP complex.
+    action: ACCEPT
+    supported_by:
+    - reference_id: PMID:9774667
+      supporting_text: Besides the essential proteins Tom22 and Tom40, the GIP complex contains three small subunits, Tom5, Tom6, and Tom7.
+- term:
+    id: GO:0045040
+    label: protein insertion into mitochondrial outer membrane
+  evidence_type: IMP
+  original_reference_id: PMID:12628251
+  qualifier: involved_in
+  review:
+    summary: Correct. Tom22 is required for biogenesis of OMM/IMS substrates routed through the TOM machinery; cytochrome c levels are greatly reduced in tom22 mutants.
+    action: ACCEPT
+    supported_by:
+    - reference_id: PMID:12628251
+      supporting_text: Mitochondria lacking the central receptor and organizing protein Tom22 contain greatly reduced levels of cytochrome c.
+- term:
+    id: GO:0005741
+    label: mitochondrial outer membrane
+  evidence_type: TAS
+  original_reference_id: Reactome:R-SCE-1252255
+  qualifier: located_in
+  review:
+    summary: Correct. Tom22 is an outer mitochondrial membrane component of the TOM complex.
+    action: ACCEPT
+    supported_by:
+    - reference_id: PMID:9774667
+      supporting_text: The preprotein translocase of the outer mitochondrial membrane (Tom) is a multisubunit machinery containing receptors and a general import pore (GIP).
+- term:
+    id: GO:0005741
+    label: mitochondrial outer membrane
+  evidence_type: TAS
+  original_reference_id: Reactome:R-SCE-8953627
+  qualifier: located_in
+  review:
+    summary: Correct. Tom22 in the MIB context is still anchored in the mitochondrial outer membrane.
+    action: ACCEPT
+    supported_by:
+    - reference_id: PMID:9774667
+      supporting_text: The preprotein translocase of the outer mitochondrial membrane (Tom) is a multisubunit machinery containing receptors and a general import pore (GIP).
+references:
+- id: GO_REF:0000002
+  title: Gene Ontology annotation through association of InterPro records with GO
+    terms
+  findings: []
+- id: GO_REF:0000033
+  title: Annotation inferences using phylogenetic trees
+  findings: []
+- id: GO_REF:0000120
+  title: Combined Automated Annotation using Multiple IEA Methods
+  findings: []
+- id: PMID:10519552
+  title: Tom22 is a multifunctional organizer of the mitochondrial preprotein translocase.
+  findings:
+  - statement: Tom22 is the central preprotein receptor of the TOM complex, binding preproteins through both its cytosolic and intermembrane space domains and stably associated with the Tom40 channel.
+    supporting_text: The central receptor Tom22 binds preproteins through both its cytosolic domain and its intermembrane space domain and is stably associated with the channel protein Tom40
+    reference_section_type: ABSTRACT
+  - statement: Tom22 is required for the higher-level organization of the TOM machinery and for tight control of Tom40 channel gating.
+    supporting_text: In the absence of Tom22, the translocase dissociates into core complexes, representing the basic import units, but lacks a tight control of channel gating.
+    reference_section_type: ABSTRACT
+  - statement: Tom22&#39;s cytosolic domain serves as the docking point for the peripheral receptors Tom20 and Tom70 onto the TOM/GIP core.
+    supporting_text: its cytosolic domain serves as docking point for the peripheral receptors Tom20 and Tom70.
+    reference_section_type: ABSTRACT
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: PubMed-verified primary research; underpins the SGD IMP for Tom22 contributes_to GO:0008320 and the IMP for involved_in GO:0030150.
+- id: PMID:11276259
+  title: Multistep assembly of the protein import channel of the mitochondrial outer
+    membrane.
+  findings:
+  - statement: Tom40 is first targeted to the OMM via the receptor proteins Tom20 and Tom22, supporting Tom22&#39;s role in protein insertion into the outer membrane.
+    supporting_text: the channel-lining Tom40 is first targeted to the membrane via the receptor proteins Tom20 and Tom22; it then assembles with Tom5 to form the 250 kDa intermediate exposed to the intermembrane space.
+    reference_section_type: ABSTRACT
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: PubMed-verified primary research; supports the Tom22 role in Tom40 biogenesis / OMM protein insertion.
+- id: PMID:12628251
+  title: &#39;Biogenesis of yeast mitochondrial cytochrome c: a unique relationship to
+    the TOM machinery.&#39;
+  findings:
+  - statement: tom22 mutants have greatly reduced cytochrome c levels, supporting Tom22&#39;s role in TOM-mediated import beyond canonical matrix presequence routes.
+    supporting_text: Mitochondria lacking the central receptor and organizing protein Tom22 contain greatly reduced levels of cytochrome c.
+    reference_section_type: ABSTRACT
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: PubMed-verified primary research; supports the IMP for GO:0045040 protein insertion into mitochondrial outer membrane.
+- id: PMID:15797382
+  title: &#39;Mitochondrial presequence translocase: switching between TOM tethering and
+    motor recruitment involves Tim21 and Tim17.&#39;
+  findings: []
+  reference_review:
+    relevance: MEDIUM
+    correctness: VERIFIED
+    review_notes: Supports Tom22 interaction with Tim21 (TIM23 coupling). Used here only to anchor the protein-binding interaction call.
+- id: PMID:16093310
+  title: Large-scale identification of yeast integral membrane protein interactions.
+  findings: []
+  reference_review:
+    relevance: LOW
+    correctness: VERIFIED
+    review_notes: Large-scale interactome data; supports Tom22–Tom40 binding at the complex level only.
+- id: PMID:16407407
+  title: Proteomic analysis of the yeast mitochondrial outer membrane reveals accumulation
+    of a subclass of preproteins.
+  findings: []
+  reference_review:
+    relevance: MEDIUM
+    correctness: VERIFIED
+    review_notes: Outer-membrane proteomics confirming Tom22 OMM localization.
+- id: PMID:16689936
+  title: Integral membrane proteins in the mitochondrial outer membrane of Saccharomyces
+    cerevisiae.
+  findings: []
+  reference_review:
+    relevance: MEDIUM
+    correctness: VERIFIED
+    review_notes: Outer-membrane proteomics confirming Tom22 OMM localization.
+- id: PMID:16823961
+  title: &#39;Toward the complete yeast mitochondrial proteome: multidimensional separation
+    techniques for mitochondrial proteomics.&#39;
+  findings: []
+  reference_review:
+    relevance: LOW
+    correctness: VERIFIED
+    review_notes: Mitochondrial proteome HDA; supports mitochondrion (parent) localization only.
+- id: PMID:17635912
+  title: The mitochondrial TOM complex is required for tBid/Bax-induced cytochrome
+    c release.
+  findings: []
+  reference_review:
+    relevance: LOW
+    correctness: VERIFIED
+    review_notes: Documents Tom22–Tom40 and Tom22–Bax interactions; protein binding annotation downgraded to over-annotated.
+- id: PMID:22009199
+  title: The mitochondrial contact site complex, a determinant of mitochondrial architecture.
+  findings: []
+  reference_review:
+    relevance: MEDIUM
+    correctness: VERIFIED
+    review_notes: Documents Tom22 interaction with Fcj1/MICOS subunits; complex/process annotations capture this better than generic binding.
+- id: PMID:22198199
+  title: The cytosolic domain of human Tom22 modulates human Bax mitochondrial translocation
+    and conformation in yeast.
+  findings: []
+  reference_review:
+    relevance: LOW
+    correctness: VERIFIED
+    review_notes: Cross-species human Tom22 study; supports the generic protein-binding call but is not core for yeast Tom22 function.
+- id: PMID:23911324
+  title: Coupling of mitochondrial import and export translocases by receptor-mediated
+    supercomplex formation.
+  findings: []
+  reference_review:
+    relevance: MEDIUM
+    correctness: VERIFIED
+    review_notes: Documents TOM–SAM supercomplex coupling involving Tom22; complex-level annotations preferred over generic protein binding.
+- id: PMID:24769239
+  title: Quantitative variations of the mitochondrial proteome and phosphoproteome
+    during fermentative and respiratory growth in Saccharomyces cerevisiae.
+  findings: []
+  reference_review:
+    relevance: LOW
+    correctness: VERIFIED
+    review_notes: Mitochondrial proteome HDA; supports broad mitochondrion localization only.
+- id: PMID:37968396
+  title: The social and structural architecture of the yeast protein interactome.
+  findings: []
+  reference_review:
+    relevance: LOW
+    correctness: VERIFIED
+    review_notes: Large-scale interactome supporting Tom22–TOM-subunit interactions at complex level.
+- id: PMID:9774667
+  title: &#39;Preprotein translocase of the outer mitochondrial membrane: molecular dissection
+    and assembly of the general import pore complex.&#39;
+  findings:
+  - statement: Tom22 is a core, essential subunit of the GIP complex stably associated with Tom40.
+    supporting_text: The receptor Tom22 stably associates with Tom40, the main component of the GIP, in a complex with a molecular weight of approximately 400,000 ( approximately 400K), while the other receptors, Tom20 and Tom70, are more loosely associated with this GIP complex and can be found in distinct subcomplexes.
+    reference_section_type: ABSTRACT
+  - statement: The TOM/GIP complex containing Tom40, Tom22, and three small Tom proteins forms the central unit of the OMM import machinery.
+    supporting_text: The GIP complex, containing Tom40, Tom22, and three small Tom proteins, forms the central unit of the outer membrane import machinery.
+    reference_section_type: ABSTRACT
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: PubMed-verified primary research; underpins multiple ACCEPT calls (TOM complex membership, OMM localization, Tom40 OMM assembly).
+- id: Reactome:R-SCE-1252255
+  title: TOM40:TOM70 complex translocates proteins from the cytosol to the mitochondrial
+    intermembrane space
+  findings: []
+- id: Reactome:R-SCE-8953627
+  title: Formation of MIB complex containing the MICOS complex
+  findings: []
+- id: file:human/TOMM22/TOMM22-deep-research-falcon.md
+  title: Falcon deep research report for human TOMM22 (used as ortholog reference for yeast Tom22)
+  findings:
+  - statement: TOMM22 functions as the central receptor of the TOM complex, recognizing mitochondrial precursor proteins and transferring them toward the Tom40 import pore.
+    supporting_text: TOMM22 functions as a **major preprotein-binding site** and **organizational scaffold** for the TOM complex, helping recognize mitochondrial precursor proteins and transfer them toward the **Tom40 import pore**.
+    reference_section_type: OTHER
+  reference_review:
+    relevance: MEDIUM
+    correctness: VERIFIED
+    review_notes: Deep-research summary of the human ortholog; used here to anchor receptor/scaffold reasoning where yeast publications are abstract-only.
+core_functions:
+- description: Tom22 is the central preprotein receptor and organizing scaffold of the TOM complex, recognizing presequence-bearing and internal-signal mitochondrial precursors via its cytosolic and IMS domains and transferring them toward the Tom40 translocation pore.
+  supported_by:
+  - reference_id: PMID:10519552
+    supporting_text: The central receptor Tom22 binds preproteins through both its cytosolic domain and its intermembrane space domain and is stably associated with the channel protein Tom40
+  - reference_id: PMID:10519552
+    supporting_text: Tom22 is a multifunctional protein that is required for the higher-level organization of the TOM machinery.
+  - reference_id: file:human/TOMM22/TOMM22-deep-research-falcon.md
+    supporting_text: TOMM22 functions as a **major preprotein-binding site** and **organizational scaffold** for the TOM complex, helping recognize mitochondrial precursor proteins and transfer them toward the **Tom40 import pore**.
+  molecular_function:
+    id: GO:0030943
+    label: mitochondrion targeting sequence binding
+  directly_involved_in:
+  - id: GO:0030150
+    label: protein import into mitochondrial matrix
+  - id: GO:0045040
+    label: protein insertion into mitochondrial outer membrane
+  locations:
+  - id: GO:0005741
+    label: mitochondrial outer membrane
+  in_complex:
+    id: GO:0005742
+    label: mitochondrial outer membrane translocase complex
+- description: Tom22 contributes to TOM complex protein transmembrane transport activity. Tom40 is the conducting pore; Tom22 is the receptor/scaffold required for preprotein delivery to that pore and for tight control of channel gating, so the `contributes_to` qualifier on GO:0008320 is the appropriate semantic.
+  supported_by:
+  - reference_id: PMID:10519552
+    supporting_text: In the absence of Tom22, the translocase dissociates into core complexes, representing the basic import units, but lacks a tight control of channel gating.
+  - reference_id: PMID:9774667
+    supporting_text: The GIP complex, containing Tom40, Tom22, and three small Tom proteins, forms the central unit of the outer membrane import machinery.
+  contributes_to_molecular_function:
+    id: GO:0008320
+    label: protein transmembrane transporter activity
+  locations:
+  - id: GO:0005741
+    label: mitochondrial outer membrane
+  in_complex:
+    id: GO:0005742
+    label: mitochondrial outer membrane translocase complex
+- description: Tom22 is required for TOM complex assembly and stability, docking Tom20 and Tom70 onto the TOM core and supporting Tom40 biogenesis/outer-membrane insertion through the TOM-SAM pathway.
+  supported_by:
+  - reference_id: PMID:9774667
+    supporting_text: The receptor Tom22 stably associates with Tom40, the main component of the GIP, in a complex with a molecular weight of approximately 400,000 ( approximately 400K), while the other receptors, Tom20 and Tom70, are more loosely associated with this GIP complex and can be found in distinct subcomplexes.
+  - reference_id: PMID:11276259
+    supporting_text: the channel-lining Tom40 is first targeted to the membrane via the receptor proteins Tom20 and Tom22; it then assembles with Tom5 to form the 250 kDa intermediate exposed to the intermembrane space.
+  directly_involved_in:
+  - id: GO:0045040
+    label: protein insertion into mitochondrial outer membrane
+  locations:
+  - id: GO:0005741
+    label: mitochondrial outer membrane
+  in_complex:
+    id: GO:0005742
+    label: mitochondrial outer membrane translocase complex
+proposed_new_terms: []
+suggested_questions:
+- question: How separable are Tom22&#39;s preprotein-receptor and TOM-complex scaffold functions in yeast, and does the IMS domain alone account for the trans presequence binding step?
+  experts: []
+- question: For the TOM-SAM handoff that inserts Tom40 β-barrels, which Tom22 surface is required, and is this distinct from the cytosolic Tom20/Tom70 docking surface?
+  experts: []
+suggested_experiments:
+- hypothesis: The `contributes_to` semantic on GO:0008320 reflects a genuine functional dependence of TOM-mediated transport on Tom22, not just a complex-membership artifact.
+  description: In purified reconstituted TOM proteoliposomes, compare preprotein translocation rates of Tom40-only vs. Tom22+Tom40 (and full TOM minus Tom22) at varying preprotein concentrations to quantify Tom22&#39;s kinetic contribution beyond gating.
+</code></pre>
+            </div>
+        </details>
+    </div>
+
+    <!-- Pathway Visualization Link -->
+    
+
+    <style>
+        /* Markdown Section Styles */
+        .markdown-section {
+            margin-bottom: 1rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .markdown-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .markdown-section summary h3 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.1rem;
+        }
+
+        .markdown-section summary:hover h3 {
+            color: #007bff;
+        }
+
+        .markdown-section[open] {
+            background-color: #fff;
+        }
+
+        .markdown-content {
+            margin-top: 1rem;
+            padding: 1rem;
+            border-top: 1px solid #dee2e6;
+        }
+
+        /* Markdown content styling */
+        .markdown-content h1 { font-size: 1.5rem; margin-top: 1.5rem; }
+        .markdown-content h2 { font-size: 1.3rem; margin-top: 1.3rem; }
+        .markdown-content h3 { font-size: 1.1rem; margin-top: 1.1rem; }
+        .markdown-content h4 { font-size: 1rem; margin-top: 1rem; }
+
+        .markdown-content pre {
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .markdown-content code {
+            background-color: #f8f9fa;
+            padding: 0.2rem 0.4rem;
+            border-radius: 3px;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+        }
+
+        .markdown-content pre code {
+            background: none;
+            padding: 0;
+        }
+
+        .markdown-content table {
+            border-collapse: collapse;
+            width: 100%;
+            margin: 1rem 0;
+        }
+
+        .markdown-content table th,
+        .markdown-content table td {
+            border: 1px solid #dee2e6;
+            padding: 0.5rem;
+            text-align: left;
+        }
+
+        .markdown-content table th {
+            background-color: #f8f9fa;
+            font-weight: bold;
+        }
+
+        .markdown-content blockquote {
+            border-left: 4px solid #007bff;
+            padding-left: 1rem;
+            margin-left: 0;
+            color: #666;
+        }
+
+        /* YAML Preview Styles */
+        .yaml-preview {
+            margin-top: 2rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .yaml-preview summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .yaml-preview summary h2 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.3rem;
+        }
+
+        .yaml-preview summary:hover h2 {
+            color: #007bff;
+        }
+
+        .yaml-preview[open] {
+            background-color: #fff;
+        }
+
+        .yaml-content {
+            margin-top: 1rem;
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .yaml-content pre {
+            margin: 0;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+            line-height: 1.4;
+        }
+
+        .yaml-content code {
+            color: #333;
+            background: none;
+            padding: 0;
+        }
+
+        /* Pathway Link Styles */
+        .pathway-link {
+            margin: 1rem 0;
+        }
+
+        .btn-link {
+            display: inline-block;
+            padding: 0.5rem 1rem;
+            background-color: #007bff;
+            color: white !important;
+            text-decoration: none;
+            border-radius: 4px;
+            font-weight: 500;
+            transition: background-color 0.2s;
+        }
+
+        .btn-link:hover {
+            background-color: #0056b3;
+            text-decoration: none;
+        }
+
+        /* Voting buttons */
+        .vote-buttons {
+            display: inline-block;
+            margin-left: 0.5rem;
+        }
+
+        .vote-btn {
+            background: none;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 2px 6px;
+            margin: 0 2px;
+            cursor: pointer;
+            font-size: 0.9rem;
+            transition: all 0.2s;
+            opacity: 0.6;
+        }
+
+        .vote-btn:hover {
+            opacity: 1;
+            transform: scale(1.1);
+        }
+
+        .vote-btn.voted {
+            opacity: 1;
+            border-color: #28a745;
+            background-color: #d4edda;
+        }
+
+        .vote-btn.voted-down {
+            border-color: #dc3545;
+            background-color: #f8d7da;
+        }
+
+        .vote-btn-small {
+            font-size: 0.7rem;
+            padding: 1px 4px;
+            margin: 0 1px;
+        }
+    </style>
+
+    <script>
+        // Add collapsible functionality
+        document.querySelectorAll('.collapsible').forEach(element => {
+            element.addEventListener('click', function() {
+                this.classList.toggle('collapsed');
+            });
+        });
+
+        // Voting functionality
+        const VOTE_URL = 'https://script.google.com/macros/s/AKfycbwPKH7d3seuPNBtB0ugVjqGeTiByyOGD5vkqB_Ck6K8eOcPQYbJqBOuz6GFgXHKBNWK/exec';
+
+        // Get or create session ID
+        let sessionId = localStorage.getItem('review_session_id');
+        if (!sessionId) {
+            sessionId = 's' + Date.now() + '_' + Math.random().toString(36).substr(2, 9);
+            localStorage.setItem('review_session_id', sessionId);
+        }
+
+        // Show previous votes on page load
+        document.addEventListener('DOMContentLoaded', function() {
+            document.querySelectorAll('.vote-buttons').forEach(container => {
+                const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+                const previousVote = localStorage.getItem(key);
+                if (previousVote) {
+                    const btn = container.querySelector(`[data-v="${previousVote}"]`);
+                    if (btn) btn.classList.add(previousVote === 'up' ? 'voted' : 'voted-down');
+                }
+            });
+        });
+
+        // Handle vote clicks - Simple image beacon approach
+        document.addEventListener('click', function(e) {
+            if (!e.target.classList.contains('vote-btn')) return;
+
+            // Prevent the click from bubbling to parent elements (like summary)
+            e.preventDefault();
+            e.stopPropagation();
+
+            const btn = e.target;
+            const container = btn.closest('.vote-buttons');
+            if (!container) return;
+
+            const voteType = btn.dataset.v;
+
+            // Check if already voted (locally)
+            const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+            const previousVote = localStorage.getItem(key);
+
+            if (previousVote === voteType) {
+                // Same vote - do nothing
+                btn.style.animation = 'shake 0.5s';
+                setTimeout(() => btn.style.animation = '', 500);
+                return;
+            }
+
+            // Build URL
+            const params = new URLSearchParams({
+                gene_id: container.dataset.g,
+                annotation_id: container.dataset.a,
+                ref_id: container.dataset.r || '',
+                action: container.dataset.act,
+                vote: voteType,
+                session_id: sessionId,
+                ua: navigator.userAgent.substring(0, 100)
+            });
+
+            // Clear previous vote styling
+            container.querySelectorAll('.vote-btn').forEach(b => {
+                b.classList.remove('voted', 'voted-down');
+            });
+
+            // Apply new vote styling immediately (optimistic UI)
+            btn.classList.add(voteType === 'up' ? 'voted' : 'voted-down');
+
+            // Store locally
+            localStorage.setItem(key, voteType);
+
+            // Send vote using fetch with no-cors mode (fire and forget)
+            const fullUrl = VOTE_URL + '?' + params;
+            console.log('Sending vote to:', fullUrl);
+
+            // Use fetch in no-cors mode - we won't get a response but the request will be sent
+            fetch(fullUrl, {
+                mode: 'no-cors',
+                method: 'GET'
+            }).then(() => {
+                console.log('Vote request sent (no response due to no-cors mode)');
+            }).catch(err => {
+                console.warn('Vote may not have been recorded, but saved locally:', err);
+
+                // Fallback: try image beacon as well
+                const img = new Image();
+                img.src = fullUrl;
+            });
+        });
+
+        // Optional: Add shake animation for feedback
+        const style = document.createElement('style');
+        style.textContent = `
+            @keyframes shake {
+                0%, 100% { transform: translateX(0); }
+                25% { transform: translateX(-5px); }
+                75% { transform: translateX(5px); }
+            }
+        `;
+        document.head.appendChild(style);
+    </script>
+</body>
+</html>

--- a/pages/projects/CAEEL_MITOPHAGY.html
+++ b/pages/projects/CAEEL_MITOPHAGY.html
@@ -408,7 +408,7 @@
 <h3 id="7-mitochondrial-importproteostasis">7. Mitochondrial Import/Proteostasis</h3>
 <ul>
 <li><strong>tin-44</strong> - TIM44 (import machinery)</li>
-<li><strong>tomm-22</strong> - TOM22 (import machinery)</li>
+<li><strong>tomm-22</strong> - <a href="../../genes/yeast/TOM22/TOM22-ai-review.html">TOM22</a> (import machinery)</li>
 <li><strong><a href="../../genes/worm/spg-7/spg-7-ai-review.html">spg-7</a></strong> - SPG7/Paraplegin (m-AAA protease)</li>
 <li><strong>phb-1/phb-2</strong> - Prohibitins</li>
 </ul>

--- a/pages/projects/MITOCHONDRIAL_IMPORT_PATHWAYS/MITOCHONDRIAL_IMPORT_PATHWAYS-research.html
+++ b/pages/projects/MITOCHONDRIAL_IMPORT_PATHWAYS/MITOCHONDRIAL_IMPORT_PATHWAYS-research.html
@@ -346,7 +346,7 @@
 <h3 id="11-tom-tim23-pam-presequence-pathway-matrix">1.1 TOM-TIM23-PAM (Presequence Pathway → Matrix)</h3>
 <ul>
 <li><strong>Substrates</strong>: Proteins with N-terminal cleavable presequences (matrix-targeted)</li>
-<li><strong>Route</strong>: Tom20 (receptor, recognizes amphipathic presequence) → Tom22 → Tom40 channel → Tim50 (IMS receptor) → Tim23-Tim17 channel → Tim44/mtHsp70 (PAM motor)</li>
+<li><strong>Route</strong>: Tom20 (receptor, recognizes amphipathic presequence) → <a href="../../../genes/yeast/TOM22/TOM22-ai-review.html">Tom22</a> → Tom40 channel → Tim50 (IMS receptor) → Tim23-Tim17 channel → Tim44/mtHsp70 (PAM motor)</li>
 <li><strong>Key insight</strong>: Cryo-EM structures (Araiso et al., Nature 2023, PMID:37344598) revealed that Tim17, not Tim23, forms the actual translocation path. Tim23 serves as a structural platform connecting Tim17, Tim44, and other subunits.</li>
 <li><strong>PAM motor</strong>: <a href="../../../genes/human/HSPA9/HSPA9-ai-review.html">HSPA9</a> (mortalin/mtHsp70 in human) drives import via ATP-dependent trapping mechanism. <a href="../../../genes/human/TIMM44/TIMM44-ai-review.html">TIMM44</a> tethers it to the channel. <a href="../../../genes/human/PAM16/PAM16-ai-review.html">PAM16</a> (Tim16/Pam16) and <a href="../../../genes/human/DNAJC19/DNAJC19-ai-review.html">DNAJC19</a> (Tim14/Pam18) regulate ATPase activity.</li>
 <li><strong>Processing</strong>: After import, MPP (<a href="../../../genes/human/PMPCA/PMPCA-ai-review.html">PMPCA</a>/PMPCB heterodimer) cleaves the presequence in the matrix.</li>
@@ -498,7 +498,7 @@
 </tr>
 <tr>
 <td><a href="../../../genes/human/TOMM22/TOMM22-ai-review.html">TOMM22</a></td>
-<td>Tom22</td>
+<td><a href="../../../genes/yeast/TOM22/TOM22-ai-review.html">Tom22</a></td>
 <td>Central receptor, connects pores</td>
 <td>Q9NS69</td>
 </tr>


### PR DESCRIPTION
## Summary

Automated regeneration of static assets after gene review or template changes.

## Generated Assets

| Asset | Count/Status |
|-------|--------------|
| Gene review YAML files | 2800 |
| Gene review HTML pages | 2800 |
| Project pages | 1079 |
| Module pages | 45 |
| Browser app (data.js) | Updated |
| Validation report | Updated |

## Trigger

This PR was triggered by changes to:
- genes/**/*.yaml - gene review data files
- src/ai_gene_review/schema/** - LinkML schema files
- src/ai_gene_review/templates/** - Jinja2 templates
- src/ai_gene_review/render.py - rendering code
- src/ai_gene_review/render_modules.py - module rendering code
- src/ai_gene_review/export/** - export code
- src/ai_gene_review/browser/** - browser app assets
- src/ai_gene_review/tools/minify_linkml_browser_data.py - browser data compaction
- projects/*.md - project definitions
- modules/**/*.yaml - module definitions
- project.justfile - just recipes used by CI
- .github/workflows/generate-pages.yaml - workflow definition

## Review

- [ ] Spot-check a few gene review HTML pages render correctly
- [ ] Spot-check module tree browser pages render correctly
- [ ] Verify browser app loads and filters work
- [ ] Check validation report for new issues
