### PR TITLE
Regenerate pages and browser app

### DIFF
--- a/genes/human/GCG/GCG-ai-review.html
+++ b/genes/human/GCG/GCG-ai-review.html
@@ -1,0 +1,6962 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>GCG - AI Gene Review</title>
+    <style>
+        :root {
+            --color-accept: #22c55e;
+            --color-remove: #ef4444;
+            --color-modify: #f97316;
+            --color-keep-non-core: #3b82f6;
+            --color-undecided: #6b7280;
+            --color-new: #8b5cf6;
+            --color-mark-over: #eab308;
+            --bg-light: #f9fafb;
+            --border-color: #e5e7eb;
+            --text-muted: #6b7280;
+            --text-primary: #111827;
+        }
+
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+            line-height: 1.6;
+            color: var(--text-primary);
+            background-color: #ffffff;
+            padding: 2rem;
+            max-width: 1400px;
+            margin: 0 auto;
+        }
+
+        .header {
+            border-bottom: 2px solid var(--border-color);
+            padding-bottom: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        h1 {
+            font-size: 2.5rem;
+            font-weight: 700;
+            margin-bottom: 0.5rem;
+            color: #1f2937;
+        }
+
+        .gene-info {
+            display: flex;
+            gap: 2rem;
+            flex-wrap: wrap;
+            margin-top: 1rem;
+        }
+
+        .info-item {
+            display: flex;
+            gap: 0.5rem;
+        }
+
+        .info-label {
+            font-weight: 600;
+            color: var(--text-muted);
+        }
+
+        .aliases {
+            display: flex;
+            gap: 0.5rem;
+            flex-wrap: wrap;
+        }
+
+        .badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.875rem;
+            font-weight: 500;
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+        }
+
+        .status-badge {
+            padding: 0.375rem 0.875rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .status-initialized {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fde68a;
+        }
+
+        .status-in-progress {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+        }
+
+        .status-draft {
+            background-color: #fce7f3;
+            color: #831843;
+            border: 1px solid #fbcfe8;
+        }
+
+        .status-complete {
+            background-color: #d1fae5;
+            color: #065f46;
+            border: 1px solid #a7f3d0;
+        }
+
+        .description-card {
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        .description-card h2 {
+            font-size: 1.25rem;
+            margin-bottom: 1rem;
+            color: #374151;
+        }
+
+        .section {
+            margin-bottom: 2.5rem;
+        }
+
+        .section-title {
+            font-size: 1.5rem;
+            font-weight: 600;
+            margin-bottom: 1.5rem;
+            color: #1f2937;
+            border-bottom: 1px solid var(--border-color);
+            padding-bottom: 0.5rem;
+        }
+
+        .annotations-table {
+            width: 100%;
+            border-collapse: collapse;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            overflow: hidden;
+        }
+
+        .annotations-table thead {
+            background-color: var(--bg-light);
+        }
+
+        .annotations-table th {
+            text-align: left;
+            padding: 1rem;
+            font-weight: 600;
+            border-bottom: 2px solid var(--border-color);
+            font-size: 0.875rem;
+            text-transform: uppercase;
+            letter-spacing: 0.05em;
+            color: var(--text-muted);
+        }
+
+        .annotations-table td {
+            padding: 1rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .annotations-table tbody tr:hover {
+            background-color: #f9fafb;
+        }
+
+        .action-badge {
+            display: inline-block;
+            padding: 0.375rem 0.75rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .action-accept {
+            background-color: var(--color-accept);
+            color: white;
+        }
+
+        .action-remove {
+            background-color: var(--color-remove);
+            color: white;
+        }
+
+        .action-modify {
+            background-color: var(--color-modify);
+            color: white;
+        }
+
+        .action-keep_as_non_core {
+            background-color: var(--color-keep-non-core);
+            color: white;
+        }
+
+        .action-undecided {
+            background-color: var(--color-undecided);
+            color: white;
+        }
+
+        .action-new {
+            background-color: var(--color-new);
+            color: white;
+        }
+
+        .action-mark_as_over_annotated {
+            background-color: var(--color-mark-over);
+            color: white;
+        }
+
+        .term-info {
+            display: flex;
+            flex-direction: column;
+            gap: 0.25rem;
+        }
+
+        .term-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .term-label {
+            font-weight: 500;
+        }
+
+        .evidence-code {
+            font-family: monospace;
+            background-color: var(--bg-light);
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .not-badge {
+            display: inline-block;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-weight: 600;
+            margin-left: 0.25rem;
+        }
+
+        .isoform-badge {
+            display: inline-block;
+            background-color: #eff6ff;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            margin-top: 0.25rem;
+        }
+
+        .core-function-card {
+            background-color: white;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 1rem;
+        }
+
+        .core-function-card h3 {
+            font-size: 1.125rem;
+            margin-bottom: 1rem;
+            color: #1f2937;
+        }
+
+        .core-function-statement {
+            margin-bottom: 1rem;
+            padding: 0.75rem;
+            background-color: var(--bg-light);
+            border-left: 4px solid var(--color-accept);
+            border-radius: 0.25rem;
+        }
+
+        .function-annotations {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin-top: 1rem;
+        }
+
+        .reference-item {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+        }
+
+        .reference-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: start;
+            margin-bottom: 0.75rem;
+        }
+
+        .reference-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #2563eb;
+        }
+
+        .supported-by {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f3f4f6;
+            border-left: 3px solid #3b82f6;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .supported-by-title {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .support-item {
+            margin-bottom: 0.5rem;
+        }
+
+        .support-ref {
+            font-weight: 500;
+            color: #2563eb;
+        }
+
+        .support-text {
+            color: #6b7280;
+            font-style: italic;
+            margin-left: 1rem;
+        }
+
+        a.term-link {
+            color: #2563eb;
+            text-decoration: none;
+        }
+
+        a.term-link:hover {
+            text-decoration: underline;
+        }
+
+        .core-function-terms {
+            margin-top: 1rem;
+        }
+
+        .function-term-group {
+            margin-bottom: 1rem;
+        }
+
+        .function-term-label {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .reference-title {
+            font-weight: 500;
+            margin-bottom: 0.5rem;
+        }
+
+        .findings-list {
+            margin-top: 1rem;
+            padding-left: 1.5rem;
+        }
+
+        .finding-item {
+            margin-bottom: 0.75rem;
+        }
+
+        .finding-statement {
+            font-weight: 500;
+            margin-bottom: 0.25rem;
+        }
+
+        .finding-text {
+            color: var(--text-muted);
+            font-size: 0.95rem;
+            font-style: italic;
+        }
+
+        .proposed-term {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #fef3c7;
+        }
+
+        .question-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #dbeafe;
+        }
+
+        .experiment-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #f3e8ff;
+        }
+
+        .prediction-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: white;
+        }
+
+        .prediction-card .prediction-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+        }
+
+        .prediction-source {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+        }
+
+        .assessment-badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.8rem;
+            font-weight: 600;
+            text-transform: uppercase;
+        }
+
+        .assessment-cor { background-color: #dcfce7; color: #166534; }
+        .assessment-cnn { background-color: #dbeafe; color: #1e40af; }
+        .assessment-lsp { background-color: #fef9c3; color: #854d0e; }
+        .assessment-unc { background-color: #f3f4f6; color: #374151; }
+        .assessment-pli { background-color: #fee2e2; color: #991b1b; }
+        .assessment-npi { background-color: #fecaca; color: #7f1d1d; }
+        .assessment-rep { background-color: #fde68a; color: #92400e; }
+
+        .confidence-score {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+            margin-left: 0.5rem;
+        }
+
+        .error-type-badge {
+            font-size: 0.75rem;
+            padding: 0.125rem 0.5rem;
+            border-radius: 0.25rem;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+        }
+
+        .isoforms-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fill, minmax(400px, 1fr));
+            gap: 1rem;
+        }
+
+        .isoform-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            background-color: white;
+            transition: box-shadow 0.2s;
+        }
+
+        .isoform-card:hover {
+            box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+        }
+
+        .functional-isoform-type {
+            display: inline-block;
+            padding: 0.2rem 0.5rem;
+            border-radius: 0.25rem;
+            font-size: 0.7rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.03em;
+        }
+
+        .type-SPLICE_VARIANT, .type-SPLICE_CLASS {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #93c5fd;
+        }
+
+        .type-CLEAVAGE_PRODUCT {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fcd34d;
+        }
+
+        .type-MODIFICATION_STATE {
+            background-color: #f3e8ff;
+            color: #6b21a8;
+            border: 1px solid #c4b5fd;
+        }
+
+        .type-CONFORMATIONAL_STATE {
+            background-color: #dcfce7;
+            color: #166534;
+            border: 1px solid #86efac;
+        }
+
+        .functional-isoform-mappings {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+            font-size: 0.85rem;
+        }
+
+        .functional-isoform-mappings .mapping-type {
+            font-weight: 600;
+            color: var(--text-muted);
+            font-size: 0.75rem;
+        }
+
+        .functional-isoform-go {
+            margin-top: 0.5rem;
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.25rem;
+        }
+
+        .go-chip {
+            display: inline-block;
+            padding: 0.15rem 0.4rem;
+            background-color: #ecfdf5;
+            color: #047857;
+            border: 1px solid #a7f3d0;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-family: monospace;
+        }
+
+        .isoform-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+            padding-bottom: 0.5rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .isoform-name {
+            font-weight: 600;
+            font-size: 1.1rem;
+            color: #1f2937;
+        }
+
+        .isoform-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .isoform-sequence-note {
+            font-size: 0.875rem;
+            color: var(--text-muted);
+            margin-bottom: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+        }
+
+        .isoform-description {
+            font-size: 0.95rem;
+            line-height: 1.5;
+        }
+
+        .collapsible {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .collapsible:after {
+            content: ' ▼';
+            font-size: 0.75rem;
+        }
+
+        .collapsible.collapsed:after {
+            content: ' ►';
+        }
+
+        .collapse-content {
+            transition: max-height 0.3s ease;
+            overflow: hidden;
+        }
+
+        .collapsed + .collapse-content {
+            max-height: 0;
+        }
+
+        .no-data {
+            color: var(--text-muted);
+            font-style: italic;
+            padding: 1rem;
+            text-align: center;
+            background-color: var(--bg-light);
+            border-radius: 0.5rem;
+        }
+
+        /* Styling for markdown section summaries with voting */
+        .markdown-section summary {
+            padding: 0.75rem;
+            background: var(--bg-light);
+            border-radius: 0.5rem;
+            margin-bottom: 0.5rem;
+        }
+
+        .markdown-section summary:hover {
+            background: #e5e7eb;
+        }
+
+        .markdown-section summary .vote-buttons {
+            margin-left: auto;
+        }
+
+        .deep-research-section {
+            margin-bottom: 1rem;
+            border: 1px solid #c7d2fe;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8faff;
+        }
+
+        .deep-research-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .deep-research-section summary h3 {
+            margin: 0;
+            color: #3730a3;
+            font-size: 1.1rem;
+        }
+
+        .report-meta {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin: 0.75rem 0 1rem;
+            align-items: center;
+        }
+
+        .report-badge {
+            display: inline-flex;
+            align-items: center;
+            border: 1px solid #c7d2fe;
+            border-radius: 999px;
+            background: #eef2ff;
+            color: #4338ca;
+            font-size: 0.78rem;
+            font-weight: 600;
+            padding: 0.2rem 0.6rem;
+        }
+
+        .report-meta-text {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+        }
+
+        .artifact-list {
+            display: grid;
+            gap: 0.75rem;
+            margin: 0.75rem 0 1rem;
+        }
+
+        .artifact-link {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+            margin-top: 0.5rem;
+            word-break: break-word;
+        }
+
+        @media print {
+            body {
+                padding: 1rem;
+            }
+
+            .collapsible:after {
+                display: none;
+            }
+
+            .collapsed + .collapse-content {
+                max-height: none !important;
+            }
+        }
+
+        @media (max-width: 768px) {
+            body {
+                padding: 1rem;
+            }
+
+            h1 {
+                font-size: 2rem;
+            }
+
+            .annotations-table {
+                font-size: 0.875rem;
+            }
+
+            .annotations-table th,
+            .annotations-table td {
+                padding: 0.5rem;
+            }
+        }
+    </style>
+</head>
+<body>
+    <div class="header">
+        <h1>GCG</h1>
+        <div class="gene-info">
+            
+            <div class="info-item">
+                
+                <span class="info-label">UniProt ID:</span>
+                <span>
+                    <a href="https://www.uniprot.org/uniprotkb/P01275" target="_blank" class="term-link">
+                        P01275
+                    </a>
+                </span>
+                
+            </div>
+            
+            
+            <div class="info-item">
+                <span class="info-label">Organism:</span>
+                <span>Homo sapiens</span>
+            </div>
+            
+            
+            <div class="info-item">
+                <span class="info-label">Review Status:</span>
+                <span class="status-badge status-complete">
+                    COMPLETE
+                </span>
+            </div>
+            
+            
+        </div>
+        <div style="margin-top: 1rem; text-align: center;">
+            <a id="feedback-form-link"
+               href="#"
+               target="_blank"
+               style="display: inline-block; padding: 10px 20px; background-color: #4CAF50; color: white; text-decoration: none; border-radius: 5px; font-weight: 600;">
+                📝 Provide Detailed Feedback
+            </a>
+            <script>
+                // Construct the form URL with proper encoding
+                // Extract organism code from the current page path (e.g., /genes/ARATH/APO1/ -> ARATH)
+                const pathParts = window.location.pathname.split('/');
+                const genesIndex = pathParts.indexOf('genes');
+                let organism = '';
+                if (genesIndex !== -1 && pathParts[genesIndex + 1]) {
+                    organism = pathParts[genesIndex + 1].toUpperCase();
+                }
+                const geneSymbol = "GCG";
+                const speciesGene = organism + ' ' + geneSymbol;
+                const formBaseUrl = 'https://docs.google.com/forms/d/e/1FAIpQLSdTot9L6GVkkZYgLQT0E8ZdAJv8RiN5ZgOVkgWNcKSbYvxxzQ/viewform';
+                const entryId = '1226477767'; // Correct entry ID for Species/Gene field
+                const formUrl = formBaseUrl + '?entry.' + entryId + '=' + encodeURIComponent(speciesGene);
+                const feedbackLink = document.getElementById('feedback-form-link');
+                feedbackLink.href = formUrl;
+                // Add tooltip showing the pre-filled value
+                feedbackLink.title = 'Opens form with pre-filled: ' + speciesGene;
+            </script>
+        </div>
+    </div>
+
+    
+    <div class="description-card">
+        <div style="display: flex; justify-content: space-between; align-items: center;">
+            <h2>Gene Description</h2>
+            <span class="vote-buttons" data-g="P01275" data-a="DESCRIPTION: GCG encodes proglucagon, a 180-residue secreted po..." data-r="" data-act="DESCRIPTION">
+                <button class="vote-btn" data-v="up" title="Agree with this description">👍</button>
+                <button class="vote-btn" data-v="down" title="Disagree with this description">👎</button>
+            </span>
+        </div>
+        <p>GCG encodes proglucagon, a 180-residue secreted polyprotein precursor that is proteolytically processed in a tissue-specific manner by prohormone convertases to yield several distinct bioactive peptide hormones, each acting through its own class B G protein-coupled receptor. In pancreatic islet alpha-cells, PCSK2/PC2 liberates glucagon, the principal counter-regulatory hormone of insulin, which binds the glucagon receptor (GCGR) on hepatocytes and raises blood glucose by stimulating gluconeogenesis and glycogenolysis while suppressing glycolysis. In intestinal enteroendocrine L-cells and selected brainstem and hypothalamic neurons, PCSK1/PC1 liberates glucagon-like peptide 1 (GLP-1), glucagon-like peptide 2 (GLP-2), oxyntomodulin, and glicentin. GLP-1 is an incretin that potentiates glucose-dependent insulin secretion, slows gastric emptying, and promotes satiety and beta-cell survival, acting via GLP1R. GLP-2 is intestinotrophic, stimulating crypt cell proliferation and villus growth via GLP2R. Oxyntomodulin reduces food intake and gastric emptying. All mature peptides are secreted hormones; the precursor itself has no intrinsic activity, and its biology is distributed across its cleavage products. The peptides signal predominantly through Gs to activate adenylyl cyclase and elevate intracellular cAMP in their respective target cells.
+</p>
+    </div>
+    
+
+    
+    <div class="section">
+        <h2 class="section-title">Functional Isoforms</h2>
+        <p style="color: var(--text-muted); margin-bottom: 1rem;">
+            Curated functional classes representing distinct biological activities. These may be splice variants,
+            cleavage products, or other forms with different functions.
+        </p>
+        <div class="isoforms-grid">
+            
+            <div class="isoform-card">
+                <div class="isoform-header">
+                    <span class="isoform-name">Glucagon</span>
+                    <span class="functional-isoform-type type-CLEAVAGE_PRODUCT">CLEAVAGE PRODUCT</span>
+                </div>
+                <div style="font-size: 0.8rem; color: var(--text-muted); margin-bottom: 0.5rem;">
+                    ID: <code>GCG_GLUCAGON</code>
+                </div>
+                
+                <div class="functional-isoform-mappings">
+                    
+                    <div>
+                        <span class="mapping-type">UNIPROT CHAIN:</span>
+                        
+                        
+                        <code>PRO_0000011256</code>
+                        
+                        
+                        
+                        <span style="color: var(--text-muted);"> (residues 53-81)</span>
+                        
+                    </div>
+                    
+                </div>
+                
+                
+                <div class="isoform-description" style="margin-top: 0.75rem; display: flex; align-items: flex-start; gap: 0.5rem;">
+                    <span style="flex: 1;">29-residue peptide, the major bioactive product of proglucagon processing in pancreatic islet alpha-cells (PCSK2/PC2). Binds and activates the glucagon receptor GCGR on hepatocytes (Gs-coupled), elevating cAMP and raising blood glucose by increasing gluconeogenesis and glycogenolysis and decreasing glycolysis. The principal counter-regulatory hormone of insulin; secreted in response to hypoglycemia. Glucagon is a substrate of insulin-degrading enzyme (IDE) and can self-assemble into amyloid fibrils in vitro. Receptor-binding/glucose-mobilizing functions belong to THIS peptide, not to the GLP-1/GLP-2 products.
+</span>
+                    <span class="vote-buttons" data-g="P01275" data-a="ISOFORM_DESC: GCG_GLUCAGON" data-r="" data-act="ISOFORM_DESC">
+                        <button class="vote-btn" data-v="up" title="Agree with this isoform description">👍</button>
+                        <button class="vote-btn" data-v="down" title="Disagree with this isoform description">👎</button>
+                    </span>
+                </div>
+                
+                
+                <div class="functional-isoform-go" style="margin-top: 0.5rem;">
+                    <span style="font-size: 0.75rem; color: var(--text-muted); margin-right: 0.25rem;">Isoform-specific terms:</span>
+                    
+                    <span style="display: inline-flex; align-items: center; margin-right: 0.5rem;">
+                        <a href="https://amigo.geneontology.org/amigo/term/GO:0031769" target="_blank" class="go-chip" title="GO:0031769">glucagon receptor binding</a>
+                        <span class="vote-buttons" style="margin-left: 0.25rem;" data-g="P01275" data-a="ISOFORM_TERM: GCG_GLUCAGON GO:0031769" data-r="" data-act="ISOFORM_TERM">
+                            <button class="vote-btn vote-btn-small" data-v="up" title="Agree this term applies to Glucagon">👍</button>
+                            <button class="vote-btn vote-btn-small" data-v="down" title="Disagree this term applies to Glucagon">👎</button>
+                        </span>
+                    </span>
+                    
+                    <span style="display: inline-flex; align-items: center; margin-right: 0.5rem;">
+                        <a href="https://amigo.geneontology.org/amigo/term/GO:0045722" target="_blank" class="go-chip" title="GO:0045722">positive regulation of gluconeogenesis</a>
+                        <span class="vote-buttons" style="margin-left: 0.25rem;" data-g="P01275" data-a="ISOFORM_TERM: GCG_GLUCAGON GO:0045722" data-r="" data-act="ISOFORM_TERM">
+                            <button class="vote-btn vote-btn-small" data-v="up" title="Agree this term applies to Glucagon">👍</button>
+                            <button class="vote-btn vote-btn-small" data-v="down" title="Disagree this term applies to Glucagon">👎</button>
+                        </span>
+                    </span>
+                    
+                </div>
+                
+            </div>
+            
+            <div class="isoform-card">
+                <div class="isoform-header">
+                    <span class="isoform-name">Glucagon-like peptide 1 (GLP-1)</span>
+                    <span class="functional-isoform-type type-CLEAVAGE_PRODUCT">CLEAVAGE PRODUCT</span>
+                </div>
+                <div style="font-size: 0.8rem; color: var(--text-muted); margin-bottom: 0.5rem;">
+                    ID: <code>GCG_GLP1</code>
+                </div>
+                
+                <div class="functional-isoform-mappings">
+                    
+                    <div>
+                        <span class="mapping-type">UNIPROT CHAIN:</span>
+                        
+                        
+                        <code>PRO_0000011258</code>, 
+                        
+                        
+                        
+                        <code>PRO_0000011259</code>, 
+                        
+                        
+                        
+                        <code>PRO_0000011260</code>
+                        
+                        
+                        
+                        <span style="color: var(--text-muted);"> (residues 92-128 / 98-128 / 98-127)</span>
+                        
+                    </div>
+                    
+                </div>
+                
+                
+                <div class="isoform-description" style="margin-top: 0.75rem; display: flex; align-items: flex-start; gap: 0.5rem;">
+                    <span style="flex: 1;">Incretin hormone produced mainly in intestinal L-cells (and pancreatic alpha-cells and some neurons) by PCSK1/PC1, then N-terminally truncated to the active GLP-1(7-37) and GLP-1(7-36)amide forms. Acts through GLP1R (Gs) to potently stimulate glucose-dependent insulin secretion, slow gastric emptying, suppress glucagon, promote satiety, and enhance beta-cell mass/survival. Rapidly inactivated by DPP4 (and slowly by FAP). The insulin-secretion, incretin, satiety and anti-apoptotic functions belong to THIS peptide.
+</span>
+                    <span class="vote-buttons" data-g="P01275" data-a="ISOFORM_DESC: GCG_GLP1" data-r="" data-act="ISOFORM_DESC">
+                        <button class="vote-btn" data-v="up" title="Agree with this isoform description">👍</button>
+                        <button class="vote-btn" data-v="down" title="Disagree with this isoform description">👎</button>
+                    </span>
+                </div>
+                
+                
+                <div class="functional-isoform-go" style="margin-top: 0.5rem;">
+                    <span style="font-size: 0.75rem; color: var(--text-muted); margin-right: 0.25rem;">Isoform-specific terms:</span>
+                    
+                    <span style="display: inline-flex; align-items: center; margin-right: 0.5rem;">
+                        <a href="https://amigo.geneontology.org/amigo/term/GO:0035774" target="_blank" class="go-chip" title="GO:0035774">positive regulation of insulin secretion involved in cellular response to glucose stimulus</a>
+                        <span class="vote-buttons" style="margin-left: 0.25rem;" data-g="P01275" data-a="ISOFORM_TERM: GCG_GLP1 GO:0035774" data-r="" data-act="ISOFORM_TERM">
+                            <button class="vote-btn vote-btn-small" data-v="up" title="Agree this term applies to Glucagon-like peptide 1 (GLP-1)">👍</button>
+                            <button class="vote-btn vote-btn-small" data-v="down" title="Disagree this term applies to Glucagon-like peptide 1 (GLP-1)">👎</button>
+                        </span>
+                    </span>
+                    
+                    <span style="display: inline-flex; align-items: center; margin-right: 0.5rem;">
+                        <a href="https://amigo.geneontology.org/amigo/term/GO:0007631" target="_blank" class="go-chip" title="GO:0007631">feeding behavior</a>
+                        <span class="vote-buttons" style="margin-left: 0.25rem;" data-g="P01275" data-a="ISOFORM_TERM: GCG_GLP1 GO:0007631" data-r="" data-act="ISOFORM_TERM">
+                            <button class="vote-btn vote-btn-small" data-v="up" title="Agree this term applies to Glucagon-like peptide 1 (GLP-1)">👍</button>
+                            <button class="vote-btn vote-btn-small" data-v="down" title="Disagree this term applies to Glucagon-like peptide 1 (GLP-1)">👎</button>
+                        </span>
+                    </span>
+                    
+                    <span style="display: inline-flex; align-items: center; margin-right: 0.5rem;">
+                        <a href="https://amigo.geneontology.org/amigo/term/GO:0043066" target="_blank" class="go-chip" title="GO:0043066">negative regulation of apoptotic process</a>
+                        <span class="vote-buttons" style="margin-left: 0.25rem;" data-g="P01275" data-a="ISOFORM_TERM: GCG_GLP1 GO:0043066" data-r="" data-act="ISOFORM_TERM">
+                            <button class="vote-btn vote-btn-small" data-v="up" title="Agree this term applies to Glucagon-like peptide 1 (GLP-1)">👍</button>
+                            <button class="vote-btn vote-btn-small" data-v="down" title="Disagree this term applies to Glucagon-like peptide 1 (GLP-1)">👎</button>
+                        </span>
+                    </span>
+                    
+                </div>
+                
+            </div>
+            
+            <div class="isoform-card">
+                <div class="isoform-header">
+                    <span class="isoform-name">Glucagon-like peptide 2 (GLP-2)</span>
+                    <span class="functional-isoform-type type-CLEAVAGE_PRODUCT">CLEAVAGE PRODUCT</span>
+                </div>
+                <div style="font-size: 0.8rem; color: var(--text-muted); margin-bottom: 0.5rem;">
+                    ID: <code>GCG_GLP2</code>
+                </div>
+                
+                <div class="functional-isoform-mappings">
+                    
+                    <div>
+                        <span class="mapping-type">UNIPROT CHAIN:</span>
+                        
+                        
+                        <code>PRO_0000011262</code>
+                        
+                        
+                        
+                        <span style="color: var(--text-muted);"> (residues 146-178)</span>
+                        
+                    </div>
+                    
+                </div>
+                
+                
+                <div class="isoform-description" style="margin-top: 0.75rem; display: flex; align-items: flex-start; gap: 0.5rem;">
+                    <span style="flex: 1;">33-residue intestinotrophic peptide produced in intestinal L-cells by PCSK1/PC1. Acts through its own receptor GLP2R (Gs), expressed in the gut, to stimulate intestinal growth, increase villus height and crypt cell proliferation, decrease enterocyte apoptosis, and enhance nutrient assimilation. The intestinal-growth functions belong to THIS peptide and signal through a distinct receptor from glucagon and GLP-1.
+</span>
+                    <span class="vote-buttons" data-g="P01275" data-a="ISOFORM_DESC: GCG_GLP2" data-r="" data-act="ISOFORM_DESC">
+                        <button class="vote-btn" data-v="up" title="Agree with this isoform description">👍</button>
+                        <button class="vote-btn" data-v="down" title="Disagree with this isoform description">👎</button>
+                    </span>
+                </div>
+                
+                
+                <div class="functional-isoform-go" style="margin-top: 0.5rem;">
+                    <span style="font-size: 0.75rem; color: var(--text-muted); margin-right: 0.25rem;">Isoform-specific terms:</span>
+                    
+                    <span style="display: inline-flex; align-items: center; margin-right: 0.5rem;">
+                        <a href="https://amigo.geneontology.org/amigo/term/GO:0005102" target="_blank" class="go-chip" title="GO:0005102">signaling receptor binding</a>
+                        <span class="vote-buttons" style="margin-left: 0.25rem;" data-g="P01275" data-a="ISOFORM_TERM: GCG_GLP2 GO:0005102" data-r="" data-act="ISOFORM_TERM">
+                            <button class="vote-btn vote-btn-small" data-v="up" title="Agree this term applies to Glucagon-like peptide 2 (GLP-2)">👍</button>
+                            <button class="vote-btn vote-btn-small" data-v="down" title="Disagree this term applies to Glucagon-like peptide 2 (GLP-2)">👎</button>
+                        </span>
+                    </span>
+                    
+                </div>
+                
+            </div>
+            
+            <div class="isoform-card">
+                <div class="isoform-header">
+                    <span class="isoform-name">Oxyntomodulin</span>
+                    <span class="functional-isoform-type type-CLEAVAGE_PRODUCT">CLEAVAGE PRODUCT</span>
+                </div>
+                <div style="font-size: 0.8rem; color: var(--text-muted); margin-bottom: 0.5rem;">
+                    ID: <code>GCG_OXYNTOMODULIN</code>
+                </div>
+                
+                <div class="functional-isoform-mappings">
+                    
+                    <div>
+                        <span class="mapping-type">UNIPROT CHAIN:</span>
+                        
+                        
+                        <code>PRO_0000011255</code>
+                        
+                        
+                        
+                        <span style="color: var(--text-muted);"> (residues 53-89)</span>
+                        
+                    </div>
+                    
+                </div>
+                
+                
+                <div class="isoform-description" style="margin-top: 0.75rem; display: flex; align-items: flex-start; gap: 0.5rem;">
+                    <span style="flex: 1;">Intestinal L-cell peptide (glucagon plus C-terminal extension). Reduces food intake and inhibits gastric emptying; a dual weak agonist of GCGR and GLP1R. Anorectic effects are attributed to THIS peptide.
+</span>
+                    <span class="vote-buttons" data-g="P01275" data-a="ISOFORM_DESC: GCG_OXYNTOMODULIN" data-r="" data-act="ISOFORM_DESC">
+                        <button class="vote-btn" data-v="up" title="Agree with this isoform description">👍</button>
+                        <button class="vote-btn" data-v="down" title="Disagree with this isoform description">👎</button>
+                    </span>
+                </div>
+                
+                
+            </div>
+            
+            <div class="isoform-card">
+                <div class="isoform-header">
+                    <span class="isoform-name">Glicentin</span>
+                    <span class="functional-isoform-type type-CLEAVAGE_PRODUCT">CLEAVAGE PRODUCT</span>
+                </div>
+                <div style="font-size: 0.8rem; color: var(--text-muted); margin-bottom: 0.5rem;">
+                    ID: <code>GCG_GLICENTIN</code>
+                </div>
+                
+                <div class="functional-isoform-mappings">
+                    
+                    <div>
+                        <span class="mapping-type">UNIPROT CHAIN:</span>
+                        
+                        
+                        <code>PRO_0000011253</code>
+                        
+                        
+                        
+                        <span style="color: var(--text-muted);"> (residues 21-89)</span>
+                        
+                    </div>
+                    
+                </div>
+                
+                
+                <div class="isoform-description" style="margin-top: 0.75rem; display: flex; align-items: flex-start; gap: 0.5rem;">
+                    <span style="flex: 1;">N-terminal proglucagon product from intestinal L-cells. Proposed to modulate gastric acid secretion and gastro-pyloro-duodenal activity and to support intestinal mucosal growth early in life; functions are weakly supported (ECO:0000303).
+</span>
+                    <span class="vote-buttons" data-g="P01275" data-a="ISOFORM_DESC: GCG_GLICENTIN" data-r="" data-act="ISOFORM_DESC">
+                        <button class="vote-btn" data-v="up" title="Agree with this isoform description">👍</button>
+                        <button class="vote-btn" data-v="down" title="Disagree with this isoform description">👎</button>
+                    </span>
+                </div>
+                
+                
+            </div>
+            
+            <div class="isoform-card">
+                <div class="isoform-header">
+                    <span class="isoform-name">Glicentin-related polypeptide (GRPP)</span>
+                    <span class="functional-isoform-type type-CLEAVAGE_PRODUCT">CLEAVAGE PRODUCT</span>
+                </div>
+                <div style="font-size: 0.8rem; color: var(--text-muted); margin-bottom: 0.5rem;">
+                    ID: <code>GCG_GRPP</code>
+                </div>
+                
+                <div class="functional-isoform-mappings">
+                    
+                    <div>
+                        <span class="mapping-type">UNIPROT CHAIN:</span>
+                        
+                        
+                        <code>PRO_0000011254</code>
+                        
+                        
+                        
+                        <span style="color: var(--text-muted);"> (residues 21-50)</span>
+                        
+                    </div>
+                    
+                </div>
+                
+                
+                <div class="isoform-description" style="margin-top: 0.75rem; display: flex; align-items: flex-start; gap: 0.5rem;">
+                    <span style="flex: 1;">N-terminal fragment of glicentin released during processing; no well-defined function established.
+</span>
+                    <span class="vote-buttons" data-g="P01275" data-a="ISOFORM_DESC: GCG_GRPP" data-r="" data-act="ISOFORM_DESC">
+                        <button class="vote-btn" data-v="up" title="Agree with this isoform description">👍</button>
+                        <button class="vote-btn" data-v="down" title="Disagree with this isoform description">👎</button>
+                    </span>
+                </div>
+                
+                
+            </div>
+            
+        </div>
+    </div>
+    
+
+    
+
+    
+    <div class="section">
+        <h2 class="section-title">Existing Annotations Review</h2>
+        <table class="annotations-table">
+            <thead>
+                <tr>
+                    <th>GO Term</th>
+                    <th>Evidence</th>
+                    <th>Action</th>
+                    <th>Reason</th>
+                </tr>
+            </thead>
+            <tbody>
+                
+                <tr>
+                    <td>
+                        <div class="term-info">
+                            
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005576" target="_blank" class="term-link">
+                                    GO:0005576
+                                </a>
+                            </span>
+                            <span class="term-label">extracellular region</span>
+                            
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+                        
+                        
+                        
+                        <br>
+                        <span style="font-size: 0.75rem;">
+                            
+                            GO_REF:0000033
+                            
+                        </span>
+                        
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P01275" data-a="GO:0005576" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+                        
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> All mature proglucagon-derived peptides are secreted hormones that act in the extracellular space. Correct cellular location.
+                        </div>
+                        
+                        
+                        
+                        
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+                            
+                            <div class="support-item">
+                                <span class="support-ref">
+                                    
+                                    UniProtKB:P01275
+                                    
+                                </span>
+                                
+                                <div class="support-text">Secreted in the A cells of the islets of Langerhans</div>
+                                
+                            </div>
+                            
+                        </div>
+                        
+                        
+                    </td>
+                </tr>
+                
+                <tr>
+                    <td>
+                        <div class="term-info">
+                            
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0001678" target="_blank" class="term-link">
+                                    GO:0001678
+                                </a>
+                            </span>
+                            <span class="term-label">intracellular glucose homeostasis</span>
+                            
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+                        
+                        
+                        
+                        <br>
+                        <span style="font-size: 0.75rem;">
+                            
+                            GO_REF:0000033
+                            
+                        </span>
+                        
+                    </td>
+                    <td>
+                        <span class="action-badge action-modify">
+                            MODIFY
+                        </span>
+                        <span class="vote-buttons" data-g="P01275" data-a="GO:0001678" data-r="GO_REF:0000033" data-act="MODIFY">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+                        
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Glucagon regulates whole-organism/blood glucose, not cell-autonomous intracellular glucose homeostasis. The IBA propagated a too-specific sibling term; the systemic term glucose homeostasis is the correct fit.
+                        </div>
+                        
+                        
+                        <div>
+                            <strong>Reason:</strong> &#34;intracellular glucose homeostasis&#34; denotes maintenance of glucose levels within a cell, whereas glucagon&#39;s role is in systemic blood-glucose homeostasis. Replace with the general glucose homeostasis term, which is also independently annotated to this gene.
+                        </div>
+                        
+                        
+                        <div style="margin-top: 0.5rem;">
+                            <strong>Proposed replacements:</strong>
+                            
+                            <span class="badge">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0042593" target="_blank" class="term-link">
+                                    glucose homeostasis
+                                </a>
+                            </span>
+                            
+                        </div>
+                        
+                        
+                        
+                    </td>
+                </tr>
+                
+                <tr>
+                    <td>
+                        <div class="term-info">
+                            
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005179" target="_blank" class="term-link">
+                                    GO:0005179
+                                </a>
+                            </span>
+                            <span class="term-label">hormone activity</span>
+                            
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+                        
+                        
+                        
+                        <br>
+                        <span style="font-size: 0.75rem;">
+                            
+                            GO_REF:0000033
+                            
+                        </span>
+                        
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P01275" data-a="GO:0005179" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+                        
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Core molecular function. The proglucagon-derived peptides are bona fide secreted peptide hormones acting on cognate receptors.
+                        </div>
+                        
+                        
+                        
+                        
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+                            
+                            <div class="support-item">
+                                <span class="support-ref">
+                                    
+                                    UniProtKB:P01275
+                                    
+                                </span>
+                                
+                                <div class="support-text">the major bioactive hormone is glucagon cleaved by PCSK2/PC2</div>
+                                
+                            </div>
+                            
+                        </div>
+                        
+                        
+                    </td>
+                </tr>
+                
+                <tr>
+                    <td>
+                        <div class="term-info">
+                            
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0007188" target="_blank" class="term-link">
+                                    GO:0007188
+                                </a>
+                            </span>
+                            <span class="term-label">adenylate cyclase-modulating G protein-coupled receptor signaling pathway</span>
+                            
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+                        
+                        
+                        
+                        <br>
+                        <span style="font-size: 0.75rem;">
+                            
+                            GO_REF:0000033
+                            
+                        </span>
+                        
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P01275" data-a="GO:0007188" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+                        
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Glucagon, GLP-1 and GLP-2 all act through class B GPCRs (GCGR, GLP1R, GLP2R) coupled to Gs, elevating cAMP. Correct, though the activating child term GO:0007189 is more precise.
+                        </div>
+                        
+                        
+                        
+                        
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+                            
+                            <div class="support-item">
+                                <span class="support-ref">
+                                    
+                                    UniProtKB:P01275
+                                    
+                                </span>
+                                
+                                <div class="support-text">couples to the G(s) G protein and elevates intracellular cAMP</div>
+                                
+                            </div>
+                            
+                        </div>
+                        
+                        
+                    </td>
+                </tr>
+                
+                <tr>
+                    <td>
+                        <div class="term-info">
+                            
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0031769" target="_blank" class="term-link">
+                                    GO:0031769
+                                </a>
+                            </span>
+                            <span class="term-label">glucagon receptor binding</span>
+                            
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+                        
+                        
+                        
+                        <br>
+                        <span style="font-size: 0.75rem;">
+                            
+                            GO_REF:0000033
+                            
+                        </span>
+                        
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P01275" data-a="GO:0031769" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+                        
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Specific, informative molecular function for the glucagon peptide chain (binds GCGR). Core function.
+                        </div>
+                        
+                        
+                        
+                        
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+                            
+                            <div class="support-item">
+                                <span class="support-ref">
+                                    
+                                    UniProtKB:P01275
+                                    
+                                </span>
+                                
+                                <div class="support-text">Binds to and activates the glucagon receptor GCGR</div>
+                                
+                            </div>
+                            
+                        </div>
+                        
+                        
+                    </td>
+                </tr>
+                
+                <tr>
+                    <td>
+                        <div class="term-info">
+                            
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0035774" target="_blank" class="term-link">
+                                    GO:0035774
+                                </a>
+                            </span>
+                            <span class="term-label">positive regulation of insulin secretion involved in cellular response to glucose stimulus</span>
+                            
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+                        
+                        
+                        
+                        <br>
+                        <span style="font-size: 0.75rem;">
+                            
+                            GO_REF:0000033
+                            
+                        </span>
+                        
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P01275" data-a="GO:0035774" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+                        
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Captures the GLP-1 incretin effect, including its hallmark glucose-dependence. Best available term for this function. Core (GLP-1 chain).
+                        </div>
+                        
+                        
+                        
+                        
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+                            
+                            <div class="support-item">
+                                <span class="support-ref">
+                                    
+                                    UniProtKB:P01275
+                                    
+                                </span>
+                                
+                                <div class="support-text">Potent stimulator of glucose-dependent insulin release</div>
+                                
+                            </div>
+                            
+                        </div>
+                        
+                        
+                    </td>
+                </tr>
+                
+                <tr>
+                    <td>
+                        <div class="term-info">
+                            
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0045722" target="_blank" class="term-link">
+                                    GO:0045722
+                                </a>
+                            </span>
+                            <span class="term-label">positive regulation of gluconeogenesis</span>
+                            
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+                        
+                        
+                        
+                        <br>
+                        <span style="font-size: 0.75rem;">
+                            
+                            GO_REF:0000033
+                            
+                        </span>
+                        
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P01275" data-a="GO:0045722" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+                        
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Glucagon raises blood glucose by stimulating hepatic gluconeogenesis. Core function (glucagon chain).
+                        </div>
+                        
+                        
+                        
+                        
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+                            
+                            <div class="support-item">
+                                <span class="support-ref">
+                                    
+                                    UniProtKB:P01275
+                                    
+                                </span>
+                                
+                                <div class="support-text">Regulates blood glucose by increasing gluconeogenesis and decreasing glycolysis</div>
+                                
+                            </div>
+                            
+                        </div>
+                        
+                        
+                    </td>
+                </tr>
+                
+                <tr>
+                    <td>
+                        <div class="term-info">
+                            
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005102" target="_blank" class="term-link">
+                                    GO:0005102
+                                </a>
+                            </span>
+                            <span class="term-label">signaling receptor binding</span>
+                            
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+                        
+                        
+                        
+                        <br>
+                        <span style="font-size: 0.75rem;">
+                            
+                            GO_REF:0000117
+                            
+                        </span>
+                        
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P01275" data-a="GO:0005102" data-r="GO_REF:0000117" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+                        
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Correct but general. The peptides bind their cognate signaling receptors; more specific descendants (glucagon receptor binding, receptor ligand activity) are also annotated and are preferable as the core MF.
+                        </div>
+                        
+                        
+                        
+                        
+                        
+                    </td>
+                </tr>
+                
+                <tr>
+                    <td>
+                        <div class="term-info">
+                            
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005179" target="_blank" class="term-link">
+                                    GO:0005179
+                                </a>
+                            </span>
+                            <span class="term-label">hormone activity</span>
+                            
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+                        
+                        
+                        
+                        <br>
+                        <span style="font-size: 0.75rem;">
+                            
+                            GO_REF:0000002
+                            
+                        </span>
+                        
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P01275" data-a="GO:0005179" data-r="GO_REF:0000002" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+                        
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Redundant with the IBA hormone activity annotation; correct core molecular function.
+                        </div>
+                        
+                        
+                        
+                        
+                        
+                    </td>
+                </tr>
+                
+                <tr>
+                    <td>
+                        <div class="term-info">
+                            
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005576" target="_blank" class="term-link">
+                                    GO:0005576
+                                </a>
+                            </span>
+                            <span class="term-label">extracellular region</span>
+                            
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+                        
+                        
+                        
+                        <br>
+                        <span style="font-size: 0.75rem;">
+                            
+                            GO_REF:0000120
+                            
+                        </span>
+                        
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P01275" data-a="GO:0005576" data-r="GO_REF:0000120" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+                        
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Secreted hormone; correct location. Redundant with other extracellular region annotations.
+                        </div>
+                        
+                        
+                        
+                        
+                        
+                    </td>
+                </tr>
+                
+                <tr>
+                    <td>
+                        <div class="term-info">
+                            
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
+                                    GO:0005515
+                                </a>
+                            </span>
+                            <span class="term-label">protein binding</span>
+                            
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+                        
+                        
+                        
+                        <br>
+                        <span style="font-size: 0.75rem;">
+                            
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/17051221" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:17051221
+                            </a>
+                            
+                                
+                                
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Structures of human insulin-degrading enzyme reveal a new su...
+                                </span>
+                                
+                            
+                            
+                        </span>
+                        
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P01275" data-a="GO:0005515" data-r="PMID:17051221" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+                        
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Records glucagon as a substrate captured in the insulin-degrading enzyme (IDE) structure. A real binary interaction but uninformative as a molecular function and not a core activity (this is hormone clearance/degradation).
+                        </div>
+                        
+                        
+                        <div>
+                            <strong>Reason:</strong> &#34;protein binding&#34; (GO:0005515) conveys no functional specificity; the interaction reflects glucagon being degraded by IDE rather than a function glucagon enables.
+                        </div>
+                        
+                        
+                        
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+                            
+                            <div class="support-item">
+                                <span class="support-ref">
+                                    
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/17051221" target="_blank" class="term-link">
+                                        PMID:17051221
+                                    </a>
+                                    
+                                </span>
+                                
+                                <div class="support-text">structures of human IDE in complex with four substrates (insulin B chain, amyloid-beta peptide (1-40), amylin and glucagon)</div>
+                                
+                            </div>
+                            
+                        </div>
+                        
+                        
+                    </td>
+                </tr>
+                
+                <tr>
+                    <td>
+                        <div class="term-info">
+                            
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
+                                    GO:0005515
+                                </a>
+                            </span>
+                            <span class="term-label">protein binding</span>
+                            
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+                        
+                        
+                        
+                        <br>
+                        <span style="font-size: 0.75rem;">
+                            
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/17715056" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:17715056
+                            </a>
+                            
+                                
+                                
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Crystal structure of the incretin-bound extracellular domain...
+                                </span>
+                                
+                            
+                            
+                        </span>
+                        
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P01275" data-a="GO:0005515" data-r="PMID:17715056" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+                        
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Derives from a structural study of the GIP receptor extracellular domain bound to the incretin GIP; supports a peptide:receptor-ECD binary interaction logged for this entry. Uninformative generic MF; not a core function.
+                        </div>
+                        
+                        
+                        <div>
+                            <strong>Reason:</strong> &#34;protein binding&#34; is non-specific. The paper structurally characterizes GIP (a paralogous incretin), and the interaction is recorded as a generic binary binding for the proglucagon entry rather than a distinct molecular activity.
+                        </div>
+                        
+                        
+                        
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+                            
+                            <div class="support-item">
+                                <span class="support-ref">
+                                    
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/17715056" target="_blank" class="term-link">
+                                        PMID:17715056
+                                    </a>
+                                    
+                                </span>
+                                
+                                <div class="support-text">the crystal structure of the complex of human GIP receptor extracellular domain (ECD) with its agonist, the incretin GIP(1-42)</div>
+                                
+                            </div>
+                            
+                        </div>
+                        
+                        
+                    </td>
+                </tr>
+                
+                <tr>
+                    <td>
+                        <div class="term-info">
+                            
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
+                                    GO:0005515
+                                </a>
+                            </span>
+                            <span class="term-label">protein binding</span>
+                            
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+                        
+                        
+                        
+                        <br>
+                        <span style="font-size: 0.75rem;">
+                            
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/21314817" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:21314817
+                            </a>
+                            
+                                
+                                
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Neuropeptide Y, B-type natriuretic peptide, substance P and ...
+                                </span>
+                                
+                            
+                            
+                        </span>
+                        
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P01275" data-a="GO:0005515" data-r="PMID:21314817" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+                        
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Records GLP-1 as a (slow) substrate of fibroblast activation protein (FAP). Real protease:substrate interaction relevant to incretin clearance, but a generic and non-core molecular function.
+                        </div>
+                        
+                        
+                        <div>
+                            <strong>Reason:</strong> Reflects degradation of GLP-1 by FAP, not an activity GLP-1 enables; &#34;protein binding&#34; is uninformative.
+                        </div>
+                        
+                        
+                        
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+                            
+                            <div class="support-item">
+                                <span class="support-ref">
+                                    
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/21314817" target="_blank" class="term-link">
+                                        PMID:21314817
+                                    </a>
+                                    
+                                </span>
+                                
+                                <div class="support-text">FAP slowly hydrolysed other hormone peptides, such as the incretins glucagon-like peptide-1 and glucose-dependent insulinotropic peptide</div>
+                                
+                            </div>
+                            
+                        </div>
+                        
+                        
+                    </td>
+                </tr>
+                
+                <tr>
+                    <td>
+                        <div class="term-info">
+                            
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
+                                    GO:0005515
+                                </a>
+                            </span>
+                            <span class="term-label">protein binding</span>
+                            
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+                        
+                        
+                        
+                        <br>
+                        <span style="font-size: 0.75rem;">
+                            
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/21314817" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:21314817
+                            </a>
+                            
+                                
+                                
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Neuropeptide Y, B-type natriuretic peptide, substance P and ...
+                                </span>
+                                
+                            
+                            
+                        </span>
+                        
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P01275" data-a="GO:0005515" data-r="PMID:21314817" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+                        
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Records GLP-1 as an efficient substrate of dipeptidyl peptidase 4 (DPP4, UniProt P27487). DPP4 is the primary enzyme responsible for GLP-1 inactivation in vivo (the pharmacological basis of gliptin-class antidiabetics). Real binary interaction but a generic, non-core molecular function.
+                        </div>
+                        
+                        
+                        <div>
+                            <strong>Reason:</strong> Reflects degradation of GLP-1 by DPP4, not an activity GLP-1 enables; &#34;protein binding&#34; is uninformative.
+                        </div>
+                        
+                        
+                        
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+                            
+                            <div class="support-item">
+                                <span class="support-ref">
+                                    
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/21314817" target="_blank" class="term-link">
+                                        PMID:21314817
+                                    </a>
+                                    
+                                </span>
+                                
+                                <div class="support-text">the incretins glucagon-like peptide-1 and glucose-dependent insulinotropic peptide, which are efficient DPP4 substrates</div>
+                                
+                            </div>
+                            
+                        </div>
+                        
+                        
+                    </td>
+                </tr>
+                
+                <tr>
+                    <td>
+                        <div class="term-info">
+                            
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0042802" target="_blank" class="term-link">
+                                    GO:0042802
+                                </a>
+                            </span>
+                            <span class="term-label">identical protein binding</span>
+                            
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+                        
+                        
+                        
+                        <br>
+                        <span style="font-size: 0.75rem;">
+                            
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/22212535" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:22212535
+                            </a>
+                            
+                                
+                                
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Mapping out the multistage fibrillation of glucagon.
+                                </span>
+                                
+                            
+                            
+                        </span>
+                        
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P01275" data-a="GO:0042802" data-r="PMID:22212535" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+                        
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Reflects glucagon self-association into amyloid-like fibrils observed in vitro under acidic, concentrated conditions (relevant to pharmaceutical formulation). Not a physiological function of the secreted hormone.
+                        </div>
+                        
+                        
+                        <div>
+                            <strong>Reason:</strong> Self-assembly into fibrils is an in-vitro biophysical property, not the in-vivo molecular function of glucagon; should not be treated as a core activity.
+                        </div>
+                        
+                        
+                        
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+                            
+                            <div class="support-item">
+                                <span class="support-ref">
+                                    
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/22212535" target="_blank" class="term-link">
+                                        PMID:22212535
+                                    </a>
+                                    
+                                </span>
+                                
+                                <div class="support-text">The 29-residue peptide hormone glucagon forms many different morphological types of amyloid-like fibrils</div>
+                                
+                            </div>
+                            
+                        </div>
+                        
+                        
+                    </td>
+                </tr>
+                
+                <tr>
+                    <td>
+                        <div class="term-info">
+                            
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005737" target="_blank" class="term-link">
+                                    GO:0005737
+                                </a>
+                            </span>
+                            <span class="term-label">cytoplasm</span>
+                            
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+                        
+                        
+                        
+                        <br>
+                        <span style="font-size: 0.75rem;">
+                            
+                            GO_REF:0000107
+                            
+                        </span>
+                        
+                    </td>
+                    <td>
+                        <span class="action-badge action-remove">
+                            REMOVE
+                        </span>
+                        <span class="vote-buttons" data-g="P01275" data-a="GO:0005737" data-r="GO_REF:0000107" data-act="REMOVE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+                        
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Incorrect functional location for a secreted peptide hormone. Proglucagon transits the ER and secretory granules and is exported; it does not function in the cytoplasm. This is an over-broad electronic ortholog transfer.
+                        </div>
+                        
+                        
+                        <div>
+                            <strong>Reason:</strong> Glucagon and the other products are secreted; &#34;cytoplasm&#34; (located_in) misrepresents their site of action and is not supported. The correct locations (extracellular region, ER lumen, secretory granule lumen) are separately annotated.
+                        </div>
+                        
+                        
+                        
+                        
+                    </td>
+                </tr>
+                
+                <tr>
+                    <td>
+                        <div class="term-info">
+                            
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005886" target="_blank" class="term-link">
+                                    GO:0005886
+                                </a>
+                            </span>
+                            <span class="term-label">plasma membrane</span>
+                            
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+                        
+                        
+                        
+                        <br>
+                        <span style="font-size: 0.75rem;">
+                            
+                            GO_REF:0000107
+                            
+                        </span>
+                        
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="P01275" data-a="GO:0005886" data-r="GO_REF:0000107" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+                        
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> The secreted peptides engage receptors located in the target-cell plasma membrane from the extracellular side; the ligand itself is not &#34;active in&#34; the plasma membrane. Likely an Ensembl ortholog-transfer artifact.
+                        </div>
+                        
+                        
+                        <div>
+                            <strong>Reason:</strong> &#34;is_active_in plasma membrane&#34; conflates the receptor&#39;s location with the ligand&#39;s; the hormone acts as an extracellular ligand, not as a plasma-membrane component.
+                        </div>
+                        
+                        
+                        
+                        
+                    </td>
+                </tr>
+                
+                <tr>
+                    <td>
+                        <div class="term-info">
+                            
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0007189" target="_blank" class="term-link">
+                                    GO:0007189
+                                </a>
+                            </span>
+                            <span class="term-label">adenylate cyclase-activating G protein-coupled receptor signaling pathway</span>
+                            
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+                        
+                        
+                        
+                        <br>
+                        <span style="font-size: 0.75rem;">
+                            
+                            GO_REF:0000107
+                            
+                        </span>
+                        
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P01275" data-a="GO:0007189" data-r="GO_REF:0000107" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+                        
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Glucagon/GLP-1/GLP-2 all activate Gs-coupled receptors that stimulate adenylyl cyclase and raise cAMP. Correct and appropriately specific.
+                        </div>
+                        
+                        
+                        
+                        
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+                            
+                            <div class="support-item">
+                                <span class="support-ref">
+                                    
+                                    UniProtKB:P01275
+                                    
+                                </span>
+                                
+                                <div class="support-text">couples to the G(s) G protein and elevates intracellular cAMP</div>
+                                
+                            </div>
+                            
+                        </div>
+                        
+                        
+                    </td>
+                </tr>
+                
+                <tr>
+                    <td>
+                        <div class="term-info">
+                            
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0014823" target="_blank" class="term-link">
+                                    GO:0014823
+                                </a>
+                            </span>
+                            <span class="term-label">response to activity</span>
+                            
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+                        
+                        
+                        
+                        <br>
+                        <span style="font-size: 0.75rem;">
+                            
+                            GO_REF:0000107
+                            
+                        </span>
+                        
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P01275" data-a="GO:0014823" data-r="GO_REF:0000107" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+                        
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Weak, context-dependent term propagated by ortholog transfer. Glucagon participates in glucose mobilization during physical activity, but this is peripheral and not a core function.
+                        </div>
+                        
+                        
+                        
+                        
+                        
+                    </td>
+                </tr>
+                
+                <tr>
+                    <td>
+                        <div class="term-info">
+                            
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0035774" target="_blank" class="term-link">
+                                    GO:0035774
+                                </a>
+                            </span>
+                            <span class="term-label">positive regulation of insulin secretion involved in cellular response to glucose stimulus</span>
+                            
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+                        
+                        
+                        
+                        <br>
+                        <span style="font-size: 0.75rem;">
+                            
+                            GO_REF:0000107
+                            
+                        </span>
+                        
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P01275" data-a="GO:0035774" data-r="GO_REF:0000107" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+                        
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> GLP-1 incretin effect; redundant with the IBA annotation of the same term. Core (GLP-1).
+                        </div>
+                        
+                        
+                        
+                        
+                        
+                    </td>
+                </tr>
+                
+                <tr>
+                    <td>
+                        <div class="term-info">
+                            
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0042593" target="_blank" class="term-link">
+                                    GO:0042593
+                                </a>
+                            </span>
+                            <span class="term-label">glucose homeostasis</span>
+                            
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+                        
+                        
+                        
+                        <br>
+                        <span style="font-size: 0.75rem;">
+                            
+                            GO_REF:0000107
+                            
+                        </span>
+                        
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P01275" data-a="GO:0042593" data-r="GO_REF:0000107" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+                        
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Central biological role: glucagon (and the incretins) regulate systemic glucose homeostasis. Correct, core.
+                        </div>
+                        
+                        
+                        
+                        
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+                            
+                            <div class="support-item">
+                                <span class="support-ref">
+                                    
+                                    UniProtKB:P01275
+                                    
+                                </span>
+                                
+                                <div class="support-text">Plays a key role in glucose metabolism and homeostasis</div>
+                                
+                            </div>
+                            
+                        </div>
+                        
+                        
+                    </td>
+                </tr>
+                
+                <tr>
+                    <td>
+                        <div class="term-info">
+                            
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0043066" target="_blank" class="term-link">
+                                    GO:0043066
+                                </a>
+                            </span>
+                            <span class="term-label">negative regulation of apoptotic process</span>
+                            
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+                        
+                        
+                        
+                        <br>
+                        <span style="font-size: 0.75rem;">
+                            
+                            GO_REF:0000107
+                            
+                        </span>
+                        
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P01275" data-a="GO:0043066" data-r="GO_REF:0000107" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+                        
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Reflects GLP-1&#39;s inhibition of pancreatic beta-cell apoptosis. Real but a general term and an indirect, downstream effect of GLP-1 receptor signaling; keep as non-core.
+                        </div>
+                        
+                        
+                        
+                        
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+                            
+                            <div class="support-item">
+                                <span class="support-ref">
+                                    
+                                    UniProtKB:P01275
+                                    
+                                </span>
+                                
+                                <div class="support-text">Inhibits beta cell apoptosis</div>
+                                
+                            </div>
+                            
+                        </div>
+                        
+                        
+                    </td>
+                </tr>
+                
+                <tr>
+                    <td>
+                        <div class="term-info">
+                            
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0048018" target="_blank" class="term-link">
+                                    GO:0048018
+                                </a>
+                            </span>
+                            <span class="term-label">receptor ligand activity</span>
+                            
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+                        
+                        
+                        
+                        <br>
+                        <span style="font-size: 0.75rem;">
+                            
+                            GO_REF:0000107
+                            
+                        </span>
+                        
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P01275" data-a="GO:0048018" data-r="GO_REF:0000107" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+                        
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Accurate core molecular function: the proglucagon peptides are agonist ligands for their cognate GPCRs.
+                        </div>
+                        
+                        
+                        
+                        
+                        
+                    </td>
+                </tr>
+                
+                <tr>
+                    <td>
+                        <div class="term-info">
+                            
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0070374" target="_blank" class="term-link">
+                                    GO:0070374
+                                </a>
+                            </span>
+                            <span class="term-label">positive regulation of ERK1 and ERK2 cascade</span>
+                            
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+                        
+                        
+                        
+                        <br>
+                        <span style="font-size: 0.75rem;">
+                            
+                            GO_REF:0000107
+                            
+                        </span>
+                        
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P01275" data-a="GO:0070374" data-r="GO_REF:0000107" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+                        
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Downstream intracellular consequence of GLP-1/glucagon receptor signaling in target cells (e.g., beta-cell proliferation). Indirect and several steps removed from the hormone&#39;s molecular function; non-core.
+                        </div>
+                        
+                        
+                        
+                        
+                        
+                    </td>
+                </tr>
+                
+                <tr>
+                    <td>
+                        <div class="term-info">
+                            
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0071377" target="_blank" class="term-link">
+                                    GO:0071377
+                                </a>
+                            </span>
+                            <span class="term-label">cellular response to glucagon stimulus</span>
+                            
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+                        
+                        
+                        
+                        <br>
+                        <span style="font-size: 0.75rem;">
+                            
+                            GO_REF:0000107
+                            
+                        </span>
+                        
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="P01275" data-a="GO:0071377" data-r="GO_REF:0000107" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+                        
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Semantically inverted for this gene. GCG is the SOURCE of the glucagon stimulus; this term describes the response program of glucagon-target cells, not a process the hormone is involved_in. Over-propagated electronic annotation.
+                        </div>
+                        
+                        
+                        <div>
+                            <strong>Reason:</strong> &#34;cellular response to glucagon stimulus&#34; belongs to cells receiving glucagon, not to the glucagon-producing gene; annotating GCG as involved_in its own stimulus-response is not meaningful.
+                        </div>
+                        
+                        
+                        
+                        
+                    </td>
+                </tr>
+                
+                <tr>
+                    <td>
+                        <div class="term-info">
+                            
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0090280" target="_blank" class="term-link">
+                                    GO:0090280
+                                </a>
+                            </span>
+                            <span class="term-label">positive regulation of calcium ion import</span>
+                            
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+                        
+                        
+                        
+                        <br>
+                        <span style="font-size: 0.75rem;">
+                            
+                            GO_REF:0000107
+                            
+                        </span>
+                        
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P01275" data-a="GO:0090280" data-r="GO_REF:0000107" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+                        
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> A downstream second-messenger effect of incretin/glucagon receptor signaling in target cells. Indirect; non-core.
+                        </div>
+                        
+                        
+                        
+                        
+                        
+                    </td>
+                </tr>
+                
+                <tr>
+                    <td>
+                        <div class="term-info">
+                            
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0032024" target="_blank" class="term-link">
+                                    GO:0032024
+                                </a>
+                            </span>
+                            <span class="term-label">positive regulation of insulin secretion</span>
+                            
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+                        
+                        
+                        
+                        <br>
+                        <span style="font-size: 0.75rem;">
+                            
+                            Reactome:R-HSA-381676
+                            
+                        </span>
+                        
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P01275" data-a="GO:0032024" data-r="Reactome:R-HSA-381676" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+                        
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> GLP-1 stimulates insulin secretion (incretin effect). Correct; a more general parent of the glucose-dependent term GO:0035774 also annotated here. Core (GLP-1).
+                        </div>
+                        
+                        
+                        
+                        
+                        
+                    </td>
+                </tr>
+                
+                <tr>
+                    <td>
+                        <div class="term-info">
+                            
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005576" target="_blank" class="term-link">
+                                    GO:0005576
+                                </a>
+                            </span>
+                            <span class="term-label">extracellular region</span>
+                            
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">EXP</span>
+                        
+                        
+                        
+                        <br>
+                        <span style="font-size: 0.75rem;">
+                            
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/22037645" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:22037645
+                            </a>
+                            
+                                
+                                
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Interleukin-6 enhances insulin secretion by increasing gluca...
+                                </span>
+                                
+                            
+                            
+                        </span>
+                        
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P01275" data-a="GO:0005576" data-r="PMID:22037645" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+                        
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Experimental support for secretion of GLP-1 (measured as a secreted/circulating hormone from L-cells and alpha-cells). Correct location.
+                        </div>
+                        
+                        
+                        
+                        
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+                            
+                            <div class="support-item">
+                                <span class="support-ref">
+                                    
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/22037645" target="_blank" class="term-link">
+                                        PMID:22037645
+                                    </a>
+                                    
+                                </span>
+                                
+                                <div class="support-text">increasing glucagon-like peptide-1</div>
+                                
+                            </div>
+                            
+                        </div>
+                        
+                        
+                    </td>
+                </tr>
+                
+                <tr>
+                    <td>
+                        <div class="term-info">
+                            
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005576" target="_blank" class="term-link">
+                                    GO:0005576
+                                </a>
+                            </span>
+                            <span class="term-label">extracellular region</span>
+                            
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">EXP</span>
+                        
+                        
+                        
+                        <br>
+                        <span style="font-size: 0.75rem;">
+                            
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/40446798" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:40446798
+                            </a>
+                            
+                                
+                                
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    A microbial amino-acid-conjugated bile acid, tryptophan-chol...
+                                </span>
+                                
+                            
+                            
+                        </span>
+                        
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P01275" data-a="GO:0005576" data-r="PMID:40446798" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+                        
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Secreted GLP-1 measured in a study of glucose homeostasis. Correct extracellular location for the secreted peptide.
+                        </div>
+                        
+                        
+                        
+                        
+                        
+                    </td>
+                </tr>
+                
+                <tr>
+                    <td>
+                        <div class="term-info">
+                            
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0048018" target="_blank" class="term-link">
+                                    GO:0048018
+                                </a>
+                            </span>
+                            <span class="term-label">receptor ligand activity</span>
+                            
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+                        
+                        
+                        
+                        <br>
+                        <span style="font-size: 0.75rem;">
+                            
+                            Reactome:R-HSA-381612
+                            
+                        </span>
+                        
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P01275" data-a="GO:0048018" data-r="Reactome:R-HSA-381612" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+                        
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> GLP-1 acts as the agonist ligand of GLP1R (Reactome reaction &#34;GLP1R binds GLP1&#34;). Correct core molecular function.
+                        </div>
+                        
+                        
+                        
+                        
+                        
+                    </td>
+                </tr>
+                
+                <tr>
+                    <td>
+                        <div class="term-info">
+                            
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005788" target="_blank" class="term-link">
+                                    GO:0005788
+                                </a>
+                            </span>
+                            <span class="term-label">endoplasmic reticulum lumen</span>
+                            
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+                        
+                        
+                        
+                        <br>
+                        <span style="font-size: 0.75rem;">
+                            
+                            Reactome:R-HSA-381799
+                            
+                        </span>
+                        
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P01275" data-a="GO:0005788" data-r="Reactome:R-HSA-381799" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+                        
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Correct biosynthetic transit location: preproglucagon is synthesized and folded in the ER lumen of L-cells. Appropriate as a pathway/location annotation.
+                        </div>
+                        
+                        
+                        
+                        
+                        
+                    </td>
+                </tr>
+                
+                <tr>
+                    <td>
+                        <div class="term-info">
+                            
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005788" target="_blank" class="term-link">
+                                    GO:0005788
+                                </a>
+                            </span>
+                            <span class="term-label">endoplasmic reticulum lumen</span>
+                            
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+                        
+                        
+                        
+                        <br>
+                        <span style="font-size: 0.75rem;">
+                            
+                            Reactome:R-HSA-421416
+                            
+                        </span>
+                        
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P01275" data-a="GO:0005788" data-r="Reactome:R-HSA-421416" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+                        
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> ER lumen transit during biosynthesis/trafficking. Redundant with the other ER-lumen annotation; correct.
+                        </div>
+                        
+                        
+                        
+                        
+                        
+                    </td>
+                </tr>
+                
+                <tr>
+                    <td>
+                        <div class="term-info">
+                            
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0034774" target="_blank" class="term-link">
+                                    GO:0034774
+                                </a>
+                            </span>
+                            <span class="term-label">secretory granule lumen</span>
+                            
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+                        
+                        
+                        
+                        <br>
+                        <span style="font-size: 0.75rem;">
+                            
+                            Reactome:R-HSA-421416
+                            
+                        </span>
+                        
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P01275" data-a="GO:0034774" data-r="Reactome:R-HSA-421416" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+                        
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Proglucagon and its products are stored in regulated secretory granules prior to exocytosis. Correct location.
+                        </div>
+                        
+                        
+                        
+                        
+                        
+                    </td>
+                </tr>
+                
+                <tr>
+                    <td>
+                        <div class="term-info">
+                            
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005576" target="_blank" class="term-link">
+                                    GO:0005576
+                                </a>
+                            </span>
+                            <span class="term-label">extracellular region</span>
+                            
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">ISS</span>
+                        
+                        
+                        
+                        <br>
+                        <span style="font-size: 0.75rem;">
+                            
+                            GO_REF:0000024
+                            
+                        </span>
+                        
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P01275" data-a="GO:0005576" data-r="GO_REF:0000024" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+                        
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Secreted hormone; correct location. Redundant with other extracellular region annotations.
+                        </div>
+                        
+                        
+                        
+                        
+                        
+                    </td>
+                </tr>
+                
+                <tr>
+                    <td>
+                        <div class="term-info">
+                            
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0014823" target="_blank" class="term-link">
+                                    GO:0014823
+                                </a>
+                            </span>
+                            <span class="term-label">response to activity</span>
+                            
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">ISS</span>
+                        
+                        
+                        
+                        <br>
+                        <span style="font-size: 0.75rem;">
+                            
+                            GO_REF:0000024
+                            
+                        </span>
+                        
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P01275" data-a="GO:0014823" data-r="GO_REF:0000024" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+                        
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Weak, context-dependent ortholog-transferred term; redundant with the IEA copy. Non-core.
+                        </div>
+                        
+                        
+                        
+                        
+                        
+                    </td>
+                </tr>
+                
+                <tr>
+                    <td>
+                        <div class="term-info">
+                            
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0042593" target="_blank" class="term-link">
+                                    GO:0042593
+                                </a>
+                            </span>
+                            <span class="term-label">glucose homeostasis</span>
+                            
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">ISS</span>
+                        
+                        
+                        
+                        <br>
+                        <span style="font-size: 0.75rem;">
+                            
+                            GO_REF:0000024
+                            
+                        </span>
+                        
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P01275" data-a="GO:0042593" data-r="GO_REF:0000024" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+                        
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Systemic glucose homeostasis; correct and central. Redundant with the IEA copy.
+                        </div>
+                        
+                        
+                        
+                        
+                        
+                    </td>
+                </tr>
+                
+                <tr>
+                    <td>
+                        <div class="term-info">
+                            
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0050796" target="_blank" class="term-link">
+                                    GO:0050796
+                                </a>
+                            </span>
+                            <span class="term-label">regulation of insulin secretion</span>
+                            
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">ISS</span>
+                        
+                        
+                        
+                        <br>
+                        <span style="font-size: 0.75rem;">
+                            
+                            GO_REF:0000024
+                            
+                        </span>
+                        
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P01275" data-a="GO:0050796" data-r="GO_REF:0000024" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+                        
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> GLP-1 regulates insulin secretion (incretin). Correct; a general parent of the more specific positive-regulation terms also annotated. Core (GLP-1).
+                        </div>
+                        
+                        
+                        
+                        
+                        
+                    </td>
+                </tr>
+                
+                <tr>
+                    <td>
+                        <div class="term-info">
+                            
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0007186" target="_blank" class="term-link">
+                                    GO:0007186
+                                </a>
+                            </span>
+                            <span class="term-label">G protein-coupled receptor signaling pathway</span>
+                            
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+                        
+                        
+                        
+                        <br>
+                        <span style="font-size: 0.75rem;">
+                            
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/7929237" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:7929237
+                            </a>
+                            
+                                
+                                
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Synergistic activation of the type I adenylyl cyclase by Ca2...
+                                </span>
+                                
+                            
+                            
+                        </span>
+                        
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P01275" data-a="GO:0007186" data-r="PMID:7929237" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+                        
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Glucagon acts via a Gs-coupled GPCR; in this study glucagon was used as a Gs-coupled receptor agonist driving adenylyl cyclase. The GPCR-signaling annotation is correct, though general. The paper&#39;s focus is adenylyl cyclase regulation, with glucagon as a tool.
+                        </div>
+                        
+                        
+                        
+                        
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+                            
+                            <div class="support-item">
+                                <span class="support-ref">
+                                    
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/7929237" target="_blank" class="term-link">
+                                        PMID:7929237
+                                    </a>
+                                    
+                                </span>
+                                
+                                <div class="support-text">500 nM glucagon alone did not stimulate the enzyme but the combination of A23187 and glucagon activated the enzyme</div>
+                                
+                            </div>
+                            
+                        </div>
+                        
+                        
+                    </td>
+                </tr>
+                
+                <tr>
+                    <td>
+                        <div class="term-info">
+                            
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005576" target="_blank" class="term-link">
+                                    GO:0005576
+                                </a>
+                            </span>
+                            <span class="term-label">extracellular region</span>
+                            
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+                        
+                        
+                        
+                        <br>
+                        <span style="font-size: 0.75rem;">
+                            
+                            Reactome:R-HSA-163625
+                            
+                        </span>
+                        
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P01275" data-a="GO:0005576" data-r="Reactome:R-HSA-163625" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+                        
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Correct location (glucagon binding GCGR occurs in the extracellular space). One of many redundant Reactome reaction-level extracellular-region annotations.
+                        </div>
+                        
+                        
+                        
+                        
+                        
+                    </td>
+                </tr>
+                
+                <tr>
+                    <td>
+                        <div class="term-info">
+                            
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005576" target="_blank" class="term-link">
+                                    GO:0005576
+                                </a>
+                            </span>
+                            <span class="term-label">extracellular region</span>
+                            
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+                        
+                        
+                        
+                        <br>
+                        <span style="font-size: 0.75rem;">
+                            
+                            Reactome:R-HSA-379044
+                            
+                        </span>
+                        
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P01275" data-a="GO:0005576" data-r="Reactome:R-HSA-379044" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+                        
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Correct but redundant Reactome extracellular-region annotation (Gs activation reaction).
+                        </div>
+                        
+                        
+                        
+                        
+                        
+                    </td>
+                </tr>
+                
+                <tr>
+                    <td>
+                        <div class="term-info">
+                            
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005576" target="_blank" class="term-link">
+                                    GO:0005576
+                                </a>
+                            </span>
+                            <span class="term-label">extracellular region</span>
+                            
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+                        
+                        
+                        
+                        <br>
+                        <span style="font-size: 0.75rem;">
+                            
+                            Reactome:R-HSA-379048
+                            
+                        </span>
+                        
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P01275" data-a="GO:0005576" data-r="Reactome:R-HSA-379048" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+                        
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Correct but redundant Reactome extracellular-region annotation (Gq/11 activation reaction).
+                        </div>
+                        
+                        
+                        
+                        
+                        
+                    </td>
+                </tr>
+                
+                <tr>
+                    <td>
+                        <div class="term-info">
+                            
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005576" target="_blank" class="term-link">
+                                    GO:0005576
+                                </a>
+                            </span>
+                            <span class="term-label">extracellular region</span>
+                            
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+                        
+                        
+                        
+                        <br>
+                        <span style="font-size: 0.75rem;">
+                            
+                            Reactome:R-HSA-744886
+                            
+                        </span>
+                        
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P01275" data-a="GO:0005576" data-r="Reactome:R-HSA-744886" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+                        
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Correct but redundant Reactome extracellular-region annotation (Ligand:GPCR:Gs dissociation).
+                        </div>
+                        
+                        
+                        
+                        
+                        
+                    </td>
+                </tr>
+                
+                <tr>
+                    <td>
+                        <div class="term-info">
+                            
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005576" target="_blank" class="term-link">
+                                    GO:0005576
+                                </a>
+                            </span>
+                            <span class="term-label">extracellular region</span>
+                            
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+                        
+                        
+                        
+                        <br>
+                        <span style="font-size: 0.75rem;">
+                            
+                            Reactome:R-HSA-744887
+                            
+                        </span>
+                        
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P01275" data-a="GO:0005576" data-r="Reactome:R-HSA-744887" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+                        
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Correct but redundant Reactome extracellular-region annotation (Gs binding reaction).
+                        </div>
+                        
+                        
+                        
+                        
+                        
+                    </td>
+                </tr>
+                
+                <tr>
+                    <td>
+                        <div class="term-info">
+                            
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005576" target="_blank" class="term-link">
+                                    GO:0005576
+                                </a>
+                            </span>
+                            <span class="term-label">extracellular region</span>
+                            
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+                        
+                        
+                        
+                        <br>
+                        <span style="font-size: 0.75rem;">
+                            
+                            Reactome:R-HSA-749448
+                            
+                        </span>
+                        
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P01275" data-a="GO:0005576" data-r="Reactome:R-HSA-749448" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+                        
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Correct but redundant Reactome extracellular-region annotation (Gq binding reaction).
+                        </div>
+                        
+                        
+                        
+                        
+                        
+                    </td>
+                </tr>
+                
+                <tr>
+                    <td>
+                        <div class="term-info">
+                            
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005576" target="_blank" class="term-link">
+                                    GO:0005576
+                                </a>
+                            </span>
+                            <span class="term-label">extracellular region</span>
+                            
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+                        
+                        
+                        
+                        <br>
+                        <span style="font-size: 0.75rem;">
+                            
+                            Reactome:R-HSA-749452
+                            
+                        </span>
+                        
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P01275" data-a="GO:0005576" data-r="Reactome:R-HSA-749452" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+                        
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Correct but redundant Reactome extracellular-region annotation (Ligand:GPCR:Gq dissociation).
+                        </div>
+                        
+                        
+                        
+                        
+                        
+                    </td>
+                </tr>
+                
+                <tr>
+                    <td>
+                        <div class="term-info">
+                            
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005576" target="_blank" class="term-link">
+                                    GO:0005576
+                                </a>
+                            </span>
+                            <span class="term-label">extracellular region</span>
+                            
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+                        
+                        
+                        
+                        <br>
+                        <span style="font-size: 0.75rem;">
+                            
+                            Reactome:R-HSA-825631
+                            
+                        </span>
+                        
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P01275" data-a="GO:0005576" data-r="Reactome:R-HSA-825631" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+                        
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Correct but redundant Reactome extracellular-region annotation (Glucagon:GCGR GTP-GDP exchange).
+                        </div>
+                        
+                        
+                        
+                        
+                        
+                    </td>
+                </tr>
+                
+                <tr>
+                    <td>
+                        <div class="term-info">
+                            
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005576" target="_blank" class="term-link">
+                                    GO:0005576
+                                </a>
+                            </span>
+                            <span class="term-label">extracellular region</span>
+                            
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+                        
+                        
+                        
+                        <br>
+                        <span style="font-size: 0.75rem;">
+                            
+                            Reactome:R-HSA-381612
+                            
+                        </span>
+                        
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P01275" data-a="GO:0005576" data-r="Reactome:R-HSA-381612" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+                        
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Correct but redundant Reactome extracellular-region annotation (GLP1R binds GLP1).
+                        </div>
+                        
+                        
+                        
+                        
+                        
+                    </td>
+                </tr>
+                
+                <tr>
+                    <td>
+                        <div class="term-info">
+                            
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005576" target="_blank" class="term-link">
+                                    GO:0005576
+                                </a>
+                            </span>
+                            <span class="term-label">extracellular region</span>
+                            
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+                        
+                        
+                        
+                        <br>
+                        <span style="font-size: 0.75rem;">
+                            
+                            Reactome:R-HSA-383313
+                            
+                        </span>
+                        
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P01275" data-a="GO:0005576" data-r="Reactome:R-HSA-383313" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+                        
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Correct location: GLP-1 is secreted from intestinal L-cells into the extracellular space. Redundant with other extracellular-region annotations.
+                        </div>
+                        
+                        
+                        
+                        
+                        
+                    </td>
+                </tr>
+                
+                <tr>
+                    <td>
+                        <div class="term-info">
+                            
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005576" target="_blank" class="term-link">
+                                    GO:0005576
+                                </a>
+                            </span>
+                            <span class="term-label">extracellular region</span>
+                            
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+                        
+                        
+                        
+                        <br>
+                        <span style="font-size: 0.75rem;">
+                            
+                            Reactome:R-HSA-9023632
+                            
+                        </span>
+                        
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P01275" data-a="GO:0005576" data-r="Reactome:R-HSA-9023632" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+                        
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Correct but redundant Reactome extracellular-region annotation (DPP4 hydrolysis of GLP-1).
+                        </div>
+                        
+                        
+                        
+                        
+                        
+                    </td>
+                </tr>
+                
+                <tr>
+                    <td>
+                        <div class="term-info">
+                            
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005576" target="_blank" class="term-link">
+                                    GO:0005576
+                                </a>
+                            </span>
+                            <span class="term-label">extracellular region</span>
+                            
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+                        
+                        
+                        
+                        <br>
+                        <span style="font-size: 0.75rem;">
+                            
+                            Reactome:R-HSA-9023633
+                            
+                        </span>
+                        
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P01275" data-a="GO:0005576" data-r="Reactome:R-HSA-9023633" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+                        
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Correct but redundant Reactome extracellular-region annotation (DPP4 hydrolysis of GLP-1).
+                        </div>
+                        
+                        
+                        
+                        
+                        
+                    </td>
+                </tr>
+                
+                <tr>
+                    <td>
+                        <div class="term-info">
+                            
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0034774" target="_blank" class="term-link">
+                                    GO:0034774
+                                </a>
+                            </span>
+                            <span class="term-label">secretory granule lumen</span>
+                            
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+                        
+                        
+                        
+                        <br>
+                        <span style="font-size: 0.75rem;">
+                            
+                            Reactome:R-HSA-383313
+                            
+                        </span>
+                        
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P01275" data-a="GO:0034774" data-r="Reactome:R-HSA-383313" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+                        
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> GLP-1 is packaged in secretory granules prior to release. Correct location; redundant with the other secretory-granule-lumen annotation.
+                        </div>
+                        
+                        
+                        
+                        
+                        
+                    </td>
+                </tr>
+                
+                <tr>
+                    <td>
+                        <div class="term-info">
+                            
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005576" target="_blank" class="term-link">
+                                    GO:0005576
+                                </a>
+                            </span>
+                            <span class="term-label">extracellular region</span>
+                            
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+                        
+                        
+                        
+                        <br>
+                        <span style="font-size: 0.75rem;">
+                            
+                            Reactome:R-HSA-420123
+                            
+                        </span>
+                        
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P01275" data-a="GO:0005576" data-r="Reactome:R-HSA-420123" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+                        
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Correct but redundant Reactome extracellular-region annotation (GLP2R binds GLP2).
+                        </div>
+                        
+                        
+                        
+                        
+                        
+                    </td>
+                </tr>
+                
+                <tr>
+                    <td>
+                        <div class="term-info">
+                            
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005102" target="_blank" class="term-link">
+                                    GO:0005102
+                                </a>
+                            </span>
+                            <span class="term-label">signaling receptor binding</span>
+                            
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+                        
+                        
+                        
+                        <br>
+                        <span style="font-size: 0.75rem;">
+                            
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/9990065" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:9990065
+                            </a>
+                            
+                                
+                                
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Prototypic G protein-coupled receptor for the intestinotroph...
+                                </span>
+                                
+                            
+                            
+                        </span>
+                        
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P01275" data-a="GO:0005102" data-r="PMID:9990065" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+                        
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> GLP-2 binds and activates its specific receptor GLP2R. Correct, informative molecular function for the GLP-2 chain.
+                        </div>
+                        
+                        
+                        
+                        
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+                            
+                            <div class="support-item">
+                                <span class="support-ref">
+                                    
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/9990065" target="_blank" class="term-link">
+                                        PMID:9990065
+                                    </a>
+                                    
+                                </span>
+                                
+                                <div class="support-text">GLP-2, like glucagon and GLP-1, exerts its actions through a distinct and specific novel receptor expressed in its principal target tissue</div>
+                                
+                            </div>
+                            
+                        </div>
+                        
+                        
+                    </td>
+                </tr>
+                
+                <tr>
+                    <td>
+                        <div class="term-info">
+                            
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0007186" target="_blank" class="term-link">
+                                    GO:0007186
+                                </a>
+                            </span>
+                            <span class="term-label">G protein-coupled receptor signaling pathway</span>
+                            
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+                        
+                        
+                        
+                        <br>
+                        <span style="font-size: 0.75rem;">
+                            
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/9990065" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:9990065
+                            </a>
+                            
+                                
+                                
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Prototypic G protein-coupled receptor for the intestinotroph...
+                                </span>
+                                
+                            
+                            
+                        </span>
+                        
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P01275" data-a="GO:0007186" data-r="PMID:9990065" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+                        
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> GLP-2 signals through the Gs-coupled GLP2R (increased cAMP). Correct GPCR-signaling annotation for the GLP-2 chain.
+                        </div>
+                        
+                        
+                        
+                        
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+                            
+                            <div class="support-item">
+                                <span class="support-ref">
+                                    
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/9990065" target="_blank" class="term-link">
+                                        PMID:9990065
+                                    </a>
+                                    
+                                </span>
+                                
+                                <div class="support-text">Cells expressing the GLP-2R responded to GLP-2</div>
+                                
+                            </div>
+                            
+                        </div>
+                        
+                        
+                    </td>
+                </tr>
+                
+                <tr>
+                    <td>
+                        <div class="term-info">
+                            
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0007631" target="_blank" class="term-link">
+                                    GO:0007631
+                                </a>
+                            </span>
+                            <span class="term-label">feeding behavior</span>
+                            
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+                        
+                        
+                        
+                        <br>
+                        <span style="font-size: 0.75rem;">
+                            
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/8538742" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:8538742
+                            </a>
+                            
+                                
+                                
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    A role for glucagon-like peptide-1 in the central regulation...
+                                </span>
+                                
+                            
+                            
+                        </span>
+                        
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P01275" data-a="GO:0007631" data-r="PMID:8538742" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+                        
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Central GLP-1 inhibits feeding and is a physiological mediator of satiety. Correct process annotation for the GLP-1 chain.
+                        </div>
+                        
+                        
+                        
+                        
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+                            
+                            <div class="support-item">
+                                <span class="support-ref">
+                                    
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/8538742" target="_blank" class="term-link">
+                                        PMID:8538742
+                                    </a>
+                                    
+                                </span>
+                                
+                                <div class="support-text">central GLP-1 is a new physiological mediator of satiety</div>
+                                
+                            </div>
+                            
+                        </div>
+                        
+                        
+                    </td>
+                </tr>
+                
+            </tbody>
+        </table>
+    </div>
+    
+
+    
+    <div class="section">
+        <h2 class="section-title">Core Functions</h2>
+        
+        <div class="core-function-card">
+            
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+                <h3>Serves as a secreted polyprotein hormone precursor that is proteolytically processed in a tissue-specific manner (PCSK2/PC2 in pancreatic alpha-cells; PCSK1/PC1 in intestinal L-cells and neurons) to yield multiple distinct peptide hormones. The precursor is synthesized in the ER, stored in secretory granules, and secreted; its biology is realized through its cleavage products.
+</h3>
+                <span class="vote-buttons" data-g="P01275" data-a="FUNCTION: Serves as a secreted polyprotein hormone precursor..." data-r="" data-act="CORE_FUNCTION">
+                    <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
+                    <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
+                </span>
+            </div>
+            
+
+            <div class="core-function-terms">
+                
+                <div class="function-term-group">
+                    <div class="function-term-label">Molecular Function:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005179" target="_blank" class="term-link">
+                            hormone activity
+                        </a>
+                    </span>
+                </div>
+                
+
+                
+
+                
+                <div class="function-term-group">
+                    <div class="function-term-label">Cellular Locations:</div>
+                    <div class="function-annotations">
+                        
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005788" target="_blank" class="term-link">
+                                endoplasmic reticulum lumen
+                            </a>
+                        </span>
+                        
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0034774" target="_blank" class="term-link">
+                                secretory granule lumen
+                            </a>
+                        </span>
+                        
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005576" target="_blank" class="term-link">
+                                extracellular region
+                            </a>
+                        </span>
+                        
+                    </div>
+                </div>
+                
+
+                
+
+                
+            </div>
+
+            
+            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
+                <strong>Supporting Evidence:</strong>
+                <ul class="findings-list">
+                    
+                    <li class="finding-item">
+                        <span class="reference-id">
+                            
+                            UniProtKB:P01275
+                            
+                        </span>
+                        
+                        <div class="finding-text">Proglucagon is post-translationally processed in a tissue-specific manner in pancreatic A cells and intestinal L cells</div>
+                        
+                    </li>
+                    
+                </ul>
+            </div>
+            
+        </div>
+        
+        <div class="core-function-card">
+            
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+                <h3>Via the glucagon peptide (residues 53-81, PRO_0000011256), binds and activates the glucagon receptor GCGR on hepatocytes, the principal counter-regulatory action to insulin: raises blood glucose by stimulating gluconeogenesis and glycogenolysis and decreasing glycolysis, signaling through Gs and elevating cAMP.
+</h3>
+                <span class="vote-buttons" data-g="P01275" data-a="FUNCTION: Via the glucagon peptide (residues 53-81, PRO_0000..." data-r="" data-act="CORE_FUNCTION">
+                    <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
+                    <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
+                </span>
+            </div>
+            
+
+            <div class="core-function-terms">
+                
+                <div class="function-term-group">
+                    <div class="function-term-label">Molecular Function:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0031769" target="_blank" class="term-link">
+                            glucagon receptor binding
+                        </a>
+                    </span>
+                </div>
+                
+
+                
+                <div class="function-term-group">
+                    <div class="function-term-label">Directly Involved In:</div>
+                    <div class="function-annotations">
+                        
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0045722" target="_blank" class="term-link">
+                                positive regulation of gluconeogenesis
+                            </a>
+                        </span>
+                        
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0042593" target="_blank" class="term-link">
+                                glucose homeostasis
+                            </a>
+                        </span>
+                        
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0007189" target="_blank" class="term-link">
+                                adenylate cyclase-activating G protein-coupled receptor signaling pathway
+                            </a>
+                        </span>
+                        
+                    </div>
+                </div>
+                
+
+                
+                <div class="function-term-group">
+                    <div class="function-term-label">Cellular Locations:</div>
+                    <div class="function-annotations">
+                        
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005576" target="_blank" class="term-link">
+                                extracellular region
+                            </a>
+                        </span>
+                        
+                    </div>
+                </div>
+                
+
+                
+
+                
+            </div>
+
+            
+            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
+                <strong>Supporting Evidence:</strong>
+                <ul class="findings-list">
+                    
+                    <li class="finding-item">
+                        <span class="reference-id">
+                            
+                            UniProtKB:P01275
+                            
+                        </span>
+                        
+                        <div class="finding-text">Regulates blood glucose by increasing gluconeogenesis and decreasing glycolysis</div>
+                        
+                    </li>
+                    
+                    <li class="finding-item">
+                        <span class="reference-id">
+                            
+                            UniProtKB:P01275
+                            
+                        </span>
+                        
+                        <div class="finding-text">Binds to and activates the glucagon receptor GCGR</div>
+                        
+                    </li>
+                    
+                </ul>
+            </div>
+            
+        </div>
+        
+        <div class="core-function-card">
+            
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+                <h3>Via glucagon-like peptide 1 (GLP-1; residues 92-128 and the active 7-37/7-36amide forms), acts as an incretin agonist of GLP1R to potentiate glucose-dependent insulin secretion, promote satiety, and support beta-cell survival. Produced chiefly by intestinal L-cells and also pancreatic alpha-cells and neurons.
+</h3>
+                <span class="vote-buttons" data-g="P01275" data-a="FUNCTION: Via glucagon-like peptide 1 (GLP-1; residues 92-12..." data-r="" data-act="CORE_FUNCTION">
+                    <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
+                    <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
+                </span>
+            </div>
+            
+
+            <div class="core-function-terms">
+                
+                <div class="function-term-group">
+                    <div class="function-term-label">Molecular Function:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0048018" target="_blank" class="term-link">
+                            receptor ligand activity
+                        </a>
+                    </span>
+                </div>
+                
+
+                
+                <div class="function-term-group">
+                    <div class="function-term-label">Directly Involved In:</div>
+                    <div class="function-annotations">
+                        
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0035774" target="_blank" class="term-link">
+                                positive regulation of insulin secretion involved in cellular response to glucose stimulus
+                            </a>
+                        </span>
+                        
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0007631" target="_blank" class="term-link">
+                                feeding behavior
+                            </a>
+                        </span>
+                        
+                    </div>
+                </div>
+                
+
+                
+                <div class="function-term-group">
+                    <div class="function-term-label">Cellular Locations:</div>
+                    <div class="function-annotations">
+                        
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005576" target="_blank" class="term-link">
+                                extracellular region
+                            </a>
+                        </span>
+                        
+                    </div>
+                </div>
+                
+
+                
+
+                
+            </div>
+
+            
+            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
+                <strong>Supporting Evidence:</strong>
+                <ul class="findings-list">
+                    
+                    <li class="finding-item">
+                        <span class="reference-id">
+                            
+                            UniProtKB:P01275
+                            
+                        </span>
+                        
+                        <div class="finding-text">Potent stimulator of glucose-dependent insulin release</div>
+                        
+                    </li>
+                    
+                    <li class="finding-item">
+                        <span class="reference-id">
+                            
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/8538742" target="_blank" class="term-link">
+                                PMID:8538742
+                            </a>
+                            
+                        </span>
+                        
+                        <div class="finding-text">central GLP-1 is a new physiological mediator of satiety</div>
+                        
+                    </li>
+                    
+                </ul>
+            </div>
+            
+        </div>
+        
+        <div class="core-function-card">
+            
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+                <h3>Via glucagon-like peptide 2 (GLP-2; residues 146-178, PRO_0000011262), binds and activates the intestine-specific receptor GLP2R to stimulate intestinal growth: increased villus height and crypt cell proliferation with decreased enterocyte apoptosis, enhancing nutrient assimilation. A distinct receptor and function from glucagon and GLP-1.
+</h3>
+                <span class="vote-buttons" data-g="P01275" data-a="FUNCTION: Via glucagon-like peptide 2 (GLP-2; residues 146-1..." data-r="" data-act="CORE_FUNCTION">
+                    <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
+                    <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
+                </span>
+            </div>
+            
+
+            <div class="core-function-terms">
+                
+                <div class="function-term-group">
+                    <div class="function-term-label">Molecular Function:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005102" target="_blank" class="term-link">
+                            signaling receptor binding
+                        </a>
+                    </span>
+                </div>
+                
+
+                
+                <div class="function-term-group">
+                    <div class="function-term-label">Directly Involved In:</div>
+                    <div class="function-annotations">
+                        
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0007186" target="_blank" class="term-link">
+                                G protein-coupled receptor signaling pathway
+                            </a>
+                        </span>
+                        
+                    </div>
+                </div>
+                
+
+                
+                <div class="function-term-group">
+                    <div class="function-term-label">Cellular Locations:</div>
+                    <div class="function-annotations">
+                        
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005576" target="_blank" class="term-link">
+                                extracellular region
+                            </a>
+                        </span>
+                        
+                    </div>
+                </div>
+                
+
+                
+
+                
+            </div>
+
+            
+            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
+                <strong>Supporting Evidence:</strong>
+                <ul class="findings-list">
+                    
+                    <li class="finding-item">
+                        <span class="reference-id">
+                            
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/9990065" target="_blank" class="term-link">
+                                PMID:9990065
+                            </a>
+                            
+                        </span>
+                        
+                        <div class="finding-text">GLP-2 stimulates intestinal growth and up-regulates villus height in the small intestine, concomitant with increased crypt cell proliferation and decreased enterocyte apoptosis</div>
+                        
+                    </li>
+                    
+                    <li class="finding-item">
+                        <span class="reference-id">
+                            
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/9990065" target="_blank" class="term-link">
+                                PMID:9990065
+                            </a>
+                            
+                        </span>
+                        
+                        <div class="finding-text">GLP-2, like glucagon and GLP-1, exerts its actions through a distinct and specific novel receptor expressed in its principal target tissue</div>
+                        
+                    </li>
+                    
+                </ul>
+            </div>
+            
+        </div>
+        
+    </div>
+    
+
+    
+    <div class="section">
+        <h2 class="section-title collapsible">References</h2>
+        <div class="collapse-content">
+            
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+                        
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000002.md" target="_blank" class="term-link">
+                            GO_REF:0000002
+                        </a>
+                        
+                    </span>
+                </div>
+                
+                <div class="reference-title">Gene Ontology annotation through association of InterPro records with GO terms</div>
+                
+                
+            </div>
+            
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+                        
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000024.md" target="_blank" class="term-link">
+                            GO_REF:0000024
+                        </a>
+                        
+                    </span>
+                </div>
+                
+                <div class="reference-title">Manual transfer of experimentally-verified manual GO annotation data to orthologs by curator judgment of sequence similarity</div>
+                
+                
+            </div>
+            
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+                        
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000033.md" target="_blank" class="term-link">
+                            GO_REF:0000033
+                        </a>
+                        
+                    </span>
+                </div>
+                
+                <div class="reference-title">Annotation inferences using phylogenetic trees</div>
+                
+                
+            </div>
+            
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+                        
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000107.md" target="_blank" class="term-link">
+                            GO_REF:0000107
+                        </a>
+                        
+                    </span>
+                </div>
+                
+                <div class="reference-title">Automatic transfer of experimentally verified manual GO annotation data to orthologs using Ensembl Compara</div>
+                
+                
+            </div>
+            
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+                        
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000117.md" target="_blank" class="term-link">
+                            GO_REF:0000117
+                        </a>
+                        
+                    </span>
+                </div>
+                
+                <div class="reference-title">Electronic Gene Ontology annotations created by ARBA machine learning models</div>
+                
+                
+            </div>
+            
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+                        
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000120.md" target="_blank" class="term-link">
+                            GO_REF:0000120
+                        </a>
+                        
+                    </span>
+                </div>
+                
+                <div class="reference-title">Combined Automated Annotation using Multiple IEA Methods</div>
+                
+                
+            </div>
+            
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+                        
+                        UniProtKB:P01275
+                        
+                    </span>
+                </div>
+                
+                <div class="reference-title">UniProtKB entry P01275 (GLUC_HUMAN), Pro-glucagon</div>
+                
+                
+                <ul class="findings-list">
+                    
+                    <li class="finding-item">
+                        <div class="finding-statement">Proglucagon is processed tissue-specifically; glucagon predominates in pancreatic A cells (PCSK2/PC2), while GLP-1, GLP-2, glicentin and oxyntomodulin are liberated in intestinal L cells (PCSK1/PC1).</div>
+                        
+                        <div class="finding-text">"Proglucagon is post-translationally processed in a tissue-specific manner in pancreatic A cells and intestinal L cells"</div>
+                        
+                    </li>
+                    
+                </ul>
+                
+            </div>
+            
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+                        
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/17051221" target="_blank" class="term-link">
+                            PMID:17051221
+                        </a>
+                        
+                    </span>
+                </div>
+                
+                <div class="reference-title">Structures of human insulin-degrading enzyme reveal a new substrate recognition mechanism.</div>
+                
+                
+                <ul class="findings-list">
+                    
+                    <li class="finding-item">
+                        <div class="finding-statement">Glucagon is one of four substrates co-crystallized with insulin-degrading enzyme (IDE), supporting glucagon as an IDE degradation substrate.</div>
+                        
+                        <div class="finding-text">"structures of human IDE in complex with four substrates (insulin B chain, amyloid-beta peptide (1-40), amylin and glucagon)"</div>
+                        
+                    </li>
+                    
+                </ul>
+                
+            </div>
+            
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+                        
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/17715056" target="_blank" class="term-link">
+                            PMID:17715056
+                        </a>
+                        
+                    </span>
+                </div>
+                
+                <div class="reference-title">Crystal structure of the incretin-bound extracellular domain of a G protein-coupled receptor.</div>
+                
+                
+                <ul class="findings-list">
+                    
+                    <li class="finding-item">
+                        <div class="finding-statement">Structural study of the GIP receptor extracellular domain bound to the incretin GIP; the structural principles are stated to be conserved among related class B hormone receptors such as GLP1R.</div>
+                        
+                        <div class="finding-text">"the crystal structure of the complex of human GIP receptor extracellular domain (ECD) with its agonist, the incretin GIP(1-42)"</div>
+                        
+                    </li>
+                    
+                </ul>
+                
+            </div>
+            
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+                        
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/21314817" target="_blank" class="term-link">
+                            PMID:21314817
+                        </a>
+                        
+                    </span>
+                </div>
+                
+                <div class="reference-title">Neuropeptide Y, B-type natriuretic peptide, substance P and peptide YY are novel substrates of fibroblast activation protein-α.</div>
+                
+                
+                <ul class="findings-list">
+                    
+                    <li class="finding-item">
+                        <div class="finding-statement">GLP-1 is a (slow) substrate of fibroblast activation protein (FAP), in addition to being an efficient DPP4 substrate.</div>
+                        
+                        <div class="finding-text">"FAP slowly hydrolysed other hormone peptides, such as the incretins glucagon-like peptide-1 and glucose-dependent insulinotropic peptide"</div>
+                        
+                    </li>
+                    
+                </ul>
+                
+            </div>
+            
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+                        
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/22037645" target="_blank" class="term-link">
+                            PMID:22037645
+                        </a>
+                        
+                    </span>
+                </div>
+                
+                <div class="reference-title">Interleukin-6 enhances insulin secretion by increasing glucagon-like peptide-1 secretion from L cells and alpha cells.</div>
+                
+                
+                <ul class="findings-list">
+                    
+                    <li class="finding-item">
+                        <div class="finding-statement">IL-6 increases GLP-1 production from alpha cells by upregulating proglucagon (GCG) and prohormone convertase 1/3, enhancing insulin secretion.</div>
+                        
+                        <div class="finding-text">"IL-6 increased GLP-1 production from alpha cells through increased proglucagon (which is encoded by GCG) and prohormone convertase 1/3 expression"</div>
+                        
+                    </li>
+                    
+                    <li class="finding-item">
+                        <div class="finding-statement">GLP-1 is a hormone that induces insulin secretion (incretin).</div>
+                        
+                        <div class="finding-text">"Glucagon-like peptide-1 (GLP-1) is a hormone that induces insulin secretion"</div>
+                        
+                    </li>
+                    
+                </ul>
+                
+            </div>
+            
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+                        
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/22212535" target="_blank" class="term-link">
+                            PMID:22212535
+                        </a>
+                        
+                    </span>
+                </div>
+                
+                <div class="reference-title">Mapping out the multistage fibrillation of glucagon.</div>
+                
+                
+                <ul class="findings-list">
+                    
+                    <li class="finding-item">
+                        <div class="finding-statement">Glucagon self-assembles into multiple morphological types of amyloid-like fibrils in vitro, the basis of the identical protein binding annotation.</div>
+                        
+                        <div class="finding-text">"The 29-residue peptide hormone glucagon forms many different morphological types of amyloid-like fibrils"</div>
+                        
+                    </li>
+                    
+                </ul>
+                
+            </div>
+            
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+                        
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/40446798" target="_blank" class="term-link">
+                            PMID:40446798
+                        </a>
+                        
+                    </span>
+                </div>
+                
+                <div class="reference-title">A microbial amino-acid-conjugated bile acid, tryptophan-cholic acid, improves glucose homeostasis via the orphan receptor MRGPRE.</div>
+                
+                
+            </div>
+            
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+                        
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/7929237" target="_blank" class="term-link">
+                            PMID:7929237
+                        </a>
+                        
+                    </span>
+                </div>
+                
+                <div class="reference-title">Synergistic activation of the type I adenylyl cyclase by Ca2+ and Gs-coupled receptors in vivo.</div>
+                
+                
+                <ul class="findings-list">
+                    
+                    <li class="finding-item">
+                        <div class="finding-statement">Glucagon, acting through its Gs-coupled receptor, synergizes with Ca2+ to activate type I adenylyl cyclase; used here as a Gs-coupled receptor agonist.</div>
+                        
+                        <div class="finding-text">"500 nM glucagon alone did not stimulate the enzyme but the combination of A23187 and glucagon activated the enzyme"</div>
+                        
+                    </li>
+                    
+                </ul>
+                
+            </div>
+            
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+                        
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/8538742" target="_blank" class="term-link">
+                            PMID:8538742
+                        </a>
+                        
+                    </span>
+                </div>
+                
+                <div class="reference-title">A role for glucagon-like peptide-1 in the central regulation of feeding.</div>
+                
+                
+                <ul class="findings-list">
+                    
+                    <li class="finding-item">
+                        <div class="finding-statement">Central (ICV) GLP-1 inhibits feeding and is a physiological mediator of satiety, establishing GLP-1&#39;s role in feeding behavior.</div>
+                        
+                        <div class="finding-text">"central GLP-1 is a new physiological mediator of satiety"</div>
+                        
+                    </li>
+                    
+                </ul>
+                
+            </div>
+            
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+                        
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/9990065" target="_blank" class="term-link">
+                            PMID:9990065
+                        </a>
+                        
+                    </span>
+                </div>
+                
+                <div class="reference-title">Prototypic G protein-coupled receptor for the intestinotrophic factor glucagon-like peptide 2.</div>
+                
+                
+                <ul class="findings-list">
+                    
+                    <li class="finding-item">
+                        <div class="finding-statement">GLP-2 is intestinotrophic and acts through its own distinct receptor (GLP2R), stimulating villus growth, crypt proliferation, and reduced enterocyte apoptosis.</div>
+                        
+                        <div class="finding-text">"GLP-2 stimulates intestinal growth and up-regulates villus height in the small intestine, concomitant with increased crypt cell proliferation and decreased enterocyte apoptosis"</div>
+                        
+                    </li>
+                    
+                    <li class="finding-item">
+                        <div class="finding-statement">GLP-2 exerts its actions through a distinct, specific receptor expressed in the gut, like glucagon and GLP-1 acting through their own receptors.</div>
+                        
+                        <div class="finding-text">"GLP-2, like glucagon and GLP-1, exerts its actions through a distinct and specific novel receptor expressed in its principal target tissue"</div>
+                        
+                    </li>
+                    
+                </ul>
+                
+            </div>
+            
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+                        
+                        Reactome:R-HSA-163625
+                        
+                    </span>
+                </div>
+                
+                <div class="reference-title">Glucagon binds to Glucagon receptor</div>
+                
+                
+            </div>
+            
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+                        
+                        Reactome:R-HSA-379044
+                        
+                    </span>
+                </div>
+                
+                <div class="reference-title">Liganded Gs-activating GPCR acts as a GEF for Gs</div>
+                
+                
+            </div>
+            
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+                        
+                        Reactome:R-HSA-379048
+                        
+                    </span>
+                </div>
+                
+                <div class="reference-title">Liganded Gq/11-activating GPCRs act as GEFs for Gq/11</div>
+                
+                
+            </div>
+            
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+                        
+                        Reactome:R-HSA-381612
+                        
+                    </span>
+                </div>
+                
+                <div class="reference-title">GLP1R binds GLP1</div>
+                
+                
+            </div>
+            
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+                        
+                        Reactome:R-HSA-381676
+                        
+                    </span>
+                </div>
+                
+                <div class="reference-title">Glucagon-like Peptide-1 (GLP1) regulates insulin secretion</div>
+                
+                
+            </div>
+            
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+                        
+                        Reactome:R-HSA-381799
+                        
+                    </span>
+                </div>
+                
+                <div class="reference-title">Synthesis of Preproglucagon in intestinal L cells</div>
+                
+                
+            </div>
+            
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+                        
+                        Reactome:R-HSA-383313
+                        
+                    </span>
+                </div>
+                
+                <div class="reference-title">Glucagon-like Peptide 1 is secreted from intestinal L cells</div>
+                
+                
+            </div>
+            
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+                        
+                        Reactome:R-HSA-420123
+                        
+                    </span>
+                </div>
+                
+                <div class="reference-title">Glucagon-like receptor 2 binds GLP2</div>
+                
+                
+            </div>
+            
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+                        
+                        Reactome:R-HSA-421416
+                        
+                    </span>
+                </div>
+                
+                <div class="reference-title">Proglucagon translocates from the ER Lumen to secretory granules</div>
+                
+                
+            </div>
+            
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+                        
+                        Reactome:R-HSA-744886
+                        
+                    </span>
+                </div>
+                
+                <div class="reference-title">The Ligand:GPCR:Gs complex dissociates</div>
+                
+                
+            </div>
+            
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+                        
+                        Reactome:R-HSA-744887
+                        
+                    </span>
+                </div>
+                
+                <div class="reference-title">Liganded Gs-activating GPCRs bind inactive heterotrimeric Gs</div>
+                
+                
+            </div>
+            
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+                        
+                        Reactome:R-HSA-749448
+                        
+                    </span>
+                </div>
+                
+                <div class="reference-title">Liganded Gq-activating GPCRs bind inactive heterotrimeric Gq</div>
+                
+                
+            </div>
+            
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+                        
+                        Reactome:R-HSA-749452
+                        
+                    </span>
+                </div>
+                
+                <div class="reference-title">The Ligand:GPCR:Gq complex dissociates</div>
+                
+                
+            </div>
+            
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+                        
+                        Reactome:R-HSA-825631
+                        
+                    </span>
+                </div>
+                
+                <div class="reference-title">Glucagon:GCGR mediates GTP-GDP exchange</div>
+                
+                
+            </div>
+            
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+                        
+                        Reactome:R-HSA-9023632
+                        
+                    </span>
+                </div>
+                
+                <div class="reference-title">DPP4(39-766) hydrolyzes Glucagon-like Peptide-1 (GLP-1)</div>
+                
+                
+            </div>
+            
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+                        
+                        Reactome:R-HSA-9023633
+                        
+                    </span>
+                </div>
+                
+                <div class="reference-title">DPP4(1-766) hydrolyzes Glucagon-like Peptide-1 (GLP-1)</div>
+                
+                
+            </div>
+            
+        </div>
+    </div>
+    
+
+
+    
+    <div class="section">
+        <h2 class="section-title">Suggested Questions for Experts</h2>
+        
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> Should GO annotations for proglucagon-derived functions be made at the level of the individual peptide chains (PRO ids) rather than the gene/precursor, to avoid conflating glucagon (GCGR), GLP-1 (GLP1R), and GLP-2 (GLP2R) functions that act through different receptors and in different tissues?</p>
+                    
+                </div>
+                <span class="vote-buttons" data-g="P01275" data-a="Q: Should GO annotations for proglucagon-derived func..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+        
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> For oxyntomodulin and glicentin, which functions are sufficiently well-supported to warrant dedicated GO annotations versus remaining as UniProt FUNCTION statements (currently ECO:0000303)?</p>
+                    
+                </div>
+                <span class="vote-buttons" data-g="P01275" data-a="Q: For oxyntomodulin and glicentin, which functions a..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+        
+    </div>
+    
+
+    
+    <div class="section">
+        <h2 class="section-title">Suggested Experiments</h2>
+        
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    
+                    <p><strong>Experiment:</strong> Chain-resolved functional annotation: use tissue-specific (alpha-cell vs L-cell) secretomics/peptidomics to confirm which mature peptides are produced where, and pair with receptor-specific (GCGR/GLP1R/GLP2R) reporter assays to assign each downstream process (insulin secretion, gluconeogenesis, intestinal growth) to the correct peptide.</p>
+                    
+                    
+                    
+                </div>
+                <span class="vote-buttons" data-g="P01275" data-a="EXPERIMENT: Chain-resolved functional annotation: use tissue-s..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+        
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    
+                    <p><strong>Experiment:</strong> Knock-in mouse models that selectively ablate processing to individual products (e.g., PC2-null pancreatic glucagon vs PC1/3-null intestinal GLP-1/GLP-2) to dissect which phenotypes (glucose mobilization, incretin/insulin secretion, intestinal trophic effects) depend on which proglucagon-derived peptide in vivo.</p>
+                    
+                    
+                    
+                </div>
+                <span class="vote-buttons" data-g="P01275" data-a="EXPERIMENT: Knock-in mouse models that selectively ablate proc..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+        
+    </div>
+    
+
+    
+
+    
+
+    <!-- Computational Predictions Section -->
+    
+
+    <!-- Deep Research Sections -->
+    
+
+    <!-- Additional Documentation Sections -->
+    
+    <div class="section">
+        <h2 class="section-title">📚 Additional Documentation</h2>
+        
+        <details class="markdown-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; cursor: pointer;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Notes</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(GCG-notes.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="P01275" data-a="DOC: Notes" data-r="" data-act="DOCUMENTATION" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This documentation is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This documentation needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+                <h1 id="gcg-proglucagon-review-notes">GCG (Proglucagon) — review notes</h1>
+<p>UniProt: P01275 (GLUC_HUMAN), 180 aa precursor. HGNC:4191. Taxon 9606.</p>
+<h2 id="core-framing-one-gene-many-chains">Core framing: one gene, many chains</h2>
+<p>GCG is the textbook example (alongside POMC) of a <strong>polyprotein precursor</strong> whose<br />
+biology lives in its <strong>cleavage products</strong>, not the precursor. Proglucagon is<br />
+processed <strong>tissue-specifically</strong> by prohormone convertases:</p>
+<ul>
+<li><strong>Pancreatic α-cells (islets of Langerhans):</strong> PCSK2/PC2 liberates <strong>glucagon</strong><br />
+  as the major bioactive hormone.</li>
+<li><strong>Intestinal L-cells and selected brain neurons:</strong> PCSK1/PC1 liberates<br />
+<strong>GLP-1, GLP-2, glicentin and oxyntomodulin</strong>.</li>
+</ul>
+<p>[UniProt:P01275 PTM, "Proglucagon is post-translationally processed in a tissue-specific manner in pancreatic A cells and intestinal L cells. In pancreatic A cells, the major bioactive hormone is glucagon cleaved by PCSK2/PC2. In the intestinal L cells PCSK1/PC1 liberates GLP-1, GLP-2, glicentin and oxyntomodulin."]</p>
+<h3 id="the-chains-uniprot-feature-table-pro-ids">The chains (UniProt feature table, PRO IDs)</h3>
+<table>
+<thead>
+<tr>
+<th>Chain</th>
+<th>Residues</th>
+<th>PRO id</th>
+<th>Receptor</th>
+<th>Core role</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>Glicentin</td>
+<td>21-89</td>
+<td>PRO_0000011253</td>
+<td>(unclear)</td>
+<td>gastric acid / mucosal growth (weak)</td>
+</tr>
+<tr>
+<td>GRPP (glicentin-related polypeptide)</td>
+<td>21-50</td>
+<td>PRO_0000011254</td>
+<td>—</td>
+<td>unknown</td>
+</tr>
+<tr>
+<td>Oxyntomodulin</td>
+<td>53-89</td>
+<td>PRO_0000011255</td>
+<td>GCGR/GLP1R (dual, weak)</td>
+<td>reduces food intake, inhibits gastric emptying</td>
+</tr>
+<tr>
+<td><strong>Glucagon</strong></td>
+<td>53-81</td>
+<td>PRO_0000011256</td>
+<td><strong>GCGR</strong></td>
+<td>raises blood glucose (gluconeogenesis↑, glycolysis↓); counter-regulatory to insulin</td>
+</tr>
+<tr>
+<td><strong>GLP-1</strong> (and 7-37 / 7-36)</td>
+<td>92-128 / 98-128 / 98-127</td>
+<td>PRO_0000011258/9/60</td>
+<td><strong>GLP1R</strong></td>
+<td>incretin: glucose-dependent insulin secretion; satiety; β-cell survival</td>
+</tr>
+<tr>
+<td><strong>GLP-2</strong></td>
+<td>146-178</td>
+<td>PRO_0000011262</td>
+<td><strong>GLP2R</strong></td>
+<td>intestinotrophic: villus growth, crypt proliferation, ↓enterocyte apoptosis</td>
+</tr>
+</tbody>
+</table>
+<p>Critical consequence for GO curation: GO annotations are attached to the <strong>precursor<br />
+P01275</strong> with <strong>no chain/PRO qualifier</strong>, so functions belonging to <em>different<br />
+peptides with different receptors</em> are conflated at the gene level. Ideally each<br />
+function would carry the PRO id of the responsible peptide. I capture this with the<br />
+<code>functional_isoforms</code> block (CLEAVAGE_PRODUCT, mapped to PRO ids) and attribute each<br />
+function in <code>core_functions</code>.</p>
+<h2 id="per-chain-function-evidence-from-uniprot-function-blocks-literature">Per-chain function evidence (from UniProt FUNCTION blocks + literature)</h2>
+<h3 id="glucagon">Glucagon</h3>
+<ul>
+<li>"Plays a key role in glucose metabolism and homeostasis. Regulates blood glucose<br />
+  by increasing gluconeogenesis and decreasing glycolysis. A counterregulatory hormone<br />
+  of insulin... Binds to and activates the glucagon receptor GCGR, which couples to<br />
+  the G(s) G protein and elevates intracellular cAMP" [UniProt:P01275 FUNCTION Glucagon; ECO:0000269|PubMed:32193322].</li>
+<li>Receptor binding: GO:0031769 glucagon receptor binding (IBA) is the specific MF.</li>
+<li>Glucagon is an <strong>IDE substrate</strong> [PMID:17051221, structure of IDE with glucagon as one of four substrates: "structures of human IDE in complex with four substrates (insulin B chain, amyloid-beta peptide (1-40), amylin and glucagon)"] — clearance, not a core function.</li>
+<li>Glucagon <strong>self-assembles into amyloid fibrils</strong> in vitro <a href="https://pubmed.ncbi.nlm.nih.gov/22212535" title="The 29-residue peptide hormone glucagon forms many different morphological types of amyloid-like fibrils">PMID:22212535</a> — basis of GO:0042802 identical protein binding (IPI). In vitro / pharmaceutical-formulation behavior, not a physiological function.</li>
+</ul>
+<h3 id="glp-1-incretin">GLP-1 (incretin)</h3>
+<ul>
+<li>"Potent stimulator of glucose-dependent insulin release" [UniProt:P01275 FUNCTION GLP-1; ECO:0000269|PubMed:22037645, PubMed:40446798]. Also gastric motility, suppression of glucagon, satiety, islet mass / β-cell proliferation, <strong>inhibits beta cell apoptosis</strong>.</li>
+<li>IL-6 increases GLP-1 production from α-cells via ↑proglucagon + PC1/3 <a href="https://pubmed.ncbi.nlm.nih.gov/22037645" title="IL-6 increased GLP-1 production from alpha cells through increased proglucagon (which is encoded by GCG) and prohormone convertase 1/3 expression">PMID:22037645</a>.</li>
+<li>Central satiety: ICV GLP-1 inhibits feeding; "central GLP-1 is a new physiological mediator of satiety" <a href="https://pubmed.ncbi.nlm.nih.gov/8538742">PMID:8538742</a>. Basis of GO:0007631 feeding behavior (TAS).</li>
+<li>GLP-1 is a <strong>DPP4</strong> substrate (Reactome R-HSA-9023632/3) and a slow <strong>FAP</strong> substrate <a href="https://pubmed.ncbi.nlm.nih.gov/21314817" title="FAP slowly hydrolysed other hormone peptides, such as the incretins glucagon-like peptide-1 and glucose-dependent insulinotropic peptide">PMID:21314817</a> — degradation/clearance, not core.</li>
+</ul>
+<h3 id="glp-2-intestinotrophic">GLP-2 (intestinotrophic)</h3>
+<ul>
+<li>"GLP-2 stimulates intestinal growth and up-regulates villus height in the small<br />
+  intestine, concomitant with increased crypt cell proliferation and decreased<br />
+  enterocyte apoptosis" <a href="https://pubmed.ncbi.nlm.nih.gov/9990065">PMID:9990065</a>. Acts through its own receptor GLP-2R:<br />
+  "GLP-2, like glucagon and GLP-1, exerts its actions through a distinct and specific<br />
+  novel receptor" <a href="https://pubmed.ncbi.nlm.nih.gov/9990065">PMID:9990065</a>. Basis of GO:0005102 signaling receptor binding (TAS) and GO:0007186 GPCR signaling (TAS) from this paper.</li>
+</ul>
+<h3 id="oxyntomodulin-glicentin">Oxyntomodulin / Glicentin</h3>
+<ul>
+<li>Oxyntomodulin: "Significantly reduces food intake. Inhibits gastric emptying"<br />
+  [UniProt:P01275 FUNCTION Oxyntomodulin]. Glicentin: gastric acid / mucosal growth (weak, ECO:0000303).</li>
+</ul>
+<h2 id="annotation-by-annotation-reasoning-highlights">Annotation-by-annotation reasoning highlights</h2>
+<ul>
+<li><strong>Hormone activity GO:0005179 (IBA/IEA), receptor ligand activity GO:0048018, glucagon<br />
+  receptor binding GO:0031769, signaling receptor binding GO:0005102</strong>: all correct, core<br />
+  MF. These are the right way to describe the peptides' molecular function (agonist/ligand).</li>
+<li><strong>GPCR / adenylate cyclase-activating signaling (GO:0007188, GO:0007189, GO:0007186)</strong>:<br />
+  all chains act through class B GPCRs (GCGR, GLP1R, GLP2R) → Gs → adenylyl cyclase → cAMP.<br />
+  Correct.</li>
+<li><strong>Insulin secretion terms (GO:0035774, GO:0032024, GO:0050796)</strong>: GLP-1 incretin effect.<br />
+  Correct, specific GO:0035774 (positive regulation of insulin secretion involved in<br />
+  cellular response to glucose stimulus) is the best term and captures glucose-dependence.</li>
+<li><strong>Gluconeogenesis GO:0045722, glucose homeostasis GO:0042593</strong>: glucagon. Correct, core.</li>
+<li><strong>GO:0001678 intracellular glucose homeostasis (IBA)</strong>: questionable term choice —<br />
+  glucagon regulates <em>systemic/blood</em> glucose, not intracellular glucose homeostasis<br />
+  (cell-autonomous). The PANTHER family IBA propagated a sibling term; GO:0042593<br />
+  glucose homeostasis is the better fit. MODIFY.</li>
+<li><strong>GO:0005737 cytoplasm located_in (IEA, Ensembl)</strong>: wrong for a secreted peptide hormone;<br />
+  proglucagon only transits cytoplasm-bounded compartments (ER → granule). Misleading.<br />
+  REMOVE.</li>
+<li><strong>GO:0005886 plasma membrane is_active_in (IEA, Ensembl)</strong>: the secreted ligand engages a<br />
+  PM receptor from the extracellular side; the peptide is not <em>active in</em> the PM. Over-annotation.</li>
+<li><strong>GO:0071377 cellular response to glucagon stimulus involved_in (IEA)</strong>: semantically<br />
+  backwards — GCG is the <em>source</em> of the glucagon stimulus, not a cell <em>responding to</em> it.<br />
+  This is the response program of glucagon TARGET cells. Over-propagated IEA. MARK_AS_OVER_ANNOTATED.</li>
+<li><strong>GO:0070374 positive regulation of ERK1/2 cascade, GO:0090280 positive regulation of<br />
+  calcium ion import, GO:0043066 negative regulation of apoptotic process (all IEA Ensembl)</strong>:<br />
+  real downstream effects of GLP-1/glucagon signaling in target cells but indirect, several<br />
+  steps removed from the hormone's molecular function; keep as non-core at most.</li>
+<li><strong>GO:0014823 response to activity (IEA/ISS)</strong>: ortholog-transferred, weak/contextual; keep non-core.</li>
+<li><strong>GO:0005515 protein binding (IPI ×3) + GO:0042802 identical protein binding (IPI)</strong>:<br />
+  real binary interactions (IDE substrate, FAP substrate, GIPR co-structure, self-fibrillation)<br />
+  but uninformative / non-physiological; KEEP_AS_NON_CORE (per guidance avoid "protein binding"<br />
+  as a core MF).</li>
+<li><strong>Locations</strong>: extracellular region GO:0005576 (secreted) = core; ER lumen GO:0005788 and<br />
+  secretory granule lumen GO:0034774 = correct biosynthetic/storage transit locations (ACCEPT).</li>
+</ul>
+<h2 id="references-checked">References checked</h2>
+<p>All 9 PMIDs read at abstract level (only PMID:22037645 has full text in cache). Reference<br />
+correctness judgments recorded in <code>reference_review</code>. PMID:7929237 (type I adenylyl cyclase)<br />
+and PMID:17715056 (GIP receptor ECD) are tool/structure papers that use a GCG product or a<br />
+paralogous incretin peripherally — flagged LOW relevance.</p>
+            </div>
+        </details>
+        
+    </div>
+    
+
+    <!-- YAML Preview Section -->
+    <div class="section">
+        <details class="yaml-preview">
+            <summary>
+                <h2 style="display: inline;">📄 View Raw YAML</h2>
+            </summary>
+            <div class="yaml-content">
+                <pre><code>id: P01275
+gene_symbol: GCG
+product_type: PROTEIN
+status: COMPLETE
+taxon:
+  id: NCBITaxon:9606
+  label: Homo sapiens
+description: &gt;
+  GCG encodes proglucagon, a 180-residue secreted polyprotein precursor that is
+  proteolytically processed in a tissue-specific manner by prohormone convertases to
+  yield several distinct bioactive peptide hormones, each acting through its own class B
+  G protein-coupled receptor. In pancreatic islet alpha-cells, PCSK2/PC2 liberates
+  glucagon, the principal counter-regulatory hormone of insulin, which binds the glucagon
+  receptor (GCGR) on hepatocytes and raises blood glucose by stimulating gluconeogenesis
+  and glycogenolysis while suppressing glycolysis. In intestinal enteroendocrine L-cells
+  and selected brainstem and hypothalamic neurons, PCSK1/PC1 liberates glucagon-like
+  peptide 1 (GLP-1), glucagon-like peptide 2 (GLP-2), oxyntomodulin, and glicentin. GLP-1
+  is an incretin that potentiates glucose-dependent insulin secretion, slows gastric
+  emptying, and promotes satiety and beta-cell survival, acting via GLP1R. GLP-2 is
+  intestinotrophic, stimulating crypt cell proliferation and villus growth via GLP2R.
+  Oxyntomodulin reduces food intake and gastric emptying. All mature peptides are secreted
+  hormones; the precursor itself has no intrinsic activity, and its biology is distributed
+  across its cleavage products. The peptides signal predominantly through Gs to activate
+  adenylyl cyclase and elevate intracellular cAMP in their respective target cells.
+
+functional_isoforms:
+- id: GCG_GLUCAGON
+  name: Glucagon
+  type: CLEAVAGE_PRODUCT
+  maps_to:
+  - type: UNIPROT_CHAIN
+    ids: [PRO_0000011256]
+    residues: &#34;53-81&#34;
+  description: &gt;
+    29-residue peptide, the major bioactive product of proglucagon processing in pancreatic
+    islet alpha-cells (PCSK2/PC2). Binds and activates the glucagon receptor GCGR on
+    hepatocytes (Gs-coupled), elevating cAMP and raising blood glucose by increasing
+    gluconeogenesis and glycogenolysis and decreasing glycolysis. The principal
+    counter-regulatory hormone of insulin; secreted in response to hypoglycemia. Glucagon
+    is a substrate of insulin-degrading enzyme (IDE) and can self-assemble into amyloid
+    fibrils in vitro. Receptor-binding/glucose-mobilizing functions belong to THIS peptide,
+    not to the GLP-1/GLP-2 products.
+  isoform_specific_terms:
+  - id: GO:0031769
+    label: glucagon receptor binding
+  - id: GO:0045722
+    label: positive regulation of gluconeogenesis
+
+- id: GCG_GLP1
+  name: Glucagon-like peptide 1 (GLP-1)
+  type: CLEAVAGE_PRODUCT
+  maps_to:
+  - type: UNIPROT_CHAIN
+    ids: [PRO_0000011258, PRO_0000011259, PRO_0000011260]
+    residues: &#34;92-128 / 98-128 / 98-127&#34;
+  description: &gt;
+    Incretin hormone produced mainly in intestinal L-cells (and pancreatic alpha-cells and
+    some neurons) by PCSK1/PC1, then N-terminally truncated to the active GLP-1(7-37) and
+    GLP-1(7-36)amide forms. Acts through GLP1R (Gs) to potently stimulate glucose-dependent
+    insulin secretion, slow gastric emptying, suppress glucagon, promote satiety, and
+    enhance beta-cell mass/survival. Rapidly inactivated by DPP4 (and slowly by FAP). The
+    insulin-secretion, incretin, satiety and anti-apoptotic functions belong to THIS peptide.
+  isoform_specific_terms:
+  - id: GO:0035774
+    label: positive regulation of insulin secretion involved in cellular response to glucose
+      stimulus
+  - id: GO:0007631
+    label: feeding behavior
+  - id: GO:0043066
+    label: negative regulation of apoptotic process
+
+- id: GCG_GLP2
+  name: Glucagon-like peptide 2 (GLP-2)
+  type: CLEAVAGE_PRODUCT
+  maps_to:
+  - type: UNIPROT_CHAIN
+    ids: [PRO_0000011262]
+    residues: &#34;146-178&#34;
+  description: &gt;
+    33-residue intestinotrophic peptide produced in intestinal L-cells by PCSK1/PC1. Acts
+    through its own receptor GLP2R (Gs), expressed in the gut, to stimulate intestinal
+    growth, increase villus height and crypt cell proliferation, decrease enterocyte
+    apoptosis, and enhance nutrient assimilation. The intestinal-growth functions belong to
+    THIS peptide and signal through a distinct receptor from glucagon and GLP-1.
+  isoform_specific_terms:
+  - id: GO:0005102
+    label: signaling receptor binding
+
+- id: GCG_OXYNTOMODULIN
+  name: Oxyntomodulin
+  type: CLEAVAGE_PRODUCT
+  maps_to:
+  - type: UNIPROT_CHAIN
+    ids: [PRO_0000011255]
+    residues: &#34;53-89&#34;
+  description: &gt;
+    Intestinal L-cell peptide (glucagon plus C-terminal extension). Reduces food intake and
+    inhibits gastric emptying; a dual weak agonist of GCGR and GLP1R. Anorectic effects are
+    attributed to THIS peptide.
+
+- id: GCG_GLICENTIN
+  name: Glicentin
+  type: CLEAVAGE_PRODUCT
+  maps_to:
+  - type: UNIPROT_CHAIN
+    ids: [PRO_0000011253]
+    residues: &#34;21-89&#34;
+  description: &gt;
+    N-terminal proglucagon product from intestinal L-cells. Proposed to modulate gastric
+    acid secretion and gastro-pyloro-duodenal activity and to support intestinal mucosal
+    growth early in life; functions are weakly supported (ECO:0000303).
+
+- id: GCG_GRPP
+  name: Glicentin-related polypeptide (GRPP)
+  type: CLEAVAGE_PRODUCT
+  maps_to:
+  - type: UNIPROT_CHAIN
+    ids: [PRO_0000011254]
+    residues: &#34;21-50&#34;
+  description: &gt;
+    N-terminal fragment of glicentin released during processing; no well-defined function
+    established.
+
+existing_annotations:
+- term:
+    id: GO:0005576
+    label: extracellular region
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: is_active_in
+  review:
+    summary: &gt;-
+      All mature proglucagon-derived peptides are secreted hormones that act in the
+      extracellular space. Correct cellular location.
+    action: ACCEPT
+    supported_by:
+    - reference_id: UniProtKB:P01275
+      supporting_text: &#34;Secreted in the A cells of the islets of Langerhans&#34;
+- term:
+    id: GO:0001678
+    label: intracellular glucose homeostasis
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Glucagon regulates whole-organism/blood glucose, not cell-autonomous intracellular
+      glucose homeostasis. The IBA propagated a too-specific sibling term; the systemic
+      term glucose homeostasis is the correct fit.
+    action: MODIFY
+    reason: &gt;-
+      &#34;intracellular glucose homeostasis&#34; denotes maintenance of glucose levels within a
+      cell, whereas glucagon&#39;s role is in systemic blood-glucose homeostasis. Replace with
+      the general glucose homeostasis term, which is also independently annotated to this gene.
+    proposed_replacement_terms:
+    - id: GO:0042593
+      label: glucose homeostasis
+- term:
+    id: GO:0005179
+    label: hormone activity
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Core molecular function. The proglucagon-derived peptides are bona fide secreted
+      peptide hormones acting on cognate receptors.
+    action: ACCEPT
+    supported_by:
+    - reference_id: UniProtKB:P01275
+      supporting_text: &#34;the major bioactive hormone is glucagon cleaved by PCSK2/PC2&#34;
+- term:
+    id: GO:0007188
+    label: adenylate cyclase-modulating G protein-coupled receptor signaling pathway
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Glucagon, GLP-1 and GLP-2 all act through class B GPCRs (GCGR, GLP1R, GLP2R) coupled
+      to Gs, elevating cAMP. Correct, though the activating child term GO:0007189 is more precise.
+    action: ACCEPT
+    supported_by:
+    - reference_id: UniProtKB:P01275
+      supporting_text: &#34;couples to the G(s) G protein and elevates intracellular cAMP&#34;
+- term:
+    id: GO:0031769
+    label: glucagon receptor binding
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Specific, informative molecular function for the glucagon peptide chain (binds GCGR).
+      Core function.
+    action: ACCEPT
+    supported_by:
+    - reference_id: UniProtKB:P01275
+      supporting_text: &#34;Binds to and activates the glucagon receptor GCGR&#34;
+- term:
+    id: GO:0035774
+    label: positive regulation of insulin secretion involved in cellular response to glucose
+      stimulus
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Captures the GLP-1 incretin effect, including its hallmark glucose-dependence. Best
+      available term for this function. Core (GLP-1 chain).
+    action: ACCEPT
+    supported_by:
+    - reference_id: UniProtKB:P01275
+      supporting_text: &#34;Potent stimulator of glucose-dependent insulin release&#34;
+- term:
+    id: GO:0045722
+    label: positive regulation of gluconeogenesis
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Glucagon raises blood glucose by stimulating hepatic gluconeogenesis. Core function
+      (glucagon chain).
+    action: ACCEPT
+    supported_by:
+    - reference_id: UniProtKB:P01275
+      supporting_text: &#34;Regulates blood glucose by increasing gluconeogenesis and decreasing
+        glycolysis&#34;
+- term:
+    id: GO:0005102
+    label: signaling receptor binding
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000117
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Correct but general. The peptides bind their cognate signaling receptors; more
+      specific descendants (glucagon receptor binding, receptor ligand activity) are also
+      annotated and are preferable as the core MF.
+    action: ACCEPT
+- term:
+    id: GO:0005179
+    label: hormone activity
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000002
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Redundant with the IBA hormone activity annotation; correct core molecular function.
+    action: ACCEPT
+- term:
+    id: GO:0005576
+    label: extracellular region
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000120
+  qualifier: located_in
+  review:
+    summary: Secreted hormone; correct location. Redundant with other extracellular region annotations.
+    action: ACCEPT
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:17051221
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Records glucagon as a substrate captured in the insulin-degrading enzyme (IDE)
+      structure. A real binary interaction but uninformative as a molecular function and not
+      a core activity (this is hormone clearance/degradation).
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      &#34;protein binding&#34; (GO:0005515) conveys no functional specificity; the interaction
+      reflects glucagon being degraded by IDE rather than a function glucagon enables.
+    supported_by:
+    - reference_id: PMID:17051221
+      supporting_text: &#34;structures of human IDE in complex with four substrates (insulin B
+        chain, amyloid-beta peptide (1-40), amylin and glucagon)&#34;
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:17715056
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Derives from a structural study of the GIP receptor extracellular domain bound to the
+      incretin GIP; supports a peptide:receptor-ECD binary interaction logged for this entry.
+      Uninformative generic MF; not a core function.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      &#34;protein binding&#34; is non-specific. The paper structurally characterizes GIP (a
+      paralogous incretin), and the interaction is recorded as a generic binary binding for
+      the proglucagon entry rather than a distinct molecular activity.
+    supported_by:
+    - reference_id: PMID:17715056
+      supporting_text: &#34;the crystal structure of the complex of human GIP receptor
+        extracellular domain (ECD) with its agonist, the incretin GIP(1-42)&#34;
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:21314817
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Records GLP-1 as a (slow) substrate of fibroblast activation protein (FAP). Real
+      protease:substrate interaction relevant to incretin clearance, but a generic and
+      non-core molecular function.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      Reflects degradation of GLP-1 by FAP, not an activity GLP-1 enables; &#34;protein binding&#34;
+      is uninformative.
+    supported_by:
+    - reference_id: PMID:21314817
+      supporting_text: &#34;FAP slowly hydrolysed other hormone peptides, such as the incretins
+        glucagon-like peptide-1 and glucose-dependent insulinotropic peptide&#34;
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:21314817
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Records GLP-1 as an efficient substrate of dipeptidyl peptidase 4 (DPP4, UniProt
+      P27487). DPP4 is the primary enzyme responsible for GLP-1 inactivation in vivo
+      (the pharmacological basis of gliptin-class antidiabetics). Real binary interaction
+      but a generic, non-core molecular function.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      Reflects degradation of GLP-1 by DPP4, not an activity GLP-1 enables; &#34;protein binding&#34;
+      is uninformative.
+    supported_by:
+    - reference_id: PMID:21314817
+      supporting_text: &#34;the incretins glucagon-like peptide-1 and glucose-dependent
+        insulinotropic peptide, which are efficient DPP4 substrates&#34;
+- term:
+    id: GO:0042802
+    label: identical protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:22212535
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Reflects glucagon self-association into amyloid-like fibrils observed in vitro under
+      acidic, concentrated conditions (relevant to pharmaceutical formulation). Not a
+      physiological function of the secreted hormone.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      Self-assembly into fibrils is an in-vitro biophysical property, not the in-vivo
+      molecular function of glucagon; should not be treated as a core activity.
+    supported_by:
+    - reference_id: PMID:22212535
+      supporting_text: &#34;The 29-residue peptide hormone glucagon forms many different
+        morphological types of amyloid-like fibrils&#34;
+- term:
+    id: GO:0005737
+    label: cytoplasm
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000107
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      Incorrect functional location for a secreted peptide hormone. Proglucagon transits the
+      ER and secretory granules and is exported; it does not function in the cytoplasm. This
+      is an over-broad electronic ortholog transfer.
+    action: REMOVE
+    reason: &gt;-
+      Glucagon and the other products are secreted; &#34;cytoplasm&#34; (located_in) misrepresents
+      their site of action and is not supported. The correct locations (extracellular region,
+      ER lumen, secretory granule lumen) are separately annotated.
+- term:
+    id: GO:0005886
+    label: plasma membrane
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000107
+  qualifier: is_active_in
+  review:
+    summary: &gt;-
+      The secreted peptides engage receptors located in the target-cell plasma membrane from
+      the extracellular side; the ligand itself is not &#34;active in&#34; the plasma membrane. Likely
+      an Ensembl ortholog-transfer artifact.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: &gt;-
+      &#34;is_active_in plasma membrane&#34; conflates the receptor&#39;s location with the ligand&#39;s; the
+      hormone acts as an extracellular ligand, not as a plasma-membrane component.
+- term:
+    id: GO:0007189
+    label: adenylate cyclase-activating G protein-coupled receptor signaling pathway
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000107
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Glucagon/GLP-1/GLP-2 all activate Gs-coupled receptors that stimulate adenylyl cyclase
+      and raise cAMP. Correct and appropriately specific.
+    action: ACCEPT
+    supported_by:
+    - reference_id: UniProtKB:P01275
+      supporting_text: &#34;couples to the G(s) G protein and elevates intracellular cAMP&#34;
+- term:
+    id: GO:0014823
+    label: response to activity
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000107
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Weak, context-dependent term propagated by ortholog transfer. Glucagon participates in
+      glucose mobilization during physical activity, but this is peripheral and not a core
+      function.
+    action: KEEP_AS_NON_CORE
+- term:
+    id: GO:0035774
+    label: positive regulation of insulin secretion involved in cellular response to glucose
+      stimulus
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000107
+  qualifier: involved_in
+  review:
+    summary: GLP-1 incretin effect; redundant with the IBA annotation of the same term. Core (GLP-1).
+    action: ACCEPT
+- term:
+    id: GO:0042593
+    label: glucose homeostasis
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000107
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Central biological role: glucagon (and the incretins) regulate systemic glucose
+      homeostasis. Correct, core.
+    action: ACCEPT
+    supported_by:
+    - reference_id: UniProtKB:P01275
+      supporting_text: &#34;Plays a key role in glucose metabolism and homeostasis&#34;
+- term:
+    id: GO:0043066
+    label: negative regulation of apoptotic process
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000107
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Reflects GLP-1&#39;s inhibition of pancreatic beta-cell apoptosis. Real but a general term
+      and an indirect, downstream effect of GLP-1 receptor signaling; keep as non-core.
+    action: KEEP_AS_NON_CORE
+    supported_by:
+    - reference_id: UniProtKB:P01275
+      supporting_text: &#34;Inhibits beta cell apoptosis&#34;
+- term:
+    id: GO:0048018
+    label: receptor ligand activity
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000107
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Accurate core molecular function: the proglucagon peptides are agonist ligands for
+      their cognate GPCRs.
+    action: ACCEPT
+- term:
+    id: GO:0070374
+    label: positive regulation of ERK1 and ERK2 cascade
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000107
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Downstream intracellular consequence of GLP-1/glucagon receptor signaling in target
+      cells (e.g., beta-cell proliferation). Indirect and several steps removed from the
+      hormone&#39;s molecular function; non-core.
+    action: KEEP_AS_NON_CORE
+- term:
+    id: GO:0071377
+    label: cellular response to glucagon stimulus
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000107
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Semantically inverted for this gene. GCG is the SOURCE of the glucagon stimulus; this
+      term describes the response program of glucagon-target cells, not a process the hormone
+      is involved_in. Over-propagated electronic annotation.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: &gt;-
+      &#34;cellular response to glucagon stimulus&#34; belongs to cells receiving glucagon, not to
+      the glucagon-producing gene; annotating GCG as involved_in its own stimulus-response is
+      not meaningful.
+- term:
+    id: GO:0090280
+    label: positive regulation of calcium ion import
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000107
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      A downstream second-messenger effect of incretin/glucagon receptor signaling in target
+      cells. Indirect; non-core.
+    action: KEEP_AS_NON_CORE
+- term:
+    id: GO:0032024
+    label: positive regulation of insulin secretion
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-381676
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      GLP-1 stimulates insulin secretion (incretin effect). Correct; a more general parent of
+      the glucose-dependent term GO:0035774 also annotated here. Core (GLP-1).
+    action: ACCEPT
+- term:
+    id: GO:0005576
+    label: extracellular region
+  evidence_type: EXP
+  original_reference_id: PMID:22037645
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      Experimental support for secretion of GLP-1 (measured as a secreted/circulating
+      hormone from L-cells and alpha-cells). Correct location.
+    action: ACCEPT
+    supported_by:
+    - reference_id: PMID:22037645
+      supporting_text: &#34;increasing glucagon-like peptide-1&#34;
+- term:
+    id: GO:0005576
+    label: extracellular region
+  evidence_type: EXP
+  original_reference_id: PMID:40446798
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      Secreted GLP-1 measured in a study of glucose homeostasis. Correct extracellular
+      location for the secreted peptide.
+    action: ACCEPT
+- term:
+    id: GO:0048018
+    label: receptor ligand activity
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-381612
+  qualifier: enables
+  review:
+    summary: &gt;-
+      GLP-1 acts as the agonist ligand of GLP1R (Reactome reaction &#34;GLP1R binds GLP1&#34;).
+      Correct core molecular function.
+    action: ACCEPT
+- term:
+    id: GO:0005788
+    label: endoplasmic reticulum lumen
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-381799
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      Correct biosynthetic transit location: preproglucagon is synthesized and folded in the
+      ER lumen of L-cells. Appropriate as a pathway/location annotation.
+    action: ACCEPT
+- term:
+    id: GO:0005788
+    label: endoplasmic reticulum lumen
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-421416
+  qualifier: located_in
+  review:
+    summary: ER lumen transit during biosynthesis/trafficking. Redundant with the other ER-lumen annotation; correct.
+    action: ACCEPT
+- term:
+    id: GO:0034774
+    label: secretory granule lumen
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-421416
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      Proglucagon and its products are stored in regulated secretory granules prior to
+      exocytosis. Correct location.
+    action: ACCEPT
+- term:
+    id: GO:0005576
+    label: extracellular region
+  evidence_type: ISS
+  original_reference_id: GO_REF:0000024
+  qualifier: located_in
+  review:
+    summary: Secreted hormone; correct location. Redundant with other extracellular region annotations.
+    action: ACCEPT
+- term:
+    id: GO:0014823
+    label: response to activity
+  evidence_type: ISS
+  original_reference_id: GO_REF:0000024
+  qualifier: involved_in
+  review:
+    summary: Weak, context-dependent ortholog-transferred term; redundant with the IEA copy. Non-core.
+    action: KEEP_AS_NON_CORE
+- term:
+    id: GO:0042593
+    label: glucose homeostasis
+  evidence_type: ISS
+  original_reference_id: GO_REF:0000024
+  qualifier: involved_in
+  review:
+    summary: Systemic glucose homeostasis; correct and central. Redundant with the IEA copy.
+    action: ACCEPT
+- term:
+    id: GO:0050796
+    label: regulation of insulin secretion
+  evidence_type: ISS
+  original_reference_id: GO_REF:0000024
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      GLP-1 regulates insulin secretion (incretin). Correct; a general parent of the more
+      specific positive-regulation terms also annotated. Core (GLP-1).
+    action: ACCEPT
+- term:
+    id: GO:0007186
+    label: G protein-coupled receptor signaling pathway
+  evidence_type: TAS
+  original_reference_id: PMID:7929237
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Glucagon acts via a Gs-coupled GPCR; in this study glucagon was used as a Gs-coupled
+      receptor agonist driving adenylyl cyclase. The GPCR-signaling annotation is correct,
+      though general. The paper&#39;s focus is adenylyl cyclase regulation, with glucagon as a tool.
+    action: ACCEPT
+    supported_by:
+    - reference_id: PMID:7929237
+      supporting_text: &#34;500 nM glucagon alone did not stimulate the enzyme but the combination
+        of A23187 and glucagon activated the enzyme&#34;
+- term:
+    id: GO:0005576
+    label: extracellular region
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-163625
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      Correct location (glucagon binding GCGR occurs in the extracellular space). One of many
+      redundant Reactome reaction-level extracellular-region annotations.
+    action: ACCEPT
+- term:
+    id: GO:0005576
+    label: extracellular region
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-379044
+  qualifier: located_in
+  review:
+    summary: Correct but redundant Reactome extracellular-region annotation (Gs activation reaction).
+    action: ACCEPT
+- term:
+    id: GO:0005576
+    label: extracellular region
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-379048
+  qualifier: located_in
+  review:
+    summary: Correct but redundant Reactome extracellular-region annotation (Gq/11 activation reaction).
+    action: ACCEPT
+- term:
+    id: GO:0005576
+    label: extracellular region
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-744886
+  qualifier: located_in
+  review:
+    summary: Correct but redundant Reactome extracellular-region annotation (Ligand:GPCR:Gs dissociation).
+    action: ACCEPT
+- term:
+    id: GO:0005576
+    label: extracellular region
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-744887
+  qualifier: located_in
+  review:
+    summary: Correct but redundant Reactome extracellular-region annotation (Gs binding reaction).
+    action: ACCEPT
+- term:
+    id: GO:0005576
+    label: extracellular region
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-749448
+  qualifier: located_in
+  review:
+    summary: Correct but redundant Reactome extracellular-region annotation (Gq binding reaction).
+    action: ACCEPT
+- term:
+    id: GO:0005576
+    label: extracellular region
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-749452
+  qualifier: located_in
+  review:
+    summary: Correct but redundant Reactome extracellular-region annotation (Ligand:GPCR:Gq dissociation).
+    action: ACCEPT
+- term:
+    id: GO:0005576
+    label: extracellular region
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-825631
+  qualifier: located_in
+  review:
+    summary: Correct but redundant Reactome extracellular-region annotation (Glucagon:GCGR GTP-GDP exchange).
+    action: ACCEPT
+- term:
+    id: GO:0005576
+    label: extracellular region
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-381612
+  qualifier: located_in
+  review:
+    summary: Correct but redundant Reactome extracellular-region annotation (GLP1R binds GLP1).
+    action: ACCEPT
+- term:
+    id: GO:0005576
+    label: extracellular region
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-383313
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      Correct location: GLP-1 is secreted from intestinal L-cells into the extracellular
+      space. Redundant with other extracellular-region annotations.
+    action: ACCEPT
+- term:
+    id: GO:0005576
+    label: extracellular region
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-9023632
+  qualifier: located_in
+  review:
+    summary: Correct but redundant Reactome extracellular-region annotation (DPP4 hydrolysis of GLP-1).
+    action: ACCEPT
+- term:
+    id: GO:0005576
+    label: extracellular region
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-9023633
+  qualifier: located_in
+  review:
+    summary: Correct but redundant Reactome extracellular-region annotation (DPP4 hydrolysis of GLP-1).
+    action: ACCEPT
+- term:
+    id: GO:0034774
+    label: secretory granule lumen
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-383313
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      GLP-1 is packaged in secretory granules prior to release. Correct location; redundant
+      with the other secretory-granule-lumen annotation.
+    action: ACCEPT
+- term:
+    id: GO:0005576
+    label: extracellular region
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-420123
+  qualifier: located_in
+  review:
+    summary: Correct but redundant Reactome extracellular-region annotation (GLP2R binds GLP2).
+    action: ACCEPT
+- term:
+    id: GO:0005102
+    label: signaling receptor binding
+  evidence_type: TAS
+  original_reference_id: PMID:9990065
+  qualifier: enables
+  review:
+    summary: &gt;-
+      GLP-2 binds and activates its specific receptor GLP2R. Correct, informative molecular
+      function for the GLP-2 chain.
+    action: ACCEPT
+    supported_by:
+    - reference_id: PMID:9990065
+      supporting_text: &#34;GLP-2, like glucagon and GLP-1, exerts its actions through a distinct
+        and specific novel receptor expressed in its principal target tissue&#34;
+- term:
+    id: GO:0007186
+    label: G protein-coupled receptor signaling pathway
+  evidence_type: TAS
+  original_reference_id: PMID:9990065
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      GLP-2 signals through the Gs-coupled GLP2R (increased cAMP). Correct GPCR-signaling
+      annotation for the GLP-2 chain.
+    action: ACCEPT
+    supported_by:
+    - reference_id: PMID:9990065
+      supporting_text: &#34;Cells expressing the GLP-2R responded to GLP-2&#34;
+- term:
+    id: GO:0007631
+    label: feeding behavior
+  evidence_type: TAS
+  original_reference_id: PMID:8538742
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Central GLP-1 inhibits feeding and is a physiological mediator of satiety. Correct
+      process annotation for the GLP-1 chain.
+    action: ACCEPT
+    supported_by:
+    - reference_id: PMID:8538742
+      supporting_text: &#34;central GLP-1 is a new physiological mediator of satiety&#34;
+
+core_functions:
+- description: &gt;
+    Serves as a secreted polyprotein hormone precursor that is proteolytically processed in a
+    tissue-specific manner (PCSK2/PC2 in pancreatic alpha-cells; PCSK1/PC1 in intestinal
+    L-cells and neurons) to yield multiple distinct peptide hormones. The precursor is
+    synthesized in the ER, stored in secretory granules, and secreted; its biology is
+    realized through its cleavage products.
+  molecular_function:
+    id: GO:0005179
+    label: hormone activity
+  locations:
+  - id: GO:0005788
+    label: endoplasmic reticulum lumen
+  - id: GO:0034774
+    label: secretory granule lumen
+  - id: GO:0005576
+    label: extracellular region
+  supported_by:
+  - reference_id: UniProtKB:P01275
+    supporting_text: &#34;Proglucagon is post-translationally processed in a tissue-specific
+      manner in pancreatic A cells and intestinal L cells&#34;
+- description: &gt;
+    Via the glucagon peptide (residues 53-81, PRO_0000011256), binds and activates the
+    glucagon receptor GCGR on hepatocytes, the principal counter-regulatory action to insulin:
+    raises blood glucose by stimulating gluconeogenesis and glycogenolysis and decreasing
+    glycolysis, signaling through Gs and elevating cAMP.
+  molecular_function:
+    id: GO:0031769
+    label: glucagon receptor binding
+  directly_involved_in:
+  - id: GO:0045722
+    label: positive regulation of gluconeogenesis
+  - id: GO:0042593
+    label: glucose homeostasis
+  - id: GO:0007189
+    label: adenylate cyclase-activating G protein-coupled receptor signaling pathway
+  locations:
+  - id: GO:0005576
+    label: extracellular region
+  supported_by:
+  - reference_id: UniProtKB:P01275
+    supporting_text: &#34;Regulates blood glucose by increasing gluconeogenesis and decreasing
+      glycolysis&#34;
+  - reference_id: UniProtKB:P01275
+    supporting_text: &#34;Binds to and activates the glucagon receptor GCGR&#34;
+- description: &gt;
+    Via glucagon-like peptide 1 (GLP-1; residues 92-128 and the active 7-37/7-36amide forms),
+    acts as an incretin agonist of GLP1R to potentiate glucose-dependent insulin secretion,
+    promote satiety, and support beta-cell survival. Produced chiefly by intestinal L-cells
+    and also pancreatic alpha-cells and neurons.
+  molecular_function:
+    id: GO:0048018
+    label: receptor ligand activity
+  directly_involved_in:
+  - id: GO:0035774
+    label: positive regulation of insulin secretion involved in cellular response to glucose
+      stimulus
+  - id: GO:0007631
+    label: feeding behavior
+  locations:
+  - id: GO:0005576
+    label: extracellular region
+  supported_by:
+  - reference_id: UniProtKB:P01275
+    supporting_text: &#34;Potent stimulator of glucose-dependent insulin release&#34;
+  - reference_id: PMID:8538742
+    supporting_text: &#34;central GLP-1 is a new physiological mediator of satiety&#34;
+- description: &gt;
+    Via glucagon-like peptide 2 (GLP-2; residues 146-178, PRO_0000011262), binds and
+    activates the intestine-specific receptor GLP2R to stimulate intestinal growth: increased
+    villus height and crypt cell proliferation with decreased enterocyte apoptosis, enhancing
+    nutrient assimilation. A distinct receptor and function from glucagon and GLP-1.
+  molecular_function:
+    id: GO:0005102
+    label: signaling receptor binding
+  directly_involved_in:
+  - id: GO:0007186
+    label: G protein-coupled receptor signaling pathway
+  locations:
+  - id: GO:0005576
+    label: extracellular region
+  anatomical_locations:
+  - id: UBERON:0002108
+    label: small intestine
+  supported_by:
+  - reference_id: PMID:9990065
+    supporting_text: &#34;GLP-2 stimulates intestinal growth and up-regulates villus height in the
+      small intestine, concomitant with increased crypt cell proliferation and decreased
+      enterocyte apoptosis&#34;
+  - reference_id: PMID:9990065
+    supporting_text: &#34;GLP-2, like glucagon and GLP-1, exerts its actions through a distinct
+      and specific novel receptor expressed in its principal target tissue&#34;
+
+proposed_new_terms: []
+
+suggested_questions:
+- question: &gt;-
+    Should GO annotations for proglucagon-derived functions be made at the level of the
+    individual peptide chains (PRO ids) rather than the gene/precursor, to avoid conflating
+    glucagon (GCGR), GLP-1 (GLP1R), and GLP-2 (GLP2R) functions that act through different
+    receptors and in different tissues?
+- question: &gt;-
+    For oxyntomodulin and glicentin, which functions are sufficiently well-supported to
+    warrant dedicated GO annotations versus remaining as UniProt FUNCTION statements
+    (currently ECO:0000303)?
+
+suggested_experiments:
+- description: &gt;-
+    Chain-resolved functional annotation: use tissue-specific (alpha-cell vs L-cell)
+    secretomics/peptidomics to confirm which mature peptides are produced where, and pair
+    with receptor-specific (GCGR/GLP1R/GLP2R) reporter assays to assign each downstream
+    process (insulin secretion, gluconeogenesis, intestinal growth) to the correct peptide.
+- description: &gt;-
+    Knock-in mouse models that selectively ablate processing to individual products (e.g.,
+    PC2-null pancreatic glucagon vs PC1/3-null intestinal GLP-1/GLP-2) to dissect which
+    phenotypes (glucose mobilization, incretin/insulin secretion, intestinal trophic effects)
+    depend on which proglucagon-derived peptide in vivo.
+
+references:
+- id: GO_REF:0000002
+  title: Gene Ontology annotation through association of InterPro records with GO terms
+  findings: []
+- id: GO_REF:0000024
+  title: Manual transfer of experimentally-verified manual GO annotation data to orthologs
+    by curator judgment of sequence similarity
+  findings: []
+- id: GO_REF:0000033
+  title: Annotation inferences using phylogenetic trees
+  findings: []
+- id: GO_REF:0000107
+  title: Automatic transfer of experimentally verified manual GO annotation data to
+    orthologs using Ensembl Compara
+  findings: []
+- id: GO_REF:0000117
+  title: Electronic Gene Ontology annotations created by ARBA machine learning models
+  findings: []
+- id: GO_REF:0000120
+  title: Combined Automated Annotation using Multiple IEA Methods
+  findings: []
+- id: UniProtKB:P01275
+  title: &#34;UniProtKB entry P01275 (GLUC_HUMAN), Pro-glucagon&#34;
+  findings:
+  - statement: Proglucagon is processed tissue-specifically; glucagon predominates in
+      pancreatic A cells (PCSK2/PC2), while GLP-1, GLP-2, glicentin and oxyntomodulin are
+      liberated in intestinal L cells (PCSK1/PC1).
+    supporting_text: &#34;Proglucagon is post-translationally processed in a tissue-specific
+      manner in pancreatic A cells and intestinal L cells&#34;
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Canonical curated entry; FUNCTION blocks are split per cleavage product and are the
+      backbone of the chain-resolved review.
+- id: PMID:17051221
+  title: Structures of human insulin-degrading enzyme reveal a new substrate recognition
+    mechanism.
+  findings:
+  - statement: Glucagon is one of four substrates co-crystallized with insulin-degrading
+      enzyme (IDE), supporting glucagon as an IDE degradation substrate.
+    supporting_text: &#34;structures of human IDE in complex with four substrates (insulin B
+      chain, amyloid-beta peptide (1-40), amylin and glucagon)&#34;
+  reference_review:
+    relevance: MEDIUM
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Correctly cited for the GCG-IDE interaction (GO:0005515 IPI). Reflects hormone
+      clearance, not a core function of glucagon.
+- id: PMID:17715056
+  title: Crystal structure of the incretin-bound extracellular domain of a G protein-coupled
+    receptor.
+  findings:
+  - statement: Structural study of the GIP receptor extracellular domain bound to the
+      incretin GIP; the structural principles are stated to be conserved among related class B
+      hormone receptors such as GLP1R.
+    supporting_text: &#34;the crystal structure of the complex of human GIP receptor extracellular
+      domain (ECD) with its agonist, the incretin GIP(1-42)&#34;
+  reference_review:
+    relevance: LOW
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Paper structurally characterizes GIP (a paralogous incretin from a different gene), not
+      a proglucagon peptide directly; underpins only a generic &#34;protein binding&#34; annotation.
+- id: PMID:21314817
+  title: Neuropeptide Y, B-type natriuretic peptide, substance P and peptide YY are novel
+    substrates of fibroblast activation protein-α.
+  findings:
+  - statement: GLP-1 is a (slow) substrate of fibroblast activation protein (FAP), in
+      addition to being an efficient DPP4 substrate.
+    supporting_text: &#34;FAP slowly hydrolysed other hormone peptides, such as the incretins
+      glucagon-like peptide-1 and glucose-dependent insulinotropic peptide&#34;
+  reference_review:
+    relevance: MEDIUM
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Supports the GCG-FAP interaction (GO:0005515 IPI); relevant to GLP-1 clearance, non-core.
+- id: PMID:22037645
+  title: Interleukin-6 enhances insulin secretion by increasing glucagon-like peptide-1
+    secretion from L cells and alpha cells.
+  findings:
+  - statement: IL-6 increases GLP-1 production from alpha cells by upregulating proglucagon
+      (GCG) and prohormone convertase 1/3, enhancing insulin secretion.
+    supporting_text: &#34;IL-6 increased GLP-1 production from alpha cells through increased
+      proglucagon (which is encoded by GCG) and prohormone convertase 1/3 expression&#34;
+  - statement: GLP-1 is a hormone that induces insulin secretion (incretin).
+    supporting_text: &#34;Glucagon-like peptide-1 (GLP-1) is a hormone that induces insulin
+      secretion&#34;
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Full text available; directly supports GLP-1 secretion (extracellular region, EXP) and
+      the incretin/insulin-secretion functions.
+- id: PMID:22212535
+  title: Mapping out the multistage fibrillation of glucagon.
+  findings:
+  - statement: Glucagon self-assembles into multiple morphological types of amyloid-like
+      fibrils in vitro, the basis of the identical protein binding annotation.
+    supporting_text: &#34;The 29-residue peptide hormone glucagon forms many different
+      morphological types of amyloid-like fibrils&#34;
+  reference_review:
+    relevance: LOW
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Correctly cited for glucagon self-association (GO:0042802 IPI), but the behavior is an
+      in-vitro biophysical property, not a physiological function.
+- id: PMID:40446798
+  title: A microbial amino-acid-conjugated bile acid, tryptophan-cholic acid, improves
+    glucose homeostasis via the orphan receptor MRGPRE.
+  findings: []
+  reference_review:
+    relevance: LOW
+    correctness: UNVERIFIED
+    review_notes: &gt;-
+      Cited (EXP) for secreted GLP-1/extracellular location; full text not in cache, so the
+      precise supporting passage could not be quoted verbatim.
+- id: PMID:7929237
+  title: Synergistic activation of the type I adenylyl cyclase by Ca2+ and Gs-coupled
+    receptors in vivo.
+  findings:
+  - statement: Glucagon, acting through its Gs-coupled receptor, synergizes with Ca2+ to
+      activate type I adenylyl cyclase; used here as a Gs-coupled receptor agonist.
+    supporting_text: &#34;500 nM glucagon alone did not stimulate the enzyme but the combination
+      of A23187 and glucagon activated the enzyme&#34;
+  reference_review:
+    relevance: LOW
+    correctness: VERIFIED
+    review_notes: &gt;-
+      The paper is about adenylyl cyclase regulation; glucagon is a tool agonist. Adequately
+      supports a general GPCR-signaling annotation but is not a primary GCG functional study.
+- id: PMID:8538742
+  title: A role for glucagon-like peptide-1 in the central regulation of feeding.
+  findings:
+  - statement: Central (ICV) GLP-1 inhibits feeding and is a physiological mediator of
+      satiety, establishing GLP-1&#39;s role in feeding behavior.
+    supporting_text: &#34;central GLP-1 is a new physiological mediator of satiety&#34;
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Classic study underpinning the GLP-1 feeding-behavior annotation (GO:0007631 TAS).
+- id: PMID:9990065
+  title: Prototypic G protein-coupled receptor for the intestinotrophic factor glucagon-like
+    peptide 2.
+  findings:
+  - statement: GLP-2 is intestinotrophic and acts through its own distinct receptor (GLP2R),
+      stimulating villus growth, crypt proliferation, and reduced enterocyte apoptosis.
+    supporting_text: &#34;GLP-2 stimulates intestinal growth and up-regulates villus height in the
+      small intestine, concomitant with increased crypt cell proliferation and decreased
+      enterocyte apoptosis&#34;
+  - statement: GLP-2 exerts its actions through a distinct, specific receptor expressed in the
+      gut, like glucagon and GLP-1 acting through their own receptors.
+    supporting_text: &#34;GLP-2, like glucagon and GLP-1, exerts its actions through a distinct
+      and specific novel receptor expressed in its principal target tissue&#34;
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Defines the GLP-2 chain function and its dedicated receptor; supports the GLP-2
+      signaling-receptor-binding and GPCR-signaling annotations.
+- id: Reactome:R-HSA-163625
+  title: Glucagon binds to Glucagon receptor
+  findings: []
+- id: Reactome:R-HSA-379044
+  title: Liganded Gs-activating GPCR acts as a GEF for Gs
+  findings: []
+- id: Reactome:R-HSA-379048
+  title: Liganded Gq/11-activating GPCRs act as GEFs for Gq/11
+  findings: []
+- id: Reactome:R-HSA-381612
+  title: GLP1R binds GLP1
+  findings: []
+- id: Reactome:R-HSA-381676
+  title: Glucagon-like Peptide-1 (GLP1) regulates insulin secretion
+  findings: []
+- id: Reactome:R-HSA-381799
+  title: Synthesis of Preproglucagon in intestinal L cells
+  findings: []
+- id: Reactome:R-HSA-383313
+  title: Glucagon-like Peptide 1 is secreted from intestinal L cells
+  findings: []
+- id: Reactome:R-HSA-420123
+  title: Glucagon-like receptor 2 binds GLP2
+  findings: []
+- id: Reactome:R-HSA-421416
+  title: Proglucagon translocates from the ER Lumen to secretory granules
+  findings: []
+- id: Reactome:R-HSA-744886
+  title: The Ligand:GPCR:Gs complex dissociates
+  findings: []
+- id: Reactome:R-HSA-744887
+  title: Liganded Gs-activating GPCRs bind inactive heterotrimeric Gs
+  findings: []
+- id: Reactome:R-HSA-749448
+  title: Liganded Gq-activating GPCRs bind inactive heterotrimeric Gq
+  findings: []
+- id: Reactome:R-HSA-749452
+  title: The Ligand:GPCR:Gq complex dissociates
+  findings: []
+- id: Reactome:R-HSA-825631
+  title: Glucagon:GCGR mediates GTP-GDP exchange
+  findings: []
+- id: Reactome:R-HSA-9023632
+  title: DPP4(39-766) hydrolyzes Glucagon-like Peptide-1 (GLP-1)
+  findings: []
+- id: Reactome:R-HSA-9023633
+  title: DPP4(1-766) hydrolyzes Glucagon-like Peptide-1 (GLP-1)
+  findings: []
+</code></pre>
+            </div>
+        </details>
+    </div>
+
+    <!-- Pathway Visualization Link -->
+    
+
+    <style>
+        /* Markdown Section Styles */
+        .markdown-section {
+            margin-bottom: 1rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .markdown-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .markdown-section summary h3 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.1rem;
+        }
+
+        .markdown-section summary:hover h3 {
+            color: #007bff;
+        }
+
+        .markdown-section[open] {
+            background-color: #fff;
+        }
+
+        .markdown-content {
+            margin-top: 1rem;
+            padding: 1rem;
+            border-top: 1px solid #dee2e6;
+        }
+
+        /* Markdown content styling */
+        .markdown-content h1 { font-size: 1.5rem; margin-top: 1.5rem; }
+        .markdown-content h2 { font-size: 1.3rem; margin-top: 1.3rem; }
+        .markdown-content h3 { font-size: 1.1rem; margin-top: 1.1rem; }
+        .markdown-content h4 { font-size: 1rem; margin-top: 1rem; }
+
+        .markdown-content pre {
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .markdown-content code {
+            background-color: #f8f9fa;
+            padding: 0.2rem 0.4rem;
+            border-radius: 3px;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+        }
+
+        .markdown-content pre code {
+            background: none;
+            padding: 0;
+        }
+
+        .markdown-content table {
+            border-collapse: collapse;
+            width: 100%;
+            margin: 1rem 0;
+        }
+
+        .markdown-content table th,
+        .markdown-content table td {
+            border: 1px solid #dee2e6;
+            padding: 0.5rem;
+            text-align: left;
+        }
+
+        .markdown-content table th {
+            background-color: #f8f9fa;
+            font-weight: bold;
+        }
+
+        .markdown-content blockquote {
+            border-left: 4px solid #007bff;
+            padding-left: 1rem;
+            margin-left: 0;
+            color: #666;
+        }
+
+        /* YAML Preview Styles */
+        .yaml-preview {
+            margin-top: 2rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .yaml-preview summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .yaml-preview summary h2 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.3rem;
+        }
+
+        .yaml-preview summary:hover h2 {
+            color: #007bff;
+        }
+
+        .yaml-preview[open] {
+            background-color: #fff;
+        }
+
+        .yaml-content {
+            margin-top: 1rem;
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .yaml-content pre {
+            margin: 0;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+            line-height: 1.4;
+        }
+
+        .yaml-content code {
+            color: #333;
+            background: none;
+            padding: 0;
+        }
+
+        /* Pathway Link Styles */
+        .pathway-link {
+            margin: 1rem 0;
+        }
+
+        .btn-link {
+            display: inline-block;
+            padding: 0.5rem 1rem;
+            background-color: #007bff;
+            color: white !important;
+            text-decoration: none;
+            border-radius: 4px;
+            font-weight: 500;
+            transition: background-color 0.2s;
+        }
+
+        .btn-link:hover {
+            background-color: #0056b3;
+            text-decoration: none;
+        }
+
+        /* Voting buttons */
+        .vote-buttons {
+            display: inline-block;
+            margin-left: 0.5rem;
+        }
+
+        .vote-btn {
+            background: none;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 2px 6px;
+            margin: 0 2px;
+            cursor: pointer;
+            font-size: 0.9rem;
+            transition: all 0.2s;
+            opacity: 0.6;
+        }
+
+        .vote-btn:hover {
+            opacity: 1;
+            transform: scale(1.1);
+        }
+
+        .vote-btn.voted {
+            opacity: 1;
+            border-color: #28a745;
+            background-color: #d4edda;
+        }
+
+        .vote-btn.voted-down {
+            border-color: #dc3545;
+            background-color: #f8d7da;
+        }
+
+        .vote-btn-small {
+            font-size: 0.7rem;
+            padding: 1px 4px;
+            margin: 0 1px;
+        }
+    </style>
+
+    <script>
+        // Add collapsible functionality
+        document.querySelectorAll('.collapsible').forEach(element => {
+            element.addEventListener('click', function() {
+                this.classList.toggle('collapsed');
+            });
+        });
+
+        // Voting functionality
+        const VOTE_URL = 'https://script.google.com/macros/s/AKfycbwPKH7d3seuPNBtB0ugVjqGeTiByyOGD5vkqB_Ck6K8eOcPQYbJqBOuz6GFgXHKBNWK/exec';
+
+        // Get or create session ID
+        let sessionId = localStorage.getItem('review_session_id');
+        if (!sessionId) {
+            sessionId = 's' + Date.now() + '_' + Math.random().toString(36).substr(2, 9);
+            localStorage.setItem('review_session_id', sessionId);
+        }
+
+        // Show previous votes on page load
+        document.addEventListener('DOMContentLoaded', function() {
+            document.querySelectorAll('.vote-buttons').forEach(container => {
+                const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+                const previousVote = localStorage.getItem(key);
+                if (previousVote) {
+                    const btn = container.querySelector(`[data-v="${previousVote}"]`);
+                    if (btn) btn.classList.add(previousVote === 'up' ? 'voted' : 'voted-down');
+                }
+            });
+        });
+
+        // Handle vote clicks - Simple image beacon approach
+        document.addEventListener('click', function(e) {
+            if (!e.target.classList.contains('vote-btn')) return;
+
+            // Prevent the click from bubbling to parent elements (like summary)
+            e.preventDefault();
+            e.stopPropagation();
+
+            const btn = e.target;
+            const container = btn.closest('.vote-buttons');
+            if (!container) return;
+
+            const voteType = btn.dataset.v;
+
+            // Check if already voted (locally)
+            const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+            const previousVote = localStorage.getItem(key);
+
+            if (previousVote === voteType) {
+                // Same vote - do nothing
+                btn.style.animation = 'shake 0.5s';
+                setTimeout(() => btn.style.animation = '', 500);
+                return;
+            }
+
+            // Build URL
+            const params = new URLSearchParams({
+                gene_id: container.dataset.g,
+                annotation_id: container.dataset.a,
+                ref_id: container.dataset.r || '',
+                action: container.dataset.act,
+                vote: voteType,
+                session_id: sessionId,
+                ua: navigator.userAgent.substring(0, 100)
+            });
+
+            // Clear previous vote styling
+            container.querySelectorAll('.vote-btn').forEach(b => {
+                b.classList.remove('voted', 'voted-down');
+            });
+
+            // Apply new vote styling immediately (optimistic UI)
+            btn.classList.add(voteType === 'up' ? 'voted' : 'voted-down');
+
+            // Store locally
+            localStorage.setItem(key, voteType);
+
+            // Send vote using fetch with no-cors mode (fire and forget)
+            const fullUrl = VOTE_URL + '?' + params;
+            console.log('Sending vote to:', fullUrl);
+
+            // Use fetch in no-cors mode - we won't get a response but the request will be sent
+            fetch(fullUrl, {
+                mode: 'no-cors',
+                method: 'GET'
+            }).then(() => {
+                console.log('Vote request sent (no response due to no-cors mode)');
+            }).catch(err => {
+                console.warn('Vote may not have been recorded, but saved locally:', err);
+
+                // Fallback: try image beacon as well
+                const img = new Image();
+                img.src = fullUrl;
+            });
+        });
+
+        // Optional: Add shake animation for feedback
+        const style = document.createElement('style');
+        style.textContent = `
+            @keyframes shake {
+                0%, 100% { transform: translateX(0); }
+                25% { transform: translateX(-5px); }
+                75% { transform: translateX(5px); }
+            }
+        `;
+        document.head.appendChild(style);
+    </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary

Automated regeneration of static assets after gene review or template changes.

## Generated Assets

| Asset | Count/Status |
|-------|--------------|
| Gene review YAML files | 2801 |
| Gene review HTML pages | 2801 |
| Project pages | 1079 |
| Module pages | 45 |
| Browser app (data.js) | Updated |
| Validation report | Updated |

## Trigger

This PR was triggered by changes to:
- genes/**/*.yaml - gene review data files
- src/ai_gene_review/schema/** - LinkML schema files
- src/ai_gene_review/templates/** - Jinja2 templates
- src/ai_gene_review/render.py - rendering code
- src/ai_gene_review/render_modules.py - module rendering code
- src/ai_gene_review/export/** - export code
- src/ai_gene_review/browser/** - browser app assets
- src/ai_gene_review/tools/minify_linkml_browser_data.py - browser data compaction
- projects/*.md - project definitions
- modules/**/*.yaml - module definitions
- project.justfile - just recipes used by CI
- .github/workflows/generate-pages.yaml - workflow definition

## Review

- [ ] Spot-check a few gene review HTML pages render correctly
- [ ] Spot-check module tree browser pages render correctly
- [ ] Verify browser app loads and filters work
- [ ] Check validation report for new issues
