### PR TITLE
Update Claude review workflow actions

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -55,24 +55,24 @@ jobs:
 
       - name: Generate ai4c-agent token
         id: ai4c-token
-        uses: actions/create-github-app-token@v1
+        uses: actions/create-github-app-token@v3
         with:
           app-id: ${{ secrets.AI4C_AGENT_APP_ID }}
           private-key: ${{ secrets.AI4C_AGENT_PRIVATE_KEY }}
 
-      - name: Prepare Claude Code install directory
-        run: mkdir -p "$HOME/.local/bin"
-
       - name: Run Claude Code Review
         id: claude-review
-        uses: anthropics/claude-code-action@v1.0.112
+        uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           github_token: ${{ steps.ai4c-token.outputs.token }}
+          # In v1, providing a prompt runs in automation mode and does not post
+          # a comment by default. Keep tracking on PR events so review runs
+          # retain the old visible-progress behavior.
           track_progress: ${{ github.event_name == 'pull_request' }}
           allowed_bots: 'claude,github-actions'
           claude_args: |
-            --model claude-opus-4-6
+            --model opus
             --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr review:*),Bash(gh api:*),Bash(cat:*),Bash(grep:*),Bash(head:*),Bash(tail:*),Bash(wc:*),Bash(find:*),Bash(ls:*),Bash(just:*),Bash(uv run:*)"
 
           prompt: |


### PR DESCRIPTION
## Summary
- update the Claude code review workflow to use the current `anthropics/claude-code-action@v1` entrypoint
- update `actions/create-github-app-token` to `@v3`
- switch the review model argument from the retired dated Opus ID to the stable `opus` alias
- remove the old Claude install-directory workaround

## Tests
- parsed `.github/workflows/claude-code-review.yml` as YAML
- ran `git diff --check`

Note: this PR does not include local uncommitted edits currently present in this worktree.