### PR TITLE
[codex] Add propagation review taxonomy

### DIFF
--- a/genes/CANAL/LPL1/LPL1-ai-review.html
+++ b/genes/CANAL/LPL1/LPL1-ai-review.html
@@ -343,6 +343,42 @@
             margin-left: 1rem;
         }
 
+        .propagation-review {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f8fafc;
+            border-left: 3px solid #64748b;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .propagation-title {
+            font-weight: 600;
+            color: #334155;
+            margin-bottom: 0.25rem;
+        }
+
+        .propagation-row {
+            margin-top: 0.25rem;
+        }
+
+        .propagation-source {
+            margin-top: 0.5rem;
+            padding-top: 0.5rem;
+            border-top: 1px solid #e5e7eb;
+        }
+
+        .propagation-source-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #1d4ed8;
+        }
+
+        .propagation-comment {
+            color: #4b5563;
+            margin-left: 1rem;
+        }
+
         a.term-link {
             color: #2563eb;
             text-decoration: none;
@@ -728,33 +764,33 @@
     <div class="header">
         <h1>LPL1</h1>
         <div class="gene-info">
-            
+
             <div class="info-item">
-                
+
                 <span class="info-label">UniProt ID:</span>
                 <span>
                     <a href="https://www.uniprot.org/uniprotkb/Q5AMS2" target="_blank" class="term-link">
                         Q5AMS2
                     </a>
                 </span>
-                
+
             </div>
-            
-            
+
+
             <div class="info-item">
                 <span class="info-label">Organism:</span>
                 <span>Candida albicans SC5314</span>
             </div>
-            
-            
+
+
             <div class="info-item">
                 <span class="info-label">Review Status:</span>
                 <span class="status-badge status-complete">
                     COMPLETE
                 </span>
             </div>
-            
-            
+
+
         </div>
         <div style="margin-top: 1rem; text-align: center;">
             <a id="feedback-form-link"
@@ -785,7 +821,7 @@
         </div>
     </div>
 
-    
+
     <div class="description-card">
         <div style="display: flex; justify-content: space-between; align-items: center;">
             <h2>Gene Description</h2>
@@ -796,13 +832,13 @@
         </div>
         <p>Putative phospholipase B homolog of S. cerevisiae LPL1, likely encoding a lipid droplet-associated enzyme with phospholipase activity on glycerophospholipids. Based on homology, predicted to contain GXSXG lipase motif and function in phospholipid metabolism during stationary phase.</p>
     </div>
-    
 
-    
 
-    
 
-    
+
+
+
+
     <div class="section">
         <h2 class="section-title">Existing Annotations Review</h2>
         <table class="annotations-table">
@@ -815,32 +851,32 @@
                 </tr>
             </thead>
             <tbody>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006629" target="_blank" class="term-link">
                                     GO:0006629
                                 </a>
                             </span>
                             <span class="term-label">lipid metabolic process</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IBA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000033
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -852,63 +888,64 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> This broad biological process term is appropriate for a phospholipase B enzyme. The S. cerevisiae homolog LPL1 is well-characterized as functioning in lipid metabolism, specifically in phospholipid hydrolysis and lipid droplet dynamics. The IBA annotation is based on phylogenetic inference from characterized orthologs.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> The annotation is supported by strong homology to S. cerevisiae LPL1, which has demonstrated roles in lipid metabolism. Phospholipase B enzymes by definition participate in lipid metabolic processes through hydrolysis of glycerophospholipids. The term accurately captures the core metabolic function without being overly specific.
                         </div>
-                        
-                        
-                        
+
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     file:CANAL/LPL1/LPL1-deep-research.md
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">The S. cerevisiae LPL1 (YOR059c) gene encodes a phospholipase B... Shows phospholipase activity with broad substrate specificity, acting on all glycerophospholipids primarily at sn-2 position, then at sn-1 position</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
-                        
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0004622" target="_blank" class="term-link">
                                     GO:0004622
                                 </a>
                             </span>
                             <span class="term-label">phosphatidylcholine lysophospholipase A1 activity</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IBA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000033
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-modify">
@@ -920,74 +957,124 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> This molecular function represents one of the three activities of phospholipase B enzymes - the lysophospholipase activity. However, this annotation is too narrow as it only captures one aspect of phospholipase B function and is specific to phosphatidylcholine substrates, while the enzyme likely has broader substrate specificity.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Phospholipase B enzymes have three distinct activities: sn-1/sn-2 fatty acid ester hydrolase, lysophospholipase, and transacylase activity. The current term only captures the lysophospholipase activity on phosphatidylcholine. The more comprehensive term GO:0102545 (phospholipase B activity) would better represent the full enzymatic capability of this protein, as it encompasses all three activities and broader substrate specificity.
                         </div>
-                        
-                        
+
+
+
+                        <div class="propagation-review">
+                            <div class="propagation-title">Propagation Review</div>
+                            <div class="propagation-row">
+                                <strong>Root cause:</strong>
+                                <span class="badge">TERM SCOPING PROBLEM</span>
+                            </div>
+
+                            <div class="propagation-row">
+                                <strong>Failure modes:</strong>
+
+                                <span class="badge">GRANULARITY MISMATCH</span>
+
+                            </div>
+
+
+                            <div class="propagation-source">
+                                <strong>Sources checked:</strong>
+
+                                <div class="propagation-row">
+                                    <span class="propagation-source-id">PANTHER:PTN000280739</span>
+
+                                    &middot; PANTHER phospholipase B source node
+
+
+                                    <span class="badge">SUPPORTS SOURCE BUT NOT TARGET</span>
+
+
+                                    <div class="propagation-comment">The source supports phospholipase activity, but the propagated phosphatidylcholine lysophospholipase term is narrower than the target&#39;s reviewed phospholipase B activity.</div>
+
+                                </div>
+
+                                <div class="propagation-row">
+                                    <span class="propagation-source-id">SGD:S000005585</span>
+
+                                    &middot; S. cerevisiae LPL1
+
+
+                                    <span class="badge">SUPPORTS SOURCE BUT NOT TARGET</span>
+
+
+                                    <div class="propagation-comment">The yeast ortholog supports broad phospholipase B activity, not a target review restricted to this single substrate-specific activity.</div>
+
+                                </div>
+
+                            </div>
+
+                        </div>
+
+
                         <div style="margin-top: 0.5rem;">
                             <strong>Proposed replacements:</strong>
-                            
+
                             <span class="badge">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0102545" target="_blank" class="term-link">
                                     phospholipase B activity
                                 </a>
                             </span>
-                            
+
                         </div>
-                        
-                        
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     file:CANAL/LPL1/LPL1-deep-research.md
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Fungal phospholipase B (PLB) enzymes harbor three distinct activities: 1. sn-1 and sn-2 fatty acid ester hydrolase activity, 2. Lysophospholipase activity, 3. Transacylase activity</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
-                        
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005811" target="_blank" class="term-link">
                                     GO:0005811
                                 </a>
                             </span>
                             <span class="term-label">lipid droplet</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IBA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000033
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -999,131 +1086,197 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> This cellular component annotation is strongly supported by characterization of the S. cerevisiae homolog LPL1, which shows exclusive localization to lipid droplets during stationary phase. This localization is consistent with the enzyme role in lipid metabolism and storage regulation.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> The S. cerevisiae LPL1 has been experimentally demonstrated to localize exclusively to lipid droplets at stationary phase. This localization makes functional sense for a phospholipase B enzyme involved in lipid metabolism and droplet dynamics. The IBA annotation based on phylogenetic inference from the well-characterized S. cerevisiae ortholog is reliable.
                         </div>
-                        
-                        
-                        
+
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     file:CANAL/LPL1/LPL1-deep-research.md
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">The S. cerevisiae LPL1 (YOR059c) gene encodes a phospholipase B localized to lipid droplets during stationary phase... Exclusively localized to lipid droplets at stationary phase</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
-                        
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0047372" target="_blank" class="term-link">
                                     GO:0047372
                                 </a>
                             </span>
                             <span class="term-label">monoacylglycerol lipase activity</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IBA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000033
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-keepasnoncore">
-                            KEEP AS NON CORE
+                        <span class="action-badge action-undecided">
+                            UNDECIDED
                         </span>
-                        <span class="vote-buttons" data-g="Q5AMS2" data-a="GO:0047372" data-r="GO_REF:0000033" data-act="KEEP_AS_NON_CORE">
+                        <span class="vote-buttons" data-g="Q5AMS2" data-a="GO:0047372" data-r="GO_REF:0000033" data-act="UNDECIDED">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> This annotation suggests additional lipase activity beyond phospholipase function. While some lipases can have promiscuous substrate specificity, there is no direct evidence that LPL1 homologs have monoacylglycerol lipase activity as a primary function. This appears to be a secondary or promiscuous activity.
+                            <strong>Summary:</strong> This IBA annotation is not established for Candida LPL1. The source trace points to the S. cerevisiae paralog ROG1, a monoacylglycerol lipase, while characterized S. cerevisiae LPL1 supports phospholipase B activity on glycerophospholipids rather than monoacylglycerol hydrolysis.
                         </div>
-                        
-                        
+
+
                         <div>
-                            <strong>Reason:</strong> The primary characterized function of LPL1 homologs is phospholipase B activity on glycerophospholipids, not monoacylglycerol hydrolysis. While the enzyme may have some activity on monoacylglycerols due to the general lipase domain, this is likely not the core function. The annotation may reflect substrate promiscuity rather than the primary enzymatic role. Keeping as non-core acknowledges potential activity without overstating its importance.
+                            <strong>Reason:</strong> The annotation should not be treated as a non-core Candida LPL1 activity without target-specific or ortholog-specific evidence. Current support for the LPL1-like branch points to phospholipase B activity on glycerophospholipids; the monoacylglycerol lipase term appears to come from a related ROG1 paralog/subfamily. Because Candida LPL1 has not been directly assayed for monoacylglycerol substrates, the conservative action is UNDECIDED pending source-tree and substrate-specificity review, rather than accepting a propagated secondary activity.
                         </div>
-                        
-                        
-                        
+
+
+
+                        <div class="propagation-review">
+                            <div class="propagation-title">Propagation Review</div>
+                            <div class="propagation-row">
+                                <strong>Root cause:</strong>
+                                <span class="badge">PROPAGATION BAD</span>
+                            </div>
+
+                            <div class="propagation-row">
+                                <strong>Failure modes:</strong>
+
+                                <span class="badge">WRONG ORTHOLOG OR PARALOG</span>
+
+                                <span class="badge">FUNCTIONAL DIVERGENCE</span>
+
+                            </div>
+
+
+                            <div class="propagation-source">
+                                <strong>Sources checked:</strong>
+
+                                <div class="propagation-row">
+                                    <span class="propagation-source-id">PANTHER:PTN000773837</span>
+
+                                    &middot; PANTHER monoacylglycerol lipase source node
+
+
+                                    <span class="badge">SUPPORTS SOURCE BUT NOT TARGET</span>
+
+
+                                    <div class="propagation-comment">The node appears to be anchored by ROG1-like monoacylglycerol lipase evidence, but transfer to the LPL1 phospholipase branch is unresolved.</div>
+
+                                </div>
+
+                                <div class="propagation-row">
+                                    <span class="propagation-source-id">SGD:S000003112</span>
+
+                                    &middot; S. cerevisiae ROG1
+
+
+                                    <span class="badge">SUPPORTS SOURCE BUT NOT TARGET</span>
+
+
+                                    <div class="propagation-comment">ROG1 supports monoacylglycerol lipase activity at the source, but it is a paralog rather than the characterized S. cerevisiae LPL1 phospholipase ortholog.</div>
+
+                                </div>
+
+                                <div class="propagation-row">
+                                    <span class="propagation-source-id">SGD:S000005585</span>
+
+                                    &middot; S. cerevisiae LPL1
+
+
+                                    <span class="badge">SUPPORTS SOURCE BUT NOT TARGET</span>
+
+
+                                    <div class="propagation-comment">The closest characterized LPL1 comparator supports broad glycerophospholipid phospholipase B activity, not established monoacylglycerol lipase activity.</div>
+
+                                </div>
+
+                            </div>
+
+                        </div>
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     file:CANAL/LPL1/LPL1-deep-research.md
-                                    
+
                                 </span>
-                                
-                                <div class="support-text">Shows phospholipase activity with broad substrate specificity, acting on all glycerophospholipids primarily at sn-2 position, then at sn-1 position [Note: no mention of monoacylglycerol substrates in primary literature]</div>
-                                
+
+                                <div class="support-text">Shows phospholipase activity with broad substrate specificity, acting on all glycerophospholipids primarily at sn-2 position, then at sn-1 position</div>
+
                             </div>
-                            
+
                         </div>
-                        
-                        
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016020" target="_blank" class="term-link">
                                     GO:0016020
                                 </a>
                             </span>
                             <span class="term-label">membrane</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000043
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-remove">
@@ -1135,74 +1288,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> This generic membrane annotation is based on automated prediction from a transmembrane domain (residues 286-306 per UniProt). However, this is inconsistent with the well-characterized lipid droplet localization of the S. cerevisiae homolog. The predicted transmembrane domain may represent a hydrophobic region for lipid droplet association rather than true membrane insertion.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> The annotation conflicts with experimental evidence showing exclusive lipid droplet localization for the S. cerevisiae homolog. While the protein has a predicted hydrophobic region (286-306), this likely mediates lipid droplet association rather than membrane integration. Lipid droplets have a unique phospholipid monolayer structure distinct from bilayer membranes. The generic &#34;membrane&#34; term is misleading and the more specific &#34;lipid droplet&#34; annotation (GO:0005811) is already present and correct.
                         </div>
-                        
-                        
-                        
+
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     file:CANAL/LPL1/LPL1-deep-research.md
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Exclusively localized to lipid droplets at stationary phase</div>
-                                
+
                             </div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     file:CANAL/LPL1/LPL1-uniprot.txt
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">FT   TRANSMEM        286..306 [Note: This hydrophobic region likely mediates lipid droplet binding rather than membrane insertion]</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
-                        
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016042" target="_blank" class="term-link">
                                     GO:0016042
                                 </a>
                             </span>
                             <span class="term-label">lipid catabolic process</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000043
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1214,63 +1368,64 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> This biological process annotation accurately describes the catabolic aspect of phospholipase B activity - the hydrolysis of phospholipids into fatty acids and lysophospholipids. This is a appropriate child term of the broader lipid metabolic process already annotated.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Phospholipase B enzymes catalyze the hydrolytic breakdown of glycerophospholipids, which is definitionally a lipid catabolic process. The annotation correctly captures this catabolic function. While based on automated keyword mapping (IEA), it aligns with the known enzymatic activity of phospholipase B family members.
                         </div>
-                        
-                        
-                        
+
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     file:CANAL/LPL1/LPL1-deep-research.md
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Phospholipase B enzymes harbor... sn-1 and sn-2 fatty acid ester hydrolase activity [hydrolysis represents catabolism of lipids]</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
-                        
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016787" target="_blank" class="term-link">
                                     GO:0016787
                                 </a>
                             </span>
                             <span class="term-label">hydrolase activity</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000043
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-remove">
@@ -1282,49 +1437,50 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> This is an overly broad molecular function term that provides minimal information about the specific enzymatic activity. While technically correct (phospholipases are hydrolases), this annotation adds no value beyond what is already captured by more specific terms.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> The term &#34;hydrolase activity&#34; is too generic and uninformative. The protein already has more specific molecular function annotations (phospholipase/lysophospholipase activities) that are children of hydrolase activity in the GO hierarchy. This broad parent term adds no additional information and represents the type of vague annotation that should be avoided according to curation guidelines. The specific phospholipase B activity (GO:0102545) provides much more informative functional annotation.
                         </div>
-                        
-                        
-                        
+
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     file:CANAL/LPL1/LPL1-deep-research.md
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Contains the canonical lipase motif GXSXG essential for catalytic activity [specific lipase, not generic hydrolase]</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
-                        
+
+
                     </td>
                 </tr>
-                
+
             </tbody>
         </table>
     </div>
-    
 
-    
+
+
     <div class="section">
         <h2 class="section-title">Core Functions</h2>
-        
+
         <div class="core-function-card">
-            
+
             <div style="display: flex; justify-content: space-between; align-items: center;">
                 <h3>Phospholipid hydrolysis at lipid droplets</h3>
                 <span class="vote-buttons" data-g="Q5AMS2" data-a="FUNCTION: Phospholipid hydrolysis at lipid droplets..." data-r="" data-act="CORE_FUNCTION">
@@ -1332,10 +1488,10 @@
                     <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
                 </span>
             </div>
-            
+
 
             <div class="core-function-terms">
-                
+
                 <div class="function-term-group">
                     <div class="function-term-label">Molecular Function:</div>
                     <span class="badge">
@@ -1344,227 +1500,227 @@
                         </a>
                     </span>
                 </div>
-                
 
-                
+
+
                 <div class="function-term-group">
                     <div class="function-term-label">Directly Involved In:</div>
                     <div class="function-annotations">
-                        
+
                         <span class="badge">
                             <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006629" target="_blank" class="term-link">
                                 lipid metabolic process
                             </a>
                         </span>
-                        
+
                         <span class="badge">
                             <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016042" target="_blank" class="term-link">
                                 lipid catabolic process
                             </a>
                         </span>
-                        
+
                     </div>
                 </div>
-                
 
-                
+
+
                 <div class="function-term-group">
                     <div class="function-term-label">Cellular Locations:</div>
                     <div class="function-annotations">
-                        
+
                         <span class="badge">
                             <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005811" target="_blank" class="term-link">
                                 lipid droplet
                             </a>
                         </span>
-                        
+
                     </div>
                 </div>
-                
 
-                
 
-                
+
+
+
             </div>
 
-            
+
             <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
                 <strong>Supporting Evidence:</strong>
                 <ul class="findings-list">
-                    
+
                     <li class="finding-item">
                         <span class="reference-id">
-                            
+
                             file:CANAL/LPL1/LPL1-deep-research.md
-                            
+
                         </span>
-                        
+
                         <div class="finding-text">Fungal phospholipase B (PLB) enzymes harbor three distinct activities: 1. sn-1 and sn-2 fatty acid ester hydrolase activity, 2. Lysophospholipase activity, 3. Transacylase activity</div>
-                        
+
                     </li>
-                    
+
                     <li class="finding-item">
                         <span class="reference-id">
-                            
+
                             file:CANAL/LPL1/LPL1-deep-research.md
-                            
+
                         </span>
-                        
+
                         <div class="finding-text">Shows phospholipase activity with broad substrate specificity, acting on all glycerophospholipids primarily at sn-2 position, then at sn-1 position</div>
-                        
+
                     </li>
-                    
+
                 </ul>
             </div>
-            
-        </div>
-        
-    </div>
-    
 
-    
+        </div>
+
+    </div>
+
+
+
     <div class="section">
         <h2 class="section-title collapsible">References</h2>
         <div class="collapse-content">
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000033.md" target="_blank" class="term-link">
                             GO_REF:0000033
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Annotation inferences using phylogenetic trees</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000043.md" target="_blank" class="term-link">
                             GO_REF:0000043
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Gene Ontology annotation based on UniProtKB/Swiss-Prot keyword mapping</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         file:CANAL/LPL1/LPL1-deep-research.md
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Deep research analysis of C. albicans LPL1 gene</div>
-                
-                
+
+
                 <ul class="findings-list">
-                    
+
                     <li class="finding-item">
                         <div class="finding-statement">S. cerevisiae homolog LPL1 encodes phospholipase B with conserved catalytic motif</div>
-                        
+
                         <div class="finding-text">"Contains the canonical lipase motif GXSXG essential for catalytic activity"</div>
-                        
+
                     </li>
-                    
+
                     <li class="finding-item">
                         <div class="finding-statement">Phospholipase B enzymes have three distinct enzymatic activities</div>
-                        
+
                         <div class="finding-text">"Fungal phospholipase B (PLB) enzymes harbor three distinct activities: 1. sn-1 and sn-2 fatty acid ester hydrolase activity, 2. Lysophospholipase activity, 3. Transacylase activity"</div>
-                        
+
                     </li>
-                    
+
                     <li class="finding-item">
                         <div class="finding-statement">Exclusive localization to lipid droplets during stationary phase</div>
-                        
+
                         <div class="finding-text">"The S. cerevisiae LPL1 (YOR059c) gene encodes a phospholipase B localized to lipid droplets during stationary phase... Exclusively localized to lipid droplets at stationary phase"</div>
-                        
+
                     </li>
-                    
+
                     <li class="finding-item">
                         <div class="finding-statement">Broad substrate specificity for glycerophospholipids</div>
-                        
+
                         <div class="finding-text">"Shows phospholipase activity with broad substrate specificity, acting on all glycerophospholipids primarily at sn-2 position, then at sn-1 position"</div>
-                        
+
                     </li>
-                    
+
                 </ul>
-                
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         file:CANAL/LPL1/LPL1-uniprot.txt
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">UniProt entry for C. albicans LPL1 (Q5AMS2)</div>
-                
-                
+
+
                 <ul class="findings-list">
-                    
+
                     <li class="finding-item">
                         <div class="finding-statement">Contains DUF676 lipase-like domain</div>
-                        
+
                         <div class="finding-text">"DOMAIN 14..213 /note=&#34;DUF676&#34;"</div>
-                        
+
                     </li>
-                    
+
                     <li class="finding-item">
                         <div class="finding-statement">Predicted hydrophobic region for lipid droplet association</div>
-                        
+
                         <div class="finding-text">"TRANSMEM 286..306 /note=&#34;Helical&#34;"</div>
-                        
+
                     </li>
-                    
+
                     <li class="finding-item">
                         <div class="finding-statement">Member of putative lipase ROG1 family</div>
-                        
+
                         <div class="finding-text">"SIMILARITY: Belongs to the putative lipase ROG1 family"</div>
-                        
+
                     </li>
-                    
+
                 </ul>
-                
+
             </div>
-            
+
         </div>
     </div>
-    
 
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
 
     <!-- Computational Predictions Section -->
-    
+
 
     <!-- Deep Research Sections -->
-    
+
     <div class="section">
         <h2 class="section-title">Deep Research</h2>
-        
+
         <details class="deep-research-section">
             <summary style="display: flex; justify-content: space-between; align-items: center; gap: 1rem;">
                 <div style="flex: 1;">
@@ -1577,8 +1733,8 @@
                 </div>
             </summary>
             <div class="markdown-content">
-                
-                
+
+
                 <h1 id="deep-research-candida-albicans-lpl1-cal0000180378q5ams2">Deep Research: Candida albicans LPL1 (CAL0000180378/Q5AMS2)</h1>
 <h2 id="gene-identification-and-basic-information">Gene Identification and Basic Information</h2>
 <h3 id="primary-identifiers">Primary Identifiers</h3>
@@ -1696,12 +1852,12 @@ These genes affect extracellular vesicle morphology, cargo, and immunostimulator
 <p>The <em>Candida albicans</em> LPL1 gene (CAL0000180378/Q5AMS2) encodes a putative phospholipase B homologous to <em>S. cerevisiae</em> LPL1. Based on family characteristics, it likely contains the GXSXG lipase motif and functions in phospholipid metabolism, potentially contributing to virulence through membrane disruption and lipid signaling. Despite its potential importance, direct experimental characterization remains limited, representing a significant knowledge gap in understanding <em>C. albicans</em> pathogenesis and identifying novel antifungal targets. The expansion of phospholipase B genes in <em>C. albicans</em> compared to non-pathogenic yeasts suggests specialized roles in host adaptation and virulence that warrant further investigation.</p>
             </div>
         </details>
-        
+
     </div>
-    
+
 
     <!-- Additional Documentation Sections -->
-    
+
 
     <!-- YAML Preview Section -->
     <div class="section">
@@ -1738,6 +1894,22 @@ existing_annotations:
     summary: This molecular function represents one of the three activities of phospholipase B enzymes - the lysophospholipase activity. However, this annotation is too narrow as it only captures one aspect of phospholipase B function and is specific to phosphatidylcholine substrates, while the enzyme likely has broader substrate specificity.
     action: MODIFY
     reason: &#39;Phospholipase B enzymes have three distinct activities: sn-1/sn-2 fatty acid ester hydrolase, lysophospholipase, and transacylase activity. The current term only captures the lysophospholipase activity on phosphatidylcholine. The more comprehensive term GO:0102545 (phospholipase B activity) would better represent the full enzymatic capability of this protein, as it encompasses all three activities and broader substrate specificity.&#39;
+    propagation_review:
+      root_cause: TERM_SCOPING_PROBLEM
+      failure_modes:
+      - GRANULARITY_MISMATCH
+      source_entities:
+      - source_id: PANTHER:PTN000280739
+        source_label: PANTHER phospholipase B source node
+        source_status: SUPPORTS_SOURCE_BUT_NOT_TARGET
+        comment: The source supports phospholipase activity, but the propagated
+          phosphatidylcholine lysophospholipase term is narrower than the target&#39;s
+          reviewed phospholipase B activity.
+      - source_id: SGD:S000005585
+        source_label: S. cerevisiae LPL1
+        source_status: SUPPORTS_SOURCE_BUT_NOT_TARGET
+        comment: The yeast ortholog supports broad phospholipase B activity, not
+          a target review restricted to this single substrate-specific activity.
     proposed_replacement_terms:
     - id: GO:0102545
       label: phospholipase B activity
@@ -1762,12 +1934,36 @@ existing_annotations:
   evidence_type: IBA
   original_reference_id: GO_REF:0000033
   review:
-    summary: This annotation suggests additional lipase activity beyond phospholipase function. While some lipases can have promiscuous substrate specificity, there is no direct evidence that LPL1 homologs have monoacylglycerol lipase activity as a primary function. This appears to be a secondary or promiscuous activity.
-    action: KEEP_AS_NON_CORE
-    reason: The primary characterized function of LPL1 homologs is phospholipase B activity on glycerophospholipids, not monoacylglycerol hydrolysis. While the enzyme may have some activity on monoacylglycerols due to the general lipase domain, this is likely not the core function. The annotation may reflect substrate promiscuity rather than the primary enzymatic role. Keeping as non-core acknowledges potential activity without overstating its importance.
+    summary: This IBA annotation is not established for Candida LPL1. The source trace points to the S. cerevisiae paralog ROG1, a monoacylglycerol lipase, while characterized S. cerevisiae LPL1 supports phospholipase B activity on glycerophospholipids rather than monoacylglycerol hydrolysis.
+    action: UNDECIDED
+    reason: The annotation should not be treated as a non-core Candida LPL1 activity without target-specific or ortholog-specific evidence. Current support for the LPL1-like branch points to phospholipase B activity on glycerophospholipids; the monoacylglycerol lipase term appears to come from a related ROG1 paralog/subfamily. Because Candida LPL1 has not been directly assayed for monoacylglycerol substrates, the conservative action is UNDECIDED pending source-tree and substrate-specificity review, rather than accepting a propagated secondary activity.
+    propagation_review:
+      root_cause: PROPAGATION_BAD
+      failure_modes:
+      - WRONG_ORTHOLOG_OR_PARALOG
+      - FUNCTIONAL_DIVERGENCE
+      source_entities:
+      - source_id: PANTHER:PTN000773837
+        source_label: PANTHER monoacylglycerol lipase source node
+        source_status: SUPPORTS_SOURCE_BUT_NOT_TARGET
+        comment: The node appears to be anchored by ROG1-like monoacylglycerol
+          lipase evidence, but transfer to the LPL1 phospholipase branch is
+          unresolved.
+      - source_id: SGD:S000003112
+        source_label: S. cerevisiae ROG1
+        source_status: SUPPORTS_SOURCE_BUT_NOT_TARGET
+        comment: ROG1 supports monoacylglycerol lipase activity at the source,
+          but it is a paralog rather than the characterized S. cerevisiae LPL1
+          phospholipase ortholog.
+      - source_id: SGD:S000005585
+        source_label: S. cerevisiae LPL1
+        source_status: SUPPORTS_SOURCE_BUT_NOT_TARGET
+        comment: The closest characterized LPL1 comparator supports broad
+          glycerophospholipid phospholipase B activity, not established
+          monoacylglycerol lipase activity.
     supported_by:
     - reference_id: file:CANAL/LPL1/LPL1-deep-research.md
-      supporting_text: &#39;Shows phospholipase activity with broad substrate specificity, acting on all glycerophospholipids primarily at sn-2 position, then at sn-1 position [Note: no mention of monoacylglycerol substrates in primary literature]&#39;
+      supporting_text: Shows phospholipase activity with broad substrate specificity, acting on all glycerophospholipids primarily at sn-2 position, then at sn-1 position
 - term:
     id: GO:0016020
     label: membrane
@@ -1858,7 +2054,7 @@ status: COMPLETE
     </div>
 
     <!-- Pathway Visualization Link -->
-    
+
     <div class="section">
         <div class="pathway-link">
             <div style="display: flex; justify-content: space-between; align-items: center;">
@@ -1878,7 +2074,7 @@ status: COMPLETE
             </p>
         </div>
     </div>
-    
+
 
     <style>
         /* Markdown Section Styles */

--- a/genes/CANAL/LPL1/LPL1-ai-review.yaml
+++ b/genes/CANAL/LPL1/LPL1-ai-review.yaml
@@ -26,6 +26,22 @@ existing_annotations:
     summary: This molecular function represents one of the three activities of phospholipase B enzymes - the lysophospholipase activity. However, this annotation is too narrow as it only captures one aspect of phospholipase B function and is specific to phosphatidylcholine substrates, while the enzyme likely has broader substrate specificity.
     action: MODIFY
     reason: 'Phospholipase B enzymes have three distinct activities: sn-1/sn-2 fatty acid ester hydrolase, lysophospholipase, and transacylase activity. The current term only captures the lysophospholipase activity on phosphatidylcholine. The more comprehensive term GO:0102545 (phospholipase B activity) would better represent the full enzymatic capability of this protein, as it encompasses all three activities and broader substrate specificity.'
+    propagation_review:
+      root_cause: TERM_SCOPING_PROBLEM
+      failure_modes:
+      - GRANULARITY_MISMATCH
+      source_entities:
+      - source_id: PANTHER:PTN000280739
+        source_label: PANTHER phospholipase B source node
+        source_status: SUPPORTS_SOURCE_BUT_NOT_TARGET
+        comment: The source supports phospholipase activity, but the propagated
+          phosphatidylcholine lysophospholipase term is narrower than the target's
+          reviewed phospholipase B activity.
+      - source_id: SGD:S000005585
+        source_label: S. cerevisiae LPL1
+        source_status: SUPPORTS_SOURCE_BUT_NOT_TARGET
+        comment: The yeast ortholog supports broad phospholipase B activity, not
+          a target review restricted to this single substrate-specific activity.
     proposed_replacement_terms:
     - id: GO:0102545
       label: phospholipase B activity
@@ -50,12 +66,36 @@ existing_annotations:
   evidence_type: IBA
   original_reference_id: GO_REF:0000033
   review:
-    summary: This annotation suggests additional lipase activity beyond phospholipase function. While some lipases can have promiscuous substrate specificity, there is no direct evidence that LPL1 homologs have monoacylglycerol lipase activity as a primary function. This appears to be a secondary or promiscuous activity.
-    action: KEEP_AS_NON_CORE
-    reason: The primary characterized function of LPL1 homologs is phospholipase B activity on glycerophospholipids, not monoacylglycerol hydrolysis. While the enzyme may have some activity on monoacylglycerols due to the general lipase domain, this is likely not the core function. The annotation may reflect substrate promiscuity rather than the primary enzymatic role. Keeping as non-core acknowledges potential activity without overstating its importance.
+    summary: This IBA annotation is not established for Candida LPL1. The source trace points to the S. cerevisiae paralog ROG1, a monoacylglycerol lipase, while characterized S. cerevisiae LPL1 supports phospholipase B activity on glycerophospholipids rather than monoacylglycerol hydrolysis.
+    action: UNDECIDED
+    reason: The annotation should not be treated as a non-core Candida LPL1 activity without target-specific or ortholog-specific evidence. Current support for the LPL1-like branch points to phospholipase B activity on glycerophospholipids; the monoacylglycerol lipase term appears to come from a related ROG1 paralog/subfamily. Because Candida LPL1 has not been directly assayed for monoacylglycerol substrates, the conservative action is UNDECIDED pending source-tree and substrate-specificity review, rather than accepting a propagated secondary activity.
+    propagation_review:
+      root_cause: PROPAGATION_BAD
+      failure_modes:
+      - WRONG_ORTHOLOG_OR_PARALOG
+      - FUNCTIONAL_DIVERGENCE
+      source_entities:
+      - source_id: PANTHER:PTN000773837
+        source_label: PANTHER monoacylglycerol lipase source node
+        source_status: SUPPORTS_SOURCE_BUT_NOT_TARGET
+        comment: The node appears to be anchored by ROG1-like monoacylglycerol
+          lipase evidence, but transfer to the LPL1 phospholipase branch is
+          unresolved.
+      - source_id: SGD:S000003112
+        source_label: S. cerevisiae ROG1
+        source_status: SUPPORTS_SOURCE_BUT_NOT_TARGET
+        comment: ROG1 supports monoacylglycerol lipase activity at the source,
+          but it is a paralog rather than the characterized S. cerevisiae LPL1
+          phospholipase ortholog.
+      - source_id: SGD:S000005585
+        source_label: S. cerevisiae LPL1
+        source_status: SUPPORTS_SOURCE_BUT_NOT_TARGET
+        comment: The closest characterized LPL1 comparator supports broad
+          glycerophospholipid phospholipase B activity, not established
+          monoacylglycerol lipase activity.
     supported_by:
     - reference_id: file:CANAL/LPL1/LPL1-deep-research.md
-      supporting_text: 'Shows phospholipase activity with broad substrate specificity, acting on all glycerophospholipids primarily at sn-2 position, then at sn-1 position [Note: no mention of monoacylglycerol substrates in primary literature]'
+      supporting_text: Shows phospholipase activity with broad substrate specificity, acting on all glycerophospholipids primarily at sn-2 position, then at sn-1 position
 - term:
     id: GO:0016020
     label: membrane

--- a/genes/MYCTU/cds1/cds1-ai-review.yaml
+++ b/genes/MYCTU/cds1/cds1-ai-review.yaml
@@ -42,6 +42,22 @@ existing_annotations:
       (4) Different EC: 4.4.1.1 (desulfhydrase) vs 2.5.1.47 (synthase);
       (5) Opposite reaction: L-cysteine → H2S + pyruvate (catabolism), not biosynthesis.
       See family analysis: interpro/panther/PTHR10314/PTHR10314-notes.md
+    propagation_review:
+      root_cause: PROPAGATION_BAD
+      failure_modes:
+      - FUNCTIONAL_DIVERGENCE
+      source_entities:
+      - source_id: PANTHER:PTN000034104
+        source_label: PANTHER PTHR10314 root node
+        source_status: SUPPORTS_SOURCE_BUT_NOT_TARGET
+        comment: The root node mixes cysteine synthase sources with the divergent
+          Cds1 desulfhydrase subfamily; biosynthesis support does not transfer
+          to the catabolic target.
+      - source_id: UniProtKB:P0ABK5
+        source_label: E. coli CysK
+        source_status: SUPPORTS_SOURCE_BUT_NOT_TARGET
+        comment: CysK supports cysteine biosynthesis, while MYCTU Cds1 is reviewed
+          as a cysteine desulfhydrase with the opposite reaction direction.
     supported_by:
     - reference_id: PMID:34439535
       supporting_text: "Identification of the enzymatic products indicates that Cds1 is a cysteine desulfhydrase that generates H2S and pyruvate from Cys."

--- a/genes/SCHPO/Epe1/Epe1-ai-review.html
+++ b/genes/SCHPO/Epe1/Epe1-ai-review.html
@@ -343,6 +343,42 @@
             margin-left: 1rem;
         }
 
+        .propagation-review {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f8fafc;
+            border-left: 3px solid #64748b;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .propagation-title {
+            font-weight: 600;
+            color: #334155;
+            margin-bottom: 0.25rem;
+        }
+
+        .propagation-row {
+            margin-top: 0.25rem;
+        }
+
+        .propagation-source {
+            margin-top: 0.5rem;
+            padding-top: 0.5rem;
+            border-top: 1px solid #e5e7eb;
+        }
+
+        .propagation-source-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #1d4ed8;
+        }
+
+        .propagation-comment {
+            color: #4b5563;
+            margin-left: 1rem;
+        }
+
         a.term-link {
             color: #2563eb;
             text-decoration: none;
@@ -728,33 +764,33 @@
     <div class="header">
         <h1>Epe1</h1>
         <div class="gene-info">
-            
+
             <div class="info-item">
-                
+
                 <span class="info-label">UniProt ID:</span>
                 <span>
                     <a href="https://www.uniprot.org/uniprotkb/O94603" target="_blank" class="term-link">
                         O94603
                     </a>
                 </span>
-                
+
             </div>
-            
-            
+
+
             <div class="info-item">
                 <span class="info-label">Organism:</span>
                 <span>Schizosaccharomyces pombe 972h-</span>
             </div>
-            
-            
+
+
             <div class="info-item">
                 <span class="info-label">Review Status:</span>
                 <span class="status-badge status-draft">
                     DRAFT
                 </span>
             </div>
-            
-            
+
+
         </div>
         <div style="margin-top: 1rem; text-align: center;">
             <a id="feedback-form-link"
@@ -785,7 +821,7 @@
         </div>
     </div>
 
-    
+
     <div class="description-card">
         <div style="display: flex; justify-content: space-between; align-items: center;">
             <h2>Gene Description</h2>
@@ -796,13 +832,13 @@
         </div>
         <p>Epe1 is a JmjC domain-containing protein that functions as a non-enzymatic anti-silencing factor in fission yeast. Despite having a JmjC domain typically associated with histone demethylases, Epe1 lacks catalytic activity due to degenerate active site residues. It maintains heterochromatin boundaries by binding HP1/Swi6, recruiting the SAGA histone acetyltransferase complex and Bdf2 bromodomain protein, and promoting nucleosome turnover at heterochromatin sites. Epe1 prevents excessive heterochromatin spreading while paradoxically enabling RNAi-mediated silencing by promoting transcription of repetitive elements.</p>
     </div>
-    
 
-    
 
-    
 
-    
+
+
+
+
     <div class="section">
         <h2 class="section-title">Existing Annotations Review</h2>
         <table class="annotations-table">
@@ -815,32 +851,32 @@
                 </tr>
             </thead>
             <tbody>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0032452" target="_blank" class="term-link">
                                     GO:0032452
                                 </a>
                             </span>
                             <span class="term-label">histone demethylase activity</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IBA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000033
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-remove">
@@ -852,113 +888,150 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> This IBA annotation is incorrect. Epe1 lacks critical catalytic residues for demethylase activity (has HVD instead of HXD motif) and shows no detectable demethylase activity in vitro despite extensive testing (Raiymbek 2020). The protein functions as a non-enzymatic anti-silencing factor that recruits SAGA histone acetyltransferase complex and Bdf2 bromodomain protein to heterochromatin boundaries.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Strong biochemical evidence demonstrates Epe1 lacks demethylase activity. Mass spectrometry assays using purified Epe1 with methylated H3K9 peptides showed no detectable removal of methyl groups, even with HP1/Swi6 present. The JmjC domain lacks conserved Fe(II)-binding residues essential for catalysis. Epe1 H297A catalytic mutant retains anti-silencing function, demonstrating demethylase activity is not required for its biological role (Bao 2019). The C-terminus alone (without JmjC) can disrupt heterochromatin (Raiymbek 2020).
                         </div>
-                        
-                        
+
+
+
+                        <div class="propagation-review">
+                            <div class="propagation-title">Propagation Review</div>
+                            <div class="propagation-row">
+                                <strong>Root cause:</strong>
+                                <span class="badge">PROPAGATION BAD</span>
+                            </div>
+
+                            <div class="propagation-row">
+                                <strong>Failure modes:</strong>
+
+                                <span class="badge">PSEUDO OR SUBACTIVITY LOSS</span>
+
+                            </div>
+
+
+                            <div class="propagation-source">
+                                <strong>Sources checked:</strong>
+
+                                <div class="propagation-row">
+                                    <span class="propagation-source-id">PANTHER:PTN000564171</span>
+
+                                    &middot; JmjC-domain PANTHER node
+
+
+                                    <span class="badge">SUPPORTS SOURCE BUT NOT TARGET</span>
+
+
+                                    <div class="propagation-comment">Active JmjC demethylase sources do not transfer to Epe1 because the target has degenerate catalytic residues and no detectable demethylase activity.</div>
+
+                                </div>
+
+                            </div>
+
+                        </div>
+
+
                         <div style="margin-top: 0.5rem;">
                             <strong>Proposed replacements:</strong>
-                            
+
                             <span class="badge">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0042393" target="_blank" class="term-link">
                                     histone binding
                                 </a>
                             </span>
-                            
+
                             <span class="badge">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0140030" target="_blank" class="term-link">
                                     modification-dependent protein binding
                                 </a>
                             </span>
-                            
+
                         </div>
-                        
-                        
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     file:SCHPO/Epe1/Epe1-deep-research.md
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Purified Epe1 has been tested in biochemical assays using methylated histone H3 peptides as substrates. These mass spectrometry-based assays showed no detectable removal of methyl groups by Epe1, either on di-methyl or tri-methyl H3K9 peptides</div>
-                                
+
                             </div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     file:SCHPO/Epe1/Epe1-bioinformatics/RESULTS.md
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">JmjC domain analysis reveals atypical Fe(II) binding motifs including HVD at position 279-282, which lacks the canonical histidine-rich coordination required for robust demethylase activity. Functions as H3K9me reader rather than eraser</div>
-                                
+
                             </div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     file:SCHPO/Epe1/Epe1-deep-research-falcon.md
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Purified Epe1 showed **no detectable H3K9 demethylase activity in vitro**; JmjC cofactor mutants (**H297A, Y307A, Y370A**) lose Swi6 binding/localization</div>
-                                
+
                             </div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     file:SCHPO/Epe1/Epe1-deep-research-falcon.md
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Isaac et al. note Epe1’s JmjC domain **lacks conservation of Fe(II)-binding residues** and that no demethylase activity was detected, arguing against a canonical Fe(II)/2-oxoglutarate demethylase mechanism.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
-                        
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006338" target="_blank" class="term-link">
                                     GO:0006338
                                 </a>
                             </span>
                             <span class="term-label">chromatin remodeling</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IBA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000033
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-modify">
@@ -970,97 +1043,134 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Epe1 does participate in chromatin remodeling through recruitment of the SAGA histone acetyltransferase complex and promotion of nucleosome turnover at heterochromatin boundaries. However, this term is quite broad and less specific than the actual molecular mechanisms.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> While Epe1 does affect chromatin structure, more specific terms better describe its function. It recruits SAGA complex for histone acetylation (Bao 2019) and promotes nucleosome turnover at heterochromatin sites. The broad chromatin remodeling term obscures the specific mechanisms.
                         </div>
-                        
-                        
+
+
+
+                        <div class="propagation-review">
+                            <div class="propagation-title">Propagation Review</div>
+                            <div class="propagation-row">
+                                <strong>Root cause:</strong>
+                                <span class="badge">TERM SCOPING PROBLEM</span>
+                            </div>
+
+                            <div class="propagation-row">
+                                <strong>Failure modes:</strong>
+
+                                <span class="badge">GRANULARITY MISMATCH</span>
+
+                            </div>
+
+
+                            <div class="propagation-source">
+                                <strong>Sources checked:</strong>
+
+                                <div class="propagation-row">
+                                    <span class="propagation-source-id">PANTHER:PTN000564171</span>
+
+                                    &middot; JmjC-domain chromatin source node
+
+
+                                    <span class="badge">SUPPORTS SOURCE BUT NOT TARGET</span>
+
+
+                                    <div class="propagation-comment">The source captures chromatin-related JmjC family biology, but Epe1 is better reviewed through more specific anti-silencing, transcriptional, and chromatin-boundary mechanisms.</div>
+
+                                </div>
+
+                            </div>
+
+                        </div>
+
+
                         <div style="margin-top: 0.5rem;">
                             <strong>Proposed replacements:</strong>
-                            
+
                             <span class="badge">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006473" target="_blank" class="term-link">
                                     protein acetylation
                                 </a>
                             </span>
-                            
+
                             <span class="badge">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006355" target="_blank" class="term-link">
                                     regulation of DNA-templated transcription
                                 </a>
                             </span>
-                            
+
                             <span class="badge">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0033696" target="_blank" class="term-link">
                                     heterochromatin boundary formation
                                 </a>
                             </span>
-                            
+
                         </div>
-                        
-                        
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     file:SCHPO/Epe1/Epe1-deep-research.md
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Bao et al. (2019) revealed that Epe1 can associate with the SAGA co-activator complex. By purifying Epe1 from cells (especially when Epe1 was overproduced) and identifying co-purifying proteins (via mass spectrometry), they found subunits of the SAGA complex tightly associated with Epe1</div>
-                                
+
                             </div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     file:SCHPO/Epe1/Epe1-deep-research-falcon.md
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Expressing Epe1’s C-terminus can disrupt heterochromatin by **outcompeting/displacing the histone deacetylase Clr3** from heterochromatin.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
-                        
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006357" target="_blank" class="term-link">
                                     GO:0006357
                                 </a>
                             </span>
                             <span class="term-label">regulation of transcription by RNA polymerase II</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IBA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000033
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1072,87 +1182,88 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Epe1 does regulate transcription at heterochromatic repeats by recruiting SAGA complex and promoting RNA Pol II occupancy. It enables transcription of centromeric repeats that feed into the RNAi pathway for heterochromatin establishment.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Epe1 promotes RNA polymerase II transcription at heterochromatic repeats through SAGA recruitment and histone acetylation. Studies show increased Pol II occupancy and transcript production from dg/dh repeats when Epe1 is overexpressed. This transcription is essential for generating RNAi substrates that maintain heterochromatin in a regulated manner.
                         </div>
-                        
-                        
-                        
+
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     file:SCHPO/Epe1/Epe1-deep-research.md
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">At pericentromeric repeats (dg/dh repeats), Epe1 overproduction increases RNA polymerase II occupancy and the expression of these noncoding RNAs</div>
-                                
+
                             </div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     file:SCHPO/Epe1/Epe1-deep-research-falcon.md
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Epe1’s association with Swi6 and role in stimulating heterochromatic ncRNA transcription relevant to RNAi-linked heterochromatin processes.</div>
-                                
+
                             </div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/36617881" target="_blank" class="term-link">
                                         PMID:36617881
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Epub 2022 Dec 20. Tandemly repeated genes promote RNAi-mediated heterochromatin formation via an antisilencing factor, Epe1, in fission yeast.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
-                        
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0003712" target="_blank" class="term-link">
                                     GO:0003712
                                 </a>
                             </span>
                             <span class="term-label">transcription coregulator activity</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IBA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000033
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1164,74 +1275,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Epe1 functions as a transcriptional coregulator by recruiting the SAGA histone acetyltransferase complex to heterochromatin sites, promoting transcriptional activation through histone acetylation.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Direct biochemical evidence shows Epe1 associates with and recruits SAGA complex, a well-characterized transcriptional co-activator. Mass spectrometry identified SAGA subunits co-purifying with Epe1. The N-terminal region contains a transcriptional activation domain that contributes to anti-silencing activity.
                         </div>
-                        
-                        
-                        
+
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     file:SCHPO/Epe1/Epe1-deep-research.md
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">The N-terminal half of Epe1 was recently found to carry a transcriptional activation (NTA) domain that contributes to this anti-silencing effect</div>
-                                
+
                             </div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     file:SCHPO/Epe1/Epe1-deep-research-falcon.md
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">an N-terminal transcriptional activation domain (NTA) can prevent de novo ectopic H3K9 methylation, whereas the JmjC module contributes to removal of established ectopic heterochromatin in vivo</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
-                        
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005634" target="_blank" class="term-link">
                                     GO:0005634
                                 </a>
                             </span>
                             <span class="term-label">nucleus</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000120
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1243,76 +1355,77 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Nuclear localization of Epe1 is well-established through direct experimental evidence including microscopy and ChIP-seq studies showing enrichment at nuclear heterochromatin domains.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Multiple experimental approaches confirm nuclear localization. Direct immunofluorescence microscopy (PMID:12773576) and ChIP-seq studies demonstrate Epe1 localizes to nuclear heterochromatin regions including centromeres, telomeres, and mating-type locus. This is consistent with its function in heterochromatin regulation.
                         </div>
-                        
-                        
-                        
+
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/12773576" target="_blank" class="term-link">
                                         PMID:12773576
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">A novel jmjC domain protein modulates heterochromatization in fission yeast.</div>
-                                
+
                             </div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     file:SCHPO/Epe1/Epe1-deep-research-falcon.md
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Epe1 is predominantly **nuclear** and enriched at **constitutive heterochromatin foci**, recruited through **Swi6/HP1** and dependent on H3K9 methylation machinery</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
-                        
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006325" target="_blank" class="term-link">
                                     GO:0006325
                                 </a>
                             </span>
                             <span class="term-label">chromatin organization</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000043
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1324,76 +1437,77 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> This broad term accurately describes Epe1 function but more specific annotations like heterochromatin boundary formation provide better resolution of its role.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Epe1 clearly participates in chromatin organization through multiple mechanisms: recruiting SAGA for histone acetylation, promoting nucleosome turnover, binding HP1/Swi6 at heterochromatin, and establishing heterochromatin boundaries. While accurate, more specific child terms better describe the precise functions.
                         </div>
-                        
-                        
-                        
+
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     file:SCHPO/Epe1/Epe1-deep-research.md
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Epe1 has been implicated in promoting histone turnover within heterochromatin. Turnover (replacement of histones with new ones) can dilute or remove modified histones</div>
-                                
+
                             </div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/24013502" target="_blank" class="term-link">
                                         PMID:24013502
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Epe1 recruits BET family bromodomain protein Bdf2 to establish heterochromatin boundaries.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
-                        
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016491" target="_blank" class="term-link">
                                     GO:0016491
                                 </a>
                             </span>
                             <span class="term-label">oxidoreductase activity</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000043
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-remove">
@@ -1405,85 +1519,86 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> This annotation is based on JmjC domain homology but is incorrect as Epe1 lacks catalytic activity. The protein has a degenerate active site missing critical Fe(II)-binding residues.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Biochemical assays definitively show Epe1 lacks oxidoreductase activity. The JmjC domain has degenerated active site residues (HVD instead of HXD motif) incompatible with Fe(II) binding and catalysis. No enzymatic activity detected in vitro with any substrate tested. Functions through protein-protein interactions, not catalysis.
                         </div>
-                        
-                        
-                        
+
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     file:SCHPO/Epe1/Epe1-deep-research.md
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Sequence analysis reveals that Epe1&#39;s JmjC domain lacks critical residues required for catalytic function. In particular, it does not conserve certain Fe(II)-binding and 2-oxoglutarate-binding amino acids that are universally present in enzymatically active JmjC demethylases</div>
-                                
+
                             </div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     file:SCHPO/Epe1/Epe1-bioinformatics/RESULTS.md
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">JmjC domain analysis reveals atypical Fe(II) binding motifs that lack the canonical coordination required for oxidoreductase activity. Functions as H3K9me reader rather than eraser</div>
-                                
+
                             </div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     file:SCHPO/Epe1/Epe1-deep-research-falcon.md
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Several studies report **no detectable in vitro H3K9 demethylase activity**, even though mutations in residues predicted to coordinate Fe(II) or 2-oxoglutarate affect Epe1 function in vivo.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
-                        
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0046872" target="_blank" class="term-link">
                                     GO:0046872
                                 </a>
                             </span>
                             <span class="term-label">metal ion binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000043
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-remove">
@@ -1495,85 +1610,86 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> This annotation is incorrect as Epe1 lacks the conserved residues required for Fe(II) binding that are present in active JmjC demethylases.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Structural analysis shows Epe1 JmjC domain lacks conserved Fe(II)-binding histidine residues found in all active JmjC enzymes. Has tyrosine at position 307 instead of catalytic histidine. The degenerate active site cannot coordinate metal ions required for catalysis. No biochemical evidence for metal binding.
                         </div>
-                        
-                        
-                        
+
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     file:SCHPO/Epe1/Epe1-deep-research.md
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Trewick et al. (2007) noted &#34;no detectable demethylase activity is associated with Epe1, and its JmjC domain lacks conservation of Fe(II)-binding residues&#34;</div>
-                                
+
                             </div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     file:SCHPO/Epe1/Epe1-bioinformatics/RESULTS.md
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Structural analysis shows Epe1 has atypical Fe(II) binding motifs (HVD at position 279-282) that lack canonical metal coordination required for demethylase activity</div>
-                                
+
                             </div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     file:SCHPO/Epe1/Epe1-deep-research-falcon.md
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Raiymbek et al. (and related mechanistic work) highlight that Epe1 has a **non-canonical HXE…Y motif** and a **histidine-to-tyrosine substitution (Y370)** at a position typically associated with iron coordination in canonical JmjC demethylases.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
-                        
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0051213" target="_blank" class="term-link">
                                     GO:0051213
                                 </a>
                             </span>
                             <span class="term-label">dioxygenase activity</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000043
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-remove">
@@ -1585,85 +1701,86 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Incorrectly inferred from JmjC domain presence. Epe1 is a pseudo-enzyme that lacks dioxygenase activity due to degenerate active site.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> No dioxygenase activity detected in any biochemical assay. The JmjC domain has evolved away from catalytic function - lacks Fe(II) coordination, has Y307 instead of catalytic histidine. Functions as a structural scaffold for protein interactions rather than as an enzyme. This is a clear example of a pseudo-enzyme retaining the fold but not the catalytic function.
                         </div>
-                        
-                        
-                        
+
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     file:SCHPO/Epe1/Epe1-deep-research.md
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">This suggests that, structurally, Epe1 might be a &#34;pseudo-demethylase&#34; – possessing the JmjC fold but not the enzymatic function</div>
-                                
+
                             </div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     file:SCHPO/Epe1/Epe1-bioinformatics/RESULTS.md
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">JmjC domain analysis confirms Epe1 as a pseudo-demethylase with structural features consistent with H3K9me recognition but lacking robust catalytic activity. Functions as chromatin reader rather than enzyme</div>
-                                
+
                             </div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     file:SCHPO/Epe1/Epe1-deep-research-falcon.md
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">whether it catalyzes histone demethylation, hydroxylation of non-histone substrates, or context-specific modification remains unresolved in vitro</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
-                        
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0140680" target="_blank" class="term-link">
                                     GO:0140680
                                 </a>
                             </span>
                             <span class="term-label">histone H3K36me/H3K36me2 demethylase activity</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000120
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-remove">
@@ -1675,96 +1792,97 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> This highly specific demethylase annotation is incorrect. Epe1 has no demonstrated demethylase activity on any histone substrate including H3K36me.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> No biochemical evidence for H3K36 demethylase activity. Mass spectrometry assays with various methylated histone peptides including H3K36me showed no demethylation. The annotation appears to be computationally inferred from weak homology to other JmjC proteins, but Epe1 is a pseudo-enzyme that has lost catalytic function while retaining the structural fold.
                         </div>
-                        
-                        
-                        
+
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     file:SCHPO/Epe1/Epe1-deep-research.md
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">These mass spectrometry-based assays showed no detectable removal of methyl groups by Epe1, either on di-methyl or tri-methyl H3K9 peptides</div>
-                                
+
                             </div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     file:SCHPO/Epe1/Epe1-bioinformatics/RESULTS.md
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">JmjC domain analysis confirms lack of canonical motifs required for H3K36 demethylase activity. Features are consistent with chromatin reader function rather than enzymatic histone modification</div>
-                                
+
                             </div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     file:SCHPO/Epe1/Epe1-deep-research-falcon.md
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">This matches the UniProt-provided identity (O94603; SPCC622.16c) and is distinct from the better-known budding-yeast “Jhd1” that demethylates H3K36.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
-                        
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/21215368" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:21215368
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     The Cul4-Ddb1(Cdt)² ubiquitin ligase inhibits invasion of a ...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-modify">
@@ -1776,123 +1894,124 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Epe1 binds multiple proteins including HP1/Swi6, SAGA complex subunits, and Bdf2. However, this term is too generic - more specific binding terms would be more informative.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> While protein binding is correct, it is uninformative. Epe1 specifically binds HP1/Swi6 through its C-terminus (demonstrated by co-IP and pull-downs), associates with SAGA complex (mass spec), and recruits Bdf2 (co-IP). More specific terms describing these interactions would be more valuable.
                         </div>
-                        
-                        
+
+
+
                         <div style="margin-top: 0.5rem;">
                             <strong>Proposed replacements:</strong>
-                            
+
                             <span class="badge">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0042393" target="_blank" class="term-link">
                                     histone binding
                                 </a>
                             </span>
-                            
+
                             <span class="badge">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0042826" target="_blank" class="term-link">
                                     histone deacetylase binding
                                 </a>
                             </span>
-                            
+
                             <span class="badge">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0035035" target="_blank" class="term-link">
                                     histone acetyltransferase binding
                                 </a>
                             </span>
-                            
+
                         </div>
-                        
-                        
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/21215368" target="_blank" class="term-link">
                                         PMID:21215368
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">The Cul4-Ddb1(Cdt)² ubiquitin ligase inhibits invasion of a boundary-associated antisilencing factor into heterochromatin.</div>
-                                
+
                             </div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     file:SCHPO/Epe1/Epe1-bioinformatics/RESULTS.md
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Extensive coiled-coil regions and multiple protein interaction domains identified throughout the protein, consistent with its role as a chromatin scaffold recruiting various complexes</div>
-                                
+
                             </div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/24013502" target="_blank" class="term-link">
                                         PMID:24013502
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Epe1 recruits BET family bromodomain protein Bdf2 to establish heterochromatin boundaries.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
-                        
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0033696" target="_blank" class="term-link">
                                     GO:0033696
                                 </a>
                             </span>
                             <span class="term-label">heterochromatin boundary formation</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IGI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/39094565" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:39094565
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Mapping the dynamics of epigenetic adaptation in S. pombe du...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1904,113 +2023,114 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> This is one of Epe1&#39;s core functions - establishing and maintaining heterochromatin boundaries through recruitment of anti-silencing factors like SAGA and Bdf2.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Extensive evidence supports this annotation. Epe1 localizes to heterochromatin boundaries at centromeres, telomeres, and mating-type locus. It recruits Bdf2 bromodomain protein to IRCs (inverted repeat centromeric boundaries) and SAGA complex for histone acetylation. Loss of Epe1 causes heterochromatin spreading beyond normal boundaries. This is a well-characterized core function.
                         </div>
-                        
-                        
-                        
+
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     file:SCHPO/Epe1/Epe1-deep-research.md
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Wang et al. found that Epe1 recruits Bdf2 to heterochromatin boundaries. Bdf2 was enriched at boundary elements (e.g. subtelomeric boundary regions called IRCs) only when Epe1 was present</div>
-                                
+
                             </div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/39094565" target="_blank" class="term-link">
                                         PMID:39094565
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Epub 2024 Aug 1. Mapping the dynamics of epigenetic adaptation in S.</div>
-                                
+
                             </div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/24013502" target="_blank" class="term-link">
                                         PMID:24013502
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Epe1 recruits BET family bromodomain protein Bdf2 to establish heterochromatin boundaries.</div>
-                                
+
                             </div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/12773576" target="_blank" class="term-link">
                                         PMID:12773576
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">A novel jmjC domain protein modulates heterochromatization in fission yeast.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
-                        
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0032454" target="_blank" class="term-link">
                                     GO:0032454
                                 </a>
                             </span>
                             <span class="term-label">histone H3K9 demethylase activity</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/25838386" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:25838386
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Epigenetics. Restricted epigenetic inheritance of H3K9 methy...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-remove">
@@ -2022,100 +2142,101 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> This annotation is incorrect despite IDA evidence code. The cited paper actually shows genetic evidence for H3K9me erasure but not direct biochemical demethylase activity. Epe1 lacks catalytic residues and shows no demethylase activity in vitro.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> The PMID:25838386 paper (Audergon et al.) shows that epe1 deletion allows H3K9me inheritance, suggesting Epe1 normally prevents it. However, this is genetic evidence for H3K9me antagonism, not direct biochemical demonstration of demethylase activity (IDA). No study has shown Epe1 directly demethylating histones in vitro. The protein lacks catalytic residues and functions through non-enzymatic mechanisms.
                         </div>
-                        
-                        
-                        
+
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/25838386" target="_blank" class="term-link">
                                         PMID:25838386
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Epigenetics. Restricted epigenetic inheritance of H3K9 methylation.</div>
-                                
+
                             </div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     file:SCHPO/Epe1/Epe1-bioinformatics/RESULTS.md
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">JmjC domain analysis confirms atypical Fe(II) binding motifs that lack canonical coordination required for demethylase activity. Structural features consistent with chromatin reader function</div>
-                                
+
                             </div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     file:SCHPO/Epe1/Epe1-deep-research-falcon.md
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Purified Epe1 showed **no detectable H3K9 demethylase activity in vitro**; JmjC cofactor mutants (**H297A, Y307A, Y370A**) lose Swi6 binding/localization</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
-                        
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0031507" target="_blank" class="term-link">
                                     GO:0031507
                                 </a>
                             </span>
                             <span class="term-label">heterochromatin formation</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
+
                         <span class="not-badge" title="This is a NOT annotation - gene does NOT have this function">NOT</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/25831549" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:25831549
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Epigenetics. Epigenetic inheritance uncoupled from sequence-...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -2127,98 +2248,99 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> This is a negative annotation (NOT|involved_in) which is correct - Epe1 does NOT promote heterochromatin formation but rather opposes it. The NOT qualifier appropriately captures Epe1&#39;s anti-silencing role in preventing heterochromatin assembly and maintenance.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> The NOT|involved_in annotation accurately reflects Epe1&#39;s function as an anti-silencing factor that opposes heterochromatin formation. The cited paper (Ragunathan 2015) demonstrates that Epe1 plays opposing roles to Clr4 in maintaining silent H3K9me domains, preventing rather than promoting heterochromatin assembly. This negative annotation is more precise than a positive annotation would be.
                         </div>
-                        
-                        
-                        
+
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/25831549" target="_blank" class="term-link">
                                         PMID:25831549
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">The putative JmjC domain H3K9 demethylase, Epe1, and the chromodomain of the H3K9 methyltransferase, Clr4/Suv39h, play opposing roles in maintaining silent H3K9me domains</div>
-                                
+
                             </div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     file:SCHPO/Epe1/Epe1-deep-research.md
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Epe1 is often described as a &#34;boundary element&#34; or &#34;heterochromatin destabilizer&#34;, meaning it localizes to heterochromatic regions and prevents the spread or maintenance of the silent state</div>
-                                
+
                             </div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     file:SCHPO/Epe1/Epe1-deep-research-falcon.md
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Epe1 emerges as a **negative regulator (“anti-silencing factor”) of heterochromatin assembly and spreading**, acting at heterochromatin boundaries and within heterochromatin to control domain stability and epigenetic variability.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
-                        
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0033696" target="_blank" class="term-link">
                                     GO:0033696
                                 </a>
                             </span>
                             <span class="term-label">heterochromatin boundary formation</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/25831549" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:25831549
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Epigenetics. Epigenetic inheritance uncoupled from sequence-...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -2230,87 +2352,88 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Correct annotation - Epe1 is essential for heterochromatin boundary formation and maintenance, preventing spreading of silent chromatin.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Multiple studies confirm this core function. Epe1 establishes boundaries through recruiting Bdf2 and SAGA, promoting histone acetylation that antagonizes heterochromatin spreading. ChIP-seq shows enrichment at boundary regions. Loss causes heterochromatin to spread into normally euchromatic regions.
                         </div>
-                        
-                        
-                        
+
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     file:SCHPO/Epe1/Epe1-deep-research.md
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Epe1 is often described as a &#34;boundary element&#34; or &#34;heterochromatin destabilizer&#34;, meaning it localizes to heterochromatic regions and prevents the spread or maintenance of the silent state</div>
-                                
+
                             </div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/25831549" target="_blank" class="term-link">
                                         PMID:25831549
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Nov 20. Epigenetics. Epigenetic inheritance uncoupled from sequence-specific recruitment.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
-                        
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0000792" target="_blank" class="term-link">
                                     GO:0000792
                                 </a>
                             </span>
                             <span class="term-label">heterochromatin</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/16762840" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:16762840
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Swi6/HP1 recruits a JmjC domain protein to facilitate transc...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -2322,76 +2445,77 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Correct cellular component annotation - Epe1 localizes to heterochromatin through its interaction with HP1/Swi6 bound to H3K9me.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> ChIP and microscopy studies confirm Epe1 localizes to heterochromatic regions. The cited paper shows Swi6/HP1 recruits Epe1 to heterochromatin. Epe1 C-terminus binds HP1 directly, and this interaction is enhanced by H3K9 methylation. Localization is essential for its boundary function.
                         </div>
-                        
-                        
-                        
+
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/16762840" target="_blank" class="term-link">
                                         PMID:16762840
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Swi6/HP1 recruits a JmjC domain protein to facilitate transcription of heterochromatic repeats</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
-                        
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005721" target="_blank" class="term-link">
                                     GO:0005721
                                 </a>
                             </span>
                             <span class="term-label">pericentric heterochromatin</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/16762840" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:16762840
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Swi6/HP1 recruits a JmjC domain protein to facilitate transc...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -2403,87 +2527,88 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Epe1 localizes to pericentric heterochromatin where it regulates boundaries and enables repeat transcription for RNAi-mediated silencing.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> ChIP studies demonstrate Epe1 enrichment at centromeric/pericentric regions. It promotes transcription of dg/dh pericentromeric repeats while maintaining boundaries. This localization is mediated by HP1/Swi6 binding to H3K9me-marked nucleosomes.
                         </div>
-                        
-                        
-                        
+
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     file:SCHPO/Epe1/Epe1-deep-research.md
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Chromatin immunoprecipitation studies show that Epe1 is enriched at heterochromatic regions – notably at centromeres, telomeres, and the mating-type locus</div>
-                                
+
                             </div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/16762840" target="_blank" class="term-link">
                                         PMID:16762840
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Swi6/HP1 recruits a JmjC domain protein to facilitate transcription of heterochromatic repeats.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
-                        
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0031934" target="_blank" class="term-link">
                                     GO:0031934
                                 </a>
                             </span>
                             <span class="term-label">mating-type region heterochromatin</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/16762840" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:16762840
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Swi6/HP1 recruits a JmjC domain protein to facilitate transc...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -2495,87 +2620,88 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Epe1 localizes to and regulates the mating-type heterochromatin region, maintaining proper boundaries.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> ChIP-seq confirms Epe1 enrichment at the mating-type locus heterochromatin. Functions to prevent excessive spreading of silent chromatin and maintains boundaries of this specialized heterochromatin domain. Well-characterized localization pattern.
                         </div>
-                        
-                        
-                        
+
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     file:SCHPO/Epe1/Epe1-deep-research.md
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Epe1 is enriched at heterochromatic regions – notably at centromeres, telomeres, and the mating-type locus – often at the boundaries of these domains</div>
-                                
+
                             </div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/16762840" target="_blank" class="term-link">
                                         PMID:16762840
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Swi6/HP1 recruits a JmjC domain protein to facilitate transcription of heterochromatic repeats.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
-                        
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0140720" target="_blank" class="term-link">
                                     GO:0140720
                                 </a>
                             </span>
                             <span class="term-label">subtelomeric heterochromatin</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/16762840" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:16762840
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Swi6/HP1 recruits a JmjC domain protein to facilitate transc...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -2587,89 +2713,90 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Epe1 localizes to subtelomeric heterochromatin regions where it establishes boundaries through Bdf2 recruitment.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> ChIP studies show Epe1 enrichment at telomeric/subtelomeric regions. Particularly important at IRC boundary elements in subtelomeric regions where it recruits Bdf2 to prevent heterochromatin spreading. Well-documented localization.
                         </div>
-                        
-                        
-                        
+
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/24013502" target="_blank" class="term-link">
                                         PMID:24013502
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Bdf2 is enriched at IRCs [subtelomeric boundary regions] through its interaction with the boundary protein Epe1</div>
-                                
+
                             </div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/16762840" target="_blank" class="term-link">
                                         PMID:16762840
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Swi6/HP1 recruits a JmjC domain protein to facilitate transcription of heterochromatic repeats.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
-                        
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:1990342" target="_blank" class="term-link">
                                     GO:1990342
                                 </a>
                             </span>
                             <span class="term-label">heterochromatin island</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/16762840" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:16762840
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Swi6/HP1 recruits a JmjC domain protein to facilitate transc...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -2681,100 +2808,101 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Epe1 prevents formation of ectopic heterochromatin islands in euchromatic regions. Its absence leads to H3K9me islands.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Studies show epe1Δ mutants accumulate aberrant small islands of H3K9me across euchromatic regions. Epe1 normally prevents these ectopic heterochromatin formations. When present at existing islands, it can promote their dissolution through SAGA recruitment and competitive HP1 binding.
                         </div>
-                        
-                        
-                        
+
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     file:SCHPO/Epe1/Epe1-deep-research.md
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">epe1- (null) mutants show elevated H3K9me3 levels in aged cells and accumulate aberrant small &#34;islands&#34; of H3K9me across euchromatic regions</div>
-                                
+
                             </div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/16762840" target="_blank" class="term-link">
                                         PMID:16762840
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Swi6/HP1 recruits a JmjC domain protein to facilitate transcription of heterochromatic repeats.</div>
-                                
+
                             </div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/31206516" target="_blank" class="term-link">
                                         PMID:31206516
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">eCollection 2019 Jun.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
-                        
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:1902801" target="_blank" class="term-link">
                                     GO:1902801
                                 </a>
                             </span>
                             <span class="term-label">regulation of siRNA-independent facultative heterochromatin formation</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IMP</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/22144463" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:22144463
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     RNA elimination machinery targeting meiotic mRNAs promotes f...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -2786,76 +2914,77 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Epe1 regulates facultative heterochromatin formation that can occur independently of the RNAi pathway, preventing excessive silencing.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> The cited study shows Epe1 regulates RNA elimination machinery-dependent facultative heterochromatin. In epe1 mutants, heterochromatin can form and be maintained without RNAi, demonstrating Epe1 normally prevents RNAi-independent silencing. This is consistent with its anti-silencing role.
                         </div>
-                        
-                        
-                        
+
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/22144463" target="_blank" class="term-link">
                                         PMID:22144463
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">RNA elimination machinery targeting meiotic mRNAs promotes facultative heterochromatin formation</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
-                        
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0032454" target="_blank" class="term-link">
                                     GO:0032454
                                 </a>
                             </span>
                             <span class="term-label">histone H3K9 demethylase activity</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">EXP</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/25838386" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:25838386
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Epigenetics. Restricted epigenetic inheritance of H3K9 methy...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-remove">
@@ -2867,87 +2996,88 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Duplicate incorrect annotation. No direct biochemical evidence for H3K9 demethylase activity exists. The paper shows genetic evidence only.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> This is a duplicate of the previous H3K9 demethylase annotation with different evidence code. The EXP code is inappropriate as no biochemical demethylase activity was demonstrated. The paper shows genetic suppression of H3K9me inheritance by Epe1, not enzymatic activity. Epe1 antagonizes H3K9me through non-catalytic mechanisms.
                         </div>
-                        
-                        
-                        
+
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/25838386" target="_blank" class="term-link">
                                         PMID:25838386
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">inactivation of the putative histone demethylase Epe1 allows H3K9 methylation and silent chromatin maintenance at the tethering site [Note: &#34;putative&#34; indicates uncertainty about enzymatic function]</div>
-                                
+
                             </div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     file:SCHPO/Epe1/Epe1-bioinformatics/RESULTS.md
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Duplicate annotation - JmjC domain analysis confirms pseudo-demethylase status with structural features indicating chromatin reader rather than enzyme function</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
-                        
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0033696" target="_blank" class="term-link">
                                     GO:0033696
                                 </a>
                             </span>
                             <span class="term-label">heterochromatin boundary formation</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IMP</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/31206516" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:31206516
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Regulation of ectopic heterochromatin-mediated epigenetic di...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -2959,76 +3089,77 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Another correct annotation for heterochromatin boundary formation, a core Epe1 function demonstrated by multiple studies.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> The Sorida 2019 paper demonstrates Epe1 regulates ectopic heterochromatin and maintains boundaries. Loss of Epe1 allows heterochromatin spreading and formation of new silenced domains. This boundary function is central to Epe1 biology.
                         </div>
-                        
-                        
-                        
+
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/31206516" target="_blank" class="term-link">
                                         PMID:31206516
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Regulation of ectopic heterochromatin-mediated epigenetic diversification by the JmjC family protein Epe1</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
-                        
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0010964" target="_blank" class="term-link">
                                     GO:0010964
                                 </a>
                             </span>
                             <span class="term-label">regulation of regulatory ncRNA-mediated heterochromatin formation</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IMP</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/36617881" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:36617881
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Tandemly repeated genes promote RNAi-mediated heterochromati...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -3040,76 +3171,77 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Epe1 enables transcription of tandem repeats that generate RNAi substrates for heterochromatin formation, paradoxically promoting RNAi-mediated silencing.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Recent study shows Epe1 is required for efficient transcription of tandemly repeated genes that trigger RNAi-dependent heterochromatin. By locally destabilizing heterochromatin to allow transcription, Epe1 enables production of RNAi substrates that reinforce silencing. This represents a regulatory feedback mechanism.
                         </div>
-                        
-                        
-                        
+
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/36617881" target="_blank" class="term-link">
                                         PMID:36617881
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Tandemly repeated genes promote RNAi-mediated heterochromatin formation via an antisilencing factor, Epe1, in fission yeast</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
-                        
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005634" target="_blank" class="term-link">
                                     GO:0005634
                                 </a>
                             </span>
                             <span class="term-label">nucleus</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/12773576" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:12773576
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     A novel jmjC domain protein modulates heterochromatization i...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -3121,76 +3253,77 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Direct experimental evidence for nuclear localization through microscopy. This supersedes the IEA annotation.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> The Ayoub 2003 paper provides direct immunofluorescence microscopy evidence for nuclear localization. This IDA evidence is stronger than the IEA computational prediction and confirms Epe1 functions in the nucleus at heterochromatin sites.
                         </div>
-                        
-                        
-                        
+
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/12773576" target="_blank" class="term-link">
                                         PMID:12773576
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">A novel jmjC domain protein modulates heterochromatization in fission yeast.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
-                        
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0033696" target="_blank" class="term-link">
                                     GO:0033696
                                 </a>
                             </span>
                             <span class="term-label">heterochromatin boundary formation</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IMP</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/12773576" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:12773576
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     A novel jmjC domain protein modulates heterochromatization i...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -3202,76 +3335,77 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> The original paper identifying Epe1 as a heterochromatin boundary factor. Foundational evidence for this core function.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> This seminal paper first characterized Epe1 as modulating heterochromatization and preventing silencing spread. Demonstrated that Epe1 mutation affects position effect variegation and heterochromatin boundaries. This established the boundary function that has been confirmed by numerous subsequent studies.
                         </div>
-                        
-                        
-                        
+
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/12773576" target="_blank" class="term-link">
                                         PMID:12773576
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">A novel jmjC domain protein modulates heterochromatization in fission yeast.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
-                        
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0033696" target="_blank" class="term-link">
                                     GO:0033696
                                 </a>
                             </span>
                             <span class="term-label">heterochromatin boundary formation</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IMP</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/17948055" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:17948055
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     The JmjC domain protein Epe1 prevents unregulated assembly a...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -3283,76 +3417,77 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Further evidence that Epe1 prevents unregulated heterochromatin assembly and maintains boundaries.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> The paper demonstrates Epe1 prevents both unregulated assembly and disassembly of heterochromatin, maintaining proper boundaries. Shows Epe1 is required for heterochromatin homeostasis and boundary integrity. Core function with strong experimental support.
                         </div>
-                        
-                        
-                        
+
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/17948055" target="_blank" class="term-link">
                                         PMID:17948055
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Oct 18. The JmjC domain protein Epe1 prevents unregulated assembly and disassembly of heterochromatin.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
-                        
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:1990342" target="_blank" class="term-link">
                                     GO:1990342
                                 </a>
                             </span>
                             <span class="term-label">heterochromatin island</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/22144463" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:22144463
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     RNA elimination machinery targeting meiotic mRNAs promotes f...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -3364,76 +3499,77 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Epe1 localizes to and regulates heterochromatin islands, preventing their inappropriate formation in euchromatin.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Study shows Epe1 is present at heterochromatin islands and regulates their formation. In its absence, ectopic heterochromatin islands form inappropriately. This cellular component annotation accurately reflects Epe1 localization and function at these specialized chromatin structures.
                         </div>
-                        
-                        
-                        
+
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/22144463" target="_blank" class="term-link">
                                         PMID:22144463
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Dec 1. RNA elimination machinery targeting meiotic mRNAs promotes facultative heterochromatin formation.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
-                        
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0000792" target="_blank" class="term-link">
                                     GO:0000792
                                 </a>
                             </span>
                             <span class="term-label">heterochromatin</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/29214404" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:29214404
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     The 19S proteasome regulates subtelomere silencing and facul...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -3445,76 +3581,77 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Confirmed heterochromatin localization in context of proteasome regulation of facultative heterochromatin.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Paper shows Epe1 at heterochromatin sites in context of 19S proteasome studies. Consistent with all other localization data showing HP1-dependent recruitment to H3K9me-marked heterochromatin. Well-established cellular component.
                         </div>
-                        
-                        
-                        
+
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/29214404" target="_blank" class="term-link">
                                         PMID:29214404
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Dec 6. The 19S proteasome regulates subtelomere silencing and facultative heterochromatin formation in fission yeast.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
-                        
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0000792" target="_blank" class="term-link">
                                     GO:0000792
                                 </a>
                             </span>
                             <span class="term-label">heterochromatin</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/17948055" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:17948055
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     The JmjC domain protein Epe1 prevents unregulated assembly a...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -3526,76 +3663,77 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Another confirmation of heterochromatin localization, demonstrating Epe1 presence at silent chromatin domains.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Multiple independent studies confirm Epe1 heterochromatin localization through ChIP and microscopy. This is mediated by direct binding to HP1/Swi6. Consistent and well-validated cellular component annotation.
                         </div>
-                        
-                        
-                        
+
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/17948055" target="_blank" class="term-link">
                                         PMID:17948055
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Oct 18. The JmjC domain protein Epe1 prevents unregulated assembly and disassembly of heterochromatin.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
-                        
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0033696" target="_blank" class="term-link">
                                     GO:0033696
                                 </a>
                             </span>
                             <span class="term-label">heterochromatin boundary formation</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IGI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/25774602" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:25774602
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Rapid epigenetic adaptation to uncontrolled heterochromatin ...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -3607,76 +3745,77 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Genetic interaction studies confirm Epe1 role in boundary formation during epigenetic adaptation to heterochromatin spreading.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Paper on rapid epigenetic adaptation shows genetic interactions demonstrating Epe1 requirement for proper heterochromatin boundaries. When heterochromatin spreading is uncontrolled, Epe1 is essential for re-establishing boundaries. Core function with genetic evidence.
                         </div>
-                        
-                        
-                        
+
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/25774602" target="_blank" class="term-link">
                                         PMID:25774602
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Rapid epigenetic adaptation to uncontrolled heterochromatin spreading.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
-                        
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0033696" target="_blank" class="term-link">
                                     GO:0033696
                                 </a>
                             </span>
                             <span class="term-label">heterochromatin boundary formation</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IMP</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/24013502" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:24013502
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Epe1 recruits BET family bromodomain protein Bdf2 to establi...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -3688,76 +3827,77 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Key paper showing Epe1 recruits Bdf2 bromodomain protein to establish heterochromatin boundaries at IRCs.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Wang 2013 demonstrates Epe1 recruits BET family protein Bdf2 to heterochromatin boundaries, particularly at inverted repeat centromeric (IRC) boundaries. Bdf2 recognizes acetylated H4 and antagonizes Sir2-mediated deacetylation, preventing heterochromatin spreading. Essential boundary mechanism.
                         </div>
-                        
-                        
-                        
+
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/24013502" target="_blank" class="term-link">
                                         PMID:24013502
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Epe1 recruits BET family bromodomain protein Bdf2 to establish heterochromatin boundaries.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
-                        
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0000792" target="_blank" class="term-link">
                                     GO:0000792
                                 </a>
                             </span>
                             <span class="term-label">heterochromatin</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/17449867" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:17449867
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Interaction of Epe1 with the heterochromatin assembly pathwa...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -3769,58 +3909,59 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Study of Epe1 interaction with heterochromatin assembly pathway confirms its heterochromatin localization.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Paper examining Epe1 interaction with heterochromatin assembly machinery confirms localization to heterochromatic regions. Shows physical and functional interactions with heterochromatin components. Consistent with HP1-mediated recruitment model.
                         </div>
-                        
-                        
-                        
+
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/17449867" target="_blank" class="term-link">
                                         PMID:17449867
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Interaction of Epe1 with the heterochromatin assembly pathway in Schizosaccharomyces pombe.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
-                        
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0031452" target="_blank" class="term-link">
                                     GO:0031452
                                 </a>
                             </span>
                             <span class="term-label">negative regulation of heterochromatin formation</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                     </td>
                     <td>
                         <span class="action-badge action-new">
@@ -3832,80 +3973,81 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> negative regulation of heterochromatin formation identified from core_functions analysis
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> This biological process term captures Epe1&#39;s primary function as an anti-silencing factor that establishes heterochromatin boundaries and prevents excessive heterochromatin spreading.
                         </div>
-                        
-                        
-                        
+
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/24013502" target="_blank" class="term-link">
                                         PMID:24013502
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Epe1 recruits BET family bromodomain protein Bdf2 to establish heterochromatin boundaries.</div>
-                                
+
                             </div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     file:SCHPO/Epe1/Epe1-deep-research.md
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Epe1 C-terminus alone can disrupt heterochromatin assembly by outcompeting HDAC Clr3 at Swi6 binding sites, demonstrating negative regulation of heterochromatin formation</div>
-                                
+
                             </div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     file:SCHPO/Epe1/Epe1-deep-research-falcon.md
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">loss of Epe1 can increase heterochromatin spreading beyond boundaries and alter the distribution of H3K9 methylation, while overexpression can disrupt heterochromatin</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
-                        
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006473" target="_blank" class="term-link">
                                     GO:0006473
                                 </a>
                             </span>
                             <span class="term-label">protein acetylation</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                     </td>
                     <td>
                         <span class="action-badge action-new">
@@ -3917,67 +4059,68 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Epe1 indirectly promotes protein acetylation by recruiting HATs
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Epe1 recruits the SAGA histone acetyltransferase complex to heterochromatin sites, thereby promoting H3 acetylation. While Epe1 itself doesn&#39;t perform acetylation, it is directly involved in enabling this process through HAT recruitment.
                         </div>
-                        
-                        
-                        
+
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     file:SCHPO/Epe1/Epe1-deep-research.md
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Mass spectrometry identified SAGA subunits co-purifying with Epe1, and overexpressed Epe1 can recruit SAGA to heterochromatic repeats, resulting in increased histone H3 acetylation</div>
-                                
+
                             </div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     file:SCHPO/Epe1/Epe1-deep-research.md
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Bao et al. (2019) revealed that Epe1 can associate with the SAGA co-activator complex and promote histone acetylation through this recruitment mechanism</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
-                        
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0140030" target="_blank" class="term-link">
                                     GO:0140030
                                 </a>
                             </span>
                             <span class="term-label">modification-dependent protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">NAS</span>
-                        
-                        
-                        
+
+
+
                     </td>
                     <td>
                         <span class="action-badge action-new">
@@ -3989,33 +4132,34 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Added to align core_functions with existing annotations.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Core function term not present in existing_annotations.
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
+
                     </td>
                 </tr>
-                
+
             </tbody>
         </table>
     </div>
-    
 
-    
+
+
     <div class="section">
         <h2 class="section-title">Core Functions</h2>
-        
+
         <div class="core-function-card">
-            
+
             <div style="display: flex; justify-content: space-between; align-items: center;">
                 <h3>Binds HP1/Swi6 at H3K9-methylated heterochromatin through C-terminal domain to antagonize silencing</h3>
                 <span class="vote-buttons" data-g="O94603" data-a="FUNCTION: Binds HP1/Swi6 at H3K9-methylated heterochromatin ..." data-r="" data-act="CORE_FUNCTION">
@@ -4023,10 +4167,10 @@
                     <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
                 </span>
             </div>
-            
+
 
             <div class="core-function-terms">
-                
+
                 <div class="function-term-group">
                     <div class="function-term-label">Molecular Function:</div>
                     <span class="badge">
@@ -4035,95 +4179,95 @@
                         </a>
                     </span>
                 </div>
-                
 
-                
+
+
                 <div class="function-term-group">
                     <div class="function-term-label">Directly Involved In:</div>
                     <div class="function-annotations">
-                        
+
                         <span class="badge">
                             <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0033696" target="_blank" class="term-link">
                                 heterochromatin boundary formation
                             </a>
                         </span>
-                        
+
                     </div>
                 </div>
-                
 
-                
+
+
                 <div class="function-term-group">
                     <div class="function-term-label">Cellular Locations:</div>
                     <div class="function-annotations">
-                        
+
                         <span class="badge">
                             <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0000792" target="_blank" class="term-link">
                                 heterochromatin
                             </a>
                         </span>
-                        
+
                         <span class="badge">
                             <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005721" target="_blank" class="term-link">
                                 pericentric heterochromatin
                             </a>
                         </span>
-                        
+
                         <span class="badge">
                             <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0031934" target="_blank" class="term-link">
                                 mating-type region heterochromatin
                             </a>
                         </span>
-                        
+
                         <span class="badge">
                             <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0140720" target="_blank" class="term-link">
                                 subtelomeric heterochromatin
                             </a>
                         </span>
-                        
+
                     </div>
                 </div>
-                
 
-                
 
-                
+
+
+
             </div>
 
-            
+
             <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
                 <strong>Supporting Evidence:</strong>
                 <ul class="findings-list">
-                    
+
                     <li class="finding-item">
                         <span class="reference-id">
-                            
+
                             file:SCHPO/Epe1/Epe1-deep-research.md
-                            
+
                         </span>
-                        
+
                         <div class="finding-text">Epe1 C-terminus binds HP1/Swi6 in a manner stimulated by H3K9 methylation</div>
-                        
+
                     </li>
-                    
+
                     <li class="finding-item">
                         <span class="reference-id">
-                            
+
                             file:SCHPO/Epe1/Epe1-bioinformatics/RESULTS.md
-                            
+
                         </span>
-                        
+
                         <div class="finding-text">Extensive coiled-coil regions detected indicating protein-protein interaction capability for HP1/Swi6 binding and complex formation</div>
-                        
+
                     </li>
-                    
+
                 </ul>
             </div>
-            
+
         </div>
-        
+
         <div class="core-function-card">
-            
+
             <div style="display: flex; justify-content: space-between; align-items: center;">
                 <h3>Recruits SAGA histone acetyltransferase complex to heterochromatin for H3 acetylation</h3>
                 <span class="vote-buttons" data-g="O94603" data-a="FUNCTION: Recruits SAGA histone acetyltransferase complex to..." data-r="" data-act="CORE_FUNCTION">
@@ -4131,10 +4275,10 @@
                     <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
                 </span>
             </div>
-            
+
 
             <div class="core-function-terms">
-                
+
                 <div class="function-term-group">
                     <div class="function-term-label">Molecular Function:</div>
                     <span class="badge">
@@ -4143,83 +4287,83 @@
                         </a>
                     </span>
                 </div>
-                
 
-                
+
+
                 <div class="function-term-group">
                     <div class="function-term-label">Directly Involved In:</div>
                     <div class="function-annotations">
-                        
+
                         <span class="badge">
                             <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006473" target="_blank" class="term-link">
                                 protein acetylation
                             </a>
                         </span>
-                        
+
                         <span class="badge">
                             <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006357" target="_blank" class="term-link">
                                 regulation of transcription by RNA polymerase II
                             </a>
                         </span>
-                        
+
                     </div>
                 </div>
-                
 
-                
+
+
                 <div class="function-term-group">
                     <div class="function-term-label">Cellular Locations:</div>
                     <div class="function-annotations">
-                        
+
                         <span class="badge">
                             <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0000792" target="_blank" class="term-link">
                                 heterochromatin
                             </a>
                         </span>
-                        
+
                     </div>
                 </div>
-                
 
-                
 
-                
+
+
+
             </div>
 
-            
+
             <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
                 <strong>Supporting Evidence:</strong>
                 <ul class="findings-list">
-                    
+
                     <li class="finding-item">
                         <span class="reference-id">
-                            
+
                             file:SCHPO/Epe1/Epe1-deep-research.md
-                            
+
                         </span>
-                        
+
                         <div class="finding-text">Mass spectrometry identified SAGA subunits co-purifying with Epe1</div>
-                        
+
                     </li>
-                    
+
                     <li class="finding-item">
                         <span class="reference-id">
-                            
+
                             file:SCHPO/Epe1/Epe1-deep-research.md
-                            
+
                         </span>
-                        
+
                         <div class="finding-text">Overexpressed Epe1 can recruit SAGA to heterochromatic repeats, resulting in increased histone H3 acetylation</div>
-                        
+
                     </li>
-                    
+
                 </ul>
             </div>
-            
+
         </div>
-        
+
         <div class="core-function-card">
-            
+
             <div style="display: flex; justify-content: space-between; align-items: center;">
                 <h3>Recruits Bdf2 bromodomain protein to heterochromatin boundaries to recognize acetylated histones</h3>
                 <span class="vote-buttons" data-g="O94603" data-a="FUNCTION: Recruits Bdf2 bromodomain protein to heterochromat..." data-r="" data-act="CORE_FUNCTION">
@@ -4227,10 +4371,10 @@
                     <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
                 </span>
             </div>
-            
+
 
             <div class="core-function-terms">
-                
+
                 <div class="function-term-group">
                     <div class="function-term-label">Molecular Function:</div>
                     <span class="badge">
@@ -4239,74 +4383,74 @@
                         </a>
                     </span>
                 </div>
-                
 
-                
+
+
                 <div class="function-term-group">
                     <div class="function-term-label">Directly Involved In:</div>
                     <div class="function-annotations">
-                        
+
                         <span class="badge">
                             <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0033696" target="_blank" class="term-link">
                                 heterochromatin boundary formation
                             </a>
                         </span>
-                        
+
                         <span class="badge">
                             <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0031452" target="_blank" class="term-link">
                                 negative regulation of heterochromatin formation
                             </a>
                         </span>
-                        
+
                     </div>
                 </div>
-                
 
-                
+
+
                 <div class="function-term-group">
                     <div class="function-term-label">Cellular Locations:</div>
                     <div class="function-annotations">
-                        
+
                         <span class="badge">
                             <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0140720" target="_blank" class="term-link">
                                 subtelomeric heterochromatin
                             </a>
                         </span>
-                        
+
                     </div>
                 </div>
-                
 
-                
 
-                
+
+
+
             </div>
 
-            
+
             <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
                 <strong>Supporting Evidence:</strong>
                 <ul class="findings-list">
-                    
+
                     <li class="finding-item">
                         <span class="reference-id">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/24013502" target="_blank" class="term-link">
                                 PMID:24013502
                             </a>
-                            
+
                         </span>
-                        
+
                         <div class="finding-text">Epe1 recruits BET family bromodomain protein Bdf2 to establish heterochromatin boundaries</div>
-                        
+
                     </li>
-                    
+
                 </ul>
             </div>
-            
+
         </div>
-        
+
         <div class="core-function-card">
-            
+
             <div style="display: flex; justify-content: space-between; align-items: center;">
                 <h3>Promotes nucleosome turnover at heterochromatin to destabilize silencing marks</h3>
                 <span class="vote-buttons" data-g="O94603" data-a="FUNCTION: Promotes nucleosome turnover at heterochromatin to..." data-r="" data-act="CORE_FUNCTION">
@@ -4314,10 +4458,10 @@
                     <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
                 </span>
             </div>
-            
+
 
             <div class="core-function-terms">
-                
+
                 <div class="function-term-group">
                     <div class="function-term-label">Molecular Function:</div>
                     <span class="badge">
@@ -4326,66 +4470,66 @@
                         </a>
                     </span>
                 </div>
-                
 
-                
+
+
                 <div class="function-term-group">
                     <div class="function-term-label">Directly Involved In:</div>
                     <div class="function-annotations">
-                        
+
                         <span class="badge">
                             <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006325" target="_blank" class="term-link">
                                 chromatin organization
                             </a>
                         </span>
-                        
+
                     </div>
                 </div>
-                
 
-                
+
+
                 <div class="function-term-group">
                     <div class="function-term-label">Cellular Locations:</div>
                     <div class="function-annotations">
-                        
+
                         <span class="badge">
                             <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0000792" target="_blank" class="term-link">
                                 heterochromatin
                             </a>
                         </span>
-                        
+
                     </div>
                 </div>
-                
 
-                
 
-                
+
+
+
             </div>
 
-            
+
             <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
                 <strong>Supporting Evidence:</strong>
                 <ul class="findings-list">
-                    
+
                     <li class="finding-item">
                         <span class="reference-id">
-                            
+
                             file:SCHPO/Epe1/Epe1-deep-research.md
-                            
+
                         </span>
-                        
+
                         <div class="finding-text">Epe1 increases nucleosome turnover rates in heterochromatic regions</div>
-                        
+
                     </li>
-                    
+
                 </ul>
             </div>
-            
+
         </div>
-        
+
         <div class="core-function-card">
-            
+
             <div style="display: flex; justify-content: space-between; align-items: center;">
                 <h3>Enables transcription of heterochromatic repeats for RNAi-mediated heterochromatin establishment</h3>
                 <span class="vote-buttons" data-g="O94603" data-a="FUNCTION: Enables transcription of heterochromatic repeats f..." data-r="" data-act="CORE_FUNCTION">
@@ -4393,10 +4537,10 @@
                     <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
                 </span>
             </div>
-            
+
 
             <div class="core-function-terms">
-                
+
                 <div class="function-term-group">
                     <div class="function-term-label">Molecular Function:</div>
                     <span class="badge">
@@ -4405,68 +4549,68 @@
                         </a>
                     </span>
                 </div>
-                
 
-                
+
+
                 <div class="function-term-group">
                     <div class="function-term-label">Directly Involved In:</div>
                     <div class="function-annotations">
-                        
+
                         <span class="badge">
                             <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0010964" target="_blank" class="term-link">
                                 regulation of regulatory ncRNA-mediated heterochromatin formation
                             </a>
                         </span>
-                        
+
                     </div>
                 </div>
-                
 
-                
+
+
                 <div class="function-term-group">
                     <div class="function-term-label">Cellular Locations:</div>
                     <div class="function-annotations">
-                        
+
                         <span class="badge">
                             <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005721" target="_blank" class="term-link">
                                 pericentric heterochromatin
                             </a>
                         </span>
-                        
+
                     </div>
                 </div>
-                
 
-                
 
-                
+
+
+
             </div>
 
-            
+
             <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
                 <strong>Supporting Evidence:</strong>
                 <ul class="findings-list">
-                    
+
                     <li class="finding-item">
                         <span class="reference-id">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/36617881" target="_blank" class="term-link">
                                 PMID:36617881
                             </a>
-                            
+
                         </span>
-                        
+
                         <div class="finding-text">Tandemly repeated genes promote RNAi-mediated heterochromatin formation via an antisilencing factor, Epe1</div>
-                        
+
                     </li>
-                    
+
                 </ul>
             </div>
-            
+
         </div>
-        
+
         <div class="core-function-card">
-            
+
             <div style="display: flex; justify-content: space-between; align-items: center;">
                 <h3>Competes with histone deacetylase Clr3 for HP1/Swi6 binding sites to prevent silencing maintenance</h3>
                 <span class="vote-buttons" data-g="O94603" data-a="FUNCTION: Competes with histone deacetylase Clr3 for HP1/Swi..." data-r="" data-act="CORE_FUNCTION">
@@ -4474,10 +4618,10 @@
                     <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
                 </span>
             </div>
-            
+
 
             <div class="core-function-terms">
-                
+
                 <div class="function-term-group">
                     <div class="function-term-label">Molecular Function:</div>
                     <span class="badge">
@@ -4486,465 +4630,465 @@
                         </a>
                     </span>
                 </div>
-                
 
-                
+
+
                 <div class="function-term-group">
                     <div class="function-term-label">Directly Involved In:</div>
                     <div class="function-annotations">
-                        
+
                         <span class="badge">
                             <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0031452" target="_blank" class="term-link">
                                 negative regulation of heterochromatin formation
                             </a>
                         </span>
-                        
+
                     </div>
                 </div>
-                
 
-                
+
+
                 <div class="function-term-group">
                     <div class="function-term-label">Cellular Locations:</div>
                     <div class="function-annotations">
-                        
+
                         <span class="badge">
                             <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0000792" target="_blank" class="term-link">
                                 heterochromatin
                             </a>
                         </span>
-                        
+
                     </div>
                 </div>
-                
 
-                
 
-                
+
+
+
             </div>
 
-            
+
             <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
                 <strong>Supporting Evidence:</strong>
                 <ul class="findings-list">
-                    
+
                     <li class="finding-item">
                         <span class="reference-id">
-                            
+
                             file:SCHPO/Epe1/Epe1-deep-research.md
-                            
+
                         </span>
-                        
+
                         <div class="finding-text">Epe1 C-terminus alone can disrupt heterochromatin assembly by outcompeting HDAC Clr3 at Swi6 binding sites</div>
-                        
+
                     </li>
-                    
+
                 </ul>
             </div>
-            
-        </div>
-        
-    </div>
-    
 
-    
+        </div>
+
+    </div>
+
+
+
     <div class="section">
         <h2 class="section-title collapsible">References</h2>
         <div class="collapse-content">
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000033.md" target="_blank" class="term-link">
                             GO_REF:0000033
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Annotation inferences using phylogenetic trees</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000043.md" target="_blank" class="term-link">
                             GO_REF:0000043
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Gene Ontology annotation based on UniProtKB/Swiss-Prot keyword mapping</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000120.md" target="_blank" class="term-link">
                             GO_REF:0000120
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Combined Automated Annotation using Multiple IEA Methods.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/12773576" target="_blank" class="term-link">
                             PMID:12773576
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">A novel jmjC domain protein modulates heterochromatization in fission yeast.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/16762840" target="_blank" class="term-link">
                             PMID:16762840
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Swi6/HP1 recruits a JmjC domain protein to facilitate transcription of heterochromatic repeats.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/17449867" target="_blank" class="term-link">
                             PMID:17449867
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Interaction of Epe1 with the heterochromatin assembly pathway in Schizosaccharomyces pombe.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/17948055" target="_blank" class="term-link">
                             PMID:17948055
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">The JmjC domain protein Epe1 prevents unregulated assembly and disassembly of heterochromatin.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/21215368" target="_blank" class="term-link">
                             PMID:21215368
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">The Cul4-Ddb1(Cdt)² ubiquitin ligase inhibits invasion of a boundary-associated antisilencing factor into heterochromatin.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/22144463" target="_blank" class="term-link">
                             PMID:22144463
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">RNA elimination machinery targeting meiotic mRNAs promotes facultative heterochromatin formation.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/24013502" target="_blank" class="term-link">
                             PMID:24013502
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Epe1 recruits BET family bromodomain protein Bdf2 to establish heterochromatin boundaries.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/25774602" target="_blank" class="term-link">
                             PMID:25774602
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Rapid epigenetic adaptation to uncontrolled heterochromatin spreading.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/25831549" target="_blank" class="term-link">
                             PMID:25831549
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Epigenetics. Epigenetic inheritance uncoupled from sequence-specific recruitment.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/25838386" target="_blank" class="term-link">
                             PMID:25838386
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Epigenetics. Restricted epigenetic inheritance of H3K9 methylation.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/29214404" target="_blank" class="term-link">
                             PMID:29214404
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">The 19S proteasome regulates subtelomere silencing and facultative heterochromatin formation in fission yeast.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/31206516" target="_blank" class="term-link">
                             PMID:31206516
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Regulation of ectopic heterochromatin-mediated epigenetic diversification by the JmjC family protein Epe1.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/36617881" target="_blank" class="term-link">
                             PMID:36617881
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Tandemly repeated genes promote RNAi-mediated heterochromatin formation via an antisilencing factor, Epe1, in fission yeast.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/39094565" target="_blank" class="term-link">
                             PMID:39094565
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Mapping the dynamics of epigenetic adaptation in S. pombe during heterochromatin misregulation.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         file:SCHPO/Epe1/Epe1-bioinformatics/RESULTS.md
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Bioinformatics Analysis of S. pombe Epe1 Protein</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         file:SCHPO/Epe1/Epe1-deep-research-falcon.md
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Falcon deep research report on S. pombe Epe1/Jhd1 (UniProt O94603)</div>
-                
-                
+
+
                 <ul class="findings-list">
-                    
+
                     <li class="finding-item">
                         <div class="finding-statement">Epe1 is a nuclear, Swi6/HP1-recruited JmjC-family protein that acts as a
 negative regulator (anti-silencing factor) of heterochromatin assembly and
 spreading, controlling heterochromatin domain stability and epigenetic
 variability.
 </div>
-                        
+
                         <div class="finding-text">"Epe1 emerges as a **negative regulator (“anti-silencing factor”) of heterochromatin assembly and spreading**, acting at heterochromatin boundaries and within heterochromatin to control domain stability and epigenetic variability."</div>
-                        
+
                     </li>
-                    
+
                     <li class="finding-item">
                         <div class="finding-statement">Despite being annotated as a putative JmjC histone demethylase, direct in
 vitro H3K9 demethylase activity is repeatedly undetectable, and influential
 studies propose Epe1&#39;s dominant in vivo functions are non-enzymatic,
 mediated by Swi6/HP1 interaction.
 </div>
-                        
+
                         <div class="finding-text">"While Epe1 is annotated as a putative 2-oxoglutarate/Fe(II) dioxygenase/histone demethylase, **direct in vitro H3K9 demethylase activity is repeatedly difficult to detect**, and several influential studies propose that Epe1’s dominant in vivo functions are **non-enzymatic**, mediated by protein–protein interactions (especially with Swi6/HP1) that antagonize histone deacetylase activity."</div>
-                        
+
                     </li>
-                    
+
                     <li class="finding-item">
                         <div class="finding-statement">Epe1&#39;s JmjC-like motif is non-canonical, lacking conserved Fe(II)-binding
 residues, with a histidine-to-tyrosine substitution (Y370) at a position
 normally associated with iron coordination in canonical JmjC demethylases.
 </div>
-                        
+
                         <div class="finding-text">"Raiymbek et al. (and related mechanistic work) highlight that Epe1 has a **non-canonical HXE…Y motif** and a **histidine-to-tyrosine substitution (Y370)** at a position typically associated with iron coordination in canonical JmjC demethylases."</div>
-                        
+
                     </li>
-                    
+
                     <li class="finding-item">
                         <div class="finding-statement">Sorida et al. define a separation-of-function: the N-terminal
 transcriptional activation (NTA) domain prevents de novo ectopic H3K9
 methylation, whereas the JmjC module contributes to removal of established
 ectopic heterochromatin in vivo.
 </div>
-                        
+
                         <div class="finding-text">"an N-terminal transcriptional activation domain (NTA) can prevent de novo ectopic H3K9 methylation, whereas the JmjC module contributes to removal of established ectopic heterochromatin in vivo"</div>
-                        
+
                     </li>
-                    
+
                     <li class="finding-item">
                         <div class="finding-statement">Epe1&#39;s C-terminus directly binds Swi6 in an H3K9me-stimulated manner and
 can disrupt heterochromatin by outcompeting/displacing the histone
 deacetylase Clr3, framing Epe1 as a regulator of heterochromatin complex
 assembly rather than only an eraser enzyme.
 </div>
-                        
+
                         <div class="finding-text">"Expressing Epe1’s C-terminus can disrupt heterochromatin by **outcompeting/displacing the histone deacetylase Clr3** from heterochromatin."</div>
-                        
+
                     </li>
-                    
+
                     <li class="finding-item">
                         <div class="finding-statement">This S. pombe Epe1/Jhd1 is distinct from the better-known budding-yeast
 Jhd1 that demethylates H3K36, confirming the target identity (O94603;
 SPCC622.16c).
 </div>
-                        
+
                         <div class="finding-text">"This matches the UniProt-provided identity (O94603; SPCC622.16c) and is distinct from the better-known budding-yeast “Jhd1” that demethylates H3K36."</div>
-                        
+
                     </li>
-                    
+
                     <li class="finding-item">
                         <div class="finding-statement">Epe1 abundance and localization are tuned by nutrient (cAMP-PKA
 translational control) and stress (proteasome-dependent N-terminal
 truncation to tEpe1) signaling, coupling environmental inputs to
 heterochromatin state and adaptive epigenetic drug resistance.
 </div>
-                        
+
                         <div class="finding-text">"Stressors (caffeine, azoles) induce **ubiquitylation and proteasome-dependent removal of the N-terminal ~150 residues**, producing **tEpe1**."</div>
-                        
+
                     </li>
-                    
+
                 </ul>
-                
+
             </div>
-            
+
         </div>
     </div>
-    
 
 
-    
+
+
     <div class="section">
         <h2 class="section-title">Suggested Questions for Experts</h2>
-        
+
         <div class="question-card">
             <div style="display: flex; justify-content: space-between; align-items: start;">
                 <div style="flex: 1;">
                     <p><strong>Q:</strong> How does Epe1 regulate heterochromatin formation and maintenance at centromeres and telomeres?</p>
-                    
+
                 </div>
                 <span class="vote-buttons" data-g="O94603" data-a="Q: How does Epe1 regulate heterochromatin formation a..." data-r="" data-act="QUESTION">
                     <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
@@ -4952,12 +5096,12 @@ heterochromatin state and adaptive epigenetic drug resistance.
                 </span>
             </div>
         </div>
-        
+
         <div class="question-card">
             <div style="display: flex; justify-content: space-between; align-items: start;">
                 <div style="flex: 1;">
                     <p><strong>Q:</strong> What determines the specificity of Epe1 for different chromatin modifications and histone variants?</p>
-                    
+
                 </div>
                 <span class="vote-buttons" data-g="O94603" data-a="Q: What determines the specificity of Epe1 for differ..." data-r="" data-act="QUESTION">
                     <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
@@ -4965,12 +5109,12 @@ heterochromatin state and adaptive epigenetic drug resistance.
                 </span>
             </div>
         </div>
-        
+
         <div class="question-card">
             <div style="display: flex; justify-content: space-between; align-items: start;">
                 <div style="flex: 1;">
                     <p><strong>Q:</strong> How does Epe1 coordinate with other chromatin remodeling factors during cell cycle progression?</p>
-                    
+
                 </div>
                 <span class="vote-buttons" data-g="O94603" data-a="Q: How does Epe1 coordinate with other chromatin remo..." data-r="" data-act="QUESTION">
                     <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
@@ -4978,12 +5122,12 @@ heterochromatin state and adaptive epigenetic drug resistance.
                 </span>
             </div>
         </div>
-        
+
         <div class="question-card">
             <div style="display: flex; justify-content: space-between; align-items: start;">
                 <div style="flex: 1;">
                     <p><strong>Q:</strong> What role does Epe1 play in epigenetic inheritance and chromatin stability across generations?</p>
-                    
+
                 </div>
                 <span class="vote-buttons" data-g="O94603" data-a="Q: What role does Epe1 play in epigenetic inheritance..." data-r="" data-act="QUESTION">
                     <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
@@ -4991,22 +5135,22 @@ heterochromatin state and adaptive epigenetic drug resistance.
                 </span>
             </div>
         </div>
-        
-    </div>
-    
 
-    
+    </div>
+
+
+
     <div class="section">
         <h2 class="section-title">Suggested Experiments</h2>
-        
+
         <div class="experiment-card">
             <div style="display: flex; justify-content: space-between; align-items: start;">
                 <div style="flex: 1;">
-                    
+
                     <p><strong>Experiment:</strong> ChIP-seq analysis to map Epe1 binding sites across the genome and correlate with chromatin modifications</p>
-                    
-                    
-                    
+
+
+
                 </div>
                 <span class="vote-buttons" data-g="O94603" data-a="EXPERIMENT: ChIP-seq analysis to map Epe1 binding sites across..." data-r="" data-act="EXPERIMENT">
                     <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
@@ -5014,15 +5158,15 @@ heterochromatin state and adaptive epigenetic drug resistance.
                 </span>
             </div>
         </div>
-        
+
         <div class="experiment-card">
             <div style="display: flex; justify-content: space-between; align-items: start;">
                 <div style="flex: 1;">
-                    
+
                     <p><strong>Experiment:</strong> Live-cell imaging of fluorescently tagged Epe1 to study its dynamics during the cell cycle</p>
-                    
-                    
-                    
+
+
+
                 </div>
                 <span class="vote-buttons" data-g="O94603" data-a="EXPERIMENT: Live-cell imaging of fluorescently tagged Epe1 to ..." data-r="" data-act="EXPERIMENT">
                     <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
@@ -5030,15 +5174,15 @@ heterochromatin state and adaptive epigenetic drug resistance.
                 </span>
             </div>
         </div>
-        
+
         <div class="experiment-card">
             <div style="display: flex; justify-content: space-between; align-items: start;">
                 <div style="flex: 1;">
-                    
+
                     <p><strong>Experiment:</strong> Genetic screens to identify Epe1 interacting factors and chromatin regulators</p>
-                    
-                    
-                    
+
+
+
                 </div>
                 <span class="vote-buttons" data-g="O94603" data-a="EXPERIMENT: Genetic screens to identify Epe1 interacting facto..." data-r="" data-act="EXPERIMENT">
                     <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
@@ -5046,15 +5190,15 @@ heterochromatin state and adaptive epigenetic drug resistance.
                 </span>
             </div>
         </div>
-        
+
         <div class="experiment-card">
             <div style="display: flex; justify-content: space-between; align-items: start;">
                 <div style="flex: 1;">
-                    
+
                     <p><strong>Experiment:</strong> Single-cell analysis of heterochromatin inheritance in Epe1 mutant cells</p>
-                    
-                    
-                    
+
+
+
                 </div>
                 <span class="vote-buttons" data-g="O94603" data-a="EXPERIMENT: Single-cell analysis of heterochromatin inheritanc..." data-r="" data-act="EXPERIMENT">
                     <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
@@ -5062,22 +5206,22 @@ heterochromatin state and adaptive epigenetic drug resistance.
                 </span>
             </div>
         </div>
-        
+
     </div>
-    
 
-    
 
-    
+
+
+
 
     <!-- Computational Predictions Section -->
-    
+
 
     <!-- Deep Research Sections -->
-    
+
     <div class="section">
         <h2 class="section-title">Deep Research</h2>
-        
+
         <details class="deep-research-section">
             <summary style="display: flex; justify-content: space-between; align-items: center; gap: 1rem;">
                 <div style="flex: 1;">
@@ -5090,43 +5234,43 @@ heterochromatin state and adaptive epigenetic drug resistance.
                 </div>
             </summary>
             <div class="markdown-content">
-                
+
                 <div class="report-meta">
-                    
+
                     <span class="report-meta-text">this with annotations you find in gene/protein databases, but these can be outdated or inaccurate.</span>
-                    
-                    
+
+
                     <span class="report-badge">Falcon</span>
-                    
-                    
+
+
                     <span class="report-badge">Edison Scientific Literature</span>
-                    
-                    
+
+
                     <span class="report-badge">51 citations</span>
-                    
-                    
+
+
                     <span class="report-badge">1 artifacts</span>
-                    
-                    
+
+
                     <span class="report-meta-text">2026-05-30T12:14:15.075021</span>
-                    
-                    
-                    
+
+
+
                 </div>
-                
-                
+
+
                 <div class="artifact-list">
-                    
-                    
-                    
+
+
+
                     <div class="artifact-link">
                         <a href="Epe1-deep-research-falcon_artifacts/artifact-00.md" class="term-link">Edison artifact artifact-00</a>
                         <span>(text/markdown)</span>
                     </div>
-                    
-                    
+
+
                 </div>
-                
+
                 <p>The research report should be a detailed narrative explaining the function, biological processes, and localization of the gene product. Citations should be given for all claims.</p>
 <p>You should prioritize authoritative reviews and primary scientific literature when conducting research. You can supplement<br />
 this with annotations you find in gene/protein databases, but these can be outdated or inaccurate.</p>
@@ -5489,7 +5633,7 @@ This provides a mechanistic lever—histone turnover control/FACT recruitment—
 </ol>
             </div>
         </details>
-        
+
         <details class="deep-research-section">
             <summary style="display: flex; justify-content: space-between; align-items: center; gap: 1rem;">
                 <div style="flex: 1;">
@@ -5502,8 +5646,8 @@ This provides a mechanistic lever—histone turnover control/FACT recruitment—
                 </div>
             </summary>
             <div class="markdown-content">
-                
-                
+
+
                 <h1 id="role-of-epe1-in-schizosaccharomyces-pombe-competing-models-of-function">Role of Epe1 in <em>Schizosaccharomyces pombe</em>: Competing Models of Function</h1>
 <h2 id="introduction">Introduction</h2>
 <p>Epe1 is a JmjC domain-containing protein in <em>Schizosaccharomyces pombe</em> known for its critical role in heterochromatin regulation<a href="https://journals.plos.org/plosgenetics/article?id=10.1371/journal.pgen.1008129#:~:text=The%20JmjC%20domain%20is%20conserved,18%5D.%20Epe1%20physically%20interacts"><em>[1]</em></a>. Heterochromatin in fission yeast is characterized by methylation of histone H3 lysine 9 (H3K9me), a mark read by HP1-family proteins (Swi6/Chp2) to enforce gene silencing<a href="https://journals.plos.org/plosgenetics/article?id=10.1371/journal.pgen.1008129#:~:text=Cul4,state%20at%20centromeres%2C%20indicating%20that"><em>[2]</em></a><em><a href="https://www.researchgate.net/figure/Epe1-associates-with-SAGA-A-Mass-spectrometry-analyses-of-purified-protein-complexes_fig1_329820574#:~:text=model%20system%2C%20we%20measured%20the,exhibit%20diffusive%20states%20consistent%20with">[3]</a></em>. <strong>Two major models</strong> have been proposed to explain how Epe1 functions in this context:</p>
@@ -5736,15 +5880,15 @@ This provides a mechanistic lever—histone turnover control/FACT recruitment—
 <p><a href="https://www.sciencedirect.com/science/article/abs/pii/S1534580724004441"><em>https://www.sciencedirect.com/science/article/abs/pii/S1534580724004441</em></a></p>
             </div>
         </details>
-        
+
     </div>
-    
+
 
     <!-- Additional Documentation Sections -->
-    
+
     <div class="section">
         <h2 class="section-title">📚 Additional Documentation</h2>
-        
+
         <details class="markdown-section">
             <summary style="display: flex; justify-content: space-between; align-items: center; cursor: pointer;">
                 <div style="flex: 1;">
@@ -5876,7 +6020,7 @@ python<span class="w"> </span>analyze_jmjc_protein.py<span class="w"> </span>--u
 <p>Tested successfully with Epe1 (O94603) and human KDM5A (Q9Y2K7). The script analyzes JmjC domains, demethylase activity potential, and chromatin-related features for any protein.</p>
             </div>
         </details>
-        
+
         <details class="markdown-section">
             <summary style="display: flex; justify-content: space-between; align-items: center; cursor: pointer;">
                 <div style="flex: 1;">
@@ -5958,7 +6102,7 @@ python<span class="w"> </span>analyze_jmjc_protein.py<span class="w"> </span>--u
 ✓ Supporting evidence documented</p>
             </div>
         </details>
-        
+
         <details class="markdown-section">
             <summary style="display: flex; justify-content: space-between; align-items: center; cursor: pointer;">
                 <div style="flex: 1;">
@@ -6003,7 +6147,7 @@ python<span class="w"> </span>analyze_jmjc_protein.py<span class="w"> </span>--u
 <p><em>Generated by <a href="https://bioreason.net">BioReason</a></em></p>
             </div>
         </details>
-        
+
         <details class="markdown-section">
             <summary style="display: flex; justify-content: space-between; align-items: center; cursor: pointer;">
                 <div style="flex: 1;">
@@ -6046,9 +6190,9 @@ python<span class="w"> </span>analyze_jmjc_protein.py<span class="w"> </span>--u
 <p>The trace shows confident but entirely wrong reasoning -- it describes "a Fe(II)/2-oxoglutarate-dependent cycle at the JmjC center" without any consideration that the catalytic site might be degenerate. The model had no mechanism to flag missing catalytic residues, which is the critical biological insight for Epe1. This represents a fundamental limitation of domain-architecture-based reasoning for pseudo-enzymes.</p>
             </div>
         </details>
-        
+
     </div>
-    
+
 
     <!-- YAML Preview Section -->
     <div class="section">
@@ -6062,14 +6206,14 @@ gene_symbol: Epe1
 taxon:
   id: NCBITaxon:284812
   label: Schizosaccharomyces pombe 972h-
-description: Epe1 is a JmjC domain-containing protein that functions as a 
-  non-enzymatic anti-silencing factor in fission yeast. Despite having a JmjC 
-  domain typically associated with histone demethylases, Epe1 lacks catalytic 
-  activity due to degenerate active site residues. It maintains heterochromatin 
-  boundaries by binding HP1/Swi6, recruiting the SAGA histone acetyltransferase 
-  complex and Bdf2 bromodomain protein, and promoting nucleosome turnover at 
+description: Epe1 is a JmjC domain-containing protein that functions as a
+  non-enzymatic anti-silencing factor in fission yeast. Despite having a JmjC
+  domain typically associated with histone demethylases, Epe1 lacks catalytic
+  activity due to degenerate active site residues. It maintains heterochromatin
+  boundaries by binding HP1/Swi6, recruiting the SAGA histone acetyltransferase
+  complex and Bdf2 bromodomain protein, and promoting nucleosome turnover at
   heterochromatin sites. Epe1 prevents excessive heterochromatin spreading while
-  paradoxically enabling RNAi-mediated silencing by promoting transcription of 
+  paradoxically enabling RNAi-mediated silencing by promoting transcription of
   repetitive elements.
 existing_annotations:
 - term:
@@ -6078,21 +6222,32 @@ existing_annotations:
   evidence_type: IBA
   original_reference_id: GO_REF:0000033
   review:
-    summary: This IBA annotation is incorrect. Epe1 lacks critical catalytic 
+    summary: This IBA annotation is incorrect. Epe1 lacks critical catalytic
       residues for demethylase activity (has HVD instead of HXD motif) and shows
-      no detectable demethylase activity in vitro despite extensive testing 
-      (Raiymbek 2020). The protein functions as a non-enzymatic anti-silencing 
-      factor that recruits SAGA histone acetyltransferase complex and Bdf2 
+      no detectable demethylase activity in vitro despite extensive testing
+      (Raiymbek 2020). The protein functions as a non-enzymatic anti-silencing
+      factor that recruits SAGA histone acetyltransferase complex and Bdf2
       bromodomain protein to heterochromatin boundaries.
     action: REMOVE
-    reason: Strong biochemical evidence demonstrates Epe1 lacks demethylase 
-      activity. Mass spectrometry assays using purified Epe1 with methylated 
-      H3K9 peptides showed no detectable removal of methyl groups, even with 
-      HP1/Swi6 present. The JmjC domain lacks conserved Fe(II)-binding residues 
-      essential for catalysis. Epe1 H297A catalytic mutant retains 
-      anti-silencing function, demonstrating demethylase activity is not 
+    reason: Strong biochemical evidence demonstrates Epe1 lacks demethylase
+      activity. Mass spectrometry assays using purified Epe1 with methylated
+      H3K9 peptides showed no detectable removal of methyl groups, even with
+      HP1/Swi6 present. The JmjC domain lacks conserved Fe(II)-binding residues
+      essential for catalysis. Epe1 H297A catalytic mutant retains
+      anti-silencing function, demonstrating demethylase activity is not
       required for its biological role (Bao 2019). The C-terminus alone (without
       JmjC) can disrupt heterochromatin (Raiymbek 2020).
+    propagation_review:
+      root_cause: PROPAGATION_BAD
+      failure_modes:
+      - PSEUDO_OR_SUBACTIVITY_LOSS
+      source_entities:
+      - source_id: PANTHER:PTN000564171
+        source_label: JmjC-domain PANTHER node
+        source_status: SUPPORTS_SOURCE_BUT_NOT_TARGET
+        comment: Active JmjC demethylase sources do not transfer to Epe1 because
+          the target has degenerate catalytic residues and no detectable demethylase
+          activity.
     proposed_replacement_terms:
     - id: GO:0042393
       label: histone binding
@@ -6122,16 +6277,27 @@ existing_annotations:
   evidence_type: IBA
   original_reference_id: GO_REF:0000033
   review:
-    summary: Epe1 does participate in chromatin remodeling through recruitment 
-      of the SAGA histone acetyltransferase complex and promotion of nucleosome 
-      turnover at heterochromatin boundaries. However, this term is quite broad 
+    summary: Epe1 does participate in chromatin remodeling through recruitment
+      of the SAGA histone acetyltransferase complex and promotion of nucleosome
+      turnover at heterochromatin boundaries. However, this term is quite broad
       and less specific than the actual molecular mechanisms.
     action: MODIFY
-    reason: While Epe1 does affect chromatin structure, more specific terms 
-      better describe its function. It recruits SAGA complex for histone 
+    reason: While Epe1 does affect chromatin structure, more specific terms
+      better describe its function. It recruits SAGA complex for histone
       acetylation (Bao 2019) and promotes nucleosome turnover at heterochromatin
-      sites. The broad chromatin remodeling term obscures the specific 
+      sites. The broad chromatin remodeling term obscures the specific
       mechanisms.
+    propagation_review:
+      root_cause: TERM_SCOPING_PROBLEM
+      failure_modes:
+      - GRANULARITY_MISMATCH
+      source_entities:
+      - source_id: PANTHER:PTN000564171
+        source_label: JmjC-domain chromatin source node
+        source_status: SUPPORTS_SOURCE_BUT_NOT_TARGET
+        comment: The source captures chromatin-related JmjC family biology, but
+          Epe1 is better reviewed through more specific anti-silencing,
+          transcriptional, and chromatin-boundary mechanisms.
     proposed_replacement_terms:
     - id: GO:0006473
       label: protein acetylation
@@ -6156,14 +6322,14 @@ existing_annotations:
   evidence_type: IBA
   original_reference_id: GO_REF:0000033
   review:
-    summary: Epe1 does regulate transcription at heterochromatic repeats by 
-      recruiting SAGA complex and promoting RNA Pol II occupancy. It enables 
-      transcription of centromeric repeats that feed into the RNAi pathway for 
+    summary: Epe1 does regulate transcription at heterochromatic repeats by
+      recruiting SAGA complex and promoting RNA Pol II occupancy. It enables
+      transcription of centromeric repeats that feed into the RNAi pathway for
       heterochromatin establishment.
     action: ACCEPT
-    reason: Epe1 promotes RNA polymerase II transcription at heterochromatic 
-      repeats through SAGA recruitment and histone acetylation. Studies show 
-      increased Pol II occupancy and transcript production from dg/dh repeats 
+    reason: Epe1 promotes RNA polymerase II transcription at heterochromatic
+      repeats through SAGA recruitment and histone acetylation. Studies show
+      increased Pol II occupancy and transcript production from dg/dh repeats
       when Epe1 is overexpressed. This transcription is essential for generating
       RNAi substrates that maintain heterochromatin in a regulated manner.
     additional_reference_ids:
@@ -6177,8 +6343,8 @@ existing_annotations:
       supporting_text: |-
         Epe1’s association with Swi6 and role in stimulating heterochromatic ncRNA transcription relevant to RNAi-linked heterochromatin processes.
     - reference_id: PMID:36617881
-      supporting_text: Epub 2022 Dec 20. Tandemly repeated genes promote 
-        RNAi-mediated heterochromatin formation via an antisilencing factor, 
+      supporting_text: Epub 2022 Dec 20. Tandemly repeated genes promote
+        RNAi-mediated heterochromatin formation via an antisilencing factor,
         Epe1, in fission yeast.
 - term:
     id: GO:0003712
@@ -6186,14 +6352,14 @@ existing_annotations:
   evidence_type: IBA
   original_reference_id: GO_REF:0000033
   review:
-    summary: Epe1 functions as a transcriptional coregulator by recruiting the 
+    summary: Epe1 functions as a transcriptional coregulator by recruiting the
       SAGA histone acetyltransferase complex to heterochromatin sites, promoting
       transcriptional activation through histone acetylation.
     action: ACCEPT
-    reason: Direct biochemical evidence shows Epe1 associates with and recruits 
-      SAGA complex, a well-characterized transcriptional co-activator. Mass 
-      spectrometry identified SAGA subunits co-purifying with Epe1. The 
-      N-terminal region contains a transcriptional activation domain that 
+    reason: Direct biochemical evidence shows Epe1 associates with and recruits
+      SAGA complex, a well-characterized transcriptional co-activator. Mass
+      spectrometry identified SAGA subunits co-purifying with Epe1. The
+      N-terminal region contains a transcriptional activation domain that
       contributes to anti-silencing activity.
     additional_reference_ids:
     supported_by:
@@ -6210,13 +6376,13 @@ existing_annotations:
   evidence_type: IEA
   original_reference_id: GO_REF:0000120
   review:
-    summary: Nuclear localization of Epe1 is well-established through direct 
-      experimental evidence including microscopy and ChIP-seq studies showing 
+    summary: Nuclear localization of Epe1 is well-established through direct
+      experimental evidence including microscopy and ChIP-seq studies showing
       enrichment at nuclear heterochromatin domains.
     action: ACCEPT
-    reason: Multiple experimental approaches confirm nuclear localization. 
-      Direct immunofluorescence microscopy (PMID:12773576) and ChIP-seq studies 
-      demonstrate Epe1 localizes to nuclear heterochromatin regions including 
+    reason: Multiple experimental approaches confirm nuclear localization.
+      Direct immunofluorescence microscopy (PMID:12773576) and ChIP-seq studies
+      demonstrate Epe1 localizes to nuclear heterochromatin regions including
       centromeres, telomeres, and mating-type locus. This is consistent with its
       function in heterochromatin regulation.
     additional_reference_ids:
@@ -6234,8 +6400,8 @@ existing_annotations:
   evidence_type: IEA
   original_reference_id: GO_REF:0000043
   review:
-    summary: This broad term accurately describes Epe1 function but more 
-      specific annotations like heterochromatin boundary formation provide 
+    summary: This broad term accurately describes Epe1 function but more
+      specific annotations like heterochromatin boundary formation provide
       better resolution of its role.
     action: ACCEPT
     reason: &#39;Epe1 clearly participates in chromatin organization through multiple
@@ -6246,11 +6412,11 @@ existing_annotations:
     - PMID:24013502
     supported_by:
     - reference_id: file:SCHPO/Epe1/Epe1-deep-research.md
-      supporting_text: Epe1 has been implicated in promoting histone turnover 
+      supporting_text: Epe1 has been implicated in promoting histone turnover
         within heterochromatin. Turnover (replacement of histones with new ones)
         can dilute or remove modified histones
     - reference_id: PMID:24013502
-      supporting_text: Epe1 recruits BET family bromodomain protein Bdf2 to 
+      supporting_text: Epe1 recruits BET family bromodomain protein Bdf2 to
         establish heterochromatin boundaries.
 - term:
     id: GO:0016491
@@ -6258,14 +6424,14 @@ existing_annotations:
   evidence_type: IEA
   original_reference_id: GO_REF:0000043
   review:
-    summary: This annotation is based on JmjC domain homology but is incorrect 
+    summary: This annotation is based on JmjC domain homology but is incorrect
       as Epe1 lacks catalytic activity. The protein has a degenerate active site
       missing critical Fe(II)-binding residues.
     action: REMOVE
-    reason: Biochemical assays definitively show Epe1 lacks oxidoreductase 
-      activity. The JmjC domain has degenerated active site residues (HVD 
-      instead of HXD motif) incompatible with Fe(II) binding and catalysis. No 
-      enzymatic activity detected in vitro with any substrate tested. Functions 
+    reason: Biochemical assays definitively show Epe1 lacks oxidoreductase
+      activity. The JmjC domain has degenerated active site residues (HVD
+      instead of HXD motif) incompatible with Fe(II) binding and catalysis. No
+      enzymatic activity detected in vitro with any substrate tested. Functions
       through protein-protein interactions, not catalysis.
     additional_reference_ids:
     - PMID:16362057
@@ -6289,13 +6455,13 @@ existing_annotations:
   evidence_type: IEA
   original_reference_id: GO_REF:0000043
   review:
-    summary: This annotation is incorrect as Epe1 lacks the conserved residues 
+    summary: This annotation is incorrect as Epe1 lacks the conserved residues
       required for Fe(II) binding that are present in active JmjC demethylases.
     action: REMOVE
-    reason: Structural analysis shows Epe1 JmjC domain lacks conserved 
-      Fe(II)-binding histidine residues found in all active JmjC enzymes. Has 
-      tyrosine at position 307 instead of catalytic histidine. The degenerate 
-      active site cannot coordinate metal ions required for catalysis. No 
+    reason: Structural analysis shows Epe1 JmjC domain lacks conserved
+      Fe(II)-binding histidine residues found in all active JmjC enzymes. Has
+      tyrosine at position 307 instead of catalytic histidine. The degenerate
+      active site cannot coordinate metal ions required for catalysis. No
       biochemical evidence for metal binding.
     additional_reference_ids:
     - PMID:16362057
@@ -6317,15 +6483,15 @@ existing_annotations:
   evidence_type: IEA
   original_reference_id: GO_REF:0000043
   review:
-    summary: Incorrectly inferred from JmjC domain presence. Epe1 is a 
-      pseudo-enzyme that lacks dioxygenase activity due to degenerate active 
+    summary: Incorrectly inferred from JmjC domain presence. Epe1 is a
+      pseudo-enzyme that lacks dioxygenase activity due to degenerate active
       site.
     action: REMOVE
-    reason: No dioxygenase activity detected in any biochemical assay. The JmjC 
-      domain has evolved away from catalytic function - lacks Fe(II) 
-      coordination, has Y307 instead of catalytic histidine. Functions as a 
-      structural scaffold for protein interactions rather than as an enzyme. 
-      This is a clear example of a pseudo-enzyme retaining the fold but not the 
+    reason: No dioxygenase activity detected in any biochemical assay. The JmjC
+      domain has evolved away from catalytic function - lacks Fe(II)
+      coordination, has Y307 instead of catalytic histidine. Functions as a
+      structural scaffold for protein interactions rather than as an enzyme.
+      This is a clear example of a pseudo-enzyme retaining the fold but not the
       catalytic function.
     additional_reference_ids:
     supported_by:
@@ -6347,15 +6513,15 @@ existing_annotations:
   evidence_type: IEA
   original_reference_id: GO_REF:0000120
   review:
-    summary: This highly specific demethylase annotation is incorrect. Epe1 has 
-      no demonstrated demethylase activity on any histone substrate including 
+    summary: This highly specific demethylase annotation is incorrect. Epe1 has
+      no demonstrated demethylase activity on any histone substrate including
       H3K36me.
     action: REMOVE
-    reason: No biochemical evidence for H3K36 demethylase activity. Mass 
-      spectrometry assays with various methylated histone peptides including 
-      H3K36me showed no demethylation. The annotation appears to be 
-      computationally inferred from weak homology to other JmjC proteins, but 
-      Epe1 is a pseudo-enzyme that has lost catalytic function while retaining 
+    reason: No biochemical evidence for H3K36 demethylase activity. Mass
+      spectrometry assays with various methylated histone peptides including
+      H3K36me showed no demethylation. The annotation appears to be
+      computationally inferred from weak homology to other JmjC proteins, but
+      Epe1 is a pseudo-enzyme that has lost catalytic function while retaining
       the structural fold.
     additional_reference_ids:
     - PMID:16362057
@@ -6377,14 +6543,14 @@ existing_annotations:
   evidence_type: IPI
   original_reference_id: PMID:21215368
   review:
-    summary: Epe1 binds multiple proteins including HP1/Swi6, SAGA complex 
-      subunits, and Bdf2. However, this term is too generic - more specific 
+    summary: Epe1 binds multiple proteins including HP1/Swi6, SAGA complex
+      subunits, and Bdf2. However, this term is too generic - more specific
       binding terms would be more informative.
     action: MODIFY
-    reason: While protein binding is correct, it is uninformative. Epe1 
-      specifically binds HP1/Swi6 through its C-terminus (demonstrated by co-IP 
-      and pull-downs), associates with SAGA complex (mass spec), and recruits 
-      Bdf2 (co-IP). More specific terms describing these interactions would be 
+    reason: While protein binding is correct, it is uninformative. Epe1
+      specifically binds HP1/Swi6 through its C-terminus (demonstrated by co-IP
+      and pull-downs), associates with SAGA complex (mass spec), and recruits
+      Bdf2 (co-IP). More specific terms describing these interactions would be
       more valuable.
     proposed_replacement_terms:
     - id: GO:0042393
@@ -6400,11 +6566,11 @@ existing_annotations:
       supporting_text: The Cul4-Ddb1(Cdt)² ubiquitin ligase inhibits invasion of
         a boundary-associated antisilencing factor into heterochromatin.
     - reference_id: file:SCHPO/Epe1/Epe1-bioinformatics/RESULTS.md
-      supporting_text: Extensive coiled-coil regions and multiple protein 
-        interaction domains identified throughout the protein, consistent with 
+      supporting_text: Extensive coiled-coil regions and multiple protein
+        interaction domains identified throughout the protein, consistent with
         its role as a chromatin scaffold recruiting various complexes
     - reference_id: PMID:24013502
-      supporting_text: Epe1 recruits BET family bromodomain protein Bdf2 to 
+      supporting_text: Epe1 recruits BET family bromodomain protein Bdf2 to
         establish heterochromatin boundaries.
 - term:
     id: GO:0033696
@@ -6413,31 +6579,31 @@ existing_annotations:
   original_reference_id: PMID:39094565
   review:
     summary: This is one of Epe1&#39;s core functions - establishing and maintaining
-      heterochromatin boundaries through recruitment of anti-silencing factors 
+      heterochromatin boundaries through recruitment of anti-silencing factors
       like SAGA and Bdf2.
     action: ACCEPT
-    reason: Extensive evidence supports this annotation. Epe1 localizes to 
-      heterochromatin boundaries at centromeres, telomeres, and mating-type 
-      locus. It recruits Bdf2 bromodomain protein to IRCs (inverted repeat 
-      centromeric boundaries) and SAGA complex for histone acetylation. Loss of 
-      Epe1 causes heterochromatin spreading beyond normal boundaries. This is a 
+    reason: Extensive evidence supports this annotation. Epe1 localizes to
+      heterochromatin boundaries at centromeres, telomeres, and mating-type
+      locus. It recruits Bdf2 bromodomain protein to IRCs (inverted repeat
+      centromeric boundaries) and SAGA complex for histone acetylation. Loss of
+      Epe1 causes heterochromatin spreading beyond normal boundaries. This is a
       well-characterized core function.
     additional_reference_ids:
     - PMID:24013502
     - PMID:12773576
     supported_by:
     - reference_id: file:SCHPO/Epe1/Epe1-deep-research.md
-      supporting_text: Wang et al. found that Epe1 recruits Bdf2 to 
+      supporting_text: Wang et al. found that Epe1 recruits Bdf2 to
         heterochromatin boundaries. Bdf2 was enriched at boundary elements (e.g.
         subtelomeric boundary regions called IRCs) only when Epe1 was present
     - reference_id: PMID:39094565
-      supporting_text: Epub 2024 Aug 1. Mapping the dynamics of epigenetic 
+      supporting_text: Epub 2024 Aug 1. Mapping the dynamics of epigenetic
         adaptation in S.
     - reference_id: PMID:24013502
-      supporting_text: Epe1 recruits BET family bromodomain protein Bdf2 to 
+      supporting_text: Epe1 recruits BET family bromodomain protein Bdf2 to
         establish heterochromatin boundaries.
     - reference_id: PMID:12773576
-      supporting_text: A novel jmjC domain protein modulates 
+      supporting_text: A novel jmjC domain protein modulates
         heterochromatization in fission yeast.
 - term:
     id: GO:0032454
@@ -6445,16 +6611,16 @@ existing_annotations:
   evidence_type: IDA
   original_reference_id: PMID:25838386
   review:
-    summary: This annotation is incorrect despite IDA evidence code. The cited 
-      paper actually shows genetic evidence for H3K9me erasure but not direct 
-      biochemical demethylase activity. Epe1 lacks catalytic residues and shows 
+    summary: This annotation is incorrect despite IDA evidence code. The cited
+      paper actually shows genetic evidence for H3K9me erasure but not direct
+      biochemical demethylase activity. Epe1 lacks catalytic residues and shows
       no demethylase activity in vitro.
     action: REMOVE
-    reason: The PMID:25838386 paper (Audergon et al.) shows that epe1 deletion 
-      allows H3K9me inheritance, suggesting Epe1 normally prevents it. However, 
-      this is genetic evidence for H3K9me antagonism, not direct biochemical 
-      demonstration of demethylase activity (IDA). No study has shown Epe1 
-      directly demethylating histones in vitro. The protein lacks catalytic 
+    reason: The PMID:25838386 paper (Audergon et al.) shows that epe1 deletion
+      allows H3K9me inheritance, suggesting Epe1 normally prevents it. However,
+      this is genetic evidence for H3K9me antagonism, not direct biochemical
+      demonstration of demethylase activity (IDA). No study has shown Epe1
+      directly demethylating histones in vitro. The protein lacks catalytic
       residues and functions through non-enzymatic mechanisms.
     additional_reference_ids:
     supported_by:
@@ -6475,16 +6641,16 @@ existing_annotations:
   original_reference_id: PMID:25831549
   negated: true
   review:
-    summary: This is a negative annotation (NOT|involved_in) which is correct - 
+    summary: This is a negative annotation (NOT|involved_in) which is correct -
       Epe1 does NOT promote heterochromatin formation but rather opposes it. The
-      NOT qualifier appropriately captures Epe1&#39;s anti-silencing role in 
+      NOT qualifier appropriately captures Epe1&#39;s anti-silencing role in
       preventing heterochromatin assembly and maintenance.
     action: ACCEPT
-    reason: The NOT|involved_in annotation accurately reflects Epe1&#39;s function 
-      as an anti-silencing factor that opposes heterochromatin formation. The 
-      cited paper (Ragunathan 2015) demonstrates that Epe1 plays opposing roles 
-      to Clr4 in maintaining silent H3K9me domains, preventing rather than 
-      promoting heterochromatin assembly. This negative annotation is more 
+    reason: The NOT|involved_in annotation accurately reflects Epe1&#39;s function
+      as an anti-silencing factor that opposes heterochromatin formation. The
+      cited paper (Ragunathan 2015) demonstrates that Epe1 plays opposing roles
+      to Clr4 in maintaining silent H3K9me domains, preventing rather than
+      promoting heterochromatin assembly. This negative annotation is more
       precise than a positive annotation would be.
     additional_reference_ids: []
     supported_by:
@@ -6508,18 +6674,18 @@ existing_annotations:
     summary: Correct annotation - Epe1 is essential for heterochromatin boundary
       formation and maintenance, preventing spreading of silent chromatin.
     action: ACCEPT
-    reason: Multiple studies confirm this core function. Epe1 establishes 
+    reason: Multiple studies confirm this core function. Epe1 establishes
       boundaries through recruiting Bdf2 and SAGA, promoting histone acetylation
-      that antagonizes heterochromatin spreading. ChIP-seq shows enrichment at 
-      boundary regions. Loss causes heterochromatin to spread into normally 
+      that antagonizes heterochromatin spreading. ChIP-seq shows enrichment at
+      boundary regions. Loss causes heterochromatin to spread into normally
       euchromatic regions.
     supported_by:
     - reference_id: file:SCHPO/Epe1/Epe1-deep-research.md
-      supporting_text: Epe1 is often described as a &#34;boundary element&#34; or 
-        &#34;heterochromatin destabilizer&#34;, meaning it localizes to heterochromatic 
+      supporting_text: Epe1 is often described as a &#34;boundary element&#34; or
+        &#34;heterochromatin destabilizer&#34;, meaning it localizes to heterochromatic
         regions and prevents the spread or maintenance of the silent state
     - reference_id: PMID:25831549
-      supporting_text: Nov 20. Epigenetics. Epigenetic inheritance uncoupled 
+      supporting_text: Nov 20. Epigenetics. Epigenetic inheritance uncoupled
         from sequence-specific recruitment.
 - term:
     id: GO:0000792
@@ -6527,18 +6693,18 @@ existing_annotations:
   evidence_type: IDA
   original_reference_id: PMID:16762840
   review:
-    summary: Correct cellular component annotation - Epe1 localizes to 
+    summary: Correct cellular component annotation - Epe1 localizes to
       heterochromatin through its interaction with HP1/Swi6 bound to H3K9me.
     action: ACCEPT
-    reason: ChIP and microscopy studies confirm Epe1 localizes to 
-      heterochromatic regions. The cited paper shows Swi6/HP1 recruits Epe1 to 
-      heterochromatin. Epe1 C-terminus binds HP1 directly, and this interaction 
-      is enhanced by H3K9 methylation. Localization is essential for its 
+    reason: ChIP and microscopy studies confirm Epe1 localizes to
+      heterochromatic regions. The cited paper shows Swi6/HP1 recruits Epe1 to
+      heterochromatin. Epe1 C-terminus binds HP1 directly, and this interaction
+      is enhanced by H3K9 methylation. Localization is essential for its
       boundary function.
     additional_reference_ids:
     supported_by:
     - reference_id: PMID:16762840
-      supporting_text: Swi6/HP1 recruits a JmjC domain protein to facilitate 
+      supporting_text: Swi6/HP1 recruits a JmjC domain protein to facilitate
         transcription of heterochromatic repeats
 - term:
     id: GO:0005721
@@ -6546,20 +6712,20 @@ existing_annotations:
   evidence_type: IDA
   original_reference_id: PMID:16762840
   review:
-    summary: Epe1 localizes to pericentric heterochromatin where it regulates 
+    summary: Epe1 localizes to pericentric heterochromatin where it regulates
       boundaries and enables repeat transcription for RNAi-mediated silencing.
     action: ACCEPT
-    reason: ChIP studies demonstrate Epe1 enrichment at centromeric/pericentric 
-      regions. It promotes transcription of dg/dh pericentromeric repeats while 
-      maintaining boundaries. This localization is mediated by HP1/Swi6 binding 
+    reason: ChIP studies demonstrate Epe1 enrichment at centromeric/pericentric
+      regions. It promotes transcription of dg/dh pericentromeric repeats while
+      maintaining boundaries. This localization is mediated by HP1/Swi6 binding
       to H3K9me-marked nucleosomes.
     supported_by:
     - reference_id: file:SCHPO/Epe1/Epe1-deep-research.md
-      supporting_text: Chromatin immunoprecipitation studies show that Epe1 is 
+      supporting_text: Chromatin immunoprecipitation studies show that Epe1 is
         enriched at heterochromatic regions – notably at centromeres, telomeres,
         and the mating-type locus
     - reference_id: PMID:16762840
-      supporting_text: Swi6/HP1 recruits a JmjC domain protein to facilitate 
+      supporting_text: Swi6/HP1 recruits a JmjC domain protein to facilitate
         transcription of heterochromatic repeats.
 - term:
     id: GO:0031934
@@ -6567,20 +6733,20 @@ existing_annotations:
   evidence_type: IDA
   original_reference_id: PMID:16762840
   review:
-    summary: Epe1 localizes to and regulates the mating-type heterochromatin 
+    summary: Epe1 localizes to and regulates the mating-type heterochromatin
       region, maintaining proper boundaries.
     action: ACCEPT
-    reason: ChIP-seq confirms Epe1 enrichment at the mating-type locus 
-      heterochromatin. Functions to prevent excessive spreading of silent 
-      chromatin and maintains boundaries of this specialized heterochromatin 
+    reason: ChIP-seq confirms Epe1 enrichment at the mating-type locus
+      heterochromatin. Functions to prevent excessive spreading of silent
+      chromatin and maintains boundaries of this specialized heterochromatin
       domain. Well-characterized localization pattern.
     supported_by:
     - reference_id: file:SCHPO/Epe1/Epe1-deep-research.md
-      supporting_text: Epe1 is enriched at heterochromatic regions – notably at 
-        centromeres, telomeres, and the mating-type locus – often at the 
+      supporting_text: Epe1 is enriched at heterochromatic regions – notably at
+        centromeres, telomeres, and the mating-type locus – often at the
         boundaries of these domains
     - reference_id: PMID:16762840
-      supporting_text: Swi6/HP1 recruits a JmjC domain protein to facilitate 
+      supporting_text: Swi6/HP1 recruits a JmjC domain protein to facilitate
         transcription of heterochromatic repeats.
 - term:
     id: GO:0140720
@@ -6588,21 +6754,21 @@ existing_annotations:
   evidence_type: IDA
   original_reference_id: PMID:16762840
   review:
-    summary: Epe1 localizes to subtelomeric heterochromatin regions where it 
+    summary: Epe1 localizes to subtelomeric heterochromatin regions where it
       establishes boundaries through Bdf2 recruitment.
     action: ACCEPT
     reason: ChIP studies show Epe1 enrichment at telomeric/subtelomeric regions.
-      Particularly important at IRC boundary elements in subtelomeric regions 
-      where it recruits Bdf2 to prevent heterochromatin spreading. 
+      Particularly important at IRC boundary elements in subtelomeric regions
+      where it recruits Bdf2 to prevent heterochromatin spreading.
       Well-documented localization.
     additional_reference_ids:
     - PMID:24013502
     supported_by:
     - reference_id: PMID:24013502
-      supporting_text: Bdf2 is enriched at IRCs [subtelomeric boundary regions] 
+      supporting_text: Bdf2 is enriched at IRCs [subtelomeric boundary regions]
         through its interaction with the boundary protein Epe1
     - reference_id: PMID:16762840
-      supporting_text: Swi6/HP1 recruits a JmjC domain protein to facilitate 
+      supporting_text: Swi6/HP1 recruits a JmjC domain protein to facilitate
         transcription of heterochromatic repeats.
 - term:
     id: GO:1990342
@@ -6610,23 +6776,23 @@ existing_annotations:
   evidence_type: IDA
   original_reference_id: PMID:16762840
   review:
-    summary: Epe1 prevents formation of ectopic heterochromatin islands in 
+    summary: Epe1 prevents formation of ectopic heterochromatin islands in
       euchromatic regions. Its absence leads to H3K9me islands.
     action: ACCEPT
-    reason: Studies show epe1Δ mutants accumulate aberrant small islands of 
-      H3K9me across euchromatic regions. Epe1 normally prevents these ectopic 
-      heterochromatin formations. When present at existing islands, it can 
-      promote their dissolution through SAGA recruitment and competitive HP1 
+    reason: Studies show epe1Δ mutants accumulate aberrant small islands of
+      H3K9me across euchromatic regions. Epe1 normally prevents these ectopic
+      heterochromatin formations. When present at existing islands, it can
+      promote their dissolution through SAGA recruitment and competitive HP1
       binding.
     additional_reference_ids:
     - PMID:31206516
     supported_by:
     - reference_id: file:SCHPO/Epe1/Epe1-deep-research.md
       supporting_text: epe1- (null) mutants show elevated H3K9me3 levels in aged
-        cells and accumulate aberrant small &#34;islands&#34; of H3K9me across 
+        cells and accumulate aberrant small &#34;islands&#34; of H3K9me across
         euchromatic regions
     - reference_id: PMID:16762840
-      supporting_text: Swi6/HP1 recruits a JmjC domain protein to facilitate 
+      supporting_text: Swi6/HP1 recruits a JmjC domain protein to facilitate
         transcription of heterochromatic repeats.
     - reference_id: PMID:31206516
       supporting_text: eCollection 2019 Jun.
@@ -6639,14 +6805,14 @@ existing_annotations:
     summary: Epe1 regulates facultative heterochromatin formation that can occur
       independently of the RNAi pathway, preventing excessive silencing.
     action: ACCEPT
-    reason: The cited study shows Epe1 regulates RNA elimination 
-      machinery-dependent facultative heterochromatin. In epe1 mutants, 
-      heterochromatin can form and be maintained without RNAi, demonstrating 
+    reason: The cited study shows Epe1 regulates RNA elimination
+      machinery-dependent facultative heterochromatin. In epe1 mutants,
+      heterochromatin can form and be maintained without RNAi, demonstrating
       Epe1 normally prevents RNAi-independent silencing. This is consistent with
       its anti-silencing role.
     supported_by:
     - reference_id: PMID:22144463
-      supporting_text: RNA elimination machinery targeting meiotic mRNAs 
+      supporting_text: RNA elimination machinery targeting meiotic mRNAs
         promotes facultative heterochromatin formation
 - term:
     id: GO:0032454
@@ -6654,13 +6820,13 @@ existing_annotations:
   evidence_type: EXP
   original_reference_id: PMID:25838386
   review:
-    summary: Duplicate incorrect annotation. No direct biochemical evidence for 
+    summary: Duplicate incorrect annotation. No direct biochemical evidence for
       H3K9 demethylase activity exists. The paper shows genetic evidence only.
     action: REMOVE
     reason: This is a duplicate of the previous H3K9 demethylase annotation with
-      different evidence code. The EXP code is inappropriate as no biochemical 
+      different evidence code. The EXP code is inappropriate as no biochemical
       demethylase activity was demonstrated. The paper shows genetic suppression
-      of H3K9me inheritance by Epe1, not enzymatic activity. Epe1 antagonizes 
+      of H3K9me inheritance by Epe1, not enzymatic activity. Epe1 antagonizes
       H3K9me through non-catalytic mechanisms.
     additional_reference_ids:
     supported_by:
@@ -6670,8 +6836,8 @@ existing_annotations:
         &#34;putative&#34; indicates uncertainty about enzymatic function]&#39;
       full_text_unavailable: true
     - reference_id: file:SCHPO/Epe1/Epe1-bioinformatics/RESULTS.md
-      supporting_text: Duplicate annotation - JmjC domain analysis confirms 
-        pseudo-demethylase status with structural features indicating chromatin 
+      supporting_text: Duplicate annotation - JmjC domain analysis confirms
+        pseudo-demethylase status with structural features indicating chromatin
         reader rather than enzyme function
 - term:
     id: GO:0033696
@@ -6679,12 +6845,12 @@ existing_annotations:
   evidence_type: IMP
   original_reference_id: PMID:31206516
   review:
-    summary: Another correct annotation for heterochromatin boundary formation, 
+    summary: Another correct annotation for heterochromatin boundary formation,
       a core Epe1 function demonstrated by multiple studies.
     action: ACCEPT
-    reason: The Sorida 2019 paper demonstrates Epe1 regulates ectopic 
-      heterochromatin and maintains boundaries. Loss of Epe1 allows 
-      heterochromatin spreading and formation of new silenced domains. This 
+    reason: The Sorida 2019 paper demonstrates Epe1 regulates ectopic
+      heterochromatin and maintains boundaries. Loss of Epe1 allows
+      heterochromatin spreading and formation of new silenced domains. This
       boundary function is central to Epe1 biology.
     supported_by:
     - reference_id: PMID:31206516
@@ -6696,19 +6862,19 @@ existing_annotations:
   evidence_type: IMP
   original_reference_id: PMID:36617881
   review:
-    summary: Epe1 enables transcription of tandem repeats that generate RNAi 
-      substrates for heterochromatin formation, paradoxically promoting 
+    summary: Epe1 enables transcription of tandem repeats that generate RNAi
+      substrates for heterochromatin formation, paradoxically promoting
       RNAi-mediated silencing.
     action: ACCEPT
-    reason: Recent study shows Epe1 is required for efficient transcription of 
-      tandemly repeated genes that trigger RNAi-dependent heterochromatin. By 
+    reason: Recent study shows Epe1 is required for efficient transcription of
+      tandemly repeated genes that trigger RNAi-dependent heterochromatin. By
       locally destabilizing heterochromatin to allow transcription, Epe1 enables
-      production of RNAi substrates that reinforce silencing. This represents a 
+      production of RNAi substrates that reinforce silencing. This represents a
       regulatory feedback mechanism.
     supported_by:
     - reference_id: PMID:36617881
-      supporting_text: Tandemly repeated genes promote RNAi-mediated 
-        heterochromatin formation via an antisilencing factor, Epe1, in fission 
+      supporting_text: Tandemly repeated genes promote RNAi-mediated
+        heterochromatin formation via an antisilencing factor, Epe1, in fission
         yeast
 - term:
     id: GO:0005634
@@ -6716,16 +6882,16 @@ existing_annotations:
   evidence_type: IDA
   original_reference_id: PMID:12773576
   review:
-    summary: Direct experimental evidence for nuclear localization through 
+    summary: Direct experimental evidence for nuclear localization through
       microscopy. This supersedes the IEA annotation.
     action: ACCEPT
-    reason: The Ayoub 2003 paper provides direct immunofluorescence microscopy 
-      evidence for nuclear localization. This IDA evidence is stronger than the 
+    reason: The Ayoub 2003 paper provides direct immunofluorescence microscopy
+      evidence for nuclear localization. This IDA evidence is stronger than the
       IEA computational prediction and confirms Epe1 functions in the nucleus at
       heterochromatin sites.
     supported_by:
     - reference_id: PMID:12773576
-      supporting_text: A novel jmjC domain protein modulates 
+      supporting_text: A novel jmjC domain protein modulates
         heterochromatization in fission yeast.
 - term:
     id: GO:0033696
@@ -6733,17 +6899,17 @@ existing_annotations:
   evidence_type: IMP
   original_reference_id: PMID:12773576
   review:
-    summary: The original paper identifying Epe1 as a heterochromatin boundary 
+    summary: The original paper identifying Epe1 as a heterochromatin boundary
       factor. Foundational evidence for this core function.
     action: ACCEPT
-    reason: This seminal paper first characterized Epe1 as modulating 
-      heterochromatization and preventing silencing spread. Demonstrated that 
-      Epe1 mutation affects position effect variegation and heterochromatin 
+    reason: This seminal paper first characterized Epe1 as modulating
+      heterochromatization and preventing silencing spread. Demonstrated that
+      Epe1 mutation affects position effect variegation and heterochromatin
       boundaries. This established the boundary function that has been confirmed
       by numerous subsequent studies.
     supported_by:
     - reference_id: PMID:12773576
-      supporting_text: A novel jmjC domain protein modulates 
+      supporting_text: A novel jmjC domain protein modulates
         heterochromatization in fission yeast.
 - term:
     id: GO:0033696
@@ -6751,12 +6917,12 @@ existing_annotations:
   evidence_type: IMP
   original_reference_id: PMID:17948055
   review:
-    summary: Further evidence that Epe1 prevents unregulated heterochromatin 
+    summary: Further evidence that Epe1 prevents unregulated heterochromatin
       assembly and maintains boundaries.
     action: ACCEPT
-    reason: The paper demonstrates Epe1 prevents both unregulated assembly and 
-      disassembly of heterochromatin, maintaining proper boundaries. Shows Epe1 
-      is required for heterochromatin homeostasis and boundary integrity. Core 
+    reason: The paper demonstrates Epe1 prevents both unregulated assembly and
+      disassembly of heterochromatin, maintaining proper boundaries. Shows Epe1
+      is required for heterochromatin homeostasis and boundary integrity. Core
       function with strong experimental support.
     supported_by:
     - reference_id: PMID:17948055
@@ -6772,12 +6938,12 @@ existing_annotations:
       their inappropriate formation in euchromatin.
     action: ACCEPT
     reason: Study shows Epe1 is present at heterochromatin islands and regulates
-      their formation. In its absence, ectopic heterochromatin islands form 
-      inappropriately. This cellular component annotation accurately reflects 
+      their formation. In its absence, ectopic heterochromatin islands form
+      inappropriately. This cellular component annotation accurately reflects
       Epe1 localization and function at these specialized chromatin structures.
     supported_by:
     - reference_id: PMID:22144463
-      supporting_text: Dec 1. RNA elimination machinery targeting meiotic mRNAs 
+      supporting_text: Dec 1. RNA elimination machinery targeting meiotic mRNAs
         promotes facultative heterochromatin formation.
 - term:
     id: GO:0000792
@@ -6785,12 +6951,12 @@ existing_annotations:
   evidence_type: IDA
   original_reference_id: PMID:29214404
   review:
-    summary: Confirmed heterochromatin localization in context of proteasome 
+    summary: Confirmed heterochromatin localization in context of proteasome
       regulation of facultative heterochromatin.
     action: ACCEPT
-    reason: Paper shows Epe1 at heterochromatin sites in context of 19S 
-      proteasome studies. Consistent with all other localization data showing 
-      HP1-dependent recruitment to H3K9me-marked heterochromatin. 
+    reason: Paper shows Epe1 at heterochromatin sites in context of 19S
+      proteasome studies. Consistent with all other localization data showing
+      HP1-dependent recruitment to H3K9me-marked heterochromatin.
       Well-established cellular component.
     supported_by:
     - reference_id: PMID:29214404
@@ -6805,9 +6971,9 @@ existing_annotations:
     summary: Another confirmation of heterochromatin localization, demonstrating
       Epe1 presence at silent chromatin domains.
     action: ACCEPT
-    reason: Multiple independent studies confirm Epe1 heterochromatin 
-      localization through ChIP and microscopy. This is mediated by direct 
-      binding to HP1/Swi6. Consistent and well-validated cellular component 
+    reason: Multiple independent studies confirm Epe1 heterochromatin
+      localization through ChIP and microscopy. This is mediated by direct
+      binding to HP1/Swi6. Consistent and well-validated cellular component
       annotation.
     supported_by:
     - reference_id: PMID:17948055
@@ -6822,13 +6988,13 @@ existing_annotations:
     summary: Genetic interaction studies confirm Epe1 role in boundary formation
       during epigenetic adaptation to heterochromatin spreading.
     action: ACCEPT
-    reason: Paper on rapid epigenetic adaptation shows genetic interactions 
+    reason: Paper on rapid epigenetic adaptation shows genetic interactions
       demonstrating Epe1 requirement for proper heterochromatin boundaries. When
-      heterochromatin spreading is uncontrolled, Epe1 is essential for 
+      heterochromatin spreading is uncontrolled, Epe1 is essential for
       re-establishing boundaries. Core function with genetic evidence.
     supported_by:
     - reference_id: PMID:25774602
-      supporting_text: Rapid epigenetic adaptation to uncontrolled 
+      supporting_text: Rapid epigenetic adaptation to uncontrolled
         heterochromatin spreading.
 - term:
     id: GO:0033696
@@ -6836,17 +7002,17 @@ existing_annotations:
   evidence_type: IMP
   original_reference_id: PMID:24013502
   review:
-    summary: Key paper showing Epe1 recruits Bdf2 bromodomain protein to 
+    summary: Key paper showing Epe1 recruits Bdf2 bromodomain protein to
       establish heterochromatin boundaries at IRCs.
     action: ACCEPT
-    reason: Wang 2013 demonstrates Epe1 recruits BET family protein Bdf2 to 
-      heterochromatin boundaries, particularly at inverted repeat centromeric 
-      (IRC) boundaries. Bdf2 recognizes acetylated H4 and antagonizes 
-      Sir2-mediated deacetylation, preventing heterochromatin spreading. 
+    reason: Wang 2013 demonstrates Epe1 recruits BET family protein Bdf2 to
+      heterochromatin boundaries, particularly at inverted repeat centromeric
+      (IRC) boundaries. Bdf2 recognizes acetylated H4 and antagonizes
+      Sir2-mediated deacetylation, preventing heterochromatin spreading.
       Essential boundary mechanism.
     supported_by:
     - reference_id: PMID:24013502
-      supporting_text: Epe1 recruits BET family bromodomain protein Bdf2 to 
+      supporting_text: Epe1 recruits BET family bromodomain protein Bdf2 to
         establish heterochromatin boundaries.
 - term:
     id: GO:0000792
@@ -6854,27 +7020,27 @@ existing_annotations:
   evidence_type: IDA
   original_reference_id: PMID:17449867
   review:
-    summary: Study of Epe1 interaction with heterochromatin assembly pathway 
+    summary: Study of Epe1 interaction with heterochromatin assembly pathway
       confirms its heterochromatin localization.
     action: ACCEPT
-    reason: Paper examining Epe1 interaction with heterochromatin assembly 
+    reason: Paper examining Epe1 interaction with heterochromatin assembly
       machinery confirms localization to heterochromatic regions. Shows physical
-      and functional interactions with heterochromatin components. Consistent 
+      and functional interactions with heterochromatin components. Consistent
       with HP1-mediated recruitment model.
     supported_by:
     - reference_id: PMID:17449867
-      supporting_text: Interaction of Epe1 with the heterochromatin assembly 
+      supporting_text: Interaction of Epe1 with the heterochromatin assembly
         pathway in Schizosaccharomyces pombe.
 - term:
     id: GO:0031452
     label: negative regulation of heterochromatin formation
   evidence_type: IEA
   review:
-    summary: negative regulation of heterochromatin formation identified from 
+    summary: negative regulation of heterochromatin formation identified from
       core_functions analysis
     action: NEW
-    reason: This biological process term captures Epe1&#39;s primary function as an 
-      anti-silencing factor that establishes heterochromatin boundaries and 
+    reason: This biological process term captures Epe1&#39;s primary function as an
+      anti-silencing factor that establishes heterochromatin boundaries and
       prevents excessive heterochromatin spreading.
     supported_by:
     - reference_id: PMID:24013502
@@ -6894,18 +7060,18 @@ existing_annotations:
   review:
     summary: Epe1 indirectly promotes protein acetylation by recruiting HATs
     action: NEW
-    reason: Epe1 recruits the SAGA histone acetyltransferase complex to 
+    reason: Epe1 recruits the SAGA histone acetyltransferase complex to
       heterochromatin sites, thereby promoting H3 acetylation. While Epe1 itself
-      doesn&#39;t perform acetylation, it is directly involved in enabling this 
+      doesn&#39;t perform acetylation, it is directly involved in enabling this
       process through HAT recruitment.
     supported_by:
     - reference_id: file:SCHPO/Epe1/Epe1-deep-research.md
-      supporting_text: Mass spectrometry identified SAGA subunits co-purifying 
-        with Epe1, and overexpressed Epe1 can recruit SAGA to heterochromatic 
+      supporting_text: Mass spectrometry identified SAGA subunits co-purifying
+        with Epe1, and overexpressed Epe1 can recruit SAGA to heterochromatic
         repeats, resulting in increased histone H3 acetylation
     - reference_id: file:SCHPO/Epe1/Epe1-deep-research.md
-      supporting_text: Bao et al. (2019) revealed that Epe1 can associate with 
-        the SAGA co-activator complex and promote histone acetylation through 
+      supporting_text: Bao et al. (2019) revealed that Epe1 can associate with
+        the SAGA co-activator complex and promote histone acetylation through
         this recruitment mechanism
 - term:
     id: GO:0140030
@@ -6916,7 +7082,7 @@ existing_annotations:
     action: NEW
     reason: Core function term not present in existing_annotations.
 core_functions:
-- description: Binds HP1/Swi6 at H3K9-methylated heterochromatin through 
+- description: Binds HP1/Swi6 at H3K9-methylated heterochromatin through
     C-terminal domain to antagonize silencing
   molecular_function:
     id: GO:0140030
@@ -6935,13 +7101,13 @@ core_functions:
     label: subtelomeric heterochromatin
   supported_by:
   - reference_id: file:SCHPO/Epe1/Epe1-deep-research.md
-    supporting_text: Epe1 C-terminus binds HP1/Swi6 in a manner stimulated by 
+    supporting_text: Epe1 C-terminus binds HP1/Swi6 in a manner stimulated by
       H3K9 methylation
   - reference_id: file:SCHPO/Epe1/Epe1-bioinformatics/RESULTS.md
-    supporting_text: Extensive coiled-coil regions detected indicating 
-      protein-protein interaction capability for HP1/Swi6 binding and complex 
+    supporting_text: Extensive coiled-coil regions detected indicating
+      protein-protein interaction capability for HP1/Swi6 binding and complex
       formation
-- description: Recruits SAGA histone acetyltransferase complex to 
+- description: Recruits SAGA histone acetyltransferase complex to
     heterochromatin for H3 acetylation
   molecular_function:
     id: GO:0035035
@@ -6956,12 +7122,12 @@ core_functions:
     label: heterochromatin
   supported_by:
   - reference_id: file:SCHPO/Epe1/Epe1-deep-research.md
-    supporting_text: Mass spectrometry identified SAGA subunits co-purifying 
+    supporting_text: Mass spectrometry identified SAGA subunits co-purifying
       with Epe1
   - reference_id: file:SCHPO/Epe1/Epe1-deep-research.md
-    supporting_text: Overexpressed Epe1 can recruit SAGA to heterochromatic 
+    supporting_text: Overexpressed Epe1 can recruit SAGA to heterochromatic
       repeats, resulting in increased histone H3 acetylation
-- description: Recruits Bdf2 bromodomain protein to heterochromatin boundaries 
+- description: Recruits Bdf2 bromodomain protein to heterochromatin boundaries
     to recognize acetylated histones
   molecular_function:
     id: GO:0042826
@@ -6976,9 +7142,9 @@ core_functions:
     label: subtelomeric heterochromatin
   supported_by:
   - reference_id: PMID:24013502
-    supporting_text: Epe1 recruits BET family bromodomain protein Bdf2 to 
+    supporting_text: Epe1 recruits BET family bromodomain protein Bdf2 to
       establish heterochromatin boundaries
-- description: Promotes nucleosome turnover at heterochromatin to destabilize 
+- description: Promotes nucleosome turnover at heterochromatin to destabilize
     silencing marks
   molecular_function:
     id: GO:0042393
@@ -6993,7 +7159,7 @@ core_functions:
   - reference_id: file:SCHPO/Epe1/Epe1-deep-research.md
     supporting_text: Epe1 increases nucleosome turnover rates in heterochromatic
       regions
-- description: Enables transcription of heterochromatic repeats for 
+- description: Enables transcription of heterochromatic repeats for
     RNAi-mediated heterochromatin establishment
   molecular_function:
     id: GO:0003712
@@ -7006,7 +7172,7 @@ core_functions:
     label: pericentric heterochromatin
   supported_by:
   - reference_id: PMID:36617881
-    supporting_text: Tandemly repeated genes promote RNAi-mediated 
+    supporting_text: Tandemly repeated genes promote RNAi-mediated
       heterochromatin formation via an antisilencing factor, Epe1
 - description: Competes with histone deacetylase Clr3 for HP1/Swi6 binding sites
     to prevent silencing maintenance
@@ -7021,7 +7187,7 @@ core_functions:
     label: heterochromatin
   supported_by:
   - reference_id: file:SCHPO/Epe1/Epe1-deep-research.md
-    supporting_text: Epe1 C-terminus alone can disrupt heterochromatin assembly 
+    supporting_text: Epe1 C-terminus alone can disrupt heterochromatin assembly
       by outcompeting HDAC Clr3 at Swi6 binding sites
 references:
 - id: GO_REF:0000033
@@ -7034,49 +7200,49 @@ references:
   title: Combined Automated Annotation using Multiple IEA Methods.
   findings: []
 - id: PMID:12773576
-  title: A novel jmjC domain protein modulates heterochromatization in fission 
+  title: A novel jmjC domain protein modulates heterochromatization in fission
     yeast.
   findings: []
 - id: PMID:16762840
-  title: Swi6/HP1 recruits a JmjC domain protein to facilitate transcription of 
+  title: Swi6/HP1 recruits a JmjC domain protein to facilitate transcription of
     heterochromatic repeats.
   findings: []
 - id: PMID:17449867
-  title: Interaction of Epe1 with the heterochromatin assembly pathway in 
+  title: Interaction of Epe1 with the heterochromatin assembly pathway in
     Schizosaccharomyces pombe.
   findings: []
 - id: PMID:17948055
-  title: The JmjC domain protein Epe1 prevents unregulated assembly and 
+  title: The JmjC domain protein Epe1 prevents unregulated assembly and
     disassembly of heterochromatin.
   findings: []
 - id: PMID:21215368
-  title: The Cul4-Ddb1(Cdt)² ubiquitin ligase inhibits invasion of a 
+  title: The Cul4-Ddb1(Cdt)² ubiquitin ligase inhibits invasion of a
     boundary-associated antisilencing factor into heterochromatin.
   findings: []
 - id: PMID:22144463
-  title: RNA elimination machinery targeting meiotic mRNAs promotes facultative 
+  title: RNA elimination machinery targeting meiotic mRNAs promotes facultative
     heterochromatin formation.
   findings: []
 - id: PMID:24013502
-  title: Epe1 recruits BET family bromodomain protein Bdf2 to establish 
+  title: Epe1 recruits BET family bromodomain protein Bdf2 to establish
     heterochromatin boundaries.
   findings: []
 - id: PMID:25774602
   title: Rapid epigenetic adaptation to uncontrolled heterochromatin spreading.
   findings: []
 - id: PMID:25831549
-  title: Epigenetics. Epigenetic inheritance uncoupled from sequence-specific 
+  title: Epigenetics. Epigenetic inheritance uncoupled from sequence-specific
     recruitment.
   findings: []
 - id: PMID:25838386
   title: Epigenetics. Restricted epigenetic inheritance of H3K9 methylation.
   findings: []
 - id: PMID:29214404
-  title: The 19S proteasome regulates subtelomere silencing and facultative 
+  title: The 19S proteasome regulates subtelomere silencing and facultative
     heterochromatin formation in fission yeast.
   findings: []
 - id: PMID:31206516
-  title: Regulation of ectopic heterochromatin-mediated epigenetic 
+  title: Regulation of ectopic heterochromatin-mediated epigenetic
     diversification by the JmjC family protein Epe1.
   findings: []
 - id: PMID:36617881
@@ -7084,7 +7250,7 @@ references:
     via an antisilencing factor, Epe1, in fission yeast.
   findings: []
 - id: PMID:39094565
-  title: Mapping the dynamics of epigenetic adaptation in S. pombe during 
+  title: Mapping the dynamics of epigenetic adaptation in S. pombe during
     heterochromatin misregulation.
   findings: []
 - id: file:SCHPO/Epe1/Epe1-bioinformatics/RESULTS.md
@@ -7148,22 +7314,22 @@ references:
     supporting_text: |-
       Stressors (caffeine, azoles) induce **ubiquitylation and proteasome-dependent removal of the N-terminal ~150 residues**, producing **tEpe1**.
 suggested_questions:
-- question: How does Epe1 regulate heterochromatin formation and maintenance at 
+- question: How does Epe1 regulate heterochromatin formation and maintenance at
     centromeres and telomeres?
-- question: What determines the specificity of Epe1 for different chromatin 
+- question: What determines the specificity of Epe1 for different chromatin
     modifications and histone variants?
-- question: How does Epe1 coordinate with other chromatin remodeling factors 
+- question: How does Epe1 coordinate with other chromatin remodeling factors
     during cell cycle progression?
-- question: What role does Epe1 play in epigenetic inheritance and chromatin 
+- question: What role does Epe1 play in epigenetic inheritance and chromatin
     stability across generations?
 suggested_experiments:
 - description: ChIP-seq analysis to map Epe1 binding sites across the genome and
     correlate with chromatin modifications
-- description: Live-cell imaging of fluorescently tagged Epe1 to study its 
+- description: Live-cell imaging of fluorescently tagged Epe1 to study its
     dynamics during the cell cycle
-- description: Genetic screens to identify Epe1 interacting factors and 
+- description: Genetic screens to identify Epe1 interacting factors and
     chromatin regulators
-- description: Single-cell analysis of heterochromatin inheritance in Epe1 
+- description: Single-cell analysis of heterochromatin inheritance in Epe1
     mutant cells
 status: DRAFT
 </code></pre>
@@ -7172,7 +7338,7 @@ status: DRAFT
     </div>
 
     <!-- Pathway Visualization Link -->
-    
+
     <div class="section">
         <div class="pathway-link">
             <div style="display: flex; justify-content: space-between; align-items: center;">
@@ -7192,7 +7358,7 @@ status: DRAFT
             </p>
         </div>
     </div>
-    
+
 
     <style>
         /* Markdown Section Styles */

--- a/genes/SCHPO/Epe1/Epe1-ai-review.yaml
+++ b/genes/SCHPO/Epe1/Epe1-ai-review.yaml
@@ -34,6 +34,17 @@ existing_annotations:
       anti-silencing function, demonstrating demethylase activity is not 
       required for its biological role (Bao 2019). The C-terminus alone (without
       JmjC) can disrupt heterochromatin (Raiymbek 2020).
+    propagation_review:
+      root_cause: PROPAGATION_BAD
+      failure_modes:
+      - PSEUDO_OR_SUBACTIVITY_LOSS
+      source_entities:
+      - source_id: PANTHER:PTN000564171
+        source_label: JmjC-domain PANTHER node
+        source_status: SUPPORTS_SOURCE_BUT_NOT_TARGET
+        comment: Active JmjC demethylase sources do not transfer to Epe1 because
+          the target has degenerate catalytic residues and no detectable demethylase
+          activity.
     proposed_replacement_terms:
     - id: GO:0042393
       label: histone binding
@@ -73,6 +84,17 @@ existing_annotations:
       acetylation (Bao 2019) and promotes nucleosome turnover at heterochromatin
       sites. The broad chromatin remodeling term obscures the specific 
       mechanisms.
+    propagation_review:
+      root_cause: TERM_SCOPING_PROBLEM
+      failure_modes:
+      - GRANULARITY_MISMATCH
+      source_entities:
+      - source_id: PANTHER:PTN000564171
+        source_label: JmjC-domain chromatin source node
+        source_status: SUPPORTS_SOURCE_BUT_NOT_TARGET
+        comment: The source captures chromatin-related JmjC family biology, but
+          Epe1 is better reviewed through more specific anti-silencing,
+          transcriptional, and chromatin-boundary mechanisms.
     proposed_replacement_terms:
     - id: GO:0006473
       label: protein acetylation

--- a/genes/VIBCH/cds1/cds1-ai-review.yaml
+++ b/genes/VIBCH/cds1/cds1-ai-review.yaml
@@ -40,6 +40,22 @@ existing_annotations:
       vs 2.5.1.47 (transferase/biosynthesis). The source proteins in the IBA WITH/FROM field
       (P0ABK5/CysK, P35520/CBS, P16703/CysM) are from SF194/SF162 synthase subfamilies, but
       Q9KT44/VC1061 is in SF135 which evolved a catabolic function.
+    propagation_review:
+      root_cause: PROPAGATION_BAD
+      failure_modes:
+      - FUNCTIONAL_DIVERGENCE
+      source_entities:
+      - source_id: PANTHER:PTN000034104
+        source_label: PANTHER PTHR10314 root node
+        source_status: SUPPORTS_SOURCE_BUT_NOT_TARGET
+        comment: The root node mixes cysteine synthase sources with the divergent
+          Cds1 desulfhydrase subfamily; biosynthesis support does not transfer
+          to the catabolic target.
+      - source_id: UniProtKB:P0ABK5
+        source_label: E. coli CysK
+        source_status: SUPPORTS_SOURCE_BUT_NOT_TARGET
+        comment: CysK supports cysteine biosynthesis, while VIBCH Cds1/VC1061 is
+          reviewed as a cysteine desulfhydrase with the opposite reaction direction.
     supported_by:
     - reference_id: PMID:34283874
       supporting_text: "The results indicate that deletion of cbs is critical in reducing H2S production from cysteine in V. cholerae"

--- a/genes/human/AGO4/AGO4-ai-review.yaml
+++ b/genes/human/AGO4/AGO4-ai-review.yaml
@@ -52,6 +52,21 @@ existing_annotations:
     action: REMOVE
     reason: AGO4 is best supported as a non-slicing Argonaute paralog; assigning RNA endonuclease
       activity would overstate AGO2-like catalytic function.
+    propagation_review:
+      root_cause: PROPAGATION_BAD
+      failure_modes:
+      - PSEUDO_OR_SUBACTIVITY_LOSS
+      source_entities:
+      - source_id: PANTHER:PTN008584027
+        source_label: Argonaute PANTHER source node
+        source_status: SUPPORTS_SOURCE_BUT_NOT_TARGET
+        comment: The family source includes slicing-competent Argonautes, but AGO4
+          is reviewed as a non-slicing paralog.
+      - source_id: UniProtKB:Q9UKV8
+        source_label: human AGO2
+        source_status: SUPPORTS_SOURCE_BUT_NOT_TARGET
+        comment: AGO2 supports RNA endonuclease activity; AGO4 lacks the same supported
+          slicer activity in the target review.
     supported_by:
     - reference_id: file:human/AGO4/AGO4-deep-research-falcon.md
       supporting_text: Human AGO4 (EIF2C4; UniProt Q9HCK5) is best supported (in the retrieved
@@ -114,6 +129,18 @@ existing_annotations:
     action: MARK_AS_OVER_ANNOTATED
     reason: The better-supported role is as a loaded Argonaute effector after small-RNA processing,
       not as the Drosha/Dicer processing enzyme for pre-miRNAs.
+    propagation_review:
+      root_cause: TERM_SCOPING_PROBLEM
+      failure_modes:
+      - ROLE_CONFLATION
+      - GRANULARITY_MISMATCH
+      source_entities:
+      - source_id: PANTHER:PTN000527278
+        source_label: Argonaute pre-miRNA processing source node
+        source_status: SUPPORTS_SOURCE_BUT_NOT_TARGET
+        comment: The source captures Argonaute participation in miRNA pathway
+          biology, but the propagated term overstates AGO4 as processing
+          machinery rather than a loaded small-RNA effector.
     supported_by:
     - reference_id: file:human/AGO4/AGO4-deep-research-falcon.md
       supporting_text: Human AGO4 (EIF2C4; UniProt Q9HCK5) is best supported (in the retrieved
@@ -144,6 +171,17 @@ existing_annotations:
     action: MARK_AS_OVER_ANNOTATED
     reason: The informative molecular function is Argonaute small-RNA/miRNA binding within RISC
       rather than a broad nucleic-acid or RNA-binding label.
+    propagation_review:
+      root_cause: TERM_SCOPING_PROBLEM
+      failure_modes:
+      - GRANULARITY_MISMATCH
+      source_entities:
+      - source_id: PANTHER:PTN000527276
+        source_label: Argonaute RNA-binding source node
+        source_status: SUPPORTS_SOURCE_BUT_NOT_TARGET
+        comment: The source supports RNA-binding Argonaute biology, but the
+          propagated term is less informative than AGO4 small-RNA/miRNA binding
+          in RISC context.
     supported_by:
     - reference_id: file:human/AGO4/AGO4-deep-research-falcon.md
       supporting_text: Human AGO4 (EIF2C4; UniProt Q9HCK5) is best supported (in the retrieved

--- a/genes/human/AKTIP/AKTIP-ai-review.yaml
+++ b/genes/human/AKTIP/AKTIP-ai-review.yaml
@@ -73,6 +73,21 @@ existing_annotations:
       even a NOT annotation (NAS) for GO:0019787 (ubiquitin-like protein transferase
       activity)
       confirming this is NOT a function of AKTIP.
+    propagation_review:
+      root_cause: PROPAGATION_BAD
+      failure_modes:
+      - PSEUDO_OR_SUBACTIVITY_LOSS
+      source_entities:
+      - source_id: PANTHER:PTN002514495
+        source_label: UBC/E2 PANTHER source node
+        source_status: SUPPORTS_SOURCE_BUT_NOT_TARGET
+        comment: The source node includes active E2 ubiquitin-conjugating enzymes,
+          but AKTIP lacks the catalytic cysteine needed for E2 activity.
+      - source_id: UniProtKB:P61077
+        source_label: human UBE2D3
+        source_status: SUPPORTS_SOURCE_BUT_NOT_TARGET
+        comment: UBE2D3 supports genuine E2 ubiquitin-conjugating activity; AKTIP
+          is an inactive UEV-domain protein.
     additional_reference_ids:
     - file:human/AKTIP/AKTIP-deep-research-falcon.md
     supported_by:
@@ -106,6 +121,23 @@ existing_annotations:
       roles in telomere replication, ESCRT function, and FHF complex - not ubiquitination.
       Requires more investigation to determine if AKTIP has a scaffold role in K63
       ubiquitination.
+    propagation_review:
+      root_cause: UNRESOLVED
+      failure_modes:
+      - PSEUDO_OR_SUBACTIVITY_LOSS
+      - SOURCE_EVIDENCE_WEAK
+      source_entities:
+      - source_id: PANTHER:PTN000630262
+        source_label: UEV/UBC13 K63-ubiquitination source node
+        source_status: UNRESOLVED
+        comment: The source node supports K63-linked ubiquitination in active
+          UBC/UEV systems, but AKTIP lacks the E2 catalytic cysteine and its
+          human scaffold role in this process is not established.
+      - source_id: UniProtKB:P61088
+        source_label: human UBE2N/UBC13
+        source_status: SUPPORTS_SOURCE_BUT_NOT_TARGET
+        comment: UBE2N supports K63-linked ubiquitination at the source; whether
+          AKTIP contributes as a non-catalytic scaffold remains unresolved.
 
 - term:
     id: GO:0006301

--- a/genes/human/CAPG/CAPG-ai-review.yaml
+++ b/genes/human/CAPG/CAPG-ai-review.yaml
@@ -122,6 +122,21 @@ existing_annotations:
         appears to be an over-extension from the gelsolin family, but CAPG specifically
         lacks severing activity. Deep research confirms "native CAPG does not sever
         filaments under typical conditions."
+      propagation_review:
+        root_cause: PROPAGATION_BAD
+        failure_modes:
+          - PSEUDO_OR_SUBACTIVITY_LOSS
+        source_entities:
+          - source_id: PANTHER:PTN000240164
+            source_label: gelsolin/villin PANTHER source node
+            source_status: SUPPORTS_SOURCE_BUT_NOT_TARGET
+            comment: The family source includes severing-capable gelsolin-like proteins,
+              but CAPG retains barbed-end capping without native severing activity.
+          - source_id: UniProtKB:P06396
+            source_label: human gelsolin
+            source_status: SUPPORTS_SOURCE_BUT_NOT_TARGET
+            comment: Gelsolin supports actin-filament severing; CAPG is the capping-only
+              branch of the family in this review.
       supported_by:
         - reference_id: PMID:1322908
           supporting_text: >-

--- a/genes/human/CRYAA/CRYAA-ai-review.yaml
+++ b/genes/human/CRYAA/CRYAA-ai-review.yaml
@@ -199,6 +199,23 @@ existing_annotations:
       for CRYAA
       because not all sHSP members have refolding activity. There is functional divergence
       within the family (PMID:19464326).
+    propagation_review:
+      root_cause: PROPAGATION_BAD
+      failure_modes:
+      - PSEUDO_OR_SUBACTIVITY_LOSS
+      - FUNCTIONAL_DIVERGENCE
+      source_entities:
+      - source_id: PANTHER:PTN000897708
+        source_label: small heat-shock protein PANTHER source node
+        source_status: SUPPORTS_SOURCE_BUT_NOT_TARGET
+        comment: The family source can include refolding-associated sHSP biology,
+          but CRYAA is reviewed as a holdase that prevents aggregation without refolding
+          clients.
+      - source_id: UniProtKB:P02470
+        source_label: bovine CRYAA NOT-refolding source
+        source_status: SUPPORTS_TRANSFER
+        comment: The independent NOT annotation from the bovine ortholog supports
+          the target review by contradicting the positive IBA to protein refolding.
     supported_by:
     - reference_id: PMID:8943244
       supporting_text: >-
@@ -253,6 +270,17 @@ existing_annotations:
       GO:0042026 protein refolding, ISS). The appropriate MF replacement is
       GO:0140309 "unfolded protein carrier activity." GO:0050821 "protein
       stabilization" is appropriate as a BP term.
+    propagation_review:
+      root_cause: TERM_SCOPING_PROBLEM
+      failure_modes:
+      - GRANULARITY_MISMATCH
+      source_entities:
+      - source_id: PANTHER:PTN000897708
+        source_label: small heat-shock protein source node
+        source_status: SUPPORTS_SOURCE_BUT_NOT_TARGET
+        comment: The source supports small heat-shock protein holdase biology,
+          but the propagated unfolded-protein-binding term is being replaced by
+          a more precise carrier/holdase activity term.
     proposed_replacement_terms:
     - id: GO:0140309
       label: unfolded protein carrier activity

--- a/genes/human/DPYSL2/DPYSL2-ai-review.yaml
+++ b/genes/human/DPYSL2/DPYSL2-ai-review.yaml
@@ -59,6 +59,22 @@ existing_annotations:
     reason: 'Domain/phylogenetic over-propagation refutable on biological grounds: the metal-cofactor-binding
       residues are absent (UniProt CAUTION), so no metallo-hydrolase activity is supported; the real function
       is a non-catalytic cytoskeletal regulator. Same basis as the DPYSL5 review.'
+    propagation_review:
+      root_cause: PROPAGATION_BAD
+      failure_modes:
+      - PSEUDO_OR_SUBACTIVITY_LOSS
+      source_entities:
+      - source_id: PANTHER:PTN000182670
+        source_label: metallo-dependent hydrolase PANTHER node
+        source_status: SUPPORTS_SOURCE_BUT_NOT_TARGET
+        comment: The source node includes active metallo-hydrolases, but DPYSL2
+          lacks the conserved metal-cofactor-binding residues needed for the propagated
+          catalytic activity.
+      - source_id: UniProtKB:Q14117
+        source_label: human DPYS
+        source_status: SUPPORTS_SOURCE_BUT_NOT_TARGET
+        comment: DPYS supports dihydropyrimidinase-family hydrolase activity; DPYSL2
+          is a non-catalytic CRMP paralog rather than an active enzyme.
     supported_by:
     - reference_id: file:human/DPYSL2/DPYSL2-uniprot.txt
       supporting_text: Lacks most of the conserved residues that are essential for

--- a/genes/human/RIMBP2/RIMBP2-ai-review.yaml
+++ b/genes/human/RIMBP2/RIMBP2-ai-review.yaml
@@ -67,6 +67,22 @@ existing_annotations:
       (2017) characterized its function at auditory endbulb synapses. A more appropriate
       term would
       capture the general role in synaptic vesicle exocytosis regulation.
+    propagation_review:
+      root_cause: PROPAGATION_BAD
+      failure_modes:
+      - CONTEXT_OR_TISSUE_MISMATCH
+      source_entities:
+      - source_id: FB:FBgn0262483
+        source_label: Drosophila RIM-binding protein
+        source_status: SUPPORTS_SOURCE_BUT_NOT_TARGET
+        comment: The fly source supports neuromuscular-junction context, whereas
+          human RIMBP2 is reviewed as a broader presynaptic active-zone scaffold
+          at CNS and auditory synapses.
+      - source_id: PANTHER:PTN002306629
+        source_label: PANTHER RIMBP2 source node
+        source_status: SUPPORTS_SOURCE_BUT_NOT_TARGET
+        comment: The family transfer preserves synaptic transmission but over-carries
+          the source organism's neuromuscular context into the human annotation.
     proposed_replacement_terms:
     - id: GO:2000300
       label: regulation of synaptic vesicle exocytosis

--- a/pages/projects/IBA_REVIEW.html
+++ b/pages/projects/IBA_REVIEW.html
@@ -250,6 +250,25 @@
         /* Project meta: maturity + tag badges */
         .project-meta { margin-bottom: 0.5rem; }
         .project-meta .badge { margin: 0 0.25rem 0.25rem 0; }
+        .gene-list {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.375rem;
+            margin-bottom: 1rem;
+        }
+        .gene-list a,
+        .gene-list span {
+            background-color: #dbeafe;
+            border-radius: 0.25rem;
+            color: #1e40af;
+            display: inline-block;
+            font-weight: 500;
+            padding: 0.125rem 0.375rem;
+        }
+        .gene-list a:hover {
+            background-color: #bfdbfe;
+            text-decoration: none;
+        }
         .m-SCOPING     { background: #fef3c7; color: #92400e; }
         .m-IN_PROGRESS { background: #dbeafe; color: #1e40af; }
         .m-MATURE      { background: #dcfce7; color: #166534; }
@@ -330,40 +349,278 @@
 
     <header class="header">
         <h1>IBA Annotation Quality Project</h1>
-        
+
         <p class="project-meta">
             <span class="badge m-COMPLETE">COMPLETE</span>
             <span class="badge tag t-PIPELINE">PIPELINE</span><span class="badge tag t-FLAGSHIP">FLAGSHIP</span>
         </p>
-        
-        
-        
+
+
+        <p><strong>Species:</strong> human, CANAL, MYCTU, VIBCH, SCHPO, ECOLI, mouse, rat, worm, yeast, ANOGA, POPTR, DANRE</p>
+
+
+        <div class="gene-list">
+            <strong>Genes:</strong>
+
+
+            <a href="../../genes/SCHPO/Epe1/Epe1-ai-review.html" title="SCHPO/Epe1">Epe1</a>
+
+
+
+            <a href="../../genes/MYCTU/cds1/cds1-ai-review.html" title="MYCTU/cds1">cds1</a>
+
+
+
+            <a href="../../genes/CANAL/LPL1/LPL1-ai-review.html" title="CANAL/LPL1">LPL1</a>
+
+
+
+            <a href="../../genes/human/UBA7/UBA7-ai-review.html" title="human/UBA7">UBA7</a>
+
+
+
+            <a href="../../genes/human/RIMBP2/RIMBP2-ai-review.html" title="human/RIMBP2">RIMBP2</a>
+
+
+
+            <a href="../../genes/ECOLI/arnF/arnF-ai-review.html" title="ECOLI/arnF">arnF</a>
+
+
+
+            <a href="../../genes/human/DPYSL2/DPYSL2-ai-review.html" title="human/DPYSL2">DPYSL2</a>
+
+
+
+            <a href="../../genes/human/CRMP1/CRMP1-ai-review.html" title="human/CRMP1">CRMP1</a>
+
+
+
+            <a href="../../genes/human/DPYSL3/DPYSL3-ai-review.html" title="human/DPYSL3">DPYSL3</a>
+
+
+
+            <a href="../../genes/human/AGO4/AGO4-ai-review.html" title="human/AGO4">AGO4</a>
+
+
+
+            <a href="../../genes/human/UBAC2/UBAC2-ai-review.html" title="human/UBAC2">UBAC2</a>
+
+
+
+            <a href="../../genes/human/CAPG/CAPG-ai-review.html" title="human/CAPG">CAPG</a>
+
+
+
+            <a href="../../genes/human/CRYAA/CRYAA-ai-review.html" title="human/CRYAA">CRYAA</a>
+
+
+
+            <a href="../../genes/human/BCL2/BCL2-ai-review.html" title="human/BCL2">BCL2</a>
+
+
+
+            <a href="../../genes/mouse/Bcl2/Bcl2-ai-review.html" title="mouse/Bcl2">Bcl2</a>
+
+
+
+            <a href="../../genes/human/BCL2L1/BCL2L1-ai-review.html" title="human/BCL2L1">BCL2L1</a>
+
+
+
+            <a href="../../genes/human/EIF4E2/EIF4E2-ai-review.html" title="human/EIF4E2">EIF4E2</a>
+
+
+
+            <a href="../../genes/rat/Aldh1l1/Aldh1l1-ai-review.html" title="rat/Aldh1l1">Aldh1l1</a>
+
+
+
+            <a href="../../genes/rat/Hmgcs2/Hmgcs2-ai-review.html" title="rat/Hmgcs2">Hmgcs2</a>
+
+
+
+            <a href="../../genes/human/PEX2/PEX2-ai-review.html" title="human/PEX2">PEX2</a>
+
+
+
+            <a href="../../genes/human/AGK/AGK-ai-review.html" title="human/AGK">AGK</a>
+
+
+
+            <a href="../../genes/human/AKTIP/AKTIP-ai-review.html" title="human/AKTIP">AKTIP</a>
+
+
+
+            <a href="../../genes/human/DPYSL4/DPYSL4-ai-review.html" title="human/DPYSL4">DPYSL4</a>
+
+
+
+            <a href="../../genes/human/SAMD8/SAMD8-ai-review.html" title="human/SAMD8">SAMD8</a>
+
+
+
+            <a href="../../genes/human/CPT1C/CPT1C-ai-review.html" title="human/CPT1C">CPT1C</a>
+
+
+
+            <a href="../../genes/human/NTN1/NTN1-ai-review.html" title="human/NTN1">NTN1</a>
+
+
+
+            <a href="../../genes/human/NTN3/NTN3-ai-review.html" title="human/NTN3">NTN3</a>
+
+
+
+            <a href="../../genes/human/NOTCH1/NOTCH1-ai-review.html" title="human/NOTCH1">NOTCH1</a>
+
+
+
+            <a href="../../genes/human/IL23R/IL23R-ai-review.html" title="human/IL23R">IL23R</a>
+
+
+
+            <a href="../../genes/human/ABRAXAS1/ABRAXAS1-ai-review.html" title="human/ABRAXAS1">ABRAXAS1</a>
+
+
+
+            <a href="../../genes/human/PIWIL1/PIWIL1-ai-review.html" title="human/PIWIL1">PIWIL1</a>
+
+
+
+            <a href="../../genes/worm/prg-1/prg-1-ai-review.html" title="worm/prg-1">prg-1</a>
+
+
+
+            <a href="../../genes/worm/wago-1/wago-1-ai-review.html" title="worm/wago-1">wago-1</a>
+
+
+
+            <a href="../../genes/human/EIF2AK3/EIF2AK3-ai-review.html" title="human/EIF2AK3">EIF2AK3</a>
+
+
+
+            <a href="../../genes/human/BIRC6/BIRC6-ai-review.html" title="human/BIRC6">BIRC6</a>
+
+
+
+            <a href="../../genes/yeast/SSB2/SSB2-ai-review.html" title="yeast/SSB2">SSB2</a>
+
+
+
+            <a href="../../genes/yeast/SSZ1/SSZ1-ai-review.html" title="yeast/SSZ1">SSZ1</a>
+
+
+
+            <a href="../../genes/human/BAIAP2L2/BAIAP2L2-ai-review.html" title="human/BAIAP2L2">BAIAP2L2</a>
+
+
+
+            <a href="../../genes/human/PIK3C3/PIK3C3-ai-review.html" title="human/PIK3C3">PIK3C3</a>
+
+
+
+            <a href="../../genes/human/SCGB1A1/SCGB1A1-ai-review.html" title="human/SCGB1A1">SCGB1A1</a>
+
+
+
+            <a href="../../genes/SCHPO/rqh1/rqh1-ai-review.html" title="SCHPO/rqh1">rqh1</a>
+
+
+
+            <a href="../../genes/yeast/HDA1/HDA1-ai-review.html" title="yeast/HDA1">HDA1</a>
+
+
+
+            <a href="../../genes/ANOGA/TOLL9/TOLL9-ai-review.html" title="ANOGA/TOLL9">TOLL9</a>
+
+
+
+            <a href="../../genes/POPTR/ndhA/ndhA-ai-review.html" title="POPTR/ndhA">ndhA</a>
+
+
+
+            <a href="../../genes/POPTR/ndhD/ndhD-ai-review.html" title="POPTR/ndhD">ndhD</a>
+
+
+
+            <a href="../../genes/POPTR/ndhK/ndhK-ai-review.html" title="POPTR/ndhK">ndhK</a>
+
+
+
+            <a href="../../genes/worm/che-3/che-3-ai-review.html" title="worm/che-3">che-3</a>
+
+
+
+            <a href="../../genes/ANOGA/D7r2/D7r2-ai-review.html" title="ANOGA/D7r2">D7r2</a>
+
+
+
+            <a href="../../genes/ANOGA/D7r4/D7r4-ai-review.html" title="ANOGA/D7r4">D7r4</a>
+
+
+
+            <a href="../../genes/ANOGA/D7r5/D7r5-ai-review.html" title="ANOGA/D7r5">D7r5</a>
+
+
+
+            <a href="../../genes/ANOGA/D7L1/D7L1-ai-review.html" title="ANOGA/D7L1">D7L1</a>
+
+
+
+            <a href="../../genes/worm/sta-2/sta-2-ai-review.html" title="worm/sta-2">sta-2</a>
+
+
+
+            <a href="../../genes/worm/fshr-1/fshr-1-ai-review.html" title="worm/fshr-1">fshr-1</a>
+
+
+
+            <a href="../../genes/DANRE/opa1/opa1-ai-review.html" title="DANRE/opa1">opa1</a>
+
+
+
+            <a href="../../genes/worm/eat-3/eat-3-ai-review.html" title="worm/eat-3">eat-3</a>
+
+
+
+            <a href="../../genes/worm/hsp-12.3/hsp-12.3-ai-review.html" title="worm/hsp-12.3">hsp-12.3</a>
+
+
+
+            <a href="../../genes/worm/hsp-12.6/hsp-12.6-ai-review.html" title="worm/hsp-12.6">hsp-12.6</a>
+
+
+
+            <a href="../../genes/yeast/YAR1/YAR1-ai-review.html" title="yeast/YAR1">YAR1</a>
+
+
+
+            <a href="../../genes/yeast/ACL4/ACL4-ai-review.html" title="yeast/ACL4">ACL4</a>
+
+
+
+            <a href="../../genes/yeast/SIR3/SIR3-ai-review.html" title="yeast/SIR3">SIR3</a>
+
+
+
+            <a href="../../genes/worm/lys-7/lys-7-ai-review.html" title="worm/lys-7">lys-7</a>
+
+
+
+            <a href="../../genes/yeast/UBP3/UBP3-ai-review.html" title="yeast/UBP3">UBP3</a>
+
+
+
+            <a href="../../genes/human/CASP12/CASP12-ai-review.html" title="human/CASP12">CASP12</a>
+
+
+        </div>
+
     </header>
 
-    
 
-    
-    <div class="warnings">
-        <h3>Warnings (7)</h3>
-        <ul>
-            
-            <li>Ambiguous symbol &#39;LPL1&#39; found in species: CANAL, yeast. Add &#39;species: [CANAL]&#39; to frontmatter to resolve.</li>
-            
-            <li>Ambiguous symbol &#39;cds1&#39; found in species: MYCTU, SCHPO, VIBCH. Add &#39;species: [MYCTU]&#39; to frontmatter to resolve.</li>
-            
-            <li>Ambiguous symbol &#39;CRYAA&#39; found in species: BOVIN, human. Add &#39;species: [BOVIN]&#39; to frontmatter to resolve.</li>
-            
-            <li>Ambiguous symbol &#39;ndhA&#39; found in species: MISSI, POPTR. Add &#39;species: [MISSI]&#39; to frontmatter to resolve.</li>
-            
-            <li>Ambiguous symbol &#39;ndhD&#39; found in species: MISSI, POPTR. Add &#39;species: [MISSI]&#39; to frontmatter to resolve.</li>
-            
-            <li>Ambiguous symbol &#39;ndhK&#39; found in species: MISSI, POPTR. Add &#39;species: [MISSI]&#39; to frontmatter to resolve.</li>
-            
-            <li>Ambiguous symbol &#39;rpoB&#39; found in species: MISSI, POPTR. Add &#39;species: [MISSI]&#39; to frontmatter to resolve.</li>
-            
-        </ul>
-    </div>
-    
+
+
 
     <div class="content">
         <h1 id="iba-annotation-quality-project">IBA Annotation Quality Project</h1>
@@ -382,6 +639,181 @@ where IBA is <em>wrong</em> (over-annotation, patterns 1–15), while<br />
 <a href="#iba-incompleteness-core-function-that-iba-fails-to-propagate">IBA Incompleteness</a><br />
 quantifies where IBA <em>under-calls</em> established biology — 511 curated human core<br />
 molecular functions that IBA alone would miss.</p>
+<h2 id="propagation-taxonomy-and-checklist">Propagation Taxonomy and Checklist</h2>
+<p>The patterns below are biological failure modes, but IBA review also needs a<br />
+root-cause call: is the source annotation bad, or is the propagation bad? Use the<br />
+same <code>review.propagation_review</code> structure as the<br />
+<a href="ISO.html#failure-taxonomy">ISO review project</a>: <code>root_cause</code>, optional<br />
+<code>failure_modes</code>, and per-source <code>source_entities</code> with short source-specific<br />
+comments.</p>
+<h3 id="root-cause-classes">Root-cause classes</h3>
+<p>These are the schema values for <code>propagation_review.root_cause</code>.</p>
+<table>
+<thead>
+<tr>
+<th>Code</th>
+<th>IBA interpretation</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><code>NO_FAILURE_CORE</code></td>
+<td>The ancestral/family inference is correct and core for the target.</td>
+</tr>
+<tr>
+<td><code>NO_FAILURE_NON_CORE</code></td>
+<td>The inference is defensible but contextual, secondary, or generic.</td>
+</tr>
+<tr>
+<td><code>SOURCE_BAD</code></td>
+<td>A seed/source annotation or family-node assertion is itself wrong, miscited, homonym-confused, or contradicted.</td>
+</tr>
+<tr>
+<td><code>SOURCE_STALE_OR_MISSING</code></td>
+<td>The transferred term no longer appears on the current source record, or the donor trace cannot recover it.</td>
+</tr>
+<tr>
+<td><code>SOURCE_WEAK_OR_INFERRED</code></td>
+<td>The source exists but is only inferred, statement-level, or otherwise weak for confident propagation.</td>
+</tr>
+<tr>
+<td><code>EVIDENCE_CIRCULAR_OR_REDUNDANT</code></td>
+<td>The chain transfers from another transfer, or the target already has stronger direct evidence.</td>
+</tr>
+<tr>
+<td><code>PROPAGATION_BAD</code></td>
+<td>The source biology is real, but the PANTHER node propagated it to the wrong target, subfamily, lineage, compartment, or role.</td>
+</tr>
+<tr>
+<td><code>TERM_SCOPING_PROBLEM</code></td>
+<td>The propagated biology is related, but the GO term is too broad, too specific, or has the wrong role/qualifier.</td>
+</tr>
+<tr>
+<td><code>UNRESOLVED</code></td>
+<td>The propagation issue was investigated but cannot yet be classified confidently.</td>
+</tr>
+</tbody>
+</table>
+<h3 id="biological-subtypes">Biological subtypes</h3>
+<p>These are the schema values for <code>propagation_review.failure_modes</code>.</p>
+<table>
+<thead>
+<tr>
+<th>Code</th>
+<th>IBA signal</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><code>WRONG_ORTHOLOG_OR_PARALOG</code></td>
+<td>Donor/source is a paralog, expanded family member, or wrong subfamily.</td>
+</tr>
+<tr>
+<td><code>FUNCTIONAL_DIVERGENCE</code></td>
+<td>Target retained fold or orthology but changed substrate, product, activity, or pathway role.</td>
+</tr>
+<tr>
+<td><code>PSEUDO_OR_SUBACTIVITY_LOSS</code></td>
+<td>Catalytic residues or a specific sub-activity are lost even though the domain remains.</td>
+</tr>
+<tr>
+<td><code>CONTEXT_OR_TISSUE_MISMATCH</code></td>
+<td>Donor evidence is tissue, developmental, organismal, or disease-context specific.</td>
+</tr>
+<tr>
+<td><code>LINEAGE_OR_TAXON_MISMATCH</code></td>
+<td>Process does not occur in the target lineage or organelle system.</td>
+</tr>
+<tr>
+<td><code>COMPARTMENT_OR_COMPLEX_MISMATCH</code></td>
+<td>Localization, complex membership, or pathway compartment does not transfer.</td>
+</tr>
+<tr>
+<td><code>REGULATORY_SIGN_INVERSION</code></td>
+<td>Family contains activators and inhibitors, and a positive/negative regulatory term leaks across members.</td>
+</tr>
+<tr>
+<td><code>ROLE_CONFLATION</code></td>
+<td>Substrate, regulator, effector, or specificity subunit is annotated as the agent or core machinery.</td>
+</tr>
+<tr>
+<td><code>GRANULARITY_MISMATCH</code></td>
+<td>Parent term is true but uninformative, or child term overstates specificity.</td>
+</tr>
+<tr>
+<td><code>SOURCE_MISCITATION</code></td>
+<td>Source evidence points to the wrong gene, organism, publication, or homonym.</td>
+</tr>
+<tr>
+<td><code>SOURCE_EVIDENCE_WEAK</code></td>
+<td>Source evidence is inferred, statement-level, stale, or otherwise too weak for confident propagation.</td>
+</tr>
+<tr>
+<td><code>CIRCULAR_PROPAGATION</code></td>
+<td>Propagation chain depends on another propagated annotation rather than independent source evidence.</td>
+</tr>
+</tbody>
+</table>
+<h3 id="source-status-values">Source status values</h3>
+<p>These are the schema values for <code>propagation_review.source_entities[].source_status</code>.</p>
+<table>
+<thead>
+<tr>
+<th>Code</th>
+<th>Source-level interpretation</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><code>SUPPORTS_TRANSFER</code></td>
+<td>Source evidence supports the term and the transfer to the target.</td>
+</tr>
+<tr>
+<td><code>SUPPORTS_SOURCE_BUT_NOT_TARGET</code></td>
+<td>Source evidence supports the source annotation, but propagation to the target is unsafe.</td>
+</tr>
+<tr>
+<td><code>SOURCE_BAD</code></td>
+<td>Source annotation or source citation is itself wrong.</td>
+</tr>
+<tr>
+<td><code>SOURCE_STALE_OR_MISSING</code></td>
+<td>Current source record no longer carries the transferred term, or tracing cannot recover it.</td>
+</tr>
+<tr>
+<td><code>SOURCE_WEAK_OR_INFERRED</code></td>
+<td>Source exists but is only inferred, statement-level, or otherwise weak.</td>
+</tr>
+<tr>
+<td><code>CIRCULAR_OR_REDUNDANT</code></td>
+<td>Source participates in a circular transfer chain or adds no independent support.</td>
+</tr>
+<tr>
+<td><code>NOT_RELEVANT</code></td>
+<td>Source was inspected but is not relevant to the target annotation.</td>
+</tr>
+<tr>
+<td><code>UNRESOLVED</code></td>
+<td>Source could not be classified confidently.</td>
+</tr>
+</tbody>
+</table>
+<p>Before a strong <code>REMOVE</code> on an IBA row, record that these checks were done:</p>
+<ul>
+<li>The GO term definition, aspect, qualifier, and taxon constraints were checked.</li>
+<li>The GOA <code>WITH/FROM</code> field was read and the PANTHER <code>PTN...</code> node and seed<br />
+  proteins were recorded.</li>
+<li>The target and seed proteins were placed in their PANTHER family/subfamily<br />
+  context. Cross-subfamily propagation is triage evidence, not a verdict.</li>
+<li>The source annotation or family-node assertion was checked separately from the<br />
+  propagation decision.</li>
+<li>Target-specific evidence was checked where relevant: direct experiments,<br />
+  curated <code>NOT</code> rows, active-site residues, domain architecture, localization,<br />
+  isoforms, organismal context, and lineage constraints.</li>
+<li><code>review.reason</code> states the biological rationale, while<br />
+<code>review.propagation_review</code> records the mechanical root cause, failure modes,<br />
+  and source entities.</li>
+</ul>
 <h2 id="slides">Slides</h2>
 <ul>
 <li><a href="IBA_REVIEW/slides/IBA_REVIEW-slides.html">Slides</a> (Marp source: <a href="IBA_REVIEW/slides/IBA_REVIEW-slides.html">IBA_REVIEW-slides.md</a>) — AI generated</li>
@@ -394,31 +826,42 @@ molecular functions that IBA alone would miss.</p>
 - Source: Related JmjC domain proteins with characterized demethylase activity<br />
 - Reality: <a href="../../genes/SCHPO/Epe1/Epe1-ai-review.html">Epe1</a> has degenerate active site (HVD vs HXD), no detectable activity<br />
 - <strong>Impact</strong>: Misleading annotation propagated via phylogenetic inference</p>
-<h3 id="2-ubiquitin-like-modifier-confusion">2. Ubiquitin-Like Modifier Confusion</h3>
-<p><strong>The Problem</strong>: Function from ubiquitin E1 transferred to ISG15-specific E1.</p>
+<h3 id="2-ubiquitin-like-modifier-specificity-iba-as-a-positive-control">2. Ubiquitin-Like Modifier Specificity: IBA as a Positive Control</h3>
+<p><strong>The contrast</strong>: <a href="../../genes/human/UBA7/UBA7-ai-review.html">UBA7</a> shows the opposite of an IBA failure. The IBA rows correctly<br />
+capture the conserved ISGylation pathway, while naive domain propagation and some<br />
+non-IBA annotations blur ISG15-specific E1 activity into generic ubiquitin-like or<br />
+ubiquitin terms.</p>
 <p><strong>Example - <a href="../../genes/human/UBA7/UBA7-ai-review.html">UBA7</a> (human)</strong>:<br />
-- IBA annotations from ubiquitin pathway:<br />
-  - <code>GO:0008641</code> (ubiquitin-like modifier activating enzyme activity) - too general<br />
-  - Various ubiquitin-related terms<br />
-- Reality: <a href="../../genes/human/UBA7/UBA7-ai-review.html">UBA7</a> specifically activates ISG15, not ubiquitin, in mammals<br />
-- <strong>Impact</strong>: Generic terms obscure specific function</p>
+- Correct IBA annotations:<br />
+  - <code>GO:0019782</code> (ISG15 activating enzyme activity)<br />
+  - <code>GO:0032020</code> (ISG15-protein conjugation)<br />
+  - <code>GO:0045087</code> (innate immune response)<br />
+- Over-generic or wrong non-IBA rows:<br />
+  - <code>GO:0008641</code> (ubiquitin-like modifier activating enzyme activity) - <code>IEA</code><br />
+    from InterPro2GO; technically related but too general.<br />
+  - <code>GO:0004842</code> (ubiquitin-protein transferase activity) and<br />
+<code>GO:0016567</code> (protein ubiquitination) - non-IBA ubiquitin terms that should<br />
+    be redirected to ISG15 activation/conjugation.<br />
+- Reality: <a href="../../genes/human/UBA7/UBA7-ai-review.html">UBA7</a> specifically activates ISG15, not ubiquitin, in mammals.<br />
+- <strong>Impact</strong>: IBA provides a useful specific annotation that corrects the less<br />
+  discriminating domain/keyword propagation.</p>
 <h3 id="3-substrate-specificity-transfer">3. Substrate Specificity Transfer</h3>
 <p><strong>The Problem</strong>: Specific substrate preference may differ between orthologs.</p>
-<p><strong>Example - LPL1 (C. albicans)</strong>:<br />
+<p><strong>Example - <a href="../../genes/CANAL/LPL1/LPL1-ai-review.html">LPL1</a> (C. albicans)</strong>:<br />
 - IBA annotation: <code>GO:0004622</code> (phosphatidylcholine lysophospholipase activity)<br />
 - Source: S. cerevisiae ortholog with characterized PC specificity<br />
 - Reality: Enzyme has broad specificity for ALL glycerophospholipids<br />
 - <strong>Impact</strong>: Over-specific annotation from ortholog doesn't capture full activity</p>
 <h3 id="4-neo-functionalization-opposite-function-in-subfamily">4. Neo-Functionalization: Opposite Function in Subfamily</h3>
 <p><strong>The Problem</strong>: When a subfamily undergoes neo-functionalization to catalyze the <strong>opposite reaction</strong>, IBA from the family root propagates the wrong function.</p>
-<p><strong>Example - Cds1 (M. tuberculosis, V. cholerae) - PTHR10314 SF135</strong>:<br />
+<p><strong>Example - <a href="../../genes/MYCTU/cds1/cds1-ai-review.html">Cds1</a> (M. tuberculosis, V. cholerae) - PTHR10314 SF135</strong>:<br />
 - IBA annotation: <code>GO:0019344</code> (cysteine biosynthetic process)<br />
 - Source: Root node (PTN000034104) of PTHR10314 family<br />
-- Reality: Cds1 catalyzes cysteine <strong>CATABOLISM</strong> (EC 4.4.1.1), the exact opposite!<br />
+- Reality: <a href="../../genes/MYCTU/cds1/cds1-ai-review.html">Cds1</a> catalyzes cysteine <strong>CATABOLISM</strong> (EC 4.4.1.1), the exact opposite!<br />
 - <strong>Impact</strong>: IBA propagates biosynthesis when the enzyme actually degrades cysteine to H2S + pyruvate</p>
 <p><strong>Why this is severe</strong>: The annotation isn't just wrong - it's <strong>directionally opposite</strong>. The enzyme produces H2S from cysteine degradation; the annotation says it synthesizes cysteine.</p>
 <p><strong>Root Cause Analysis</strong>:<br />
-| Evidence | SF135 (Cds1) | SF194/SF162 (Synthases) |<br />
+| Evidence | SF135 (<a href="../../genes/MYCTU/cds1/cds1-ai-review.html">Cds1</a>) | SF194/SF162 (Synthases) |<br />
 |----------|--------------|-------------------------|<br />
 | EC Number | <strong>4.4.1.1</strong> (lyase) | 2.5.1.47 (transferase) |<br />
 | Reaction | L-Cys → H2S + pyruvate | O-Ac-Ser + H2S → L-Cys |<br />
@@ -426,12 +869,21 @@ molecular functions that IBA alone would miss.</p>
 | Seq identity to synthases | <strong>~24%</strong> | 40-43% between each other |<br />
 | Active site motif | <strong>ASSGST</strong> | PTSGNTG |</p>
 <p>The subfamily SF135 shares only 24% identity with synthases - less than synthases share with each other (43%). The longest branch length indicates maximum divergence and neo-functionalization.</p>
-<h3 id="5-secondary-activity-promotion">5. Secondary Activity Promotion</h3>
-<p><strong>The Problem</strong>: Non-core activities from well-characterized orthologs promoted to uncharacterized proteins.</p>
-<p><strong>Example - LPL1 (C. albicans)</strong>:<br />
+<h3 id="5-paralogsecondary-activity-transfer">5. Paralog/Secondary Activity Transfer</h3>
+<p><strong>The Problem</strong>: A real activity in one paralog or source subfamily can be<br />
+promoted to a related but distinct target whose closest characterized comparator<br />
+supports a different substrate class. This should not be called<br />
+<code>KEEP_AS_NON_CORE</code> unless there is evidence the target actually has the activity<br />
+as a secondary function.</p>
+<p><strong>Example - <a href="../../genes/CANAL/LPL1/LPL1-ai-review.html">LPL1</a> (C. albicans)</strong>:<br />
 - IBA annotation: <code>GO:0047372</code> (monoacylglycerol lipase activity)<br />
-- This is likely substrate promiscuity, not core function<br />
-- <strong>Action</strong>: KEEP_AS_NON_CORE rather than ACCEPT</p>
+- Source trace: <code>PANTHER:PTN000773837|SGD:S000003112</code>, corresponding to the<br />
+  S. cerevisiae ROG1 monoacylglycerol lipase source<br />
+- Closest characterized <a href="../../genes/CANAL/LPL1/LPL1-ai-review.html">LPL1</a> comparator: S. cerevisiae <a href="../../genes/CANAL/LPL1/LPL1-ai-review.html">LPL1</a>, a lipid-droplet<br />
+  phospholipase B acting on glycerophospholipids<br />
+- <strong>Action</strong>: UNDECIDED for C. albicans <a href="../../genes/CANAL/LPL1/LPL1-ai-review.html">LPL1</a> pending source-tree and substrate<br />
+  review; do not mark as non-core without evidence that Candida <a href="../../genes/CANAL/LPL1/LPL1-ai-review.html">LPL1</a> hydrolyzes<br />
+  monoacylglycerols</p>
 <h3 id="6-organismtissue-context-transfer">6. Organism/Tissue Context Transfer</h3>
 <p><strong>The Problem</strong>: Annotations derived from organism-specific experimental systems carry that context to orthologs where it doesn't apply.</p>
 <p><strong>Example - <a href="../../genes/human/RIMBP2/RIMBP2-ai-review.html">RIMBP2</a> (human)</strong>:<br />
@@ -456,8 +908,8 @@ molecular functions that IBA alone would miss.</p>
 <p><strong>Examples (REMOVE — verified)</strong>:<br />
 - <strong><a href="../../genes/human/CAPG/CAPG-ai-review.html">CAPG</a> (human)</strong> — <code>GO:0051014</code> (actin filament <strong>severing</strong>): <a href="../../genes/human/CAPG/CAPG-ai-review.html">CAPG</a> caps but does <strong>not</strong> sever. The original characterization (cached PMID:1322908) states verbatim that <a href="../../genes/human/CAPG/CAPG-ai-review.html">CAPG</a> <em>"reversibly blocks the barbed ends of actin filaments but does not sever preformed actin"</em>. The severing term over-extends from the gelsolin/villin family; <a href="../../genes/human/CAPG/CAPG-ai-review.html">CAPG</a> retains capping only.<br />
 - <strong><a href="../../genes/human/CRYAA/CRYAA-ai-review.html">human/CRYAA</a></strong> — <code>GO:0042026</code> (protein <strong>refolding</strong>): αA-crystallin is an ATP-independent <strong>holdase</strong> that prevents aggregation but cannot refold clients. This one is corroborated <strong>inside GOA itself</strong>: there is an explicit curated <code>NOT|involved_in</code> (ISS) annotation to <a href="http://amigo.geneontology.org/amigo/term/GO:0042026">GO:0042026</a>, which the IBA directly contradicts. UniProt describes only aggregation-prevention chaperone activity, no refolding.<br />
-- <strong>Worm small heat-shock proteins</strong> — <code>GO:0042026</code> (protein refolding): a stronger version of the CRYAA case. <a href="../../genes/worm/hsp-16.2/hsp-16.2-ai-review.html">hsp-16.2</a> is a holdase, not a foldase; and <strong><a href="../../genes/worm/hsp-12.3/hsp-12.3-ai-review.html">hsp-12.3</a> / <a href="../../genes/worm/hsp-12.6/hsp-12.6-ai-review.html">hsp-12.6</a> have <em>no</em> chaperone activity at all</strong> — the title of PMID:9744800 is literally <em>"…Hsp12.2 and Hsp12.3 form tetramers and have no chaperone-like activity."</em> They are pseudo-sHSPs (tetramers/monomers rather than the large oligomers holdase function needs), so the family-level refolding IBA is fully refuted.<br />
-- <strong>Lesson</strong>: capping≠severing and holdase≠foldase are sub-activity distinctions that family-level IBA flattens. The CRYAA and <a href="../../genes/worm/hsp-12.3/hsp-12.3-ai-review.html">hsp-12.3</a> cases are especially clean because a curator negated the term (CRYAA) or a paper demonstrated zero activity (<a href="../../genes/worm/hsp-12.3/hsp-12.3-ai-review.html">hsp-12.3</a>).</p>
+- <strong>Worm small heat-shock proteins</strong> — <code>GO:0042026</code> (protein refolding): a stronger version of the <a href="../../genes/human/CRYAA/CRYAA-ai-review.html">CRYAA</a> case. <a href="../../genes/worm/hsp-16.2/hsp-16.2-ai-review.html">hsp-16.2</a> is a holdase, not a foldase; and <strong><a href="../../genes/worm/hsp-12.3/hsp-12.3-ai-review.html">hsp-12.3</a> / <a href="../../genes/worm/hsp-12.6/hsp-12.6-ai-review.html">hsp-12.6</a> have <em>no</em> chaperone activity at all</strong> — the title of PMID:9744800 is literally <em>"…Hsp12.2 and Hsp12.3 form tetramers and have no chaperone-like activity."</em> They are pseudo-sHSPs (tetramers/monomers rather than the large oligomers holdase function needs), so the family-level refolding IBA is fully refuted.<br />
+- <strong>Lesson</strong>: capping≠severing and holdase≠foldase are sub-activity distinctions that family-level IBA flattens. The <a href="../../genes/human/CRYAA/CRYAA-ai-review.html">CRYAA</a> and <a href="../../genes/worm/hsp-12.3/hsp-12.3-ai-review.html">hsp-12.3</a> cases are especially clean because a curator negated the term (<a href="../../genes/human/CRYAA/CRYAA-ai-review.html">CRYAA</a>) or a paper demonstrated zero activity (<a href="../../genes/worm/hsp-12.3/hsp-12.3-ai-review.html">hsp-12.3</a>).</p>
 <h3 id="9-regulatory-sign-inversion-within-a-family">9. Regulatory-Sign Inversion Within a Family</h3>
 <p><strong>The Problem</strong>: When a protein family contains members with <strong>opposite regulatory signs</strong> (activators vs inhibitors of the same process), a family-node IBA can transfer the wrong sign.</p>
 <p><strong>Example - <a href="../../genes/human/BCL2/BCL2-ai-review.html">BCL2</a> (human and mouse)</strong>:<br />
@@ -475,7 +927,7 @@ molecular functions that IBA alone would miss.</p>
 - <strong><a href="../../genes/human/CIRBP/CIRBP-ai-review.html">CIRBP</a> (human)</strong> — <code>GO:0005681</code> (spliceosomal complex) + <code>GO:0000398</code> (mRNA splicing, via spliceosome): the cold-inducible RNA-binding protein <a href="../../genes/human/CIRBP/CIRBP-ai-review.html">CIRBP</a> shares only the N-terminal RRM with the transformer-2/RBMX splicing factors that anchor these terms. PANTHER PAINT shows the splicing IBD sits at ancestral node <strong>PTN000391532</strong> (seeded by TRA2A, <a href="../../genes/human/TRA2B/TRA2B-ai-review.html">TRA2B</a>, RBMX, <em>Drosophila</em> tra2, rat Tra2 — all bona fide splicing factors), while <a href="../../genes/human/CIRBP/CIRBP-ai-review.html">CIRBP</a>'s own subfamily node <strong>PTN008729690</strong> carries only <code>mRNA binding</code>. <a href="../../genes/human/CIRBP/CIRBP-ai-review.html">CIRBP</a> has no experimental splicing evidence; its function is 3'-UTR binding, mRNA stabilization and translational control. A non-enzyme instance of complex-membership over-transfer across a functional-divergence boundary. <em>(See Featured Example and <code>families/PTHR48034/PTHR48034-review.md</code>.)</em><br />
 - <strong>Lesson</strong>: complex membership, compartment, and downstream pathway are not conserved across paralogs even when the fold/reaction is; verify the protein actually occupies the annotated complex/compartment and that its product reaches the annotated pathway.</p>
 <h3 id="11-substrate-over-propagation-from-a-multi-specificity-enzyme-family">11. Substrate Over-Propagation From a Multi-Specificity Enzyme Family</h3>
-<p><strong>The Problem</strong>: A PANTHER family lumps enzymes of <strong>different substrate specificities</strong>; a substrate-specific term is then propagated to a member that experimentally lacks that activity. Unlike LPL1 (a real but secondary/broader specificity), here the propagated activity is <strong>absent</strong> in the target.</p>
+<p><strong>The Problem</strong>: A PANTHER family lumps enzymes of <strong>different substrate specificities</strong>; a substrate-specific term is then propagated to a member that experimentally lacks that activity. Unlike <a href="../../genes/CANAL/LPL1/LPL1-ai-review.html">LPL1</a> (a real but secondary/broader specificity), here the propagated activity is <strong>absent</strong> in the target.</p>
 <p><strong>Example - <a href="../../genes/human/AGK/AGK-ai-review.html">AGK</a> (human)</strong> — <code>GO:0001729</code> (ceramide kinase), <code>GO:0046513</code>/<code>GO:0046512</code> (ceramide/sphingosine biosynthesis):<br />
 - <a href="../../genes/human/AGK/AGK-ai-review.html">AGK</a> sits in PANTHER <strong>PTHR12358</strong>, which lumps "ACYLGLYCEROL KINASE" with "SPHINGOSINE KINASE." The ceramide-kinase IBA is propagated from a family node (Drosophila + mouse + node PTN008994514); the IEA/ISS variants both trace to one rodent ortholog (Q9ESW4).<br />
 - <strong>Three independent lines refute the activity in human <a href="../../genes/human/AGK/AGK-ai-review.html">AGK</a></strong>, outweighing the family inference:<br />
@@ -518,7 +970,7 @@ molecular functions that IBA alone would miss.</p>
 <p><strong>The Problem</strong>: Phylogenetic inference crosses kingdom/clade boundaries and lands a biological-process term on an organism where <strong>the process does not exist</strong> — or where the homolog was repurposed into a different system. The WITH/FROM typically names a vertebrate or <em>Drosophila</em> source. This is one of the largest and cleanest BP error classes.</p>
 <p><strong>Examples (REMOVE — verified via UniProt + WITH/FROM):</strong><br />
 - <strong><a href="../../genes/ANOGA/TOLL9/TOLL9-ai-review.html">TOLL9</a> (mosquito, ANOGA)</strong> — <code>GO:0006954</code> (inflammatory response): the IBA traces to <strong>human TLR4 (O00206)</strong> and other mammalian TLRs. Insects have Toll-pathway innate immunity but no vertebrate inflammation (no vasculature, immune-cell infiltration); the term is lineage-inappropriate.<br />
-- <strong>ndhA / ndhD / ndhK (poplar, POPTR)</strong> — <code>GO:0009060</code> (aerobic respiration): UniProt labels these <em>"NAD(P)H-quinone oxidoreductase, </em><em>chloroplastic</em><em>"</em> (<code>OG Plastid; Chloroplast</code>). They are photosynthetic plastid NDH subunits homologous to mitochondrial complex I — an <strong>organelle-system swap</strong>, not mitochondrial respiration.<br />
+- <strong><a href="../../genes/POPTR/ndhA/ndhA-ai-review.html">ndhA</a> / <a href="../../genes/POPTR/ndhD/ndhD-ai-review.html">ndhD</a> / <a href="../../genes/POPTR/ndhK/ndhK-ai-review.html">ndhK</a> (poplar, POPTR)</strong> — <code>GO:0009060</code> (aerobic respiration): UniProt labels these <em>"NAD(P)H-quinone oxidoreductase, </em><em>chloroplastic</em><em>"</em> (<code>OG Plastid; Chloroplast</code>). They are photosynthetic plastid NDH subunits homologous to mitochondrial complex I — an <strong>organelle-system swap</strong>, not mitochondrial respiration.<br />
 - <strong><a href="../../genes/worm/che-3/che-3-ai-review.html">che-3</a> (worm)</strong> — <code>GO:0060294</code> (cilium movement involved in cell motility): <a href="../../genes/worm/che-3/che-3-ai-review.html">che-3</a> is cytoplasmic <strong>dynein-2</strong> (retrograde IFT motor); <em>C. elegans</em> sensory cilia are <strong>non-motile</strong>. The motility term comes from axonemal-dynein orthologs in organisms with motile cilia.<br />
 - <strong>D7 salivary proteins (mosquito, ANOGA: <a href="../../genes/ANOGA/D7r2/D7r2-ai-review.html">D7r2</a>/D7r4/D7r5/D7L1)</strong> — <code>GO:0007608</code> (sensory perception of smell): UniProt calls <a href="../../genes/ANOGA/D7r4/D7r4-ai-review.html">D7r4</a> a <em>"salivary protein… modulates blood feeding,"</em> female-saliva-specific. The OBP/PBP-GOBP fold was repurposed for binding biogenic amines/eicosanoids in saliva — these proteins are not expressed in antennae and have no olfactory role.<br />
 - <strong><a href="../../genes/worm/sta-2/sta-2-ai-review.html">sta-2</a> (worm)</strong> — <code>GO:0007259</code> (JAK-STAT signaling): transferred from fly/mammalian STATs, but <em>C. elegans</em> has <strong>no JAK kinases</strong>; <a href="../../genes/worm/sta-2/sta-2-ai-review.html">STA-2</a> is activated via SNF-12/hemidesmosomes.<br />
@@ -531,7 +983,7 @@ molecular functions that IBA alone would miss.</p>
 - <strong><a href="../../genes/worm/lys-7/lys-7-ai-review.html">lys-7</a> (worm)</strong> — <code>GO:0007165</code> (signal transduction): <a href="../../genes/worm/lys-7/lys-7-ai-review.html">LYS-7</a> is an antimicrobial <strong>effector</strong> whose expression is regulated <em>by</em> signaling; it is not itself a signaling component. (Same logical error as <a href="../../genes/ECOLI/arnF/arnF-ai-review.html">arnF</a>'s "response to iron" — see §<a href="../../genes/ECOLI/arnF/arnF-ai-review.html">arnF</a>.)<br />
 - <strong><a href="../../genes/yeast/SIR3/SIR3-ai-review.html">SIR3</a> (yeast)</strong> — <code>GO:0006270</code> (DNA replication initiation): <a href="../../genes/yeast/SIR3/SIR3-ai-review.html">SIR3</a> <strong>represses</strong> origin firing (negative regulation of MCM loading), the opposite of being part of the initiation machinery (ORC/CDC6/CDT1/MCM2-7).<br />
 - <strong><a href="../../genes/yeast/UBP3/UBP3-ai-review.html">UBP3</a> (yeast)</strong> — <code>GO:0031647</code> (regulation of protein stability): a downstream <em>consequence</em> of its deubiquitinase activity (<code>GO:0004843</code>, the direct function), not a separate function.<br />
-- <strong><a href="../../genes/BACSU/sigF/sigF-ai-review.html">sigF</a> / <a href="../../genes/BACSU/sigG/sigG-ai-review.html">sigG</a> / <a href="../../genes/BACSU/sigK/sigK-ai-review.html">sigK</a> (<em>B. subtilis</em>)</strong> — <code>GO:0003899</code> (DNA-directed RNA polymerase activity): these are <strong>sigma initiation factors</strong> (UniProt: <em>"initiation factors that promote…"</em> promoter recognition) — they confer promoter specificity to RNA polymerase but have <strong>no catalytic polymerase activity</strong>, which belongs to the core enzyme (RpoB/RpoC). A regulatory subunit assigned the <strong>holoenzyme's</strong> catalytic activity.<br />
+- <strong><a href="../../genes/BACSU/sigF/sigF-ai-review.html">sigF</a> / <a href="../../genes/BACSU/sigG/sigG-ai-review.html">sigG</a> / <a href="../../genes/BACSU/sigK/sigK-ai-review.html">sigK</a> (<em>B. subtilis</em>)</strong> — <code>GO:0003899</code> (DNA-directed RNA polymerase activity): these are <strong>sigma initiation factors</strong> (UniProt: <em>"initiation factors that promote…"</em> promoter recognition) — they confer promoter specificity to RNA polymerase but have <strong>no catalytic polymerase activity</strong>, which belongs to the core enzyme (<a href="../../genes/POPTR/rpoB/rpoB-ai-review.html">RpoB</a>/RpoC). A regulatory subunit assigned the <strong>holoenzyme's</strong> catalytic activity.<br />
 - <strong>Lesson</strong>: distinguish "does X" from "regulates/enables/results-in X." Effectors are not signal transducers; repressors are not part of the machinery they inhibit; a specificity subunit does not carry the catalytic activity of the complex it joins; downstream consequences are not direct molecular functions.</p>
 <h2 id="featured-examples">Featured Examples</h2>
 <h3 id="epe1-pseudo-demethylase"><a href="../../genes/SCHPO/Epe1/Epe1-ai-review.html">Epe1</a> - Pseudo-Demethylase</h3>
@@ -548,16 +1000,21 @@ molecular functions that IBA alone would miss.</p>
 <h3 id="uba7-isg15-specific-e1"><a href="../../genes/human/UBA7/UBA7-ai-review.html">UBA7</a> - ISG15-Specific E1</h3>
 <p><strong>Species</strong>: human<br />
 <strong>Status</strong>: COMPLETE</p>
-<p><strong>IBA Annotations Flagged</strong>:<br />
+<p><strong>Annotations reviewed</strong>:<br />
 | Term | Issue | Action |<br />
 |------|-------|--------|<br />
-| <a href="http://amigo.geneontology.org/amigo/term/GO:0005737">GO:0005737</a> cytoplasm | Correct | ACCEPT |<br />
-| <a href="http://amigo.geneontology.org/amigo/term/GO:0019782">GO:0019782</a> ISG15 activating enzyme activity | Correct, specific | ACCEPT |<br />
-| <a href="http://amigo.geneontology.org/amigo/term/GO:0032020">GO:0032020</a> ISG15-protein conjugation | Correct | ACCEPT |<br />
-| <a href="http://amigo.geneontology.org/amigo/term/GO:0045087">GO:0045087</a> innate immune response | Correct | ACCEPT |<br />
-| <a href="http://amigo.geneontology.org/amigo/term/GO:0006974">GO:0006974</a> DNA damage response | Correct | ACCEPT |</p>
-<p><strong>Note</strong>: <a href="../../genes/human/UBA7/UBA7-ai-review.html">UBA7</a> IBA annotations are largely correct because the ISGylation pathway is conserved.</p>
-<h3 id="lpl1-phospholipase-specificity">LPL1 - Phospholipase Specificity</h3>
+| <a href="http://amigo.geneontology.org/amigo/term/GO:0005737">GO:0005737</a> cytoplasm | IBA, correct | ACCEPT |<br />
+| <a href="http://amigo.geneontology.org/amigo/term/GO:0019782">GO:0019782</a> ISG15 activating enzyme activity | IBA, correct and specific | ACCEPT |<br />
+| <a href="http://amigo.geneontology.org/amigo/term/GO:0032020">GO:0032020</a> ISG15-protein conjugation | IBA, correct | ACCEPT |<br />
+| <a href="http://amigo.geneontology.org/amigo/term/GO:0045087">GO:0045087</a> innate immune response | IBA, correct | ACCEPT |<br />
+| <a href="http://amigo.geneontology.org/amigo/term/GO:0006974">GO:0006974</a> DNA damage response | IBA, correct | ACCEPT |<br />
+| <a href="http://amigo.geneontology.org/amigo/term/GO:0008641">GO:0008641</a> ubiquitin-like modifier activating enzyme activity | InterPro2GO IEA, too general | MODIFY to <a href="http://amigo.geneontology.org/amigo/term/GO:0019782">GO:0019782</a> |<br />
+| <a href="http://amigo.geneontology.org/amigo/term/GO:0004842">GO:0004842</a> ubiquitin-protein transferase activity | Non-IBA ubiquitin term, wrong activity class | MODIFY to <a href="http://amigo.geneontology.org/amigo/term/GO:0019782">GO:0019782</a> |<br />
+| <a href="http://amigo.geneontology.org/amigo/term/GO:0016567">GO:0016567</a> protein ubiquitination | UniPathway IEA, wrong modifier process | MODIFY to <a href="http://amigo.geneontology.org/amigo/term/GO:0032020">GO:0032020</a> |</p>
+<p><strong>Lesson</strong>: <a href="../../genes/human/UBA7/UBA7-ai-review.html">UBA7</a> should be highlighted as a positive-control case for IBA<br />
+specificity. The bad rows are not IBA propagation errors; they are generic or<br />
+ubiquitin-biased non-IBA mappings that the IBA annotations help correct.</p>
+<h3 id="lpl1-phospholipase-specificity"><a href="../../genes/CANAL/LPL1/LPL1-ai-review.html">LPL1</a> - Phospholipase Specificity</h3>
 <p><strong>Species</strong>: CANAL<br />
 <strong>Status</strong>: COMPLETE</p>
 <p><strong>IBA Annotations Flagged</strong>:<br />
@@ -566,7 +1023,7 @@ molecular functions that IBA alone would miss.</p>
 | <a href="http://amigo.geneontology.org/amigo/term/GO:0006629">GO:0006629</a> lipid metabolic process | Correct | ACCEPT |<br />
 | <a href="http://amigo.geneontology.org/amigo/term/GO:0004622">GO:0004622</a> PC lysophospholipase activity | Too narrow | MODIFY |<br />
 | <a href="http://amigo.geneontology.org/amigo/term/GO:0005811">GO:0005811</a> lipid droplet | Correct | ACCEPT |<br />
-| <a href="http://amigo.geneontology.org/amigo/term/GO:0047372">GO:0047372</a> monoacylglycerol lipase activity | Secondary activity | KEEP_AS_NON_CORE |</p>
+| <a href="http://amigo.geneontology.org/amigo/term/GO:0047372">GO:0047372</a> monoacylglycerol lipase activity | ROG1-paralog/substrate-specificity transfer; target evidence absent | UNDECIDED |</p>
 <h3 id="rimbp2-context-specific-term-transfer"><a href="../../genes/human/RIMBP2/RIMBP2-ai-review.html">RIMBP2</a> - Context-Specific Term Transfer</h3>
 <p><strong>Species</strong>: human<br />
 <strong>Status</strong>: COMPLETE<br />
@@ -601,7 +1058,7 @@ molecular functions that IBA alone would miss.</p>
 - <strong>Gdx/SugE</strong> (P69937) — <strong>guanidinium export</strong><br />
 - <strong>Mmr</strong> (P9WGF1) — <em>M. tuberculosis</em> multidrug resistance</p>
 <p>The IBA inference of "transmembrane transporter activity" comes from propagating annotations from these bona fide solute exporters (EmrE, MdtI/J, Gdx, Mmr) to <a href="../../genes/ECOLI/arnF/arnF-ai-review.html">ArnF</a>. But <a href="../../genes/ECOLI/arnF/arnF-ai-review.html">ArnF</a> does something mechanistically different: it <strong>flips a lipid-linked sugar between membrane leaflets</strong>, not export a solute across the membrane. The correct MF term is <a href="http://amigo.geneontology.org/amigo/term/GO:0140303">GO:0140303</a> (intramembrane lipid transporter activity).</p>
-<p><strong>Why this is instructive</strong>: Unlike the cds1 case (opposite reaction) or <a href="../../genes/SCHPO/Epe1/Epe1-ai-review.html">Epe1</a> (lost activity), <a href="../../genes/ECOLI/arnF/arnF-ai-review.html">arnF</a> retains <em>transport</em> function — the IBA isn't wrong in kind, just wrong in specificity. The SMR superfamily is a case where sequence homology correctly identifies the structural fold (small multidrug resistance-like) but the functional annotation doesn't track the divergence from drug efflux to lipid flipping. This is a <strong>moderate severity</strong> issue because the parent term "transmembrane transporter" is not false, but it's misleading about mechanism.</p>
+<p><strong>Why this is instructive</strong>: Unlike the <a href="../../genes/MYCTU/cds1/cds1-ai-review.html">cds1</a> case (opposite reaction) or <a href="../../genes/SCHPO/Epe1/Epe1-ai-review.html">Epe1</a> (lost activity), <a href="../../genes/ECOLI/arnF/arnF-ai-review.html">arnF</a> retains <em>transport</em> function — the IBA isn't wrong in kind, just wrong in specificity. The SMR superfamily is a case where sequence homology correctly identifies the structural fold (small multidrug resistance-like) but the functional annotation doesn't track the divergence from drug efflux to lipid flipping. This is a <strong>moderate severity</strong> issue because the parent term "transmembrane transporter" is not false, but it's misleading about mechanism.</p>
 <p><strong>EcoCyc vs. IBA comparison</strong>: EcoCyc contributed 5 annotations for <a href="../../genes/ECOLI/arnF/arnF-ai-review.html">arnF</a>, including two "response to iron(III) ion" annotations (IGI from PMID:12139617, IEP from PMID:15322361) that were marked as over-annotated — they conflate transcriptional regulation of the <a href="../../genes/BPT4/arn/arn-ai-review.html">arn</a> operon by BasS-BasR with direct gene function. The IMP annotations from EcoCyc (carbohydrate derivative transport/transporter activity, plasma membrane IDA) are well-supported. The IBA annotations from GO_Central are reasonable at the superfamily level but miss the flippase specialization.</p>
 <p><strong>Root Cause Analysis</strong>:<br />
 | Feature | ArnE/ArnF | EmrE | MdtI/J | Gdx |<br />
@@ -610,7 +1067,7 @@ molecular functions that IBA alone would miss.</p>
 | Substrate | Lipid-linked sugar | Lipophilic cations | Spermidine | Guanidinium |<br />
 | Mechanism | Intramembrane flip | Transmembrane export | Transmembrane export | Transmembrane export |<br />
 | PANTHER SF | SF9 | (family-level) | SF6 | (family-level) |</p>
-<h3 id="cds1-pthr10314-neo-functionalization-opposite-reaction">Cds1 (PTHR10314) - Neo-Functionalization (Opposite Reaction)</h3>
+<h3 id="cds1-pthr10314-neo-functionalization-opposite-reaction"><a href="../../genes/MYCTU/cds1/cds1-ai-review.html">Cds1</a> (PTHR10314) - Neo-Functionalization (Opposite Reaction)</h3>
 <p><strong>Species</strong>: MYCTU (Mycobacterium tuberculosis), VIBCH (Vibrio cholerae)<br />
 <strong>Status</strong>: COMPLETE<br />
 <strong>Family</strong>: PTHR10314 (Cysteine Synthase/Cystathionine Beta-Synthase)</p>
@@ -618,18 +1075,18 @@ molecular functions that IBA alone would miss.</p>
 | Term | Issue | Action |<br />
 |------|-------|--------|<br />
 | <a href="http://amigo.geneontology.org/amigo/term/GO:0019344">GO:0019344</a> cysteine biosynthetic process | <strong>Opposite function</strong> - enzyme is catabolic | REMOVE |</p>
-<p><strong>Lesson</strong>: This is the most severe type of IBA error - the annotation isn't merely imprecise, it's <strong>directionally wrong</strong>. Cds1 (subfamily SF135) catalyzes cysteine <strong>degradation</strong> (EC 4.4.1.1), producing H2S + pyruvate from L-cysteine. The IBA annotation <a href="http://amigo.geneontology.org/amigo/term/GO:0019344">GO:0019344</a> says it participates in cysteine <strong>biosynthesis</strong> - the exact opposite reaction!</p>
+<p><strong>Lesson</strong>: This is the most severe type of IBA error - the annotation isn't merely imprecise, it's <strong>directionally wrong</strong>. <a href="../../genes/MYCTU/cds1/cds1-ai-review.html">Cds1</a> (subfamily SF135) catalyzes cysteine <strong>degradation</strong> (EC 4.4.1.1), producing H2S + pyruvate from L-cysteine. The IBA annotation <a href="http://amigo.geneontology.org/amigo/term/GO:0019344">GO:0019344</a> says it participates in cysteine <strong>biosynthesis</strong> - the exact opposite reaction!</p>
 <p><strong>Root Cause Analysis</strong>:<br />
 1. <a href="http://amigo.geneontology.org/amigo/term/GO:0019344">GO:0019344</a> is annotated at the PANTHER family root node (PTN000034104)<br />
-2. Root annotation propagates to ALL descendants, including subfamily SF135 (Cds1)<br />
+2. Root annotation propagates to ALL descendants, including subfamily SF135 (<a href="../../genes/MYCTU/cds1/cds1-ai-review.html">Cds1</a>)<br />
 3. SF135 underwent <strong>neo-functionalization</strong>: same fold, opposite reaction<br />
 4. Evidence of neo-functionalization:<br />
    - Longest branch length (0.528) from root = most divergent<br />
    - Different EC class: 4.4.1.1 (lyase/catabolism) vs 2.5.1.47 (transferase/biosynthesis)<br />
    - Only 24% sequence identity with synthases (synthases share 40-43% with each other)<br />
-   - Distinct active site motif: ASSGST (Cds1) vs PTSGNTG (synthases)</p>
+   - Distinct active site motif: ASSGST (<a href="../../genes/MYCTU/cds1/cds1-ai-review.html">Cds1</a>) vs PTSGNTG (synthases)</p>
 <p><strong>Experimental Evidence</strong>:<br />
-- PMID:34439535 (M. tuberculosis): Cds1 produces H2S, pyruvate from cysteine; KM=11.26 mM, kcat=78.71/s<br />
+- PMID:34439535 (M. tuberculosis): <a href="../../genes/MYCTU/cds1/cds1-ai-review.html">Cds1</a> produces H2S, pyruvate from cysteine; KM=11.26 mM, kcat=78.71/s<br />
 - PMID:34283874 (V. cholerae): VC1061/cds1 is principal enzyme for cysteine-derived H2S production</p>
 <p><strong>Recommendation for PANTHER Curators</strong>:<br />
 - Remove <a href="http://amigo.geneontology.org/amigo/term/GO:0019344">GO:0019344</a> propagation to SF135<br />
@@ -677,14 +1134,14 @@ molecular functions that IBA alone would miss.</p>
 <td>COMPLETE</td>
 </tr>
 <tr>
-<td>cds1</td>
+<td><a href="../../genes/MYCTU/cds1/cds1-ai-review.html">cds1</a></td>
 <td>MYCTU, VIBCH</td>
 <td><strong>Neo-functionalization (opposite reaction)</strong></td>
 <td><strong>CRITICAL</strong></td>
 <td>COMPLETE</td>
 </tr>
 <tr>
-<td>LPL1</td>
+<td><a href="../../genes/CANAL/LPL1/LPL1-ai-review.html">LPL1</a></td>
 <td>CANAL</td>
 <td>Substrate specificity</td>
 <td>MEDIUM</td>
@@ -693,8 +1150,8 @@ molecular functions that IBA alone would miss.</p>
 <tr>
 <td><a href="../../genes/human/UBA7/UBA7-ai-review.html">UBA7</a></td>
 <td>human</td>
-<td>Generic vs specific terms</td>
-<td>LOW</td>
+<td>Positive control: IBA corrects generic/domain propagation</td>
+<td>N/A</td>
 <td>COMPLETE</td>
 </tr>
 <tr>
@@ -740,7 +1197,7 @@ molecular functions that IBA alone would miss.</p>
 <td>COMPLETE</td>
 </tr>
 <tr>
-<td>CRYAA</td>
+<td><a href="../../genes/human/CRYAA/CRYAA-ai-review.html">CRYAA</a></td>
 <td>human</td>
 <td>Partial sub-activity loss (holdase not foldase; curated NOT(refolding))</td>
 <td>MEDIUM</td>
@@ -894,7 +1351,7 @@ molecular functions that IBA alone would miss.</p>
 <td>COMPLETE</td>
 </tr>
 <tr>
-<td>ndhA/ndhD/ndhK</td>
+<td><a href="../../genes/POPTR/ndhA/ndhA-ai-review.html">ndhA</a>/ndhD/ndhK</td>
 <td>POPTR</td>
 <td>Organelle swap: chloroplast NDH annotated as mito respiration</td>
 <td>MEDIUM</td>
@@ -1131,7 +1588,7 @@ experimentally defined activity rather than as a finished call.</p>
 <li><strong>Check for functional divergence</strong>: Especially in rapidly evolving families</li>
 <li><strong>Consider organism-specific biases</strong>: Source annotations may reflect experimental systems (e.g., NMJ in flies) that don't apply to target species</li>
 <li><strong>Validate annotations at family root</strong>: Root-level annotations propagate everywhere - ensure they're truly universal to ALL subfamilies</li>
-<li><strong>Synthesize multiple lines of evidence before flagging — never a single keyword</strong>: a UniProt keyword (especially "By similarity"), a PANTHER node label, and a review assertion are each <em>individually</em> weak. Cross-check the term definition, direct experimental papers in the target species, the IBA WITH/FROM provenance, the MSA/active-site residues, and phylogenetic placement, and reason over the whole picture. The strongest REMOVE cases pair an explicit UniProt CAUTION/NOT with direct enzymology (<a href="../../genes/human/DPYSL2/DPYSL2-ai-review.html">DPYSL2</a>, <a href="../../genes/human/AGO4/AGO4-ai-review.html">AGO4</a>, CRYAA, <a href="../../genes/human/AGK/AGK-ai-review.html">AGK</a>)</li>
+<li><strong>Synthesize multiple lines of evidence before flagging — never a single keyword</strong>: a UniProt keyword (especially "By similarity"), a PANTHER node label, and a review assertion are each <em>individually</em> weak. Cross-check the term definition, direct experimental papers in the target species, the IBA WITH/FROM provenance, the MSA/active-site residues, and phylogenetic placement, and reason over the whole picture. The strongest REMOVE cases pair an explicit UniProt CAUTION/NOT with direct enzymology (<a href="../../genes/human/DPYSL2/DPYSL2-ai-review.html">DPYSL2</a>, <a href="../../genes/human/AGO4/AGO4-ai-review.html">AGO4</a>, <a href="../../genes/human/CRYAA/CRYAA-ai-review.html">CRYAA</a>, <a href="../../genes/human/AGK/AGK-ai-review.html">AGK</a>)</li>
 <li><strong>Watch for opposite-sign family members</strong>: When a family contains both activators and inhibitors (e.g., <a href="../../genes/human/BCL2/BCL2-ai-review.html">BCL2</a> family), a family-node IBA can transfer the wrong regulatory sign — inspect the WITH/FROM list for mixed members (but check whether independent non-IBA evidence also supports the term before calling it flatly wrong)</li>
 <li><strong>Distinguish sub-activities</strong>: capping vs severing, holdase vs foldase, slicing vs non-slicing — family-level IBA flattens these distinctions</li>
 <li><strong>Don't inherit a paralog's compartment/complex</strong>: family members share folds but not localization or complex membership — verify the protein actually occupies the annotated complex/compartment (<a href="../../genes/human/EIF4E2/EIF4E2-ai-review.html">EIF4E2</a>, <a href="../../genes/rat/Aldh1l1/Aldh1l1-ai-review.html">ALDH1L1</a>, <a href="../../genes/human/PEX2/PEX2-ai-review.html">PEX2</a>)</li>
@@ -1153,7 +1610,7 @@ experimentally defined activity rather than as a finished call.</p>
 <p><strong>NOT reliable grounds for flagging — verify with reasoning, not a single keyword</strong>:<br />
 - A label that merely <em>looks</em> opposite — check the term <strong>definition</strong>. <a href="http://amigo.geneontology.org/amigo/term/GO:0015677">GO:0015677</a> "copper ion import" covers movement into a cell <em>or organelle</em>, so a Golgi-loading copper exporter (<a href="../../genes/human/ATP7B/ATP7B-ai-review.html">ATP7B</a>) still satisfies it. (This is why <a href="../../genes/human/ATP7B/ATP7B-ai-review.html">ATP7B</a> was <strong>not</strong> flagged.)<br />
 - A shared reaction that is <em>classified</em> under a pathway does not prove pathway membership in vivo — but it does mean the activity is real, so prefer "over-annotation/non-core" over "absent" (<a href="../../genes/rat/Hmgcs2/Hmgcs2-ai-review.html">HMGCS2</a>: the HMG-CoA-synthase step is genuine; only the FPP-pathway <em>flux</em> belongs to the other paralog).<br />
-- <strong>Neither</strong> a UniProt keyword <strong>nor</strong> a review assertion is sufficient on its own. Weigh all lines: a UniProt "By similarity" tag is weak and can be overturned by direct experimental papers (<a href="../../genes/human/AGK/AGK-ai-review.html">AGK</a>: "ceramide By similarity" is refuted by two papers reporting no ceramide/sphingosine phosphorylation — so <a href="../../genes/human/AGK/AGK-ai-review.html">AGK</a> <em>was</em> flagged); an explicit UniProt CAUTION or a curated NOT annotation is strong (<a href="../../genes/human/DPYSL2/DPYSL2-ai-review.html">DPYSL2</a>, CRYAA).<br />
+- <strong>Neither</strong> a UniProt keyword <strong>nor</strong> a review assertion is sufficient on its own. Weigh all lines: a UniProt "By similarity" tag is weak and can be overturned by direct experimental papers (<a href="../../genes/human/AGK/AGK-ai-review.html">AGK</a>: "ceramide By similarity" is refuted by two papers reporting no ceramide/sphingosine phosphorylation — so <a href="../../genes/human/AGK/AGK-ai-review.html">AGK</a> <em>was</em> flagged); an explicit UniProt CAUTION or a curated NOT annotation is strong (<a href="../../genes/human/DPYSL2/DPYSL2-ai-review.html">DPYSL2</a>, <a href="../../genes/human/CRYAA/CRYAA-ai-review.html">CRYAA</a>).<br />
 - A broad <strong>subsuming compartment</strong> is not wrong just because a more specific location is known. <code>GO:0005737</code> cytoplasm includes mitochondrion, ER, Golgi, and lysosome (<code>part_of</code> cytoplasm), so "cytoplasm" is defensible for an organellar protein; only nucleus, plasma membrane, the extracellular space, or a <em>different</em> organelle are mutually exclusive enough to justify a localization REMOVE (see Pattern 13).</p>
 <p><strong>Signs of reliable IBA</strong>:<br />
 - Core metabolic enzymes with conserved mechanism<br />

--- a/pages/projects/IBA_REVIEW/HISTORY.html
+++ b/pages/projects/IBA_REVIEW/HISTORY.html
@@ -250,6 +250,25 @@
         /* Project meta: maturity + tag badges */
         .project-meta { margin-bottom: 0.5rem; }
         .project-meta .badge { margin: 0 0.25rem 0.25rem 0; }
+        .gene-list {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.375rem;
+            margin-bottom: 1rem;
+        }
+        .gene-list a,
+        .gene-list span {
+            background-color: #dbeafe;
+            border-radius: 0.25rem;
+            color: #1e40af;
+            display: inline-block;
+            font-weight: 500;
+            padding: 0.125rem 0.375rem;
+        }
+        .gene-list a:hover {
+            background-color: #bfdbfe;
+            text-decoration: none;
+        }
         .m-SCOPING     { background: #fef3c7; color: #92400e; }
         .m-IN_PROGRESS { background: #dbeafe; color: #1e40af; }
         .m-MATURE      { background: #dcfce7; color: #166534; }
@@ -330,31 +349,101 @@
 
     <header class="header">
         <h1>IBA Annotation Quality — History, Methodology &amp; Lessons</h1>
-        
-        
-        
+
+
+        <p><strong>Species:</strong> human, MYCTU, VIBCH, SCHPO, ECOLI, CANAL, worm, yeast, ANOGA, POPTR, DANRE</p>
+
+
+        <div class="gene-list">
+            <strong>Genes:</strong>
+
+
+            <a href="../../../genes/human/DPYSL2/DPYSL2-ai-review.html" title="human/DPYSL2">DPYSL2</a>
+
+
+
+            <a href="../../../genes/human/CRMP1/CRMP1-ai-review.html" title="human/CRMP1">CRMP1</a>
+
+
+
+            <a href="../../../genes/human/DPYSL3/DPYSL3-ai-review.html" title="human/DPYSL3">DPYSL3</a>
+
+
+
+            <a href="../../../genes/human/AGO4/AGO4-ai-review.html" title="human/AGO4">AGO4</a>
+
+
+
+            <a href="../../../genes/human/UBAC2/UBAC2-ai-review.html" title="human/UBAC2">UBAC2</a>
+
+
+
+            <a href="../../../genes/human/CAPG/CAPG-ai-review.html" title="human/CAPG">CAPG</a>
+
+
+
+            <a href="../../../genes/human/CRYAA/CRYAA-ai-review.html" title="human/CRYAA">CRYAA</a>
+
+
+
+            <a href="../../../genes/human/CRY1/CRY1-ai-review.html" title="human/CRY1">CRY1</a>
+
+
+
+            <a href="../../../genes/human/CRY2/CRY2-ai-review.html" title="human/CRY2">CRY2</a>
+
+
+
+            <a href="../../../genes/human/BCL2/BCL2-ai-review.html" title="human/BCL2">BCL2</a>
+
+
+
+            <a href="../../../genes/human/EIF4E2/EIF4E2-ai-review.html" title="human/EIF4E2">EIF4E2</a>
+
+
+
+            <a href="../../../genes/human/AGK/AGK-ai-review.html" title="human/AGK">AGK</a>
+
+
+
+            <a href="../../../genes/human/PIWIL1/PIWIL1-ai-review.html" title="human/PIWIL1">PIWIL1</a>
+
+
+
+            <a href="../../../genes/MYCTU/cds1/cds1-ai-review.html" title="MYCTU/cds1">cds1</a>
+
+
+
+            <a href="../../../genes/human/RIMBP2/RIMBP2-ai-review.html" title="human/RIMBP2">RIMBP2</a>
+
+
+
+            <a href="../../../genes/ECOLI/arnF/arnF-ai-review.html" title="ECOLI/arnF">arnF</a>
+
+
+
+            <a href="../../../genes/POPTR/ndhA/ndhA-ai-review.html" title="POPTR/ndhA">ndhA</a>
+
+
+
+            <a href="../../../genes/POPTR/ndhD/ndhD-ai-review.html" title="POPTR/ndhD">ndhD</a>
+
+
+
+            <a href="../../../genes/POPTR/ndhK/ndhK-ai-review.html" title="POPTR/ndhK">ndhK</a>
+
+
+
+            <a href="../../../genes/POPTR/rpoB/rpoB-ai-review.html" title="POPTR/rpoB">rpoB</a>
+
+
+        </div>
+
     </header>
 
-    
 
-    
-    <div class="warnings">
-        <h3>Warnings (5)</h3>
-        <ul>
-            
-            <li>Ambiguous symbol &#39;rpoB&#39; found in species: MISSI, POPTR. Add &#39;species: [MISSI]&#39; to frontmatter to resolve.</li>
-            
-            <li>Ambiguous symbol &#39;ndhA&#39; found in species: MISSI, POPTR. Add &#39;species: [MISSI]&#39; to frontmatter to resolve.</li>
-            
-            <li>Ambiguous symbol &#39;CRYAA&#39; found in species: BOVIN, human. Add &#39;species: [BOVIN]&#39; to frontmatter to resolve.</li>
-            
-            <li>Ambiguous symbol &#39;CRY1&#39; found in species: ARATH, human. Add &#39;species: [ARATH]&#39; to frontmatter to resolve.</li>
-            
-            <li>Ambiguous symbol &#39;cds1&#39; found in species: MYCTU, SCHPO, VIBCH. Add &#39;species: [MYCTU]&#39; to frontmatter to resolve.</li>
-            
-        </ul>
-    </div>
-    
+
+
 
     <div class="content">
         <h1 id="iba-annotation-quality-history-methodology-lessons">IBA Annotation Quality — History, Methodology &amp; Lessons</h1>
@@ -480,7 +569,7 @@ This is the lesson-5 / lesson-9 method applied properly; cited from Pattern 7.</
 <strong><a href="../../../genes/mouse/Serpinh1/Serpinh1-ai-review.html">Serpinh1</a>/HSP47</strong> (non-inhibitory serpin; collagen ER chaperone).<br />
 - Regulator/effector (Pattern 15): <strong><a href="../../../genes/BACSU/sigF/sigF-ai-review.html">sigF</a>/sigG/sigK</strong> sigma factors given RNA-polymerase<br />
   catalytic activity — a specificity subunit assigned the holoenzyme's catalytic activity<br />
-  (belongs to RpoB/RpoC).</p>
+  (belongs to <a href="../../../genes/POPTR/rpoB/rpoB-ai-review.html">RpoB</a>/RpoC).</p>
 <p><strong>Excluded for insufficient verification (discipline):</strong> <a href="../../../genes/ANOGA/PGRPLC/PGRPLC-ai-review.html">PGRPLC</a>/PGRPS1 (the PGRP/amidase-2<br />
 family has both catalytic and non-catalytic members; flagging amidase activity needs the<br />
 same residue check I did for CRMP — not done). Left in backlog with <a href="../../../genes/human/UQCRC1/UQCRC1-ai-review.html">UQCRC1</a>.</p>
@@ -493,7 +582,7 @@ have diminished.</p>
 <p>Triaged the 53 BP REMOVE candidates (44 genes). Verified each flagship against UniProt<br />
 + WITH/FROM + (where cited) cached papers. Two new patterns, two reinforced.</p>
 <p><strong>New Pattern 14 — lineage-inappropriate / cross-kingdom process transfer</strong> (largest BP<br />
-class): <a href="../../../genes/ANOGA/TOLL9/TOLL9-ai-review.html">TOLL9</a> inflammatory response ← human TLR4 (O00206); ndhA/D/K aerobic respiration<br />
+class): <a href="../../../genes/ANOGA/TOLL9/TOLL9-ai-review.html">TOLL9</a> inflammatory response ← human TLR4 (O00206); <a href="../../../genes/POPTR/ndhA/ndhA-ai-review.html">ndhA</a>/D/K aerobic respiration<br />
 (UniProt: chloroplastic NDH, plastid); <a href="../../../genes/worm/che-3/che-3-ai-review.html">che-3</a> cilium motility (dynein-2 IFT; worm cilia<br />
 non-motile); <a href="../../../genes/ANOGA/D7r2/D7r2-ai-review.html">D7r2</a>/r4/r5/L1 smell perception (UniProt: blood-feeding salivary proteins);<br />
 <a href="../../../genes/worm/sta-2/sta-2-ai-review.html">sta-2</a> JAK-STAT (no JAK in worms; from fly/mouse STATs); <a href="../../../genes/worm/fshr-1/fshr-1-ai-review.html">fshr-1</a> hormone signaling (no<br />
@@ -503,7 +592,7 @@ courtship (Drosophila-specific term).</p>
 effector, not a signal transducer); <a href="../../../genes/yeast/SIR3/SIR3-ai-review.html">SIR3</a> (represses origins ≠ replication initiation);<br />
 <a href="../../../genes/yeast/UBP3/UBP3-ai-review.html">UBP3</a> (regulation of protein stability is downstream of its DUB activity).</p>
 <p><strong>Reinforced Pattern 8 (sub-activity)</strong>: worm pseudo-sHSPs — <a href="../../../genes/worm/hsp-12.3/hsp-12.3-ai-review.html">hsp-12.3</a>/hsp-12.6 have <em>no</em><br />
-chaperone activity (PMID:9744800 title verbatim), stronger than CRYAA. <strong>Reinforced<br />
+chaperone activity (PMID:9744800 title verbatim), stronger than <a href="../../../genes/human/CRYAA/CRYAA-ai-review.html">CRYAA</a>. <strong>Reinforced<br />
 Pattern 12 (mis-grouping)</strong>: <a href="../../../genes/DANRE/opa1/opa1-ai-review.html">opa1</a>/eat-3 peroxisome fission on mitochondrial-fusion <a href="../../../genes/DANRE/opa1/opa1-ai-review.html">OPA1</a><br />
 (DRP1-branch transfer); <a href="../../../genes/yeast/YAR1/YAR1-ai-review.html">YAR1</a> transcription term on an RPS3-binding 40S-biogenesis factor;<br />
 <a href="../../../genes/yeast/ACL4/ACL4-ai-review.html">ACL4</a> mito-import by TOM70-family over-transfer; plus BP versions of the PIWI/germ-granule<br />
@@ -561,7 +650,7 @@ extended pseudo-enzyme + substrate/neofunctionalization sets).</p>
 <p><strong>Still in the backlog (not yet adjudicated):</strong> many generic localization<br />
 over-propagations (<code>GO:0005737</code> cytoplasm / <code>GO:0005634</code> nucleus on <a href="../../../genes/human/DHCR24/DHCR24-ai-review.html">DHCR24</a>, <a href="../../../genes/human/PIWIL1/PIWIL1-ai-review.html">PIWIL1</a>,<br />
 <a href="../../../genes/human/BIRC6/BIRC6-ai-review.html">BIRC6</a>, <a href="../../../genes/human/EIF2AK3/EIF2AK3-ai-review.html">EIF2AK3</a>, <a href="../../../genes/human/GLA/GLA-ai-review.html">GLA</a>, <a href="../../../genes/human/GK5/GK5-ai-review.html">GK5</a>, <a href="../../../genes/human/SCGB1A1/SCGB1A1-ai-review.html">SCGB1A1</a>, …) — these look like a high-frequency "default<br />
-compartment" category worth a dedicated future pass; CRY1/CRY2 photo-entrainment<br />
+compartment" category worth a dedicated future pass; <a href="../../../genes/human/CRY1/CRY1-ai-review.html">CRY1</a>/CRY2 photo-entrainment<br />
 (contested); <a href="../../../genes/human/ANKZF1/ANKZF1-ai-review.html">ankzf1</a> ERAD-vs-RQC; <a href="../../../genes/human/CALCOCO2/CALCOCO2-ai-review.html">CALCOCO2</a> PML-body; <a href="../../../genes/human/BAIAP2L2/BAIAP2L2-ai-review.html">BAIAP2L2</a> nucleoplasm.</p>
 <hr />
 <h2 id="2026-06-20-second-corpus-pass-verification">2026-06-20 — Second corpus pass (+ verification)</h2>
@@ -604,7 +693,7 @@ family composition, cached <code>publications/</code>, and the gene <code>-notes
 </tbody>
 </table>
 <p><strong>Final verified additions (on the findings page):</strong> pseudo-enzyme cluster<br />
-(<a href="../../../genes/human/DPYSL2/DPYSL2-ai-review.html">DPYSL2</a>/CRMP1/DPYSL3, <a href="../../../genes/human/AGO4/AGO4-ai-review.html">AGO4</a>, <a href="../../../genes/human/UBAC2/UBAC2-ai-review.html">UBAC2</a>), partial sub-activity loss (<a href="../../../genes/human/CAPG/CAPG-ai-review.html">CAPG</a>, CRYAA),<br />
+(<a href="../../../genes/human/DPYSL2/DPYSL2-ai-review.html">DPYSL2</a>/CRMP1/DPYSL3, <a href="../../../genes/human/AGO4/AGO4-ai-review.html">AGO4</a>, <a href="../../../genes/human/UBAC2/UBAC2-ai-review.html">UBAC2</a>), partial sub-activity loss (<a href="../../../genes/human/CAPG/CAPG-ai-review.html">CAPG</a>, <a href="../../../genes/human/CRYAA/CRYAA-ai-review.html">CRYAA</a>),<br />
 regulatory-sign inversion (<a href="../../../genes/human/BCL2/BCL2-ai-review.html">BCL2</a>, with caveat), complex/compartment/pathway<br />
 over-transfer (<a href="../../../genes/human/EIF4E2/EIF4E2-ai-review.html">EIF4E2</a>, <a href="../../../genes/rat/Aldh1l1/Aldh1l1-ai-review.html">ALDH1L1</a>, <a href="../../../genes/rat/Hmgcs2/Hmgcs2-ai-review.html">HMGCS2</a>, <a href="../../../genes/human/PEX2/PEX2-ai-review.html">PEX2</a>), substrate over-propagation (<a href="../../../genes/human/AGK/AGK-ai-review.html">AGK</a>).</p>
 <p><strong>Evidence anchors per gene:</strong><br />
@@ -612,7 +701,7 @@ over-transfer (<a href="../../../genes/human/EIF4E2/EIF4E2-ai-review.html">EIF4E
 - <strong><a href="../../../genes/human/AGO4/AGO4-ai-review.html">AGO4</a></strong> — UniProt FUNCTION: <em>"Lacks endonuclease activity and does not appear to cleave target mRNAs"</em>.<br />
 - <strong><a href="../../../genes/human/UBAC2/UBAC2-ai-review.html">UBAC2</a></strong> — rhomboid-<em>like</em> fold (inactive-rhomboid clan) + no curated protease activity (no explicit CAUTION → kept MEDIUM/cautious).<br />
 - <strong><a href="../../../genes/human/CAPG/CAPG-ai-review.html">CAPG</a></strong> — cached PMID:1322908 verbatim <em>"blocks the barbed ends … but does not sever preformed actin"</em>.<br />
-- <strong>CRYAA</strong> — GOA already contains a curated <code>NOT|involved_in</code> (ISS) to <code>GO:0042026</code> (refolding) that the IBA contradicts.<br />
+- <strong><a href="../../../genes/human/CRYAA/CRYAA-ai-review.html">CRYAA</a></strong> — GOA already contains a curated <code>NOT|involved_in</code> (ISS) to <code>GO:0042026</code> (refolding) that the IBA contradicts.<br />
 - <strong><a href="../../../genes/human/BCL2/BCL2-ai-review.html">BCL2</a></strong> — WITH/FROM node PTN000135648 mixes pro-apoptotic BAX (Q07812)/BAK1 (Q16611) with anti-apoptotic members; caveat: a separate NAS annotation to the same term exists + context-dependent pro-apoptotic roles → "IBA sign unreliable," not "impossible".<br />
 - <strong><a href="../../../genes/human/EIF4E2/EIF4E2-ai-review.html">EIF4E2</a></strong> — UniProt: <em>"is unable to bind eIF4G"</em>, <em>"Does not interact with eIF4G"</em>.<br />
 - <strong><a href="../../../genes/rat/Aldh1l1/Aldh1l1-ai-review.html">ALDH1L1</a></strong> — UniProt <em>Cytosolic 10-formyltetrahydrofolate dehydrogenase</em>, <code>Cytoplasm, cytosol</code>, cytosol IDA; mito work is ALDH1L2.<br />
@@ -636,8 +725,8 @@ isn't wrong in kind (it <em>is</em> a transporter), just wrong in mechanism. Eco
 contributed two "response to iron(III) ion" over-annotations (IGI PMID:12139617,<br />
 IEP PMID:15322361) that conflate BasS-BasR transcriptional regulation of the <a href="../../../genes/BPT4/arn/arn-ai-review.html">arn</a><br />
 operon with direct function.</p>
-<h2 id="2026-01-26-added-cds1-neo-functionalization-opposite-reaction-rimbp2">2026-01-26 — Added cds1 (neo-functionalization, opposite reaction) + <a href="../../../genes/human/RIMBP2/RIMBP2-ai-review.html">RIMBP2</a></h2>
-<p><strong>cds1 (PTHR10314 SF135)</strong> — the most severe error type: <code>GO:0019344</code> (cysteine<br />
+<h2 id="2026-01-26-added-cds1-neo-functionalization-opposite-reaction-rimbp2">2026-01-26 — Added <a href="../../../genes/MYCTU/cds1/cds1-ai-review.html">cds1</a> (neo-functionalization, opposite reaction) + <a href="../../../genes/human/RIMBP2/RIMBP2-ai-review.html">RIMBP2</a></h2>
+<p><strong><a href="../../../genes/MYCTU/cds1/cds1-ai-review.html">cds1</a> (PTHR10314 SF135)</strong> — the most severe error type: <code>GO:0019344</code> (cysteine<br />
 <em>biosynthesis</em>) propagated from the family root (PTN000034104) to a subfamily that<br />
 catalyzes cysteine <em>catabolism</em> (EC 4.4.1.1: L-Cys → H2S + pyruvate). Evidence of<br />
 neo-functionalization in SF135: longest branch length (0.528), different EC class,<br />

--- a/pages/projects/IBA_REVIEW/msa/RESULTS.html
+++ b/pages/projects/IBA_REVIEW/msa/RESULTS.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>MSA check of two pseudo-enzyme claims - AI Gene Review Projects</title>
+    <title>IBA Pseudo-Enzyme MSA Checks - AI Gene Review Projects</title>
     <style>
         :root {
             --color-accept: #22c55e;
@@ -250,6 +250,25 @@
         /* Project meta: maturity + tag badges */
         .project-meta { margin-bottom: 0.5rem; }
         .project-meta .badge { margin: 0 0.25rem 0.25rem 0; }
+        .gene-list {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.375rem;
+            margin-bottom: 1rem;
+        }
+        .gene-list a,
+        .gene-list span {
+            background-color: #dbeafe;
+            border-radius: 0.25rem;
+            color: #1e40af;
+            display: inline-block;
+            font-weight: 500;
+            padding: 0.125rem 0.375rem;
+        }
+        .gene-list a:hover {
+            background-color: #bfdbfe;
+            text-decoration: none;
+        }
         .m-SCOPING     { background: #fef3c7; color: #92400e; }
         .m-IN_PROGRESS { background: #dbeafe; color: #1e40af; }
         .m-MATURE      { background: #dcfce7; color: #166534; }
@@ -325,28 +344,58 @@
     <nav class="breadcrumb">
         <a href="../index.html">Home</a> &raquo;
         <a href="index.html">Projects</a> &raquo;
-        MSA check of two pseudo-enzyme claims
+        IBA Pseudo-Enzyme MSA Checks
     </nav>
 
     <header class="header">
-        <h1>MSA check of two pseudo-enzyme claims</h1>
-        
-        
-        
+        <h1>IBA Pseudo-Enzyme MSA Checks</h1>
+
+
+        <p><strong>Species:</strong> human</p>
+
+
+        <div class="gene-list">
+            <strong>Genes:</strong>
+
+
+            <a href="../../../../genes/human/AGO1/AGO1-ai-review.html" title="human/AGO1">AGO1</a>
+
+
+
+            <a href="../../../../genes/human/AGO2/AGO2-ai-review.html" title="human/AGO2">AGO2</a>
+
+
+
+            <a href="../../../../genes/human/AGO3/AGO3-ai-review.html" title="human/AGO3">AGO3</a>
+
+
+
+            <a href="../../../../genes/human/AGO4/AGO4-ai-review.html" title="human/AGO4">AGO4</a>
+
+
+
+            <a href="../../../../genes/human/DPYSL2/DPYSL2-ai-review.html" title="human/DPYSL2">DPYSL2</a>
+
+
+
+            <a href="../../../../genes/human/CRMP1/CRMP1-ai-review.html" title="human/CRMP1">CRMP1</a>
+
+
+
+            <a href="../../../../genes/human/DPYSL3/DPYSL3-ai-review.html" title="human/DPYSL3">DPYSL3</a>
+
+
+
+            <a href="../../../../genes/human/DPYSL4/DPYSL4-ai-review.html" title="human/DPYSL4">DPYSL4</a>
+
+
+        </div>
+
     </header>
 
-    
 
-    
-    <div class="warnings">
-        <h3>Warnings (1)</h3>
-        <ul>
-            
-            <li>Ambiguous symbol &#39;AGO1&#39; found in species: ARATH, human. Add &#39;species: [ARATH]&#39; to frontmatter to resolve.</li>
-            
-        </ul>
-    </div>
-    
+
+
 
     <div class="content">
         <h1 id="msa-check-of-two-pseudo-enzyme-claims">MSA check of two pseudo-enzyme claims</h1>
@@ -360,7 +409,7 @@ active enzyme (DPYS) and the catalytic-residue <strong>positions</strong> are pu
 UniProt REST feature tables (with a documented hardcoded fallback for the <a href="../../../../genes/human/AGO2/AGO2-ai-review.html">AGO2</a><br />
 positions if the API returns none — not triggered in the runs reported here, which<br />
 used the live metal-binding-site features).</p>
-<h2 id="1-human-argonautes-ago14-rnase-h-like-catalytic-site-ddh-of-the-dedh-tetrad">1. Human Argonautes AGO1–4 — RNase-H-like catalytic site (DDH of the DEDH tetrad)</h2>
+<h2 id="1-human-argonautes-ago14-rnase-h-like-catalytic-site-ddh-of-the-dedh-tetrad">1. Human Argonautes <a href="../../../../genes/human/AGO1/AGO1-ai-review.html">AGO1</a>–4 — RNase-H-like catalytic site (DDH of the DEDH tetrad)</h2>
 <p>Residues at the positions UniProt annotates on <a href="../../../../genes/human/AGO2/AGO2-ai-review.html">AGO2</a> as divalent-metal-binding<br />
 (the catalytic Asp/Asp/His — i.e. the DDH metal-coordinating subset of the<br />
 canonical DEDH slicer tetrad; the catalytic-glutamate "finger" is discussed in<br />
@@ -369,7 +418,7 @@ the caveats and is not in the metal-binding feature set):</p>
 <thead>
 <tr>
 <th><a href="../../../../genes/human/AGO2/AGO2-ai-review.html">AGO2</a> position</th>
-<th>AGO1</th>
+<th><a href="../../../../genes/human/AGO1/AGO1-ai-review.html">AGO1</a></th>
 <th><a href="../../../../genes/human/AGO2/AGO2-ai-review.html">AGO2</a></th>
 <th><a href="../../../../genes/human/AGO3/AGO3-ai-review.html">AGO3</a></th>
 <th><a href="../../../../genes/human/AGO4/AGO4-ai-review.html">AGO4</a></th>
@@ -406,7 +455,7 @@ the caveats and is not in the metal-binding feature set):</p>
   (<code>GO:0004521</code> RNA endonuclease activity).</li>
 <li>Nuance the MSA reveals: <strong><a href="../../../../genes/human/AGO3/AGO3-ai-review.html">AGO3</a> retains the full tetrad</strong> (D/D/H), so its weak slicing<br />
   is <em>not</em> explained by tetrad loss — a blanket "only <a href="../../../../genes/human/AGO2/AGO2-ai-review.html">AGO2</a> has the residues" would have<br />
-  been wrong. AGO1 loses only the catalytic His (H→R).</li>
+  been wrong. <a href="../../../../genes/human/AGO1/AGO1-ai-review.html">AGO1</a> loses only the catalytic His (H→R).</li>
 </ul>
 <h2 id="2-crmpdpysl-family-vs-active-dihydropyrimidinase-dpys-q14117">2. CRMP/DPYSL family vs active dihydropyrimidinase (DPYS, Q14117)</h2>
 <p>Residues at DPYS's UniProt-annotated Zn(2+)-coordinating / active-site positions:</p>

--- a/pages/projects/ISO.html
+++ b/pages/projects/ISO.html
@@ -250,6 +250,25 @@
         /* Project meta: maturity + tag badges */
         .project-meta { margin-bottom: 0.5rem; }
         .project-meta .badge { margin: 0 0.25rem 0.25rem 0; }
+        .gene-list {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.375rem;
+            margin-bottom: 1rem;
+        }
+        .gene-list a,
+        .gene-list span {
+            background-color: #dbeafe;
+            border-radius: 0.25rem;
+            color: #1e40af;
+            display: inline-block;
+            font-weight: 500;
+            padding: 0.125rem 0.375rem;
+        }
+        .gene-list a:hover {
+            background-color: #bfdbfe;
+            text-decoration: none;
+        }
         .m-SCOPING     { background: #fef3c7; color: #92400e; }
         .m-IN_PROGRESS { background: #dbeafe; color: #1e40af; }
         .m-MATURE      { background: #dcfce7; color: #166534; }
@@ -330,106 +349,442 @@
 
     <header class="header">
         <h1>Inferred from Sequence Orthology (ISO) Evidence Code Review</h1>
-        
+
         <p class="project-meta">
-            <span class="badge m-SCOPING">SCOPING</span>
+            <span class="badge m-IN_PROGRESS">IN_PROGRESS</span>
             <span class="badge tag t-PIPELINE">PIPELINE</span>
         </p>
-        
-        
+
+
         <p><strong>Species:</strong> human, mouse, rat</p>
-        
-        
+
+
     </header>
 
-    
 
-    
+
+
 
     <div class="content">
         <h1 id="inferred-from-sequence-orthology-iso-evidence-code-review">Inferred from Sequence Orthology (ISO) Evidence Code Review</h1>
 <h2 id="overview">Overview</h2>
-<p>ISO (Inferred from Sequence Orthology, ECO:0000266) is one of the most widely used<br />
-evidence codes in GO annotation, particularly for transferring annotations from<br />
-well-characterized model organisms to less-studied species. This project examines<br />
-ISO annotations in detail to assess their quality, identify systematic issues, and<br />
-develop review guidelines.</p>
-<h2 id="background">Background</h2>
-<h3 id="what-iso-means">What ISO means</h3>
-<p>ISO annotations are created when a GO term is transferred from one gene to its<br />
-ortholog in another species based on orthology relationships. The logic:<br />
-- Gene A in species 1 has experimentally validated annotation X<br />
-- Gene B in species 2 is an ortholog of Gene A<br />
-- Therefore Gene B receives annotation X with ISO evidence</p>
-<h3 id="scale-and-impact">Scale and impact</h3>
-<ul>
-<li>ISO is among the top evidence codes by volume in GOA</li>
-<li>Mouse, rat, and other model organism genes receive many ISO annotations<br />
-  transferred from human experimental data (and vice versa)</li>
-<li>Quality depends on: orthology call accuracy, functional conservation across<br />
-  species, and whether the specific GO term (not just broad function) is conserved</li>
-</ul>
-<h3 id="known-concerns">Known concerns</h3>
+<p>ISO (Inferred from Sequence Orthology, ECO:0000266) transfers GO annotations<br />
+between orthologous genes. The code is often reliable for conserved molecular<br />
+functions, but the current reviewed corpus shows that ISO rows need a different<br />
+review question from ordinary evidence rows:</p>
+<blockquote>
+<p>Is the source annotation itself sound, and is this specific term safe to<br />
+propagate across this orthology relationship?</p>
+</blockquote>
+<p>The answer is not binary. Existing reviews show three common outcomes:</p>
 <ol>
-<li><strong>Over-transfer</strong>: Broad functional conservation doesn't guarantee that specific<br />
-   GO terms transfer correctly. Paralogs may have diverged in substrate specificity,<br />
-   subcellular localization, or regulatory context.</li>
-<li><strong>Circular evidence</strong>: If species A annotates from species B (ISO) and species B<br />
-   annotates from species A (ISO), neither has primary experimental backing.</li>
-<li><strong>Granularity mismatch</strong>: A specific MF term validated in human may not apply at<br />
-   the same specificity in mouse if the gene has subtly different biochemistry.</li>
-<li><strong>Orthology method sensitivity</strong>: Different orthology resources (PANTHER, OMA,<br />
-   InParanoid, EggNOG) may disagree on orthology calls, especially for multi-copy<br />
-   gene families.</li>
+<li>The transfer is correct, sometimes even redundant with target-species<br />
+   experimental evidence.</li>
+<li>The source annotation is weak, stale, circular, or miscited.</li>
+<li>The source annotation is sound, but propagation to the target is unsafe<br />
+   because the target is a paralog, a diverged family member, a different<br />
+   isoform/compartment context, or a different physiological context.</li>
 </ol>
-<h2 id="review-strategy">Review Strategy</h2>
-<p>For each gene reviewed under this project:<br />
-1. Identify all ISO annotations<br />
-2. Trace each to its source (which ortholog, which species, what experimental evidence<br />
-   does the source have?)<br />
-3. Assess whether the specific GO term (not just the broad function) is likely<br />
-   conserved in the target species<br />
-4. Flag annotations where:<br />
-   - The source gene is a paralog, not a true ortholog<br />
-   - The GO term is too specific for confident cross-species transfer<br />
-   - The experimental evidence in the source species is itself weak<br />
-   - There's contradictory experimental evidence in the target species</p>
-<h2 id="initial-gene-targets">Initial Gene Targets</h2>
+<h2 id="corpus-snapshot">Corpus Snapshot</h2>
+<p>Read-only inventory on 2026-06-29 of reviewed <code>*-ai-review.yaml</code> files containing<br />
+<code>evidence_type: ISO</code>:</p>
 <table>
 <thead>
 <tr>
-<th>Gene</th>
-<th>Species</th>
-<th>Why interesting</th>
+<th>Metric</th>
+<th style="text-align: right;">Count</th>
 </tr>
 </thead>
 <tbody>
 <tr>
-<td><a href="../../genes/mouse/Calm3/Calm3-ai-review.html">Calm3</a></td>
-<td>mouse</td>
-<td>Calmodulin family — highly conserved but subtle paralog differences between <a href="../../genes/mouse/Calm1/Calm1-ai-review.html">Calm1</a>/2/3</td>
+<td>Reviewed ISO rows</td>
+<td style="text-align: right;">4,189</td>
 </tr>
 <tr>
-<td></td>
-<td></td>
-<td></td>
+<td>Gene review files with ISO rows</td>
+<td style="text-align: right;">153</td>
+</tr>
+<tr>
+<td>Mouse ISO rows</td>
+<td style="text-align: right;">3,228</td>
+</tr>
+<tr>
+<td>Rat ISO rows</td>
+<td style="text-align: right;">926</td>
+</tr>
+<tr>
+<td>Other species ISO rows</td>
+<td style="text-align: right;">35</td>
 </tr>
 </tbody>
 </table>
-<h2 id="notes">Notes</h2>
-<h3 id="calmodulin-family-context">Calmodulin family context</h3>
-<p><a href="../../genes/mouse/Calm1/Calm1-ai-review.html">Calm1</a>, <a href="../../genes/mouse/Calm2/Calm2-ai-review.html">Calm2</a>, and <a href="../../genes/mouse/Calm3/Calm3-ai-review.html">Calm3</a> encode identical protein sequences in many mammals but differ<br />
-in UTR regulation, tissue expression patterns, and potentially in interaction partners.<br />
-ISO annotations that transfer from human <a href="../../genes/human/CALM1/CALM1-ai-review.html">CALM1</a>/2/3 to mouse <a href="../../genes/mouse/Calm1/Calm1-ai-review.html">Calm1</a>/2/3 should be<br />
-scrutinized for whether paralog-specific annotations are being inappropriately<br />
-transferred across the family.</p>
+<p>Disposition across those reviewed ISO rows:</p>
+<table>
+<thead>
+<tr>
+<th>Review action</th>
+<th style="text-align: right;">Count</th>
+<th>Interpretation</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><code>ACCEPT</code></td>
+<td style="text-align: right;">1,374</td>
+<td>Conserved enough to keep as core or correct annotation.</td>
+</tr>
+<tr>
+<td><code>KEEP_AS_NON_CORE</code></td>
+<td style="text-align: right;">1,970</td>
+<td>Often true, but contextual, tissue-specific, downstream, or generic localization.</td>
+</tr>
+<tr>
+<td><code>MARK_AS_OVER_ANNOTATED</code></td>
+<td style="text-align: right;">378</td>
+<td>Biology may be related, but the propagated term overstates the direct role.</td>
+</tr>
+<tr>
+<td><code>REMOVE</code></td>
+<td style="text-align: right;">217</td>
+<td>Strong evidence that the annotation should not be retained.</td>
+</tr>
+<tr>
+<td><code>MODIFY</code></td>
+<td style="text-align: right;">114</td>
+<td>The transfer captures the right idea but needs a better GO term.</td>
+</tr>
+<tr>
+<td><code>UNDECIDED</code></td>
+<td style="text-align: right;">127</td>
+<td>Evidence could not be adjudicated confidently.</td>
+</tr>
+<tr>
+<td><code>NEW</code></td>
+<td style="text-align: right;">9</td>
+<td>Orthology-supported new-annotation candidates recorded in review files.</td>
+</tr>
+</tbody>
+</table>
+<p>Most reviewed ISO rows are therefore not catastrophic failures. The main curation<br />
+value is discriminating correct/non-core transfers from source or propagation<br />
+defects.</p>
+<h2 id="existing-review-synthesis">Existing Review Synthesis</h2>
+<h3 id="calmodulin-valid-family-wide-transfer-with-locus-specific-caveats">Calmodulin: valid family-wide transfer, with locus-specific caveats</h3>
+<p><a href="../../genes/mouse/Calm3/Calm3-ai-review.html">Calm3</a> is the clean positive control. Mouse <code>Calm1</code>, <code>Calm2</code>, and <code>Calm3</code> encode<br />
+the same calmodulin protein, so ISO transfer of core protein functions such as<br />
+calcium binding, channel<br />
+regulation, calcineurin/CaMKII-related signaling, and cytoplasmic localization is<br />
+biochemically sound. The remaining issue is not protein orthology but locus and<br />
+context: <a href="../../genes/mouse/Calm3/Calm3-ai-review.html">Calm3</a> has a distinct 3-UTR/Stau2-dependent dendritic mRNA-localization<br />
+mechanism, while many synaptic, cardiac, spindle, centrosome, and sarcomere rows<br />
+are best retained as non-core context rather than treated as defining <a href="../../genes/mouse/Calm3/Calm3-ai-review.html">Calm3</a><br />
+function.</p>
+<h3 id="ghr-direct-donor-support-mixed-with-circular-and-stale-transfers"><a href="../../genes/mouse/Ghr/Ghr-ai-review.html">Ghr</a>: direct donor support mixed with circular and stale transfers</h3>
+<p><a href="../../genes/mouse/Ghr/Ghr-ai-review.html">Ghr</a> shows why ISO review must trace the donor edge. The manual donor trace<br />
+(<code>genes/mouse/Ghr/Ghr-iso-donor-trace.md</code>) separates<br />
+human and rat donor rows into direct receptor biology, redundant/circular<br />
+transfer chains, and stale or context-heavy rows.</p>
+<p>Good transfers include growth hormone receptor activity, peptide hormone binding,<br />
+plasma membrane/cell surface localization, receptor complex terms, and<br />
+growth-hormone/JAK-STAT pathway terms. Problem rows include lipid binding, growth<br />
+factor binding, receptor internalization, response to estradiol, response to<br />
+cycloheximide, IGF receptor signaling, cytosol, cytoplasmic RNP granule,<br />
+proteasome-mediated catabolism, and negative regulation of GHR signaling. Several<br />
+are not simply "wrong ortholog" cases; they are transfer-of-transfer artifacts<br />
+or donor rows with no current source-side support.</p>
+<p>The <a href="../../genes/mouse/Ghr/Ghr-ai-review.html">Ghr</a> review also shows an isoform trap: extracellular-space annotations can<br />
+fit the GH-binding protein product, while signaling annotations apply to the<br />
+full-length membrane receptor.</p>
+<h3 id="ang2-source-and-propagation-defects-reinforce-each-other"><a href="../../genes/mouse/Ang2/Ang2-ai-review.html">Ang2</a>: source and propagation defects reinforce each other</h3>
+<p><a href="../../genes/mouse/Ang2/Ang2-ai-review.html">Ang2</a> is the strongest ISO negative control. A reproducible source trace<br />
+(<code>genes/mouse/Ang2/Ang2-bioinformatics/RESULTS.md</code>) found that<br />
+all 46 local ISO rows were transferred from human <a href="../../genes/human/ANG/ANG-ai-review.html">ANG</a> (<code>UniProtKB:P03950</code>) via<br />
+<code>GO_REF:0000119</code>. The trace classified the human source side as:</p>
+<table>
+<thead>
+<tr>
+<th>Source-side status</th>
+<th style="text-align: right;">Count</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>Current human <a href="../../genes/human/ANG/ANG-ai-review.html">ANG</a> term with direct experimental support</td>
+<td style="text-align: right;">34</td>
+</tr>
+<tr>
+<td>Current human <a href="../../genes/human/ANG/ANG-ai-review.html">ANG</a> term with inferred support only</td>
+<td style="text-align: right;">4</td>
+</tr>
+<tr>
+<td>No current matching human <a href="../../genes/human/ANG/ANG-ai-review.html">ANG</a> source term</td>
+<td style="text-align: right;">8</td>
+</tr>
+</tbody>
+</table>
+<p>Even many directly supported human <a href="../../genes/human/ANG/ANG-ai-review.html">ANG</a> annotations are unsafe for mouse <a href="../../genes/mouse/Ang2/Ang2-ai-review.html">Ang2</a>,<br />
+because mouse <a href="../../genes/mouse/Ang2/Ang2-ai-review.html">Ang2</a>/Angrp is a divergent angiogenin paralog: direct mouse evidence<br />
+supports RNase/tRNA-cleavage activity but not canonical angiogenesis, receptor<br />
+binding, signaling, stress-response, nuclear-trafficking, or immune-effector<br />
+roles. The reviewed <a href="../../genes/mouse/Ang2/Ang2-ai-review.html">Ang2</a> ISO rows ended up mostly <code>REMOVE</code>:</p>
+<table>
+<thead>
+<tr>
+<th>Action for <a href="../../genes/mouse/Ang2/Ang2-ai-review.html">Ang2</a> ISO rows</th>
+<th style="text-align: right;">Count</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><code>REMOVE</code></td>
+<td style="text-align: right;">41</td>
+</tr>
+<tr>
+<td><code>ACCEPT</code></td>
+<td style="text-align: right;">2</td>
+</tr>
+<tr>
+<td><code>KEEP_AS_NON_CORE</code></td>
+<td style="text-align: right;">2</td>
+</tr>
+<tr>
+<td><code>MODIFY</code></td>
+<td style="text-align: right;">1</td>
+</tr>
+</tbody>
+</table>
+<p><a href="../../genes/mouse/Ang2/Ang2-ai-review.html">Ang2</a> also exposed source-annotation hygiene problems outside the ISO block:<br />
+several experimental GOA rows trace to angiopoietin-2, angiotensin II, or ZNF418<br />
+papers rather than to mouse <a href="../../genes/mouse/Ang2/Ang2-ai-review.html">Ang2</a>/Angrp. This is the clearest example where<br />
+"source annotation bad" and "propagation bad" both matter.</p>
+<h3 id="broad-mouse-and-rat-iso-the-common-pattern-is-non-core-context">Broad mouse and rat ISO: the common pattern is non-core context</h3>
+<p>The largest reviewed ISO blocks are not dominated by outright removals. Many<br />
+mouse and rat signaling genes carry large ISO sets where the core molecular<br />
+function is correct but the transferred rows include many tissue, pathway,<br />
+phenotype, complex, or localization contexts. Typical review actions are<br />
+<code>KEEP_AS_NON_CORE</code>, <code>MARK_AS_OVER_ANNOTATED</code>, or <code>MODIFY</code>, not <code>REMOVE</code>.</p>
+<p>This matters for reviewer tone: ISO is not mostly garbage. The risk is that a<br />
+large cloud of true-but-contextual annotations can obscure the small number of<br />
+source defects, stale transfers, and paralog-specific propagation failures.</p>
+<h2 id="failure-taxonomy">Failure Taxonomy</h2>
+<p>Use two labels when reviewing IBA or ISO propagation:</p>
+<ol>
+<li>A <strong>root-cause class</strong>: where the defect lives.</li>
+<li>A <strong>biological subtype</strong>: what kind of transfer mistake it is.</li>
+</ol>
+<p>Record these in <code>review.propagation_review</code>. Keep the narrative rationale in<br />
+<code>review.reason</code>; the structured object should stay mechanical.</p>
+<p>Example:</p>
+<div class="codehilite"><pre><span></span><code><span class="nt">review</span><span class="p">:</span>
+<span class="w">  </span><span class="nt">action</span><span class="p">:</span><span class="w"> </span><span class="l l-Scalar l-Scalar-Plain">REMOVE</span>
+<span class="w">  </span><span class="nt">reason</span><span class="p">:</span><span class="w"> </span><span class="l l-Scalar l-Scalar-Plain">Mouse Ang2/Angrp retains RNase activity but lacks the angiogenic function of human ANG.</span>
+<span class="w">  </span><span class="nt">propagation_review</span><span class="p">:</span>
+<span class="w">    </span><span class="nt">root_cause</span><span class="p">:</span><span class="w"> </span><span class="l l-Scalar l-Scalar-Plain">PROPAGATION_BAD</span>
+<span class="w">    </span><span class="nt">failure_modes</span><span class="p">:</span>
+<span class="w">      </span><span class="p p-Indicator">-</span><span class="w"> </span><span class="l l-Scalar l-Scalar-Plain">WRONG_ORTHOLOG_OR_PARALOG</span>
+<span class="w">      </span><span class="p p-Indicator">-</span><span class="w"> </span><span class="l l-Scalar l-Scalar-Plain">FUNCTIONAL_DIVERGENCE</span>
+<span class="w">    </span><span class="nt">source_entities</span><span class="p">:</span>
+<span class="w">      </span><span class="p p-Indicator">-</span><span class="w"> </span><span class="nt">source_id</span><span class="p">:</span><span class="w"> </span><span class="l l-Scalar l-Scalar-Plain">UniProtKB:P03950</span>
+<span class="w">        </span><span class="nt">source_label</span><span class="p">:</span><span class="w"> </span><span class="l l-Scalar l-Scalar-Plain">ANG</span>
+<span class="w">        </span><span class="nt">source_status</span><span class="p">:</span><span class="w"> </span><span class="l l-Scalar l-Scalar-Plain">SUPPORTS_SOURCE_BUT_NOT_TARGET</span>
+<span class="w">        </span><span class="nt">comment</span><span class="p">:</span><span class="w"> </span><span class="l l-Scalar l-Scalar-Plain">Human ANG supports angiogenesis; mouse Ang2/Angrp is non-angiogenic.</span>
+</code></pre></div>
+
+<h3 id="root-cause-classes">Root-cause classes</h3>
+<table>
+<thead>
+<tr>
+<th>Code</th>
+<th>Meaning</th>
+<th>Fix target</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><code>NO_FAILURE_CORE</code></td>
+<td>Transfer is correct and core for the target.</td>
+<td>Keep annotation.</td>
+</tr>
+<tr>
+<td><code>NO_FAILURE_NON_CORE</code></td>
+<td>Transfer is biologically defensible but contextual or secondary.</td>
+<td>Keep as non-core.</td>
+</tr>
+<tr>
+<td><code>SOURCE_BAD</code></td>
+<td>Source annotation is wrong, miscited, homonym-confused, or contradicted.</td>
+<td>Fix source annotation before judging transfer.</td>
+</tr>
+<tr>
+<td><code>SOURCE_STALE_OR_MISSING</code></td>
+<td>Transferred term no longer appears on the current source record, or donor trace cannot recover it.</td>
+<td>Remove or re-source the transfer.</td>
+</tr>
+<tr>
+<td><code>SOURCE_WEAK_OR_INFERRED</code></td>
+<td>Source exists but is only inferred, statement-level, or otherwise weak for transfer.</td>
+<td>Downgrade confidence; require target/family corroboration.</td>
+</tr>
+<tr>
+<td><code>EVIDENCE_CIRCULAR_OR_REDUNDANT</code></td>
+<td>ISO chain transfers from another transfer, or target already has stronger direct evidence.</td>
+<td>Do not treat ISO edge as independent support.</td>
+</tr>
+<tr>
+<td><code>PROPAGATION_BAD</code></td>
+<td>Source annotation is sound, but the term should not propagate to this target.</td>
+<td>Fix orthology/family/node propagation.</td>
+</tr>
+<tr>
+<td><code>TERM_SCOPING_PROBLEM</code></td>
+<td>Biology is related, but the GO term is too broad, too specific, or wrong in role/qualifier.</td>
+<td><code>MODIFY</code> or mark over-annotated.</td>
+</tr>
+<tr>
+<td><code>UNRESOLVED</code></td>
+<td>Propagation issue was investigated but cannot yet be classified confidently.</td>
+<td>Use <code>UNDECIDED</code> or defer until source/target evidence is resolved.</td>
+</tr>
+</tbody>
+</table>
+<h3 id="biological-subtypes">Biological subtypes</h3>
+<table>
+<thead>
+<tr>
+<th>Code</th>
+<th>Applies to</th>
+<th>Typical signal</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><code>WRONG_ORTHOLOG_OR_PARALOG</code></td>
+<td>ISO and IBA</td>
+<td>Donor/source is a paralog, expanded family member, or wrong subfamily.</td>
+</tr>
+<tr>
+<td><code>FUNCTIONAL_DIVERGENCE</code></td>
+<td>ISO and IBA</td>
+<td>Target retained fold/orthology but changed substrate, product, activity, or pathway role.</td>
+</tr>
+<tr>
+<td><code>PSEUDO_OR_SUBACTIVITY_LOSS</code></td>
+<td>Mostly IBA, sometimes ISO</td>
+<td>Catalytic residues or a specific sub-activity are lost even though the domain remains.</td>
+</tr>
+<tr>
+<td><code>CONTEXT_OR_TISSUE_MISMATCH</code></td>
+<td>ISO and IBA</td>
+<td>Donor evidence is tissue, developmental, organismal, or disease-context specific.</td>
+</tr>
+<tr>
+<td><code>LINEAGE_OR_TAXON_MISMATCH</code></td>
+<td>Mostly IBA</td>
+<td>Process does not occur in the target lineage or organelle system.</td>
+</tr>
+<tr>
+<td><code>COMPARTMENT_OR_COMPLEX_MISMATCH</code></td>
+<td>ISO and IBA</td>
+<td>Localization, complex membership, or pathway compartment does not transfer.</td>
+</tr>
+<tr>
+<td><code>REGULATORY_SIGN_INVERSION</code></td>
+<td>ISO and IBA</td>
+<td>Family contains activators and inhibitors; positive/negative term leaks across members.</td>
+</tr>
+<tr>
+<td><code>ROLE_CONFLATION</code></td>
+<td>ISO and IBA</td>
+<td>Substrate, regulator, effector, or specificity subunit is annotated as the agent/core machinery.</td>
+</tr>
+<tr>
+<td><code>GRANULARITY_MISMATCH</code></td>
+<td>ISO and IBA</td>
+<td>Parent term is true but uninformative, or child term overstates specificity.</td>
+</tr>
+<tr>
+<td><code>SOURCE_MISCITATION</code></td>
+<td>ISO and IBA</td>
+<td>Source evidence points to the wrong gene, organism, publication, or homonym.</td>
+</tr>
+<tr>
+<td><code>SOURCE_EVIDENCE_WEAK</code></td>
+<td>ISO and IBA</td>
+<td>Source evidence is inferred, statement-level, stale, or otherwise too weak for confident propagation.</td>
+</tr>
+<tr>
+<td><code>CIRCULAR_PROPAGATION</code></td>
+<td>Mostly ISO, sometimes IBA</td>
+<td>Propagation chain depends on another propagated annotation rather than independent source evidence.</td>
+</tr>
+</tbody>
+</table>
+<p>Examples:</p>
+<ul>
+<li><a href="../../genes/mouse/Ang2/Ang2-ai-review.html">Ang2</a> human ANG-to-mouse <a href="../../genes/mouse/Ang2/Ang2-ai-review.html">Ang2</a> angiogenesis rows:<br />
+<code>PROPAGATION_BAD</code> + <code>WRONG_ORTHOLOG_OR_PARALOG</code> + <code>FUNCTIONAL_DIVERGENCE</code>.</li>
+<li><a href="../../genes/mouse/Ghr/Ghr-ai-review.html">Ghr</a> receptor internalization:<br />
+<code>SOURCE_STALE_OR_MISSING</code> + <code>EVIDENCE_CIRCULAR_OR_REDUNDANT</code>.</li>
+<li><a href="../../genes/mouse/Ghr/Ghr-ai-review.html">Ghr</a> hormone-mediated signaling:<br />
+<code>TERM_SCOPING_PROBLEM</code> + <code>GRANULARITY_MISMATCH</code>.</li>
+<li><a href="../../genes/mouse/Calm3/Calm3-ai-review.html">Calm3</a> calcium ion binding:<br />
+<code>NO_FAILURE_CORE</code>.</li>
+<li><a href="../../genes/mouse/Calm3/Calm3-ai-review.html">Calm3</a> spindle/centrosome contexts:<br />
+<code>NO_FAILURE_NON_CORE</code> + <code>CONTEXT_OR_TISSUE_MISMATCH</code>.</li>
+</ul>
+<h2 id="reviewer-checklist">Reviewer Checklist</h2>
+<p>Use this checklist before making a strong <code>REMOVE</code> call on ISO or IBA.</p>
+<h3 id="source-annotation-checked">Source annotation checked</h3>
+<ul>
+<li>Record the target row: gene, species, GO term, qualifier, aspect, evidence code,<br />
+  reference, <code>WITH/FROM</code>, and assigned-by source.</li>
+<li>Verify the GO term definition, not just the label.</li>
+<li>Resolve the source gene/product(s) named by <code>WITH/FROM</code>.</li>
+<li>Check whether the current source record still carries the same GO term.</li>
+<li>Record the source evidence code and original source reference.</li>
+<li>If the source evidence is experimental, verify that the cited paper supports<br />
+  the source gene and term. If only abstract text is cached, avoid claiming a<br />
+  curator misread full text.</li>
+<li>Check for source-side <code>NOT</code> annotations or contradictory direct evidence.</li>
+</ul>
+<h3 id="propagation-checked">Propagation checked</h3>
+<ul>
+<li>For ISO, confirm whether the donor-target relation is one-to-one orthology,<br />
+  one-to-many, in-paralog, identical protein sequence, or broader family<br />
+  similarity.</li>
+<li>For IBA, inspect the PANTHER family/node, seed genes, <code>WITH/FROM</code> proteins, and<br />
+  whether seeds map to the same functional subfamily as the target.</li>
+<li>Ask whether the exact term should transfer, not only whether the broad family<br />
+  function is conserved.</li>
+<li>Check active-site residues, key domains, isoforms, compartment targeting,<br />
+  lineage constraints, and target-species direct evidence when relevant.</li>
+<li>Distinguish source defects from propagation defects. Do not hide a bad source<br />
+  annotation under "orthology failure," and do not blame a source annotation when<br />
+  the real problem is target-specific divergence.</li>
+</ul>
+<h3 id="disposition-recorded">Disposition recorded</h3>
+<ul>
+<li>Assign <code>propagation_review.root_cause</code> and any relevant<br />
+<code>propagation_review.failure_modes</code>.</li>
+<li>Add <code>propagation_review.source_entities</code> entries for donor genes, seed<br />
+  proteins, PANTHER nodes, family nodes, or other source entities that were<br />
+  checked.</li>
+<li>State whether the recommended fix is source-side, propagation-side, term<br />
+  replacement, or non-core retention.</li>
+<li>Prefer <code>UNDECIDED</code> when the source full text or family-node evidence cannot be<br />
+  checked.</li>
+</ul>
 <h2 id="action-items">Action Items</h2>
 <ul>
-<li>[ ] Review mouse <a href="../../genes/mouse/Calm3/Calm3-ai-review.html">Calm3</a> ISO annotations as initial test case</li>
-<li>[ ] Develop ISO-specific review criteria for the review skill</li>
-<li>[ ] Assess scale: how many ISO annotations exist for mouse genes in GOA?</li>
-<li>[ ] Compare orthology sources used for ISO transfers (PANTHER vs OMA)</li>
-<li>[ ] Identify systematic patterns in problematic ISO transfers</li>
+<li>[x] Review mouse <a href="../../genes/mouse/Calm3/Calm3-ai-review.html">Calm3</a> ISO annotations as the initial positive-control case.</li>
+<li>[x] Summarize existing ISO reviews across the repository.</li>
+<li>[x] Add an ISO/IBA failure taxonomy that distinguishes source defects from<br />
+      propagation defects.</li>
+<li>[x] Add a source/family annotation checklist for future ISO and IBA reviews.</li>
+<li>[x] Add structured <code>review.propagation_review</code> schema fields for the taxonomy<br />
+      and per-source entity comments.</li>
+<li>[ ] Add a reusable ISO donor-trace script that handles multiple source entities<br />
+      and writes the same source-status fields used in the <a href="../../genes/mouse/Ang2/Ang2-ai-review.html">Ang2</a> trace.</li>
 </ul>
     </div>
 

--- a/projects/IBA_REVIEW.md
+++ b/projects/IBA_REVIEW.md
@@ -2,6 +2,71 @@
 title: "IBA Annotation Quality Project"
 maturity: COMPLETE
 tags: [PIPELINE, FLAGSHIP]
+species: [human, CANAL, MYCTU, VIBCH, SCHPO, ECOLI, mouse, rat, worm, yeast, ANOGA, POPTR, DANRE]
+genes:
+  - Epe1
+  - cds1
+  - LPL1
+  - UBA7
+  - RIMBP2
+  - arnF
+  - DPYSL2
+  - CRMP1
+  - DPYSL3
+  - AGO4
+  - UBAC2
+  - CAPG
+  - CRYAA
+  - BCL2
+  - Bcl2
+  - BCL2L1
+  - EIF4E2
+  - Aldh1l1
+  - Hmgcs2
+  - PEX2
+  - AGK
+  - AKTIP
+  - DPYSL4
+  - SAMD8
+  - CPT1C
+  - NTN1
+  - NTN3
+  - NOTCH1
+  - IL23R
+  - ABRAXAS1
+  - PIWIL1
+  - prg-1
+  - wago-1
+  - EIF2AK3
+  - BIRC6
+  - SSB2
+  - SSZ1
+  - BAIAP2L2
+  - PIK3C3
+  - SCGB1A1
+  - rqh1
+  - HDA1
+  - TOLL9
+  - ndhA
+  - ndhD
+  - ndhK
+  - che-3
+  - D7r2
+  - D7r4
+  - D7r5
+  - D7L1
+  - sta-2
+  - fshr-1
+  - opa1
+  - eat-3
+  - hsp-12.3
+  - hsp-12.6
+  - YAR1
+  - ACL4
+  - SIR3
+  - lys-7
+  - UBP3
+  - CASP12
 ---
 
 # IBA Annotation Quality Project
@@ -24,6 +89,81 @@ where IBA is *wrong* (over-annotation, patterns 1–15), while
 quantifies where IBA *under-calls* established biology — 511 curated human core
 molecular functions that IBA alone would miss.
 
+## Propagation Taxonomy and Checklist
+
+The patterns below are biological failure modes, but IBA review also needs a
+root-cause call: is the source annotation bad, or is the propagation bad? Use the
+same `review.propagation_review` structure as the
+[ISO review project](ISO.md#failure-taxonomy): `root_cause`, optional
+`failure_modes`, and per-source `source_entities` with short source-specific
+comments.
+
+### Root-cause classes
+
+These are the schema values for `propagation_review.root_cause`.
+
+| Code | IBA interpretation |
+|---|---|
+| `NO_FAILURE_CORE` | The ancestral/family inference is correct and core for the target. |
+| `NO_FAILURE_NON_CORE` | The inference is defensible but contextual, secondary, or generic. |
+| `SOURCE_BAD` | A seed/source annotation or family-node assertion is itself wrong, miscited, homonym-confused, or contradicted. |
+| `SOURCE_STALE_OR_MISSING` | The transferred term no longer appears on the current source record, or the donor trace cannot recover it. |
+| `SOURCE_WEAK_OR_INFERRED` | The source exists but is only inferred, statement-level, or otherwise weak for confident propagation. |
+| `EVIDENCE_CIRCULAR_OR_REDUNDANT` | The chain transfers from another transfer, or the target already has stronger direct evidence. |
+| `PROPAGATION_BAD` | The source biology is real, but the PANTHER node propagated it to the wrong target, subfamily, lineage, compartment, or role. |
+| `TERM_SCOPING_PROBLEM` | The propagated biology is related, but the GO term is too broad, too specific, or has the wrong role/qualifier. |
+| `UNRESOLVED` | The propagation issue was investigated but cannot yet be classified confidently. |
+
+### Biological subtypes
+
+These are the schema values for `propagation_review.failure_modes`.
+
+| Code | IBA signal |
+|---|---|
+| `WRONG_ORTHOLOG_OR_PARALOG` | Donor/source is a paralog, expanded family member, or wrong subfamily. |
+| `FUNCTIONAL_DIVERGENCE` | Target retained fold or orthology but changed substrate, product, activity, or pathway role. |
+| `PSEUDO_OR_SUBACTIVITY_LOSS` | Catalytic residues or a specific sub-activity are lost even though the domain remains. |
+| `CONTEXT_OR_TISSUE_MISMATCH` | Donor evidence is tissue, developmental, organismal, or disease-context specific. |
+| `LINEAGE_OR_TAXON_MISMATCH` | Process does not occur in the target lineage or organelle system. |
+| `COMPARTMENT_OR_COMPLEX_MISMATCH` | Localization, complex membership, or pathway compartment does not transfer. |
+| `REGULATORY_SIGN_INVERSION` | Family contains activators and inhibitors, and a positive/negative regulatory term leaks across members. |
+| `ROLE_CONFLATION` | Substrate, regulator, effector, or specificity subunit is annotated as the agent or core machinery. |
+| `GRANULARITY_MISMATCH` | Parent term is true but uninformative, or child term overstates specificity. |
+| `SOURCE_MISCITATION` | Source evidence points to the wrong gene, organism, publication, or homonym. |
+| `SOURCE_EVIDENCE_WEAK` | Source evidence is inferred, statement-level, stale, or otherwise too weak for confident propagation. |
+| `CIRCULAR_PROPAGATION` | Propagation chain depends on another propagated annotation rather than independent source evidence. |
+
+### Source status values
+
+These are the schema values for `propagation_review.source_entities[].source_status`.
+
+| Code | Source-level interpretation |
+|---|---|
+| `SUPPORTS_TRANSFER` | Source evidence supports the term and the transfer to the target. |
+| `SUPPORTS_SOURCE_BUT_NOT_TARGET` | Source evidence supports the source annotation, but propagation to the target is unsafe. |
+| `SOURCE_BAD` | Source annotation or source citation is itself wrong. |
+| `SOURCE_STALE_OR_MISSING` | Current source record no longer carries the transferred term, or tracing cannot recover it. |
+| `SOURCE_WEAK_OR_INFERRED` | Source exists but is only inferred, statement-level, or otherwise weak. |
+| `CIRCULAR_OR_REDUNDANT` | Source participates in a circular transfer chain or adds no independent support. |
+| `NOT_RELEVANT` | Source was inspected but is not relevant to the target annotation. |
+| `UNRESOLVED` | Source could not be classified confidently. |
+
+Before a strong `REMOVE` on an IBA row, record that these checks were done:
+
+- The GO term definition, aspect, qualifier, and taxon constraints were checked.
+- The GOA `WITH/FROM` field was read and the PANTHER `PTN...` node and seed
+  proteins were recorded.
+- The target and seed proteins were placed in their PANTHER family/subfamily
+  context. Cross-subfamily propagation is triage evidence, not a verdict.
+- The source annotation or family-node assertion was checked separately from the
+  propagation decision.
+- Target-specific evidence was checked where relevant: direct experiments,
+  curated `NOT` rows, active-site residues, domain architecture, localization,
+  isoforms, organismal context, and lineage constraints.
+- `review.reason` states the biological rationale, while
+  `review.propagation_review` records the mechanical root cause, failure modes,
+  and source entities.
+
 ## Slides
 
 - [Slides](IBA_REVIEW/slides/IBA_REVIEW-slides.html) (Marp source: [IBA_REVIEW-slides.md](IBA_REVIEW/slides/IBA_REVIEW-slides.md)) — AI generated
@@ -40,16 +180,27 @@ molecular functions that IBA alone would miss.
 - Reality: Epe1 has degenerate active site (HVD vs HXD), no detectable activity
 - **Impact**: Misleading annotation propagated via phylogenetic inference
 
-### 2. Ubiquitin-Like Modifier Confusion
+### 2. Ubiquitin-Like Modifier Specificity: IBA as a Positive Control
 
-**The Problem**: Function from ubiquitin E1 transferred to ISG15-specific E1.
+**The contrast**: UBA7 shows the opposite of an IBA failure. The IBA rows correctly
+capture the conserved ISGylation pathway, while naive domain propagation and some
+non-IBA annotations blur ISG15-specific E1 activity into generic ubiquitin-like or
+ubiquitin terms.
 
 **Example - UBA7 (human)**:
-- IBA annotations from ubiquitin pathway:
-  - `GO:0008641` (ubiquitin-like modifier activating enzyme activity) - too general
-  - Various ubiquitin-related terms
-- Reality: UBA7 specifically activates ISG15, not ubiquitin, in mammals
-- **Impact**: Generic terms obscure specific function
+- Correct IBA annotations:
+  - `GO:0019782` (ISG15 activating enzyme activity)
+  - `GO:0032020` (ISG15-protein conjugation)
+  - `GO:0045087` (innate immune response)
+- Over-generic or wrong non-IBA rows:
+  - `GO:0008641` (ubiquitin-like modifier activating enzyme activity) - `IEA`
+    from InterPro2GO; technically related but too general.
+  - `GO:0004842` (ubiquitin-protein transferase activity) and
+    `GO:0016567` (protein ubiquitination) - non-IBA ubiquitin terms that should
+    be redirected to ISG15 activation/conjugation.
+- Reality: UBA7 specifically activates ISG15, not ubiquitin, in mammals.
+- **Impact**: IBA provides a useful specific annotation that corrects the less
+  discriminating domain/keyword propagation.
 
 ### 3. Substrate Specificity Transfer
 
@@ -84,14 +235,23 @@ molecular functions that IBA alone would miss.
 
 The subfamily SF135 shares only 24% identity with synthases - less than synthases share with each other (43%). The longest branch length indicates maximum divergence and neo-functionalization.
 
-### 5. Secondary Activity Promotion
+### 5. Paralog/Secondary Activity Transfer
 
-**The Problem**: Non-core activities from well-characterized orthologs promoted to uncharacterized proteins.
+**The Problem**: A real activity in one paralog or source subfamily can be
+promoted to a related but distinct target whose closest characterized comparator
+supports a different substrate class. This should not be called
+`KEEP_AS_NON_CORE` unless there is evidence the target actually has the activity
+as a secondary function.
 
 **Example - LPL1 (C. albicans)**:
 - IBA annotation: `GO:0047372` (monoacylglycerol lipase activity)
-- This is likely substrate promiscuity, not core function
-- **Action**: KEEP_AS_NON_CORE rather than ACCEPT
+- Source trace: `PANTHER:PTN000773837|SGD:S000003112`, corresponding to the
+  S. cerevisiae ROG1 monoacylglycerol lipase source
+- Closest characterized LPL1 comparator: S. cerevisiae LPL1, a lipid-droplet
+  phospholipase B acting on glycerophospholipids
+- **Action**: UNDECIDED for C. albicans LPL1 pending source-tree and substrate
+  review; do not mark as non-core without evidence that Candida LPL1 hydrolyzes
+  monoacylglycerols
 
 ### 6. Organism/Tissue Context Transfer
 
@@ -251,16 +411,21 @@ The subfamily SF135 shares only 24% identity with synthases - less than synthase
 **Species**: human
 **Status**: COMPLETE
 
-**IBA Annotations Flagged**:
+**Annotations reviewed**:
 | Term | Issue | Action |
 |------|-------|--------|
-| GO:0005737 cytoplasm | Correct | ACCEPT |
-| GO:0019782 ISG15 activating enzyme activity | Correct, specific | ACCEPT |
-| GO:0032020 ISG15-protein conjugation | Correct | ACCEPT |
-| GO:0045087 innate immune response | Correct | ACCEPT |
-| GO:0006974 DNA damage response | Correct | ACCEPT |
+| GO:0005737 cytoplasm | IBA, correct | ACCEPT |
+| GO:0019782 ISG15 activating enzyme activity | IBA, correct and specific | ACCEPT |
+| GO:0032020 ISG15-protein conjugation | IBA, correct | ACCEPT |
+| GO:0045087 innate immune response | IBA, correct | ACCEPT |
+| GO:0006974 DNA damage response | IBA, correct | ACCEPT |
+| GO:0008641 ubiquitin-like modifier activating enzyme activity | InterPro2GO IEA, too general | MODIFY to GO:0019782 |
+| GO:0004842 ubiquitin-protein transferase activity | Non-IBA ubiquitin term, wrong activity class | MODIFY to GO:0019782 |
+| GO:0016567 protein ubiquitination | UniPathway IEA, wrong modifier process | MODIFY to GO:0032020 |
 
-**Note**: UBA7 IBA annotations are largely correct because the ISGylation pathway is conserved.
+**Lesson**: UBA7 should be highlighted as a positive-control case for IBA
+specificity. The bad rows are not IBA propagation errors; they are generic or
+ubiquitin-biased non-IBA mappings that the IBA annotations help correct.
 
 ### LPL1 - Phospholipase Specificity
 
@@ -273,7 +438,7 @@ The subfamily SF135 shares only 24% identity with synthases - less than synthase
 | GO:0006629 lipid metabolic process | Correct | ACCEPT |
 | GO:0004622 PC lysophospholipase activity | Too narrow | MODIFY |
 | GO:0005811 lipid droplet | Correct | ACCEPT |
-| GO:0047372 monoacylglycerol lipase activity | Secondary activity | KEEP_AS_NON_CORE |
+| GO:0047372 monoacylglycerol lipase activity | ROG1-paralog/substrate-specificity transfer; target evidence absent | UNDECIDED |
 
 ### RIMBP2 - Context-Specific Term Transfer
 
@@ -402,7 +567,7 @@ See detailed family analysis: `families/PTHR48034/PTHR48034-review.md`
 | Epe1 | pombe | Pseudo-enzyme propagation | HIGH | COMPLETE |
 | cds1 | MYCTU, VIBCH | **Neo-functionalization (opposite reaction)** | **CRITICAL** | COMPLETE |
 | LPL1 | CANAL | Substrate specificity | MEDIUM | COMPLETE |
-| UBA7 | human | Generic vs specific terms | LOW | COMPLETE |
+| UBA7 | human | Positive control: IBA corrects generic/domain propagation | N/A | COMPLETE |
 | RIMBP2 | human | Context-specific term transfer | MEDIUM | COMPLETE |
 | arnF | ECOLI | Functional divergence within SMR superfamily | MEDIUM | COMPLETE |
 | DPYSL2/CRMP1/DPYSL3 | human | Pseudo-enzyme (UniProt CAUTION: metallo-hydrolase residues absent) | HIGH | COMPLETE |

--- a/projects/IBA_REVIEW/HISTORY.md
+++ b/projects/IBA_REVIEW/HISTORY.md
@@ -1,5 +1,27 @@
 ---
 title: "IBA Annotation Quality — History, Methodology & Lessons"
+species: [human, MYCTU, VIBCH, SCHPO, ECOLI, CANAL, worm, yeast, ANOGA, POPTR, DANRE]
+genes:
+  - DPYSL2
+  - CRMP1
+  - DPYSL3
+  - AGO4
+  - UBAC2
+  - CAPG
+  - CRYAA
+  - CRY1
+  - CRY2
+  - BCL2
+  - EIF4E2
+  - AGK
+  - PIWIL1
+  - cds1
+  - RIMBP2
+  - arnF
+  - ndhA
+  - ndhD
+  - ndhK
+  - rpoB
 ---
 
 # IBA Annotation Quality — History, Methodology & Lessons

--- a/projects/IBA_REVIEW/msa/RESULTS.md
+++ b/projects/IBA_REVIEW/msa/RESULTS.md
@@ -1,3 +1,9 @@
+---
+title: "IBA Pseudo-Enzyme MSA Checks"
+species: [human]
+genes: [AGO1, AGO2, AGO3, AGO4, DPYSL2, CRMP1, DPYSL3, DPYSL4]
+---
+
 # MSA check of two pseudo-enzyme claims
 
 Reproducible alignment-level verification of catalytic-residue loss for two of the

--- a/projects/ISO.md
+++ b/projects/ISO.md
@@ -1,6 +1,6 @@
 ---
 title: "Inferred from Sequence Orthology (ISO) Evidence Code Review"
-maturity: SCOPING
+maturity: IN_PROGRESS
 tags: [PIPELINE]
 species: [human, mouse, rat]
 ---
@@ -8,74 +8,253 @@ species: [human, mouse, rat]
 
 ## Overview
 
-ISO (Inferred from Sequence Orthology, ECO:0000266) is one of the most widely used
-evidence codes in GO annotation, particularly for transferring annotations from
-well-characterized model organisms to less-studied species. This project examines
-ISO annotations in detail to assess their quality, identify systematic issues, and
-develop review guidelines.
+ISO (Inferred from Sequence Orthology, ECO:0000266) transfers GO annotations
+between orthologous genes. The code is often reliable for conserved molecular
+functions, but the current reviewed corpus shows that ISO rows need a different
+review question from ordinary evidence rows:
 
-## Background
+> Is the source annotation itself sound, and is this specific term safe to
+> propagate across this orthology relationship?
 
-### What ISO means
-ISO annotations are created when a GO term is transferred from one gene to its
-ortholog in another species based on orthology relationships. The logic:
-- Gene A in species 1 has experimentally validated annotation X
-- Gene B in species 2 is an ortholog of Gene A
-- Therefore Gene B receives annotation X with ISO evidence
+The answer is not binary. Existing reviews show three common outcomes:
 
-### Scale and impact
-- ISO is among the top evidence codes by volume in GOA
-- Mouse, rat, and other model organism genes receive many ISO annotations
-  transferred from human experimental data (and vice versa)
-- Quality depends on: orthology call accuracy, functional conservation across
-  species, and whether the specific GO term (not just broad function) is conserved
+1. The transfer is correct, sometimes even redundant with target-species
+   experimental evidence.
+2. The source annotation is weak, stale, circular, or miscited.
+3. The source annotation is sound, but propagation to the target is unsafe
+   because the target is a paralog, a diverged family member, a different
+   isoform/compartment context, or a different physiological context.
 
-### Known concerns
-1. **Over-transfer**: Broad functional conservation doesn't guarantee that specific
-   GO terms transfer correctly. Paralogs may have diverged in substrate specificity,
-   subcellular localization, or regulatory context.
-2. **Circular evidence**: If species A annotates from species B (ISO) and species B
-   annotates from species A (ISO), neither has primary experimental backing.
-3. **Granularity mismatch**: A specific MF term validated in human may not apply at
-   the same specificity in mouse if the gene has subtly different biochemistry.
-4. **Orthology method sensitivity**: Different orthology resources (PANTHER, OMA,
-   InParanoid, EggNOG) may disagree on orthology calls, especially for multi-copy
-   gene families.
+## Corpus Snapshot
 
-## Review Strategy
+Read-only inventory on 2026-06-29 of reviewed `*-ai-review.yaml` files containing
+`evidence_type: ISO`:
 
-For each gene reviewed under this project:
-1. Identify all ISO annotations
-2. Trace each to its source (which ortholog, which species, what experimental evidence
-   does the source have?)
-3. Assess whether the specific GO term (not just the broad function) is likely
-   conserved in the target species
-4. Flag annotations where:
-   - The source gene is a paralog, not a true ortholog
-   - The GO term is too specific for confident cross-species transfer
-   - The experimental evidence in the source species is itself weak
-   - There's contradictory experimental evidence in the target species
+| Metric | Count |
+|---|---:|
+| Reviewed ISO rows | 4,189 |
+| Gene review files with ISO rows | 153 |
+| Mouse ISO rows | 3,228 |
+| Rat ISO rows | 926 |
+| Other species ISO rows | 35 |
 
-## Initial Gene Targets
+Disposition across those reviewed ISO rows:
 
-| Gene | Species | Why interesting |
-|------|---------|-----------------|
-| Calm3 | mouse | Calmodulin family — highly conserved but subtle paralog differences between Calm1/2/3 |
-| | | |
+| Review action | Count | Interpretation |
+|---|---:|---|
+| `ACCEPT` | 1,374 | Conserved enough to keep as core or correct annotation. |
+| `KEEP_AS_NON_CORE` | 1,970 | Often true, but contextual, tissue-specific, downstream, or generic localization. |
+| `MARK_AS_OVER_ANNOTATED` | 378 | Biology may be related, but the propagated term overstates the direct role. |
+| `REMOVE` | 217 | Strong evidence that the annotation should not be retained. |
+| `MODIFY` | 114 | The transfer captures the right idea but needs a better GO term. |
+| `UNDECIDED` | 127 | Evidence could not be adjudicated confidently. |
+| `NEW` | 9 | Orthology-supported new-annotation candidates recorded in review files. |
 
-## Notes
+Most reviewed ISO rows are therefore not catastrophic failures. The main curation
+value is discriminating correct/non-core transfers from source or propagation
+defects.
 
-### Calmodulin family context
-Calm1, Calm2, and Calm3 encode identical protein sequences in many mammals but differ
-in UTR regulation, tissue expression patterns, and potentially in interaction partners.
-ISO annotations that transfer from human CALM1/2/3 to mouse Calm1/2/3 should be
-scrutinized for whether paralog-specific annotations are being inappropriately
-transferred across the family.
+## Existing Review Synthesis
+
+### Calmodulin: valid family-wide transfer, with locus-specific caveats
+
+Calm3 is the clean positive control. Mouse `Calm1`, `Calm2`, and `Calm3` encode
+the same calmodulin protein, so ISO transfer of core protein functions such as
+calcium binding, channel
+regulation, calcineurin/CaMKII-related signaling, and cytoplasmic localization is
+biochemically sound. The remaining issue is not protein orthology but locus and
+context: Calm3 has a distinct 3-UTR/Stau2-dependent dendritic mRNA-localization
+mechanism, while many synaptic, cardiac, spindle, centrosome, and sarcomere rows
+are best retained as non-core context rather than treated as defining Calm3
+function.
+
+### Ghr: direct donor support mixed with circular and stale transfers
+
+Ghr shows why ISO review must trace the donor edge. The manual donor trace
+(`genes/mouse/Ghr/Ghr-iso-donor-trace.md`) separates
+human and rat donor rows into direct receptor biology, redundant/circular
+transfer chains, and stale or context-heavy rows.
+
+Good transfers include growth hormone receptor activity, peptide hormone binding,
+plasma membrane/cell surface localization, receptor complex terms, and
+growth-hormone/JAK-STAT pathway terms. Problem rows include lipid binding, growth
+factor binding, receptor internalization, response to estradiol, response to
+cycloheximide, IGF receptor signaling, cytosol, cytoplasmic RNP granule,
+proteasome-mediated catabolism, and negative regulation of GHR signaling. Several
+are not simply "wrong ortholog" cases; they are transfer-of-transfer artifacts
+or donor rows with no current source-side support.
+
+The Ghr review also shows an isoform trap: extracellular-space annotations can
+fit the GH-binding protein product, while signaling annotations apply to the
+full-length membrane receptor.
+
+### Ang2: source and propagation defects reinforce each other
+
+Ang2 is the strongest ISO negative control. A reproducible source trace
+(`genes/mouse/Ang2/Ang2-bioinformatics/RESULTS.md`) found that
+all 46 local ISO rows were transferred from human ANG (`UniProtKB:P03950`) via
+`GO_REF:0000119`. The trace classified the human source side as:
+
+| Source-side status | Count |
+|---|---:|
+| Current human ANG term with direct experimental support | 34 |
+| Current human ANG term with inferred support only | 4 |
+| No current matching human ANG source term | 8 |
+
+Even many directly supported human ANG annotations are unsafe for mouse Ang2,
+because mouse Ang2/Angrp is a divergent angiogenin paralog: direct mouse evidence
+supports RNase/tRNA-cleavage activity but not canonical angiogenesis, receptor
+binding, signaling, stress-response, nuclear-trafficking, or immune-effector
+roles. The reviewed Ang2 ISO rows ended up mostly `REMOVE`:
+
+| Action for Ang2 ISO rows | Count |
+|---|---:|
+| `REMOVE` | 41 |
+| `ACCEPT` | 2 |
+| `KEEP_AS_NON_CORE` | 2 |
+| `MODIFY` | 1 |
+
+Ang2 also exposed source-annotation hygiene problems outside the ISO block:
+several experimental GOA rows trace to angiopoietin-2, angiotensin II, or ZNF418
+papers rather than to mouse Ang2/Angrp. This is the clearest example where
+"source annotation bad" and "propagation bad" both matter.
+
+### Broad mouse and rat ISO: the common pattern is non-core context
+
+The largest reviewed ISO blocks are not dominated by outright removals. Many
+mouse and rat signaling genes carry large ISO sets where the core molecular
+function is correct but the transferred rows include many tissue, pathway,
+phenotype, complex, or localization contexts. Typical review actions are
+`KEEP_AS_NON_CORE`, `MARK_AS_OVER_ANNOTATED`, or `MODIFY`, not `REMOVE`.
+
+This matters for reviewer tone: ISO is not mostly garbage. The risk is that a
+large cloud of true-but-contextual annotations can obscure the small number of
+source defects, stale transfers, and paralog-specific propagation failures.
+
+## Failure Taxonomy
+
+Use two labels when reviewing IBA or ISO propagation:
+
+1. A **root-cause class**: where the defect lives.
+2. A **biological subtype**: what kind of transfer mistake it is.
+
+Record these in `review.propagation_review`. Keep the narrative rationale in
+`review.reason`; the structured object should stay mechanical.
+
+Example:
+
+```yaml
+review:
+  action: REMOVE
+  reason: Mouse Ang2/Angrp retains RNase activity but lacks the angiogenic function of human ANG.
+  propagation_review:
+    root_cause: PROPAGATION_BAD
+    failure_modes:
+      - WRONG_ORTHOLOG_OR_PARALOG
+      - FUNCTIONAL_DIVERGENCE
+    source_entities:
+      - source_id: UniProtKB:P03950
+        source_label: ANG
+        source_status: SUPPORTS_SOURCE_BUT_NOT_TARGET
+        comment: Human ANG supports angiogenesis; mouse Ang2/Angrp is non-angiogenic.
+```
+
+### Root-cause classes
+
+| Code | Meaning | Fix target |
+|---|---|---|
+| `NO_FAILURE_CORE` | Transfer is correct and core for the target. | Keep annotation. |
+| `NO_FAILURE_NON_CORE` | Transfer is biologically defensible but contextual or secondary. | Keep as non-core. |
+| `SOURCE_BAD` | Source annotation is wrong, miscited, homonym-confused, or contradicted. | Fix source annotation before judging transfer. |
+| `SOURCE_STALE_OR_MISSING` | Transferred term no longer appears on the current source record, or donor trace cannot recover it. | Remove or re-source the transfer. |
+| `SOURCE_WEAK_OR_INFERRED` | Source exists but is only inferred, statement-level, or otherwise weak for transfer. | Downgrade confidence; require target/family corroboration. |
+| `EVIDENCE_CIRCULAR_OR_REDUNDANT` | ISO chain transfers from another transfer, or target already has stronger direct evidence. | Do not treat ISO edge as independent support. |
+| `PROPAGATION_BAD` | Source annotation is sound, but the term should not propagate to this target. | Fix orthology/family/node propagation. |
+| `TERM_SCOPING_PROBLEM` | Biology is related, but the GO term is too broad, too specific, or wrong in role/qualifier. | `MODIFY` or mark over-annotated. |
+| `UNRESOLVED` | Propagation issue was investigated but cannot yet be classified confidently. | Use `UNDECIDED` or defer until source/target evidence is resolved. |
+
+### Biological subtypes
+
+| Code | Applies to | Typical signal |
+|---|---|---|
+| `WRONG_ORTHOLOG_OR_PARALOG` | ISO and IBA | Donor/source is a paralog, expanded family member, or wrong subfamily. |
+| `FUNCTIONAL_DIVERGENCE` | ISO and IBA | Target retained fold/orthology but changed substrate, product, activity, or pathway role. |
+| `PSEUDO_OR_SUBACTIVITY_LOSS` | Mostly IBA, sometimes ISO | Catalytic residues or a specific sub-activity are lost even though the domain remains. |
+| `CONTEXT_OR_TISSUE_MISMATCH` | ISO and IBA | Donor evidence is tissue, developmental, organismal, or disease-context specific. |
+| `LINEAGE_OR_TAXON_MISMATCH` | Mostly IBA | Process does not occur in the target lineage or organelle system. |
+| `COMPARTMENT_OR_COMPLEX_MISMATCH` | ISO and IBA | Localization, complex membership, or pathway compartment does not transfer. |
+| `REGULATORY_SIGN_INVERSION` | ISO and IBA | Family contains activators and inhibitors; positive/negative term leaks across members. |
+| `ROLE_CONFLATION` | ISO and IBA | Substrate, regulator, effector, or specificity subunit is annotated as the agent/core machinery. |
+| `GRANULARITY_MISMATCH` | ISO and IBA | Parent term is true but uninformative, or child term overstates specificity. |
+| `SOURCE_MISCITATION` | ISO and IBA | Source evidence points to the wrong gene, organism, publication, or homonym. |
+| `SOURCE_EVIDENCE_WEAK` | ISO and IBA | Source evidence is inferred, statement-level, stale, or otherwise too weak for confident propagation. |
+| `CIRCULAR_PROPAGATION` | Mostly ISO, sometimes IBA | Propagation chain depends on another propagated annotation rather than independent source evidence. |
+
+Examples:
+
+- Ang2 human ANG-to-mouse Ang2 angiogenesis rows:
+  `PROPAGATION_BAD` + `WRONG_ORTHOLOG_OR_PARALOG` + `FUNCTIONAL_DIVERGENCE`.
+- Ghr receptor internalization:
+  `SOURCE_STALE_OR_MISSING` + `EVIDENCE_CIRCULAR_OR_REDUNDANT`.
+- Ghr hormone-mediated signaling:
+  `TERM_SCOPING_PROBLEM` + `GRANULARITY_MISMATCH`.
+- Calm3 calcium ion binding:
+  `NO_FAILURE_CORE`.
+- Calm3 spindle/centrosome contexts:
+  `NO_FAILURE_NON_CORE` + `CONTEXT_OR_TISSUE_MISMATCH`.
+
+## Reviewer Checklist
+
+Use this checklist before making a strong `REMOVE` call on ISO or IBA.
+
+### Source annotation checked
+
+- Record the target row: gene, species, GO term, qualifier, aspect, evidence code,
+  reference, `WITH/FROM`, and assigned-by source.
+- Verify the GO term definition, not just the label.
+- Resolve the source gene/product(s) named by `WITH/FROM`.
+- Check whether the current source record still carries the same GO term.
+- Record the source evidence code and original source reference.
+- If the source evidence is experimental, verify that the cited paper supports
+  the source gene and term. If only abstract text is cached, avoid claiming a
+  curator misread full text.
+- Check for source-side `NOT` annotations or contradictory direct evidence.
+
+### Propagation checked
+
+- For ISO, confirm whether the donor-target relation is one-to-one orthology,
+  one-to-many, in-paralog, identical protein sequence, or broader family
+  similarity.
+- For IBA, inspect the PANTHER family/node, seed genes, `WITH/FROM` proteins, and
+  whether seeds map to the same functional subfamily as the target.
+- Ask whether the exact term should transfer, not only whether the broad family
+  function is conserved.
+- Check active-site residues, key domains, isoforms, compartment targeting,
+  lineage constraints, and target-species direct evidence when relevant.
+- Distinguish source defects from propagation defects. Do not hide a bad source
+  annotation under "orthology failure," and do not blame a source annotation when
+  the real problem is target-specific divergence.
+
+### Disposition recorded
+
+- Assign `propagation_review.root_cause` and any relevant
+  `propagation_review.failure_modes`.
+- Add `propagation_review.source_entities` entries for donor genes, seed
+  proteins, PANTHER nodes, family nodes, or other source entities that were
+  checked.
+- State whether the recommended fix is source-side, propagation-side, term
+  replacement, or non-core retention.
+- Prefer `UNDECIDED` when the source full text or family-node evidence cannot be
+  checked.
 
 ## Action Items
 
-- [ ] Review mouse Calm3 ISO annotations as initial test case
-- [ ] Develop ISO-specific review criteria for the review skill
-- [ ] Assess scale: how many ISO annotations exist for mouse genes in GOA?
-- [ ] Compare orthology sources used for ISO transfers (PANTHER vs OMA)
-- [ ] Identify systematic patterns in problematic ISO transfers
+- [x] Review mouse Calm3 ISO annotations as the initial positive-control case.
+- [x] Summarize existing ISO reviews across the repository.
+- [x] Add an ISO/IBA failure taxonomy that distinguishes source defects from
+      propagation defects.
+- [x] Add a source/family annotation checklist for future ISO and IBA reviews.
+- [x] Add structured `review.propagation_review` schema fields for the taxonomy
+      and per-source entity comments.
+- [ ] Add a reusable ISO donor-trace script that handles multiple source entities
+      and writes the same source-status fields used in the Ang2 trace.

--- a/src/ai_gene_review/datamodel/gene_review_model.py
+++ b/src/ai_gene_review/datamodel/gene_review_model.py
@@ -410,6 +410,140 @@ class EvidenceType(str, Enum):
     """
 
 
+class PropagationRootCauseEnum(str, Enum):
+    """
+    Mechanical root-cause classification for propagated or inferred annotations. This distinguishes bad source annotations from bad propagation decisions and term-scoping issues.
+    """
+    NO_FAILURE_CORE = "NO_FAILURE_CORE"
+    """
+    The propagated annotation is correct and core for the target.
+    """
+    NO_FAILURE_NON_CORE = "NO_FAILURE_NON_CORE"
+    """
+    The propagated annotation is biologically defensible but contextual, secondary, or generic.
+    """
+    SOURCE_BAD = "SOURCE_BAD"
+    """
+    The source annotation is wrong, miscited, homonym-confused, or contradicted.
+    """
+    SOURCE_STALE_OR_MISSING = "SOURCE_STALE_OR_MISSING"
+    """
+    The transferred term no longer appears on the current source record, or donor tracing cannot recover it.
+    """
+    SOURCE_WEAK_OR_INFERRED = "SOURCE_WEAK_OR_INFERRED"
+    """
+    The source exists but is only inferred, statement-level, or otherwise weak for propagation.
+    """
+    EVIDENCE_CIRCULAR_OR_REDUNDANT = "EVIDENCE_CIRCULAR_OR_REDUNDANT"
+    """
+    The propagation chain transfers from another transfer, or the target already has stronger direct evidence.
+    """
+    PROPAGATION_BAD = "PROPAGATION_BAD"
+    """
+    The source annotation is sound, but the term should not propagate to this target.
+    """
+    TERM_SCOPING_PROBLEM = "TERM_SCOPING_PROBLEM"
+    """
+    The biology is related, but the GO term is too broad, too specific, or has the wrong role or qualifier.
+    """
+    UNRESOLVED = "UNRESOLVED"
+    """
+    The propagation issue was investigated but could not be classified confidently.
+    """
+
+
+class PropagationFailureModeEnum(str, Enum):
+    """
+    Biological subtype for a propagation or inference issue.
+    """
+    WRONG_ORTHOLOG_OR_PARALOG = "WRONG_ORTHOLOG_OR_PARALOG"
+    """
+    Donor/source is a paralog, expanded family member, or wrong subfamily.
+    """
+    FUNCTIONAL_DIVERGENCE = "FUNCTIONAL_DIVERGENCE"
+    """
+    Target retained fold or orthology but changed substrate, product, activity, or pathway role.
+    """
+    PSEUDO_OR_SUBACTIVITY_LOSS = "PSEUDO_OR_SUBACTIVITY_LOSS"
+    """
+    Catalytic residues or a specific sub-activity are lost even though the domain remains.
+    """
+    CONTEXT_OR_TISSUE_MISMATCH = "CONTEXT_OR_TISSUE_MISMATCH"
+    """
+    Donor evidence is tissue, developmental, organismal, or disease-context specific.
+    """
+    LINEAGE_OR_TAXON_MISMATCH = "LINEAGE_OR_TAXON_MISMATCH"
+    """
+    Process does not occur in the target lineage or organelle system.
+    """
+    COMPARTMENT_OR_COMPLEX_MISMATCH = "COMPARTMENT_OR_COMPLEX_MISMATCH"
+    """
+    Localization, complex membership, or pathway compartment does not transfer.
+    """
+    REGULATORY_SIGN_INVERSION = "REGULATORY_SIGN_INVERSION"
+    """
+    Family contains activators and inhibitors, and a positive/negative regulatory term leaks across members.
+    """
+    ROLE_CONFLATION = "ROLE_CONFLATION"
+    """
+    Substrate, regulator, effector, or specificity subunit is annotated as the agent or core machinery.
+    """
+    GRANULARITY_MISMATCH = "GRANULARITY_MISMATCH"
+    """
+    Parent term is true but uninformative, or child term overstates specificity.
+    """
+    SOURCE_MISCITATION = "SOURCE_MISCITATION"
+    """
+    Source evidence points to the wrong gene, organism, publication, or homonym.
+    """
+    SOURCE_EVIDENCE_WEAK = "SOURCE_EVIDENCE_WEAK"
+    """
+    Source evidence is inferred, statement-level, stale, or otherwise too weak for confident propagation.
+    """
+    CIRCULAR_PROPAGATION = "CIRCULAR_PROPAGATION"
+    """
+    Propagation chain depends on another propagated annotation rather than independent source evidence.
+    """
+
+
+class PropagationSourceStatusEnum(str, Enum):
+    """
+    Mechanical status of a source entity with respect to a propagated target annotation.
+    """
+    SUPPORTS_TRANSFER = "SUPPORTS_TRANSFER"
+    """
+    Source evidence supports the term and the transfer to the target.
+    """
+    SUPPORTS_SOURCE_BUT_NOT_TARGET = "SUPPORTS_SOURCE_BUT_NOT_TARGET"
+    """
+    Source evidence supports the source annotation, but propagation to the target is unsafe.
+    """
+    SOURCE_BAD = "SOURCE_BAD"
+    """
+    Source annotation or source citation is itself wrong.
+    """
+    SOURCE_STALE_OR_MISSING = "SOURCE_STALE_OR_MISSING"
+    """
+    Current source record no longer carries the transferred term, or tracing cannot recover it.
+    """
+    SOURCE_WEAK_OR_INFERRED = "SOURCE_WEAK_OR_INFERRED"
+    """
+    Source exists but is only inferred, statement-level, or otherwise weak.
+    """
+    CIRCULAR_OR_REDUNDANT = "CIRCULAR_OR_REDUNDANT"
+    """
+    Source participates in a circular transfer chain or adds no independent support.
+    """
+    NOT_RELEVANT = "NOT_RELEVANT"
+    """
+    Source was inspected but is not relevant to the target annotation.
+    """
+    UNRESOLVED = "UNRESOLVED"
+    """
+    Source could not be classified confidently.
+    """
+
+
 class ActionEnum(str, Enum):
     ACCEPT = "ACCEPT"
     """
@@ -1852,7 +1986,7 @@ class EvidenceItem(ConfiguredBaseModel):
     """
     linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'from_schema': 'https://ai4curation.io/ai-gene-review'})
 
-    source_id: str = Field(default=..., description="""Identifier for the evidence source, e.g. PMID:123456, DOI:..., Reactome:R-HSA-..., MetaCyc:..., file:...""", json_schema_extra = { "linkml_meta": {'alias': 'source_id', 'domain_of': ['EvidenceItem']} })
+    source_id: str = Field(default=..., description="""Identifier for the evidence source, e.g. PMID:123456, DOI:..., Reactome:R-HSA-..., MetaCyc:..., file:...""", json_schema_extra = { "linkml_meta": {'alias': 'source_id', 'domain_of': ['EvidenceItem', 'PropagationSource']} })
     title: Optional[str] = Field(default=None, json_schema_extra = { "linkml_meta": {'alias': 'title',
          'domain_of': ['Reference',
                        'EvidenceItem',
@@ -3851,6 +3985,30 @@ class Review(ConfiguredBaseModel):
                        'ModuleNode',
                        'Review',
                        'CoreFunction']} })
+    propagation_review: Optional[PropagationReview] = Field(default=None, description="""Mechanical review metadata for annotations whose evidence depends on propagation or inference from source genes, family nodes, orthogroups, or other non-target evidence. Use this to classify source-side vs propagation-side failure modes without duplicating the prose rationale in review.reason.""", json_schema_extra = { "linkml_meta": {'alias': 'propagation_review', 'domain_of': ['Review']} })
+
+
+class PropagationReview(ConfiguredBaseModel):
+    """
+    Structured, mechanical assessment of a propagated or inferred annotation. The detailed biological rationale remains in review.reason; this object records the reusable taxonomy and optional per-source-gene/node comments.
+    """
+    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'from_schema': 'https://ai4curation.io/ai-gene-review'})
+
+    root_cause: PropagationRootCauseEnum = Field(default=..., description="""Where the issue lies, or that no issue was found: source annotation, propagation decision, term scoping, circular/redundant evidence, or no propagation failure.""", json_schema_extra = { "linkml_meta": {'alias': 'root_cause', 'domain_of': ['PropagationReview']} })
+    failure_modes: Optional[list[PropagationFailureModeEnum]] = Field(default=None, description="""Biological shape of the propagation issue. Multiple values are allowed when a case combines, for example, paralog transfer and functional divergence.""", json_schema_extra = { "linkml_meta": {'alias': 'failure_modes', 'domain_of': ['PropagationReview']} })
+    source_entities: Optional[list[PropagationSource]] = Field(default=None, description="""Source genes, gene products, PANTHER nodes, family nodes, or other source entities inspected for the propagated annotation.""", json_schema_extra = { "linkml_meta": {'alias': 'source_entities', 'domain_of': ['PropagationReview']} })
+
+
+class PropagationSource(ConfiguredBaseModel):
+    """
+    A source entity considered while reviewing an inferred annotation. This is intentionally compact: use comment for source-specific caveats, not for restating the whole review rationale.
+    """
+    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'from_schema': 'https://ai4curation.io/ai-gene-review'})
+
+    source_id: str = Field(default=..., description="""Identifier for the source entity, e.g. UniProtKB:P03950, MGI:MGI:104579, PANTHER:PTN002745520, or a GO_REF/source label when no gene product identifier is available.""", json_schema_extra = { "linkml_meta": {'alias': 'source_id', 'domain_of': ['EvidenceItem', 'PropagationSource']} })
+    source_label: Optional[str] = Field(default=None, description="""Human-readable source label, such as a gene symbol or node label.""", json_schema_extra = { "linkml_meta": {'alias': 'source_label', 'domain_of': ['PropagationSource']} })
+    source_status: Optional[PropagationSourceStatusEnum] = Field(default=None, description="""Mechanical status of this source with respect to the target annotation.""", json_schema_extra = { "linkml_meta": {'alias': 'source_status', 'domain_of': ['PropagationSource']} })
+    comment: Optional[str] = Field(default=None, description="""Short source-specific comment, e.g. \"human ANG supports angiogenesis, but mouse Ang2/Angrp is non-angiogenic\" or \"seed is inferred-only\".""", json_schema_extra = { "linkml_meta": {'alias': 'comment', 'domain_of': ['PropagationSource']} })
 
 
 class CoreFunction(ConfiguredBaseModel):
@@ -4711,6 +4869,8 @@ ModuleContext.model_rebuild()
 ModuleConnection.model_rebuild()
 ExistingAnnotation.model_rebuild()
 Review.model_rebuild()
+PropagationReview.model_rebuild()
+PropagationSource.model_rebuild()
 CoreFunction.model_rebuild()
 AnnotationExtension.model_rebuild()
 TermMapping.model_rebuild()

--- a/src/ai_gene_review/render.py
+++ b/src/ai_gene_review/render.py
@@ -651,7 +651,7 @@ def render_html(
     template = env.get_template(template_path.name)
     html = template.render(gene=data, yaml_content=yaml_content)
 
-    return html
+    return "\n".join(line.rstrip() for line in html.splitlines()) + "\n"
 
 
 def render_gene_review(

--- a/src/ai_gene_review/render_projects.py
+++ b/src/ai_gene_review/render_projects.py
@@ -148,6 +148,15 @@ def _frontmatter_bool(value: Any, default: bool) -> bool:
     return default
 
 
+def _as_string_list(value: Any) -> List[str]:
+    """Normalize a frontmatter scalar/list to a list of strings."""
+    if value is None:
+        return []
+    if isinstance(value, (list, tuple, set)):
+        return [str(v) for v in value]
+    return [str(value)]
+
+
 def should_autolink_gene_symbols(frontmatter: Dict[str, Any]) -> bool:
     """Return whether automatic prose gene-symbol linking should run.
 
@@ -166,6 +175,70 @@ def should_autolink_gene_symbols(frontmatter: Dict[str, Any]) -> bool:
             default=False,
         )
     return True
+
+
+def resolve_frontmatter_gene_links(
+    genes_value: Any,
+    symbol_index: Dict[str, List[str]],
+    species_hints: Optional[List[str]] = None,
+    genes_dir: Path = Path("genes"),
+    base_path: str = "../../genes",
+) -> Tuple[List[Dict[str, str]], List[str]]:
+    """Resolve ``genes:`` frontmatter entries to gene-review links.
+
+    Bare symbols use the same priority-ordered ``species:`` hint semantics as
+    prose autolinking. Entries may also be species-qualified as ``CODE/symbol``
+    to target a specific review in multispecies projects.
+    """
+    species_hints = species_hints or []
+    links: List[Dict[str, str]] = []
+    warnings: List[str] = []
+
+    for raw_gene in _as_string_list(genes_value):
+        label = raw_gene
+        species = ""
+        symbol = raw_gene
+        url = ""
+
+        if "/" in raw_gene:
+            code, candidate_symbol = raw_gene.split("/", 1)
+            if (genes_dir / code / candidate_symbol).is_dir():
+                species = code
+                symbol = candidate_symbol
+                url = f"{base_path}/{species}/{symbol}/{symbol}-ai-review.html"
+            elif (genes_dir / code).is_dir():
+                warnings.append(
+                    f"Frontmatter gene '{raw_gene}' not found "
+                    f"(no genes/{code}/{candidate_symbol})."
+                )
+        else:
+            species_list = symbol_index.get(raw_gene, [])
+            if len(species_list) == 1:
+                species = species_list[0]
+                url = f"{base_path}/{species}/{symbol}/{symbol}-ai-review.html"
+            elif species_list:
+                for hint in species_hints:
+                    if hint in species_list:
+                        species = hint
+                        url = f"{base_path}/{species}/{symbol}/{symbol}-ai-review.html"
+                        break
+                if not url:
+                    warnings.append(
+                        f"Ambiguous frontmatter gene '{raw_gene}' found in species: "
+                        f"{', '.join(species_list)}. Add a matching species hint "
+                        "or use CODE/symbol in genes: to resolve."
+                    )
+
+        links.append(
+            {
+                "label": label,
+                "species": species,
+                "symbol": symbol,
+                "url": url,
+            }
+        )
+
+    return links, warnings
 
 
 def replace_gene_symbols(
@@ -1072,6 +1145,17 @@ def render_project(
     if isinstance(species_hints, str):
         species_hints = [species_hints]
 
+    frontmatter = dict(frontmatter)
+    gene_links, frontmatter_gene_warnings = resolve_frontmatter_gene_links(
+        frontmatter.get("genes"),
+        symbol_index,
+        species_hints=species_hints,
+        genes_dir=genes_dir,
+        base_path=genes_base_path,
+    )
+    if gene_links:
+        frontmatter["gene_links"] = gene_links
+
     # Replace explicit gene tags first. The generated markdown links are then
     # preserved by the ordinary auto-linker.
     content, tag_warnings = replace_gene_tags(
@@ -1100,7 +1184,9 @@ def render_project(
         )
     else:
         linked_content, symbol_warnings = content, []
-    warnings = tag_warnings + qualified_warnings + symbol_warnings
+    warnings = (
+        frontmatter_gene_warnings + tag_warnings + qualified_warnings + symbol_warnings
+    )
 
     # Link raw SPKW sample rows such as `MCP/P06491` to UniProt. Local review
     # links are already explicit via <gene> tags or ordinary symbol autolinks.
@@ -1145,6 +1231,7 @@ def render_project(
         warnings=warnings,
         frontmatter=frontmatter,
     )
+    html = "\n".join(line.rstrip() for line in html.splitlines()) + "\n"
 
     # Create output directory and write file, mirroring subfolder structure
     output_path = output_dir / rel_path.with_suffix(".html")
@@ -1379,6 +1466,7 @@ def render_projects_table(
         all_species=all_species,
         all_review_statuses=all_review_statuses,
     )
+    html = "\n".join(line.rstrip() for line in html.splitlines()) + "\n"
 
     output_dir.mkdir(parents=True, exist_ok=True)
     output_path = output_dir / "all-projects.html"

--- a/src/ai_gene_review/schema/gene_review.yaml
+++ b/src/ai_gene_review/schema/gene_review.yaml
@@ -291,6 +291,14 @@ slots:
       everywhere else the schema records what IS known; here it records, with the
       same evidentiary discipline, what is not. See the Function Knowledge Gaps
       project (projects/FUNCTION_KNOWLEDGE_GAPS.md).
+  propagation_review:
+    range: PropagationReview
+    description: >-
+      Mechanical review metadata for annotations whose evidence depends on
+      propagation or inference from source genes, family nodes, orthogroups, or
+      other non-target evidence. Use this to classify source-side vs
+      propagation-side failure modes without duplicating the prose rationale in
+      review.reason.
   status:
     range: GeneReviewStatusEnum
     description: Overall status of the gene review
@@ -1225,6 +1233,7 @@ classes:
       - additional_reference_ids
       - supported_by
       - knowledge_gaps
+      - propagation_review
     rules:
       - preconditions:
           slot_conditions:
@@ -1234,6 +1243,59 @@ classes:
           slot_conditions:
             proposed_replacement_terms:
               required: true
+
+  PropagationReview:
+    description: >-
+      Structured, mechanical assessment of a propagated or inferred annotation.
+      The detailed biological rationale remains in review.reason; this object
+      records the reusable taxonomy and optional per-source-gene/node comments.
+    attributes:
+      root_cause:
+        range: PropagationRootCauseEnum
+        required: true
+        description: >-
+          Where the issue lies, or that no issue was found: source annotation,
+          propagation decision, term scoping, circular/redundant evidence, or no
+          propagation failure.
+      failure_modes:
+        range: PropagationFailureModeEnum
+        multivalued: true
+        description: >-
+          Biological shape of the propagation issue. Multiple values are allowed
+          when a case combines, for example, paralog transfer and functional
+          divergence.
+      source_entities:
+        range: PropagationSource
+        multivalued: true
+        inlined_as_list: true
+        description: >-
+          Source genes, gene products, PANTHER nodes, family nodes, or other
+          source entities inspected for the propagated annotation.
+
+  PropagationSource:
+    description: >-
+      A source entity considered while reviewing an inferred annotation. This is
+      intentionally compact: use comment for source-specific caveats, not for
+      restating the whole review rationale.
+    attributes:
+      source_id:
+        range: string
+        required: true
+        description: >-
+          Identifier for the source entity, e.g. UniProtKB:P03950,
+          MGI:MGI:104579, PANTHER:PTN002745520, or a GO_REF/source label when
+          no gene product identifier is available.
+      source_label:
+        range: string
+        description: Human-readable source label, such as a gene symbol or node label.
+      source_status:
+        range: PropagationSourceStatusEnum
+        description: Mechanical status of this source with respect to the target annotation.
+      comment:
+        range: string
+        description: >-
+          Short source-specific comment, e.g. "human ANG supports angiogenesis,
+          but mouse Ang2/Angrp is non-angiogenic" or "seed is inferred-only".
         
   CoreFunction:
     description: A core function is a GO-CAM-like annotation of the core evolved functions of a gene.
@@ -2325,6 +2387,78 @@ enums:
         description: Inferred from Electronic Annotation
         meaning: ECO:0000501
 
+  PropagationRootCauseEnum:
+    description: >-
+      Mechanical root-cause classification for propagated or inferred
+      annotations. This distinguishes bad source annotations from bad
+      propagation decisions and term-scoping issues.
+    permissible_values:
+      NO_FAILURE_CORE:
+        description: The propagated annotation is correct and core for the target.
+      NO_FAILURE_NON_CORE:
+        description: The propagated annotation is biologically defensible but contextual, secondary, or generic.
+      SOURCE_BAD:
+        description: The source annotation is wrong, miscited, homonym-confused, or contradicted.
+      SOURCE_STALE_OR_MISSING:
+        description: The transferred term no longer appears on the current source record, or donor tracing cannot recover it.
+      SOURCE_WEAK_OR_INFERRED:
+        description: The source exists but is only inferred, statement-level, or otherwise weak for propagation.
+      EVIDENCE_CIRCULAR_OR_REDUNDANT:
+        description: The propagation chain transfers from another transfer, or the target already has stronger direct evidence.
+      PROPAGATION_BAD:
+        description: The source annotation is sound, but the term should not propagate to this target.
+      TERM_SCOPING_PROBLEM:
+        description: The biology is related, but the GO term is too broad, too specific, or has the wrong role or qualifier.
+      UNRESOLVED:
+        description: The propagation issue was investigated but could not be classified confidently.
+
+  PropagationFailureModeEnum:
+    description: Biological subtype for a propagation or inference issue.
+    permissible_values:
+      WRONG_ORTHOLOG_OR_PARALOG:
+        description: Donor/source is a paralog, expanded family member, or wrong subfamily.
+      FUNCTIONAL_DIVERGENCE:
+        description: Target retained fold or orthology but changed substrate, product, activity, or pathway role.
+      PSEUDO_OR_SUBACTIVITY_LOSS:
+        description: Catalytic residues or a specific sub-activity are lost even though the domain remains.
+      CONTEXT_OR_TISSUE_MISMATCH:
+        description: Donor evidence is tissue, developmental, organismal, or disease-context specific.
+      LINEAGE_OR_TAXON_MISMATCH:
+        description: Process does not occur in the target lineage or organelle system.
+      COMPARTMENT_OR_COMPLEX_MISMATCH:
+        description: Localization, complex membership, or pathway compartment does not transfer.
+      REGULATORY_SIGN_INVERSION:
+        description: Family contains activators and inhibitors, and a positive/negative regulatory term leaks across members.
+      ROLE_CONFLATION:
+        description: Substrate, regulator, effector, or specificity subunit is annotated as the agent or core machinery.
+      GRANULARITY_MISMATCH:
+        description: Parent term is true but uninformative, or child term overstates specificity.
+      SOURCE_MISCITATION:
+        description: Source evidence points to the wrong gene, organism, publication, or homonym.
+      SOURCE_EVIDENCE_WEAK:
+        description: Source evidence is inferred, statement-level, stale, or otherwise too weak for confident propagation.
+      CIRCULAR_PROPAGATION:
+        description: Propagation chain depends on another propagated annotation rather than independent source evidence.
+
+  PropagationSourceStatusEnum:
+    description: Mechanical status of a source entity with respect to a propagated target annotation.
+    permissible_values:
+      SUPPORTS_TRANSFER:
+        description: Source evidence supports the term and the transfer to the target.
+      SUPPORTS_SOURCE_BUT_NOT_TARGET:
+        description: Source evidence supports the source annotation, but propagation to the target is unsafe.
+      SOURCE_BAD:
+        description: Source annotation or source citation is itself wrong.
+      SOURCE_STALE_OR_MISSING:
+        description: Current source record no longer carries the transferred term, or tracing cannot recover it.
+      SOURCE_WEAK_OR_INFERRED:
+        description: Source exists but is only inferred, statement-level, or otherwise weak.
+      CIRCULAR_OR_REDUNDANT:
+        description: Source participates in a circular transfer chain or adds no independent support.
+      NOT_RELEVANT:
+        description: Source was inspected but is not relevant to the target annotation.
+      UNRESOLVED:
+        description: Source could not be classified confidently.
 
   ActionEnum:
     permissible_values:

--- a/src/ai_gene_review/templates/gene_review.html.j2
+++ b/src/ai_gene_review/templates/gene_review.html.j2
@@ -343,6 +343,42 @@
             margin-left: 1rem;
         }
 
+        .propagation-review {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f8fafc;
+            border-left: 3px solid #64748b;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .propagation-title {
+            font-weight: 600;
+            color: #334155;
+            margin-bottom: 0.25rem;
+        }
+
+        .propagation-row {
+            margin-top: 0.25rem;
+        }
+
+        .propagation-source {
+            margin-top: 0.5rem;
+            padding-top: 0.5rem;
+            border-top: 1px solid #e5e7eb;
+        }
+
+        .propagation-source-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #1d4ed8;
+        }
+
+        .propagation-comment {
+            color: #4b5563;
+            margin-left: 1rem;
+        }
+
         a.term-link {
             color: #2563eb;
             text-decoration: none;
@@ -1032,6 +1068,43 @@
                         {% if annotation.reason %}
                         <div>
                             <strong>Reason:</strong> {{ annotation.reason }}
+                        </div>
+                        {% endif %}
+                        {% if annotation.review and annotation.review.propagation_review %}
+                        {% set propagation = annotation.review.propagation_review %}
+                        <div class="propagation-review">
+                            <div class="propagation-title">Propagation Review</div>
+                            <div class="propagation-row">
+                                <strong>Root cause:</strong>
+                                <span class="badge">{{ propagation.root_cause | replace('_', ' ') }}</span>
+                            </div>
+                            {% if propagation.failure_modes %}
+                            <div class="propagation-row">
+                                <strong>Failure modes:</strong>
+                                {% for mode in propagation.failure_modes %}
+                                <span class="badge">{{ mode | replace('_', ' ') }}</span>
+                                {% endfor %}
+                            </div>
+                            {% endif %}
+                            {% if propagation.source_entities %}
+                            <div class="propagation-source">
+                                <strong>Sources checked:</strong>
+                                {% for source in propagation.source_entities %}
+                                <div class="propagation-row">
+                                    <span class="propagation-source-id">{{ source.source_id }}</span>
+                                    {% if source.source_label %}
+                                    &middot; {{ source.source_label }}
+                                    {% endif %}
+                                    {% if source.source_status %}
+                                    <span class="badge">{{ source.source_status | replace('_', ' ') }}</span>
+                                    {% endif %}
+                                    {% if source.comment %}
+                                    <div class="propagation-comment">{{ source.comment }}</div>
+                                    {% endif %}
+                                </div>
+                                {% endfor %}
+                            </div>
+                            {% endif %}
                         </div>
                         {% endif %}
                         {% if annotation.proposed_replacement_terms %}

--- a/src/ai_gene_review/templates/project.html.j2
+++ b/src/ai_gene_review/templates/project.html.j2
@@ -250,6 +250,25 @@
         /* Project meta: maturity + tag badges */
         .project-meta { margin-bottom: 0.5rem; }
         .project-meta .badge { margin: 0 0.25rem 0.25rem 0; }
+        .gene-list {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.375rem;
+            margin-bottom: 1rem;
+        }
+        .gene-list a,
+        .gene-list span {
+            background-color: #dbeafe;
+            border-radius: 0.25rem;
+            color: #1e40af;
+            display: inline-block;
+            font-weight: 500;
+            padding: 0.125rem 0.375rem;
+        }
+        .gene-list a:hover {
+            background-color: #bfdbfe;
+            text-decoration: none;
+        }
         .m-SCOPING     { background: #fef3c7; color: #92400e; }
         .m-IN_PROGRESS { background: #dbeafe; color: #1e40af; }
         .m-MATURE      { background: #dcfce7; color: #166534; }
@@ -339,8 +358,17 @@
         {% if frontmatter.species %}
         <p><strong>Species:</strong> {{ frontmatter.species | join(', ') if frontmatter.species is iterable and frontmatter.species is not string else frontmatter.species }}</p>
         {% endif %}
-        {% if frontmatter.genes %}
-        <p><strong>Genes:</strong> {{ frontmatter.genes | join(', ') if frontmatter.genes is iterable and frontmatter.genes is not string else frontmatter.genes }}</p>
+        {% if frontmatter.gene_links %}
+        <div class="gene-list">
+            <strong>Genes:</strong>
+            {% for gene in frontmatter.gene_links %}
+            {% if gene.url %}
+            <a href="{{ gene.url }}" title="{{ gene.species }}/{{ gene.symbol }}">{{ gene.label }}</a>
+            {% else %}
+            <span>{{ gene.label }}</span>
+            {% endif %}
+            {% endfor %}
+        </div>
         {% endif %}
     </header>
 

--- a/src/ai_gene_review/validation/validator.py
+++ b/src/ai_gene_review/validation/validator.py
@@ -32,6 +32,15 @@ from ai_gene_review.validation.validation_report import (
 from ai_gene_review.validation.goa_validator import GOAValidator
 
 
+PROPAGATION_REVIEW_EVIDENCE_TYPES = {"IBA", "ISO"}
+PROPAGATION_REVIEW_ACTIONS = {
+    "REMOVE",
+    "MODIFY",
+    "MARK_AS_OVER_ANNOTATED",
+    "UNDECIDED",
+}
+
+
 @contextmanager
 def timer(name: str, callback: Optional[Callable] = None):
     """Context manager for timing operations with optional progress callback."""
@@ -225,6 +234,38 @@ def check_best_practices_rules(
                         path=f"existing_annotations[{i}].original_reference_id",
                         suggestion=f"Add a reference with ID '{ref_id}' to the references section or correct the reference ID",
                     )
+
+    # Check for structured propagation reviews on corrective IBA/ISO decisions.
+    # These annotations depend on source genes/nodes; corrective calls should
+    # distinguish source-side defects from propagation-side defects mechanically.
+    if "existing_annotations" in data and data["existing_annotations"]:
+        for i, annotation in enumerate(data["existing_annotations"]):
+            if not isinstance(annotation, dict):
+                continue
+            evidence_type = annotation.get("evidence_type")
+            review = annotation.get("review")
+            if not isinstance(review, dict):
+                continue
+            action = review.get("action")
+            if (
+                evidence_type in PROPAGATION_REVIEW_EVIDENCE_TYPES
+                and action in PROPAGATION_REVIEW_ACTIONS
+                and not review.get("propagation_review")
+            ):
+                report.add_issue(
+                    ValidationSeverity.WARNING,
+                    (
+                        f"{evidence_type} annotation with action {action} is missing "
+                        "structured propagation_review metadata"
+                    ),
+                    path=f"existing_annotations[{i}].review.propagation_review",
+                    suggestion=(
+                        "Add propagation_review with root_cause, failure_modes, "
+                        "and source_entities when source genes/nodes were inspected"
+                    ),
+                    validation_category="BestPractices",
+                    check_type="missing_propagation_review",
+                )
 
     # Helper function to validate file references
     def validate_file_reference(ref_id: str, path: str) -> None:

--- a/tests/test_propagation_review_validation.py
+++ b/tests/test_propagation_review_validation.py
@@ -6,10 +6,10 @@ import tempfile
 import yaml
 
 from ai_gene_review.datamodel.gene_review_model import Review
-from ai_gene_review.validation import validate_gene_review
+from ai_gene_review.validation import ValidationReport, validate_gene_review
 
 
-def _validate(yaml_data: dict) -> object:
+def _validate(yaml_data: dict) -> ValidationReport:
     """Validate a minimal gene review YAML from a temporary file."""
     with tempfile.TemporaryDirectory() as tmpdir:
         path = Path(tmpdir) / "TEST-ai-review.yaml"
@@ -51,7 +51,7 @@ def _base_yaml(annotation: dict) -> dict:
     }
 
 
-def _has_missing_propagation_review_warning(report: object) -> bool:
+def _has_missing_propagation_review_warning(report: ValidationReport) -> bool:
     """Return whether the propagation-review best-practice warning fired."""
     return any(
         issue.check_type == "missing_propagation_review"

--- a/tests/test_propagation_review_validation.py
+++ b/tests/test_propagation_review_validation.py
@@ -1,0 +1,126 @@
+"""Validation checks for structured propagation reviews on inferred annotations."""
+
+from pathlib import Path
+import tempfile
+
+import yaml
+
+from ai_gene_review.datamodel.gene_review_model import Review
+from ai_gene_review.validation import validate_gene_review
+
+
+def _validate(yaml_data: dict) -> object:
+    """Validate a minimal gene review YAML from a temporary file."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        path = Path(tmpdir) / "TEST-ai-review.yaml"
+        path.write_text(yaml.dump(yaml_data))
+        return validate_gene_review(path, check_best_practices=True)
+
+
+def _base_annotation(evidence_type: str, action: str, review_extra: dict | None = None) -> dict:
+    """Build a single existing annotation row for propagation-review tests."""
+    review = {
+        "summary": "test",
+        "action": action,
+        "reason": "test",
+    }
+    if review_extra:
+        review.update(review_extra)
+    return {
+        "term": {"id": "GO:0005515", "label": "protein binding"},
+        "evidence_type": evidence_type,
+        "original_reference_id": "GO_REF:0000033",
+        "review": review,
+    }
+
+
+def _base_yaml(annotation: dict) -> dict:
+    """Construct a minimal review document for a single annotation."""
+    return {
+        "id": "Q12345",
+        "gene_symbol": "TEST",
+        "taxon": {"id": "NCBITaxon:9606", "label": "Homo sapiens"},
+        "description": "Test gene",
+        "references": [
+            {
+                "id": "GO_REF:0000033",
+                "title": "Annotation inferences using phylogenetic trees",
+            }
+        ],
+        "existing_annotations": [annotation],
+    }
+
+
+def _has_missing_propagation_review_warning(report: object) -> bool:
+    """Return whether the propagation-review best-practice warning fired."""
+    return any(
+        issue.check_type == "missing_propagation_review"
+        for issue in report.issues
+    )
+
+
+def test_iba_remove_without_propagation_review_warns():
+    """Corrective IBA actions should carry structured propagation-review metadata."""
+    report = _validate(_base_yaml(_base_annotation("IBA", "REMOVE")))
+    assert _has_missing_propagation_review_warning(report)
+
+
+def test_iso_modify_with_propagation_review_does_not_warn():
+    """The warning is suppressed when propagation_review is present."""
+    annotation = _base_annotation(
+        "ISO",
+        "MODIFY",
+        {
+            "propagation_review": {
+                "root_cause": "PROPAGATION_BAD",
+                "failure_modes": ["WRONG_ORTHOLOG_OR_PARALOG"],
+                "source_entities": [
+                    {
+                        "source_id": "UniProtKB:P03950",
+                        "source_label": "ANG",
+                        "source_status": "SUPPORTS_SOURCE_BUT_NOT_TARGET",
+                        "comment": "Source supports angiogenesis for human ANG; transfer to mouse Ang2 is unsafe.",
+                    }
+                ],
+            }
+        },
+    )
+    report = _validate(_base_yaml(annotation))
+    assert not _has_missing_propagation_review_warning(report)
+
+
+def test_experimental_remove_without_propagation_review_does_not_warn():
+    """Experimental evidence rows are not propagation-review targets."""
+    report = _validate(_base_yaml(_base_annotation("IDA", "REMOVE")))
+    assert not _has_missing_propagation_review_warning(report)
+
+
+def test_iba_accept_without_propagation_review_does_not_warn():
+    """Accepted IBA rows may omit propagation_review during gradual adoption."""
+    report = _validate(_base_yaml(_base_annotation("IBA", "ACCEPT")))
+    assert not _has_missing_propagation_review_warning(report)
+
+
+def test_generated_review_model_accepts_propagation_review():
+    """The generated Pydantic model accepts the new structured metadata."""
+    review = Review(
+        action="REMOVE",
+        reason="test",
+        propagation_review={
+            "root_cause": "SOURCE_BAD",
+            "failure_modes": ["SOURCE_MISCITATION"],
+            "source_entities": [
+                {
+                    "source_id": "UniProtKB:P03950",
+                    "source_label": "ANG",
+                    "source_status": "SOURCE_BAD",
+                    "comment": "Wrong source annotation for this transfer.",
+                }
+            ],
+        },
+    )
+
+    assert review.propagation_review is not None
+    assert review.propagation_review.root_cause == "SOURCE_BAD"
+    assert review.propagation_review.source_entities is not None
+    assert review.propagation_review.source_entities[0].source_id == "UniProtKB:P03950"

--- a/tests/test_render_projects.py
+++ b/tests/test_render_projects.py
@@ -14,6 +14,7 @@ from ai_gene_review.render_projects import (
     replace_species_qualified_symbols,
     render_project,
     render_project_bundle,
+    resolve_frontmatter_gene_links,
     should_autolink_gene_symbols,
 )
 
@@ -408,6 +409,52 @@ class TestReplaceGeneSymbols:
 
         assert "[ManY](../../genes/ECOLI/manY/manY-ai-review.html)" in result
         assert warnings == []
+
+
+class TestFrontmatterGeneLinks:
+    """Tests for resolving ``genes:`` frontmatter into project-page links."""
+
+    def test_priority_ordered_species_hints(self, tmp_path):
+        genes_dir = tmp_path / "genes"
+        (genes_dir / "human" / "CRYAA").mkdir(parents=True)
+        (genes_dir / "BOVIN" / "CRYAA").mkdir(parents=True)
+
+        index = build_symbol_to_species_index(genes_dir)
+        links, warnings = resolve_frontmatter_gene_links(
+            ["CRYAA"],
+            index,
+            species_hints=["human", "BOVIN"],
+            genes_dir=genes_dir,
+            base_path="../../genes",
+        )
+
+        assert warnings == []
+        assert links == [
+            {
+                "label": "CRYAA",
+                "species": "human",
+                "symbol": "CRYAA",
+                "url": "../../genes/human/CRYAA/CRYAA-ai-review.html",
+            }
+        ]
+
+    def test_species_qualified_entry(self, tmp_path):
+        genes_dir = tmp_path / "genes"
+        (genes_dir / "MYCTU" / "cds1").mkdir(parents=True)
+        (genes_dir / "VIBCH" / "cds1").mkdir(parents=True)
+
+        index = build_symbol_to_species_index(genes_dir)
+        links, warnings = resolve_frontmatter_gene_links(
+            ["VIBCH/cds1"],
+            index,
+            species_hints=["MYCTU"],
+            genes_dir=genes_dir,
+            base_path="../../genes",
+        )
+
+        assert warnings == []
+        assert links[0]["label"] == "VIBCH/cds1"
+        assert links[0]["url"] == "../../genes/VIBCH/cds1/cds1-ai-review.html"
 
 
 class TestReplaceGeneTags:


### PR DESCRIPTION
## Summary

- Adds structured `propagation_review` schema support for propagated/inferred annotation reviews, including root-cause classes, biological failure modes, and per-source comments.
- Renders propagation review details on gene review pages and gene chips from project frontmatter.
- Aligns IBA/ISO project documentation with the taxonomy and backfills representative IBA cases, including LPL1 as `UNDECIDED` for the ROG1-paralog MAG lipase transfer.

## Validation

- `uv run pytest tests/test_propagation_review_validation.py tests/test_render_projects.py`
- `git diff --check` and `git diff --cached --check`
- `just validate CANAL LPL1`
- `just validate SCHPO Epe1`
- `just validate human AGO4`
- `just validate human AKTIP`
- `just validate human CRYAA`
- `just validate human CAPG`
- `just validate human DPYSL2`
- `just validate human RIMBP2`
- `just validate MYCTU cds1` (valid; pre-existing core-function/new-annotation warning remains)
- `just validate VIBCH cds1` (valid; pre-existing core-function/new-annotation warning remains)
- `just render CANAL LPL1`
- `just render SCHPO Epe1`
- `uv run ai-gene-review render-projects projects/IBA_REVIEW.md -o pages/projects`
- `uv run ai-gene-review render-projects projects/ISO.md -o pages/projects`
