### PR TITLE
Regenerate pages and browser app

### DIFF
--- a/pages/projects/PATHWAY_SATISFIABILITY/methods.html
+++ b/pages/projects/PATHWAY_SATISFIABILITY/methods.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Pathway satisfiability: context-resolved module logic - AI Gene Review Projects</title>
+    <title>Pathway satisfiability — methods &amp; reproduction - AI Gene Review Projects</title>
     <style>
         :root {
             --color-accept: #22c55e;
@@ -325,11 +325,11 @@
     <nav class="breadcrumb">
         <a href="../index.html">Home</a> &raquo;
         <a href="index.html">Projects</a> &raquo;
-        Pathway satisfiability: context-resolved module logic
+        Pathway satisfiability — methods &amp; reproduction
     </nav>
 
     <header class="header">
-        <h1>Pathway satisfiability: context-resolved module logic</h1>
+        <h1>Pathway satisfiability — methods &amp; reproduction</h1>
         
         <p class="project-meta">
             <span class="badge m-IN_PROGRESS">IN_PROGRESS</span>
@@ -345,157 +345,67 @@
     
 
     <div class="content">
-        <h1 id="pathway-satisfiability">Pathway satisfiability</h1>
-<p><strong>We ask not "does this genome have the pathway?" but "is the pathway wired up <em>here</em> — in<br />
-this tissue, this cell zone, this genome?" A curation module is read as a boolean formula<br />
-over steps; a context (expression, genome content) supplies the truth values. When a pathway<br />
-is independently known to run but the logic says it can't, the gap becomes a reviewable,<br />
-gene-localised hypothesis.</strong></p>
-<h2 id="bottom-line">Bottom line</h2>
+        <h1 id="methods-reproduction">Methods &amp; reproduction</h1>
+<p>Companion to <a href="../PATHWAY_SATISFIABILITY.html">Pathway satisfiability</a>. This page holds the<br />
+model, the engine internals, and the commands to reproduce every result. Nothing here is<br />
+needed to read the main page — start there for the bottom line.</p>
+<h2 id="the-model">The model</h2>
+<p>A curation <strong>module</strong> (<code>modules/*.yaml</code>, the <code>ModuleReview</code> schema) is treated as a monotone<br />
+boolean circuit and evaluated against a <em>context oracle</em>:</p>
 <ul>
-<li><strong>It recovers textbook biology from data alone.</strong> Across GTEx's 54 tissues the human<br />
-  gluconeogenesis module lights up in exactly <strong>liver, kidney cortex, small intestine</strong> — no<br />
-  false positives, no misses — and every other tissue fails at the <em>same</em> gate step<br />
-  (gluconeogenic glucose-6-phosphatase), resisting the ubiquitous non-gluconeogenic paralog.</li>
-<li><strong>It resolves <em>within</em> an organ, not just between organs.</strong> With a liver-zonation oracle the<br />
-  route is satisfiable at the <strong>periportal</strong> pole and blocked at the <strong>pericentral</strong> pole — the<br />
-  metazoan question ("which isozyme, in which context") that genome-level tools can't ask.</li>
-<li><strong>One engine, many contexts.</strong> The same logic reconstructs L-methionine biosynthesis across<br />
-  microbial genomes from KEGG orthologs (picking the encoded route per organism), i.e. it<br />
-  reproduces GapMind-style step-finding as a special case.</li>
-<li><strong>A gap is a hypothesis, not just a hole.</strong> Crossing satisfiability with an <em>independent</em><br />
-  activity claim turns unexplained gaps into structured leads: <strong>intestinal gluconeogenesis →<br />
-  G6PC1</strong>, <strong>liver ketolysis → OXCT1/SCOT</strong>, plus microbial "metabolic dark matter" targets<br />
-  (<em>Synechocystis</em>, <em>M. jannaschii</em>) that make methionine with no canonical enzyme for a step.</li>
+<li>a module's <strong>parts / annotons are AND</strong>; its <strong>variant_sets are OR</strong>;</li>
+<li>a leaf <strong>annoton (a step) is an atom</strong> whose truth value comes from the oracle;</li>
+<li>the engine enumerates <strong>routes</strong> (one branch per variant set), tests <strong>satisfiability</strong><br />
+  in a context, finds the <strong>gate</strong> atoms required by every route, and reports the<br />
+<strong>unsatisfied steps</strong> (gaps).</li>
 </ul>
-<p>Why this matters: pathway-completeness tools (KEGG/Reactome coverage) ask a genome-level<br />
-question — right for a microbe, wrong for a metazoan, where every cell carries the whole<br />
-genome and the discriminating variable is <strong>which isozyme is expressed in which context</strong>.<br />
-Gluconeogenesis is "present" in every human cell, yet glucose output is restricted to a few<br />
-tissues and, within the liver, to a few cell layers. This project resolves the pathway <em>into</em><br />
-that context.</p>
-<blockquote>
-<p><strong>How it works</strong> (model, engine, <code>src</code> paths, and commands to reproduce every result) lives<br />
-in the companion notebook: <strong><a href="PATHWAY_SATISFIABILITY/methods.html">Methods &amp; reproduction</a></strong>.<br />
-It is the eukaryotic analogue of GapMind's prokaryotic step-finding.</p>
-</blockquote>
-<h2 id="results">Results</h2>
-<h3 id="between-organs-gtex-bulk-tissue">Between organs (GTEx bulk tissue)</h3>
-<p>Evaluating the human gluconeogenesis module across 54 tissues recovers exactly the textbook<br />
-gluconeogenic set — <strong>liver, kidney cortex, small intestine</strong> — with no false positives and<br />
-no misses. Every non-gluconeogenic tissue fails at the <em>same</em> gate atom, the gluconeogenic<br />
-glucose-6-phosphatase catalytic subunit, and the engine resists the ubiquitous paralog<br />
-(expressed everywhere but not gluconeogenic). The gate is graded: raising the expression<br />
-threshold drops tissues in the order liver → kidney → intestine, matching their known<br />
-quantitative contribution.</p>
-<h3 id="within-an-organ-halpern-2017-liver-zonation">Within an organ (Halpern 2017 liver zonation)</h3>
-<p>Reusing the same engine with a liver-lobule zonation oracle, the gluconeogenesis route is<br />
-satisfiable only toward the <strong>periportal</strong> pole and is blocked at the <strong>pericentral</strong> pole —<br />
-at the same gate atom. The porto-central orientation is inferred from landmark genes (not<br />
-assumed), so the periportal restriction is a derivation, not a restatement.</p>
-<h3 id="which-precursor-substrate-entry-routes">Which precursor? (substrate-entry routes)</h3>
-<p>A precursor-resolved module makes lactate / alanine (via pyruvate) and glycerol (bypassing<br />
-the carboxylation backbone) explicit. Because glycerol skips that backbone, the <strong>only</strong><br />
-universally required step is the terminal glucose-6-phosphatase system. Per tissue the engine<br />
-then reports which precursors are usable, with physiologically faithful skews (kidney<br />
-lactate-dominant; liver highest alanine capacity).</p>
-<h3 id="across-genomes-kegg-genome-presence-the-gapmind-reproduction">Across genomes (KEGG genome presence) — the GapMind reproduction</h3>
-<p>The <em>same</em> engine reconstructs L-methionine biosynthesis from KEGG orthologs across genomes.<br />
-It selects the encoded route per organism (succinyl vs acetyl acylation; trans-sulfuration vs<br />
-direct sulfhydrylation; cobalamin-dependent vs -independent methylation), completes<br />
-<em>C. glutamicum</em> through the alternative branch despite a missing trans-sulfuration enzyme, and<br />
-flags genome-reduced organisms as gaps.</p>
-<h3 id="abduction-a-gap-is-a-hypothesis">Abduction — a gap is a hypothesis</h3>
-<p>Crossing satisfiability with an <strong>independent</strong> activity phenotype:</p>
-<table>
-<thead>
-<tr>
-<th>outcome</th>
-<th>meaning</th>
-<th>example</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>CONSISTENT_ACTIVE</td>
-<td>reconstructable &amp; known prototroph</td>
-<td>E. coli, B. subtilis, C. glutamicum</td>
-</tr>
-<tr>
-<td><strong>ABDUCTION_TARGET</strong></td>
-<td><strong>makes methionine but a step has no candidate</strong></td>
-<td><strong>Synechocystis, M. jannaschii</strong></td>
-</tr>
-<tr>
-<td>CONSISTENT_INACTIVE</td>
-<td>gap correctly predicts a known auxotrophy</td>
-<td>Rickettsia prowazekii</td>
-</tr>
-</tbody>
-</table>
-<p>The two abduction targets are real metabolic dark matter: both are autotrophs that synthesise<br />
-methionine yet encode none of the canonical acylation/sulfur enzymes, so the engine emits a<br />
-structured lead ("an unannotated / non-orthologous enzyme must fill this step"). The same<br />
-machinery does <em>not</em> over-call <em>Rickettsia</em>, whose gap is correctly read as its auxotrophy.</p>
-<p>The same <code>abduce()</code> runs on the <strong>eukaryotic</strong> side against GTEx, with the independent claim<br />
-now a documented tissue function (and an extra "not cell-autonomous" explanation, since a<br />
-metazoan pathway can be split across organs):</p>
-<table>
-<thead>
-<tr>
-<th>outcome</th>
-<th>meaning</th>
-<th>example</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>CONSISTENT_ACTIVE</td>
-<td>tissue oxidises ketones, enzymes expressed</td>
-<td>heart, brain, muscle, kidney</td>
-</tr>
-<tr>
-<td>CONSISTENT_INACTIVE</td>
-<td>gap correctly predicts the function's absence</td>
-<td><strong>liver ketolysis → gap at OXCT1/SCOT</strong></td>
-</tr>
-<tr>
-<td>ABDUCTION_TARGET</td>
-<td>function reported but a step's gene barely expressed</td>
-<td><strong>intestinal gluconeogenesis → G6PC1</strong></td>
-</tr>
-</tbody>
-</table>
-<p>Ketone-body oxidation pinpoints why the liver cannot consume the ketones it makes — it is the<br />
-one tissue lacking OXCT1/SCOT (GTEx liver = 0 TPM) — reproducing a textbook fact from<br />
-expression alone. Intestinal gluconeogenesis, genuinely debated because intestinal<br />
-glucose-6-phosphatase is low, surfaces as a lead localised to one gene, which is exactly the<br />
-form a reviewer can act on.</p>
-<h2 id="epistemics">Epistemics</h2>
+<p>The logic core carries no biological data; only the oracle changes between contexts. This is<br />
+deliberately the eukaryotic analogue of GapMind's prokaryotic step-finding.</p>
+<h2 id="architecture">Architecture</h2>
+<div class="mermaid">
+flowchart LR
+  M[Module YAML\nparts=AND, variant_sets=OR] --> C[compile_module\n→ boolean circuit]
+  C --> E{module_logic engine\nroutes · gate · gaps · abduction}
+  O1[GTEx bulk tissue] --> E
+  O2[Halpern liver zonation] --> E
+  O3[GTEx substrate entry] --> E
+  O4[KEGG genome presence] --> E
+  E --> R[per-context result:\nsatisfiable? which route?\nwhich gate / gap?]
+  P[independent activity\nphenotype / flux] --> A[abduce]
+  E --> A
+  A --> H[reviewable gap hypothesis]
+</div>
+
+<p>The engine lives at <code>src/ai_gene_review/module_logic.py</code> (frozen <code>Atom</code>; <code>compile_module</code>,<br />
+<code>enumerate_routes</code>, <code>is_satisfied</code>, <code>core_atoms</code>, <code>unsatisfied_steps</code>, <code>abduce</code>; doctested,<br />
+mypy-clean) with <code>tests/test_module_logic.py</code>. The oracles and per-context resolvers are in<br />
+<code>modules/experimental/gluconeogenesis-context/</code> (see its <code>RESULTS.md</code> for full output).</p>
+<h2 id="reproduce">Reproduce</h2>
+<div class="codehilite"><pre><span></span><code><span class="c1"># engine + tests</span>
+uv<span class="w"> </span>run<span class="w"> </span>pytest<span class="w"> </span>tests/test_module_logic.py<span class="w"> </span>-q
+uv<span class="w"> </span>run<span class="w"> </span>pytest<span class="w"> </span>--doctest-modules<span class="w"> </span>src/ai_gene_review/module_logic.py
+
+<span class="c1"># per-context resolvers (from modules/experimental/gluconeogenesis-context/)</span>
+uv<span class="w"> </span>run<span class="w"> </span>python<span class="w"> </span>resolve_context.py<span class="w">       </span><span class="c1"># between organs (GTEx)</span>
+uv<span class="w"> </span>run<span class="w"> </span>python<span class="w"> </span>resolve_zonation.py<span class="w">      </span><span class="c1"># within liver (Halpern zonation)</span>
+uv<span class="w"> </span>run<span class="w"> </span>python<span class="w"> </span>resolve_substrates.py<span class="w">    </span><span class="c1"># which precursor per tissue</span>
+uv<span class="w"> </span>run<span class="w"> </span>python<span class="w"> </span>resolve_genomes.py<span class="w">       </span><span class="c1"># methionine across genomes (KEGG)</span>
+uv<span class="w"> </span>run<span class="w"> </span>python<span class="w"> </span>resolve_abduction.py<span class="w">     </span><span class="c1"># microbial gaps vs phenotype → leads / auxotrophy</span>
+uv<span class="w"> </span>run<span class="w"> </span>python<span class="w"> </span>resolve_eukaryotic_abduction.py<span class="w">   </span><span class="c1"># tissue gaps vs function (ketolysis, gluconeogenesis)</span>
+</code></pre></div>
+
+<h2 id="artifacts">Artifacts</h2>
 <ul>
-<li><strong>Presence ≠ flux.</strong> Expression/genome presence is used asymmetrically: absence excludes a<br />
-  route (strong), presence only permits it. A satisfiable set is an upper bound on capacity.</li>
-<li><strong>Derived, not assumed.</strong> Zonation orientation comes from landmark genes; tissue/zone<br />
-  identity from data — never from the answer being sought.</li>
-<li><strong>Abduction is independent.</strong> The activity column (growth phenotype) is independent of the<br />
-  ortholog oracle, so a scored gap is a genuine prediction, and "the assertion is wrong" is<br />
-  always retained as an explicit hypothesis.</li>
-</ul>
-<h2 id="methods-reproduction">Methods &amp; reproduction</h2>
-<p>The model, engine internals (<code>module_logic.py</code>), architecture diagram, source paths, and the<br />
-exact commands to reproduce every result above are in the companion notebook:<br />
-<strong><a href="PATHWAY_SATISFIABILITY/methods.html">Methods &amp; reproduction</a></strong>.</p>
-<h2 id="next-steps">Next steps</h2>
-<ul>
-<li>A human liver zonation oracle to remove the mouse-ortholog step in the zonation result.</li>
-<li>Apply the engine to additional curated modules (it is module-agnostic).</li>
-<li>Promote the resolvers from <code>modules/experimental/</code> into a small CLI once the oracle<br />
-  interfaces stabilise.</li>
+<li>Engine: <code>src/ai_gene_review/module_logic.py</code>; tests: <code>tests/test_module_logic.py</code></li>
+<li>Modules: <code>modules/gluconeogenesis_human.yaml</code>, <code>modules/gluconeogenesis_human_substrates.yaml</code>,<br />
+<code>modules/methionine_biosynthesis.yaml</code>, <code>modules/ketone_body_oxidation.yaml</code></li>
+<li>Oracles &amp; resolvers + full results: <code>modules/experimental/gluconeogenesis-context/</code><br />
+  (<code>RESULTS.md</code>)</li>
 </ul>
     </div>
 
     <footer>
-        <small>Generated from PATHWAY_SATISFIABILITY.md</small>
+        <small>Generated from methods.md</small>
         <small>AI Gene Review Project</small>
     </footer>
 </body>

--- a/pages/projects/all-projects.html
+++ b/pages/projects/all-projects.html
@@ -83,7 +83,7 @@
         <p class="subtitle">Complete, automatically generated index of every project page in <code>projects/</code></p>
     </div>
 
-    <p class="meta-note"><span id="visible-count">132</span> of 132 projects.
+    <p class="meta-note"><span id="visible-count">133</span> of 133 projects.
     Derived from each project's YAML frontmatter; the <a href="index.html">curated index</a> is the hand-organized entry point.
     Filters combine (AND across groups, OR within a group).</p>
 
@@ -848,6 +848,22 @@
             </tr>
         
             <tr
+                data-title="genome-wide validation: system-level plausibility of annotation sets"
+                data-slug="genome_wide_validation"
+                data-maturity="SCOPING"
+                data-review=""
+                data-tags="PIPELINE"
+                data-species="">
+                <td><a href="GENOME_WIDE_VALIDATION.html">Genome-wide validation: system-level plausibility of annotation sets</a><br><code class="muted">GENOME_WIDE_VALIDATION</code></td>
+                <td><span class="badge m-SCOPING">SCOPING</span></td>
+                <td><span class="muted">&mdash;</span></td>
+                <td><span class="tag t-PIPELINE">PIPELINE</span></td>
+                <td><span class="muted">&mdash;</span></td>
+                <td><span class="muted">&mdash;</span></td>
+                <td>2</td>
+            </tr>
+        
+            <tr
                 data-title="geranylgeranyl reductase activity — obsoletion &amp; replacement"
                 data-slug="geranylgeranyl_reductase_obsoletion"
                 data-maturity="IN_PROGRESS"
@@ -1500,7 +1516,7 @@
                 <td><span class="tag t-PIPELINE">PIPELINE</span></td>
                 <td><span class="muted">&mdash;</span></td>
                 <td><span class="muted">&mdash;</span></td>
-                <td><span class="muted">&mdash;</span></td>
+                <td>1</td>
             </tr>
         
             <tr


### PR DESCRIPTION
## Summary

Automated regeneration of static assets after gene review or template changes.

## Generated Assets

| Asset | Count/Status |
|-------|--------------|
| Gene review YAML files | 2848 |
| Gene review HTML pages | 2848 |
| Project pages | 1095 |
| Module pages | 87 |
| Browser app (data.js) | Updated |
| Validation report | Updated |

## Trigger

This PR was triggered by changes to:
- genes/**/*.yaml - gene review data files
- src/ai_gene_review/schema/** - LinkML schema files
- src/ai_gene_review/templates/** - Jinja2 templates
- src/ai_gene_review/render.py - rendering code
- src/ai_gene_review/render_modules.py - module rendering code
- src/ai_gene_review/export/** - export code
- src/ai_gene_review/browser/** - browser app assets
- src/ai_gene_review/tools/minify_linkml_browser_data.py - browser data compaction
- projects/*.md - project definitions
- modules/**/*.yaml - module definitions
- project.justfile - just recipes used by CI
- .github/workflows/generate-pages.yaml - workflow definition

## Review

- [ ] Spot-check a few gene review HTML pages render correctly
- [ ] Spot-check module tree browser pages render correctly
- [ ] Verify browser app loads and filters work
- [ ] Check validation report for new issues
