### PR TITLE
Regenerate pages and browser app

### DIFF
--- a/genes/mouse/Hsp90aa1/Hsp90aa1-ai-review.html
+++ b/genes/mouse/Hsp90aa1/Hsp90aa1-ai-review.html
@@ -5758,10 +5758,10 @@
                         
                     </td>
                     <td>
-                        <span class="action-badge action-keepasnoncore">
-                            KEEP AS NON CORE
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
                         </span>
-                        <span class="vote-buttons" data-g="P07901" data-a="GO:0042220" data-r="GO_REF:0000107" data-act="KEEP_AS_NON_CORE">
+                        <span class="vote-buttons" data-g="P07901" data-a="GO:0042220" data-r="GO_REF:0000107" data-act="MARK_AS_OVER_ANNOTATED">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
@@ -5769,31 +5769,15 @@
                     <td>
                         
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> response to cocaine is supported or plausible for a specific Hsp90aa1 client, localization, stress, or tissue context, but it is not the conserved core chaperone function.
+                            <strong>Summary:</strong> IEA orthology projection (GO_REF:0000107, Ensembl Compara) of a drug-response term onto a general cytosolic/nuclear molecular chaperone. There is no Hsp90aa1-specific experimental evidence that &#34;response to cocaine&#34; reflects a distinct biological role of this gene; any involvement would be the generic chaperoning of a client protein, not a cocaine-response function.
                         </div>
                         
                         
                         <div>
-                            <strong>Reason:</strong> Retain this annotation as context-specific while keeping the core review focused on ATP-dependent chaperone activity and cytosolic/nuclear chaperone complexes.
+                            <strong>Reason:</strong> Over-propagation by ortholog transfer onto a hub chaperone. HSP90 buffers thousands of clients, so projecting a single-species drug-response phenotype onto it adds no functional information and is not supported by direct Hsp90aa1 evidence. This mirrors the treatment of the identical IEA cocaine annotation on SMAD3 (also GO_REF:0000107), which is marked as over-annotated for the same reason.
                         </div>
                         
                         
-                        
-                        <div class="supported-by">
-                            <div class="supported-by-title">Supporting Evidence:</div>
-                            
-                            <div class="support-item">
-                                <span class="support-ref">
-                                    
-                                    file:mouse/Hsp90aa1/Hsp90aa1-notes.md
-                                    
-                                </span>
-                                
-                                <div class="support-text">Core location rule: Cytosol/cytoplasm and nucleus are core Hsp90aa1 locations</div>
-                                
-                            </div>
-                            
-                        </div>
                         
                         
                     </td>
@@ -18423,14 +18407,17 @@ existing_annotations:
   evidence_type: IEA
   original_reference_id: GO_REF:0000107
   review:
-    summary: response to cocaine is supported or plausible for a specific Hsp90aa1 client,
-      localization, stress, or tissue context, but it is not the conserved core chaperone function.
-    action: KEEP_AS_NON_CORE
-    reason: Retain this annotation as context-specific while keeping the core review focused on
-      ATP-dependent chaperone activity and cytosolic/nuclear chaperone complexes.
-    supported_by:
-    - reference_id: file:mouse/Hsp90aa1/Hsp90aa1-notes.md
-      supporting_text: &#39;Core location rule: Cytosol/cytoplasm and nucleus are core Hsp90aa1 locations&#39;
+    summary: IEA orthology projection (GO_REF:0000107, Ensembl Compara) of a drug-response
+      term onto a general cytosolic/nuclear molecular chaperone. There is no Hsp90aa1-specific
+      experimental evidence that &#34;response to cocaine&#34; reflects a distinct biological role of
+      this gene; any involvement would be the generic chaperoning of a client protein, not a
+      cocaine-response function.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: Over-propagation by ortholog transfer onto a hub chaperone. HSP90 buffers thousands
+      of clients, so projecting a single-species drug-response phenotype onto it adds no
+      functional information and is not supported by direct Hsp90aa1 evidence. This mirrors the
+      treatment of the identical IEA cocaine annotation on SMAD3 (also GO_REF:0000107), which is
+      marked as over-annotated for the same reason.
 - term:
     id: GO:0042307
     label: positive regulation of protein import into nucleus

--- a/pages/projects/REVIEW_QUALITY_AUDIT/scan_boilerplate.py
+++ b/pages/projects/REVIEW_QUALITY_AUDIT/scan_boilerplate.py
@@ -50,7 +50,8 @@ NOT_REVIEWED = {None, "", "PENDING", "UNREVIEWED"}
 
 def scan_file(path: str) -> dict | None:
     try:
-        doc = yaml.load(open(path), Loader=Loader)
+        with open(path) as fh:
+            doc = yaml.load(fh, Loader=Loader)
     except Exception:
         return None
     if not isinstance(doc, dict):

--- a/pages/projects/all-projects.html
+++ b/pages/projects/all-projects.html
@@ -83,7 +83,7 @@
         <p class="subtitle">Complete, automatically generated index of every project page in <code>projects/</code></p>
     </div>
 
-    <p class="meta-note"><span id="visible-count">128</span> of 128 projects.
+    <p class="meta-note"><span id="visible-count">130</span> of 130 projects.
     Derived from each project's YAML frontmatter; the <a href="index.html">curated index</a> is the hand-organized entry point.
     Filters combine (AND across groups, OR within a group).</p>
 
@@ -107,7 +107,7 @@
         <div class="control-group">
             <span class="label">Species</span>
             <div class="chips" data-filter="species">
-                <span class="chip" data-value="9BILA">9BILA</span><span class="chip" data-value="9PRIM">9PRIM</span><span class="chip" data-value="ABRPR">ABRPR</span><span class="chip" data-value="ACET2">ACET2</span><span class="chip" data-value="AEDAE">AEDAE</span><span class="chip" data-value="ANOGA">ANOGA</span><span class="chip" data-value="AQUCT">AQUCT</span><span class="chip" data-value="ARAHY">ARAHY</span><span class="chip" data-value="ARATH">ARATH</span><span class="chip" data-value="ARTAN">ARTAN</span><span class="chip" data-value="ASPNG">ASPNG</span><span class="chip" data-value="ASPOR">ASPOR</span><span class="chip" data-value="BACSU">BACSU</span><span class="chip" data-value="BALMU">BALMU</span><span class="chip" data-value="BORPE">BORPE</span><span class="chip" data-value="BOVIN">BOVIN</span><span class="chip" data-value="BRUMA">BRUMA</span><span class="chip" data-value="CAEBR">CAEBR</span><span class="chip" data-value="CAEEL">CAEEL</span><span class="chip" data-value="CALMI">CALMI</span><span class="chip" data-value="CANAL">CANAL</span><span class="chip" data-value="CANGA">CANGA</span><span class="chip" data-value="CANLF">CANLF</span><span class="chip" data-value="CHRVO">CHRVO</span><span class="chip" data-value="CLOCL">CLOCL</span><span class="chip" data-value="COLLI">COLLI</span><span class="chip" data-value="COTJA">COTJA</span><span class="chip" data-value="CRIGR">CRIGR</span><span class="chip" data-value="CUCME">CUCME</span><span class="chip" data-value="DANRE">DANRE</span><span class="chip" data-value="DEIRA">DEIRA</span><span class="chip" data-value="DESRO">DESRO</span><span class="chip" data-value="DESVH">DESVH</span><span class="chip" data-value="DOROP">DOROP</span><span class="chip" data-value="DORPE">DORPE</span><span class="chip" data-value="DROME">DROME</span><span class="chip" data-value="DROPS">DROPS</span><span class="chip" data-value="DROVI">DROVI</span><span class="chip" data-value="ECOLI">ECOLI</span><span class="chip" data-value="EUPSC">EUPSC</span><span class="chip" data-value="GADMO">GADMO</span><span class="chip" data-value="GIBF5">GIBF5</span><span class="chip" data-value="HYPJE">HYPJE</span><span class="chip" data-value="JUGRE">JUGRE</span><span class="chip" data-value="MACFA">MACFA</span><span class="chip" data-value="MAIZE">MAIZE</span><span class="chip" data-value="METEA">METEA</span><span class="chip" data-value="METJA">METJA</span><span class="chip" data-value="METTP">METTP</span><span class="chip" data-value="MYCTU">MYCTU</span><span class="chip" data-value="MYTGA">MYTGA</span><span class="chip" data-value="NEUCR">NEUCR</span><span class="chip" data-value="NICAT">NICAT</span><span class="chip" data-value="OCTBM">OCTBM</span><span class="chip" data-value="OCTVU">OCTVU</span><span class="chip" data-value="ORYSI">ORYSI</span><span class="chip" data-value="ORYSJ">ORYSJ</span><span class="chip" data-value="PANPA">PANPA</span><span class="chip" data-value="PARTE">PARTE</span><span class="chip" data-value="PHATC">PHATC</span><span class="chip" data-value="POPTR">POPTR</span><span class="chip" data-value="PRIPA">PRIPA</span><span class="chip" data-value="PSEAE">PSEAE</span><span class="chip" data-value="PSEPK">PSEPK</span><span class="chip" data-value="RABIT">RABIT</span><span class="chip" data-value="RAMVA">RAMVA</span><span class="chip" data-value="SALTY">SALTY</span><span class="chip" data-value="SCHPO">SCHPO</span><span class="chip" data-value="SEPOF">SEPOF</span><span class="chip" data-value="SOYBN">SOYBN</span><span class="chip" data-value="STECR">STECR</span><span class="chip" data-value="STHOU">STHOU</span><span class="chip" data-value="STRCO">STRCO</span><span class="chip" data-value="TAKRU">TAKRU</span><span class="chip" data-value="TOBAC">TOBAC</span><span class="chip" data-value="TRIV3">TRIV3</span><span class="chip" data-value="WHEAT">WHEAT</span><span class="chip" data-value="XANCP">XANCP</span><span class="chip" data-value="XENNA">XENNA</span><span class="chip" data-value="XENTR">XENTR</span><span class="chip" data-value="human">human</span><span class="chip" data-value="mouse">mouse</span><span class="chip" data-value="rat">rat</span><span class="chip" data-value="worm">worm</span><span class="chip" data-value="yeast">yeast</span>
+                <span class="chip" data-value="9BILA">9BILA</span><span class="chip" data-value="9PRIM">9PRIM</span><span class="chip" data-value="ABRPR">ABRPR</span><span class="chip" data-value="ACET2">ACET2</span><span class="chip" data-value="AEDAE">AEDAE</span><span class="chip" data-value="ANOGA">ANOGA</span><span class="chip" data-value="AQUCT">AQUCT</span><span class="chip" data-value="ARAHY">ARAHY</span><span class="chip" data-value="ARATH">ARATH</span><span class="chip" data-value="ARTAN">ARTAN</span><span class="chip" data-value="ASPNG">ASPNG</span><span class="chip" data-value="ASPOR">ASPOR</span><span class="chip" data-value="BACSU">BACSU</span><span class="chip" data-value="BALMU">BALMU</span><span class="chip" data-value="BORPE">BORPE</span><span class="chip" data-value="BOVIN">BOVIN</span><span class="chip" data-value="BRUMA">BRUMA</span><span class="chip" data-value="CAEBR">CAEBR</span><span class="chip" data-value="CAEEL">CAEEL</span><span class="chip" data-value="CALMI">CALMI</span><span class="chip" data-value="CANAL">CANAL</span><span class="chip" data-value="CANGA">CANGA</span><span class="chip" data-value="CANLF">CANLF</span><span class="chip" data-value="CHRVO">CHRVO</span><span class="chip" data-value="CLOCL">CLOCL</span><span class="chip" data-value="COLLI">COLLI</span><span class="chip" data-value="COTJA">COTJA</span><span class="chip" data-value="CRIGR">CRIGR</span><span class="chip" data-value="CUCME">CUCME</span><span class="chip" data-value="DANRE">DANRE</span><span class="chip" data-value="DAPPU">DAPPU</span><span class="chip" data-value="DEIRA">DEIRA</span><span class="chip" data-value="DESRO">DESRO</span><span class="chip" data-value="DESVH">DESVH</span><span class="chip" data-value="DOROP">DOROP</span><span class="chip" data-value="DORPE">DORPE</span><span class="chip" data-value="DROME">DROME</span><span class="chip" data-value="DROPS">DROPS</span><span class="chip" data-value="DROVI">DROVI</span><span class="chip" data-value="ECOLI">ECOLI</span><span class="chip" data-value="EUPSC">EUPSC</span><span class="chip" data-value="GADMO">GADMO</span><span class="chip" data-value="GIBF5">GIBF5</span><span class="chip" data-value="HYPJE">HYPJE</span><span class="chip" data-value="JUGRE">JUGRE</span><span class="chip" data-value="MACFA">MACFA</span><span class="chip" data-value="MAIZE">MAIZE</span><span class="chip" data-value="METEA">METEA</span><span class="chip" data-value="METJA">METJA</span><span class="chip" data-value="METTP">METTP</span><span class="chip" data-value="MYCTU">MYCTU</span><span class="chip" data-value="MYTGA">MYTGA</span><span class="chip" data-value="NEUCR">NEUCR</span><span class="chip" data-value="NICAT">NICAT</span><span class="chip" data-value="OCTBM">OCTBM</span><span class="chip" data-value="OCTVU">OCTVU</span><span class="chip" data-value="ORYSI">ORYSI</span><span class="chip" data-value="ORYSJ">ORYSJ</span><span class="chip" data-value="PANPA">PANPA</span><span class="chip" data-value="PARTE">PARTE</span><span class="chip" data-value="PHATC">PHATC</span><span class="chip" data-value="POPTR">POPTR</span><span class="chip" data-value="PRIPA">PRIPA</span><span class="chip" data-value="PSEAE">PSEAE</span><span class="chip" data-value="PSEPK">PSEPK</span><span class="chip" data-value="RABIT">RABIT</span><span class="chip" data-value="RAMVA">RAMVA</span><span class="chip" data-value="SALTY">SALTY</span><span class="chip" data-value="SCHPO">SCHPO</span><span class="chip" data-value="SEPOF">SEPOF</span><span class="chip" data-value="SOYBN">SOYBN</span><span class="chip" data-value="STECR">STECR</span><span class="chip" data-value="STHOU">STHOU</span><span class="chip" data-value="STRCO">STRCO</span><span class="chip" data-value="TAKRU">TAKRU</span><span class="chip" data-value="TOBAC">TOBAC</span><span class="chip" data-value="TRIV3">TRIV3</span><span class="chip" data-value="WHEAT">WHEAT</span><span class="chip" data-value="XANCP">XANCP</span><span class="chip" data-value="XENNA">XENNA</span><span class="chip" data-value="XENTR">XENTR</span><span class="chip" data-value="human">human</span><span class="chip" data-value="mouse">mouse</span><span class="chip" data-value="rat">rat</span><span class="chip" data-value="worm">worm</span><span class="chip" data-value="yeast">yeast</span>
             </div>
         </div>
         
@@ -301,6 +301,22 @@
                 <td><span class="sp">BACSU</span></td>
                 <td><span class="muted">&mdash;</span></td>
                 <td>1</td>
+            </tr>
+        
+            <tr
+                data-title="behaviour annotation project"
+                data-slug="behavior"
+                data-maturity="IN_PROGRESS"
+                data-review=""
+                data-tags="PIPELINE FLAGSHIP"
+                data-species="mouse human rat worm yeast DANRE DROME DAPPU">
+                <td><a href="BEHAVIOR.html">Behaviour Annotation Project</a><br><code class="muted">BEHAVIOR</code></td>
+                <td><span class="badge m-IN_PROGRESS">IN_PROGRESS</span></td>
+                <td><span class="muted">&mdash;</span></td>
+                <td><span class="tag t-PIPELINE">PIPELINE</span><span class="tag t-FLAGSHIP">FLAGSHIP</span></td>
+                <td><span class="sp">mouse</span><span class="sp">human</span><span class="sp">rat</span><span class="sp">worm</span><span class="sp">yeast</span><span class="sp">DANRE</span><span class="sp">DROME</span><span class="sp">DAPPU</span></td>
+                <td><span title="App, STAT3, nphp-1, Casp3, Drd1, CRY, lov-1, pkd-2, GCG, daf-2, trpm7, Tuba1a, Agtr1a, Mtor, Fyn">15</span></td>
+                <td>4</td>
             </tr>
         
             <tr
@@ -1725,6 +1741,22 @@
                 <td><span class="muted">&mdash;</span></td>
                 <td><span class="muted">&mdash;</span></td>
                 <td><span class="muted">&mdash;</span></td>
+            </tr>
+        
+            <tr
+                data-title="review quality audit"
+                data-slug="review_quality_audit"
+                data-maturity="IN_PROGRESS"
+                data-review=""
+                data-tags="PIPELINE"
+                data-species="">
+                <td><a href="REVIEW_QUALITY_AUDIT.html">Review Quality Audit</a><br><code class="muted">REVIEW_QUALITY_AUDIT</code></td>
+                <td><span class="badge m-IN_PROGRESS">IN_PROGRESS</span></td>
+                <td><span class="muted">&mdash;</span></td>
+                <td><span class="tag t-PIPELINE">PIPELINE</span></td>
+                <td><span class="muted">&mdash;</span></td>
+                <td><span class="muted">&mdash;</span></td>
+                <td>1</td>
             </tr>
         
             <tr


### PR DESCRIPTION
## Summary

Automated regeneration of static assets after gene review or template changes.

## Generated Assets

| Asset | Count/Status |
|-------|--------------|
| Gene review YAML files | 2801 |
| Gene review HTML pages | 2801 |
| Project pages | 1087 |
| Module pages | 45 |
| Browser app (data.js) | Updated |
| Validation report | Updated |

## Trigger

This PR was triggered by changes to:
- genes/**/*.yaml - gene review data files
- src/ai_gene_review/schema/** - LinkML schema files
- src/ai_gene_review/templates/** - Jinja2 templates
- src/ai_gene_review/render.py - rendering code
- src/ai_gene_review/render_modules.py - module rendering code
- src/ai_gene_review/export/** - export code
- src/ai_gene_review/browser/** - browser app assets
- src/ai_gene_review/tools/minify_linkml_browser_data.py - browser data compaction
- projects/*.md - project definitions
- modules/**/*.yaml - module definitions
- project.justfile - just recipes used by CI
- .github/workflows/generate-pages.yaml - workflow definition

## Review

- [ ] Spot-check a few gene review HTML pages render correctly
- [ ] Spot-check module tree browser pages render correctly
- [ ] Verify browser app loads and filters work
- [ ] Check validation report for new issues
