### PR TITLE
Regenerate pages and browser app

### DIFF
--- a/genes/PSEAE/Q9HTB8/Q9HTB8-ai-review.html
+++ b/genes/PSEAE/Q9HTB8/Q9HTB8-ai-review.html
@@ -1,0 +1,3561 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>wzm - AI Gene Review</title>
+    <style>
+        :root {
+            --color-accept: #22c55e;
+            --color-remove: #ef4444;
+            --color-modify: #f97316;
+            --color-keep-non-core: #3b82f6;
+            --color-undecided: #6b7280;
+            --color-new: #8b5cf6;
+            --color-mark-over: #eab308;
+            --bg-light: #f9fafb;
+            --border-color: #e5e7eb;
+            --text-muted: #6b7280;
+            --text-primary: #111827;
+        }
+
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+            line-height: 1.6;
+            color: var(--text-primary);
+            background-color: #ffffff;
+            padding: 2rem;
+            max-width: 1400px;
+            margin: 0 auto;
+        }
+
+        .header {
+            border-bottom: 2px solid var(--border-color);
+            padding-bottom: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        h1 {
+            font-size: 2.5rem;
+            font-weight: 700;
+            margin-bottom: 0.5rem;
+            color: #1f2937;
+        }
+
+        .gene-info {
+            display: flex;
+            gap: 2rem;
+            flex-wrap: wrap;
+            margin-top: 1rem;
+        }
+
+        .info-item {
+            display: flex;
+            gap: 0.5rem;
+        }
+
+        .info-label {
+            font-weight: 600;
+            color: var(--text-muted);
+        }
+
+        .aliases {
+            display: flex;
+            gap: 0.5rem;
+            flex-wrap: wrap;
+        }
+
+        .badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.875rem;
+            font-weight: 500;
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+        }
+
+        .status-badge {
+            padding: 0.375rem 0.875rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .status-initialized {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fde68a;
+        }
+
+        .status-in-progress {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+        }
+
+        .status-draft {
+            background-color: #fce7f3;
+            color: #831843;
+            border: 1px solid #fbcfe8;
+        }
+
+        .status-complete {
+            background-color: #d1fae5;
+            color: #065f46;
+            border: 1px solid #a7f3d0;
+        }
+
+        .description-card {
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        .description-card h2 {
+            font-size: 1.25rem;
+            margin-bottom: 1rem;
+            color: #374151;
+        }
+
+        .section {
+            margin-bottom: 2.5rem;
+        }
+
+        .section-title {
+            font-size: 1.5rem;
+            font-weight: 600;
+            margin-bottom: 1.5rem;
+            color: #1f2937;
+            border-bottom: 1px solid var(--border-color);
+            padding-bottom: 0.5rem;
+        }
+
+        .annotations-table {
+            width: 100%;
+            border-collapse: collapse;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            overflow: hidden;
+        }
+
+        .annotations-table thead {
+            background-color: var(--bg-light);
+        }
+
+        .annotations-table th {
+            text-align: left;
+            padding: 1rem;
+            font-weight: 600;
+            border-bottom: 2px solid var(--border-color);
+            font-size: 0.875rem;
+            text-transform: uppercase;
+            letter-spacing: 0.05em;
+            color: var(--text-muted);
+        }
+
+        .annotations-table td {
+            padding: 1rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .annotations-table tbody tr:hover {
+            background-color: #f9fafb;
+        }
+
+        .action-badge {
+            display: inline-block;
+            padding: 0.375rem 0.75rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .action-accept {
+            background-color: var(--color-accept);
+            color: white;
+        }
+
+        .action-remove {
+            background-color: var(--color-remove);
+            color: white;
+        }
+
+        .action-modify {
+            background-color: var(--color-modify);
+            color: white;
+        }
+
+        .action-keep_as_non_core {
+            background-color: var(--color-keep-non-core);
+            color: white;
+        }
+
+        .action-undecided {
+            background-color: var(--color-undecided);
+            color: white;
+        }
+
+        .action-new {
+            background-color: var(--color-new);
+            color: white;
+        }
+
+        .action-mark_as_over_annotated {
+            background-color: var(--color-mark-over);
+            color: white;
+        }
+
+        .term-info {
+            display: flex;
+            flex-direction: column;
+            gap: 0.25rem;
+        }
+
+        .term-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .term-label {
+            font-weight: 500;
+        }
+
+        .evidence-code {
+            font-family: monospace;
+            background-color: var(--bg-light);
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .not-badge {
+            display: inline-block;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-weight: 600;
+            margin-left: 0.25rem;
+        }
+
+        .isoform-badge {
+            display: inline-block;
+            background-color: #eff6ff;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            margin-top: 0.25rem;
+        }
+
+        .core-function-card {
+            background-color: white;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 1rem;
+        }
+
+        .core-function-card h3 {
+            font-size: 1.125rem;
+            margin-bottom: 1rem;
+            color: #1f2937;
+        }
+
+        .core-function-statement {
+            margin-bottom: 1rem;
+            padding: 0.75rem;
+            background-color: var(--bg-light);
+            border-left: 4px solid var(--color-accept);
+            border-radius: 0.25rem;
+        }
+
+        .function-annotations {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin-top: 1rem;
+        }
+
+        .reference-item {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+        }
+
+        .reference-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: start;
+            margin-bottom: 0.75rem;
+        }
+
+        .reference-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #2563eb;
+        }
+
+        .supported-by {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f3f4f6;
+            border-left: 3px solid #3b82f6;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .supported-by-title {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .support-item {
+            margin-bottom: 0.5rem;
+        }
+
+        .support-ref {
+            font-weight: 500;
+            color: #2563eb;
+        }
+
+        .support-text {
+            color: #6b7280;
+            font-style: italic;
+            margin-left: 1rem;
+        }
+
+        .propagation-review {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f8fafc;
+            border-left: 3px solid #64748b;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .propagation-title {
+            font-weight: 600;
+            color: #334155;
+            margin-bottom: 0.25rem;
+        }
+
+        .propagation-row {
+            margin-top: 0.25rem;
+        }
+
+        .propagation-source {
+            margin-top: 0.5rem;
+            padding-top: 0.5rem;
+            border-top: 1px solid #e5e7eb;
+        }
+
+        .propagation-source-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #1d4ed8;
+        }
+
+        .propagation-comment {
+            color: #4b5563;
+            margin-left: 1rem;
+        }
+
+        a.term-link {
+            color: #2563eb;
+            text-decoration: none;
+        }
+
+        a.term-link:hover {
+            text-decoration: underline;
+        }
+
+        .core-function-terms {
+            margin-top: 1rem;
+        }
+
+        .function-term-group {
+            margin-bottom: 1rem;
+        }
+
+        .function-term-label {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .reference-title {
+            font-weight: 500;
+            margin-bottom: 0.5rem;
+        }
+
+        .findings-list {
+            margin-top: 1rem;
+            padding-left: 1.5rem;
+        }
+
+        .finding-item {
+            margin-bottom: 0.75rem;
+        }
+
+        .finding-statement {
+            font-weight: 500;
+            margin-bottom: 0.25rem;
+        }
+
+        .finding-text {
+            color: var(--text-muted);
+            font-size: 0.95rem;
+            font-style: italic;
+        }
+
+        .proposed-term {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #fef3c7;
+        }
+
+        .question-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #dbeafe;
+        }
+
+        .experiment-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #f3e8ff;
+        }
+
+        .prediction-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: white;
+        }
+
+        .prediction-card .prediction-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+        }
+
+        .prediction-source {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+        }
+
+        .assessment-badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.8rem;
+            font-weight: 600;
+            text-transform: uppercase;
+        }
+
+        .assessment-cor { background-color: #dcfce7; color: #166534; }
+        .assessment-cnn { background-color: #dbeafe; color: #1e40af; }
+        .assessment-lsp { background-color: #fef9c3; color: #854d0e; }
+        .assessment-unc { background-color: #f3f4f6; color: #374151; }
+        .assessment-pli { background-color: #fee2e2; color: #991b1b; }
+        .assessment-npi { background-color: #fecaca; color: #7f1d1d; }
+        .assessment-rep { background-color: #fde68a; color: #92400e; }
+
+        .confidence-score {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+            margin-left: 0.5rem;
+        }
+
+        .error-type-badge {
+            font-size: 0.75rem;
+            padding: 0.125rem 0.5rem;
+            border-radius: 0.25rem;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+        }
+
+        .isoforms-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fill, minmax(400px, 1fr));
+            gap: 1rem;
+        }
+
+        .isoform-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            background-color: white;
+            transition: box-shadow 0.2s;
+        }
+
+        .isoform-card:hover {
+            box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+        }
+
+        .functional-isoform-type {
+            display: inline-block;
+            padding: 0.2rem 0.5rem;
+            border-radius: 0.25rem;
+            font-size: 0.7rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.03em;
+        }
+
+        .type-SPLICE_VARIANT, .type-SPLICE_CLASS {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #93c5fd;
+        }
+
+        .type-CLEAVAGE_PRODUCT {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fcd34d;
+        }
+
+        .type-MODIFICATION_STATE {
+            background-color: #f3e8ff;
+            color: #6b21a8;
+            border: 1px solid #c4b5fd;
+        }
+
+        .type-CONFORMATIONAL_STATE {
+            background-color: #dcfce7;
+            color: #166534;
+            border: 1px solid #86efac;
+        }
+
+        .functional-isoform-mappings {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+            font-size: 0.85rem;
+        }
+
+        .functional-isoform-mappings .mapping-type {
+            font-weight: 600;
+            color: var(--text-muted);
+            font-size: 0.75rem;
+        }
+
+        .functional-isoform-go {
+            margin-top: 0.5rem;
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.25rem;
+        }
+
+        .go-chip {
+            display: inline-block;
+            padding: 0.15rem 0.4rem;
+            background-color: #ecfdf5;
+            color: #047857;
+            border: 1px solid #a7f3d0;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-family: monospace;
+        }
+
+        .isoform-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+            padding-bottom: 0.5rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .isoform-name {
+            font-weight: 600;
+            font-size: 1.1rem;
+            color: #1f2937;
+        }
+
+        .isoform-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .isoform-sequence-note {
+            font-size: 0.875rem;
+            color: var(--text-muted);
+            margin-bottom: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+        }
+
+        .isoform-description {
+            font-size: 0.95rem;
+            line-height: 1.5;
+        }
+
+        .collapsible {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .collapsible:after {
+            content: ' ▼';
+            font-size: 0.75rem;
+        }
+
+        .collapsible.collapsed:after {
+            content: ' ►';
+        }
+
+        .collapse-content {
+            transition: max-height 0.3s ease;
+            overflow: hidden;
+        }
+
+        .collapsed + .collapse-content {
+            max-height: 0;
+        }
+
+        .no-data {
+            color: var(--text-muted);
+            font-style: italic;
+            padding: 1rem;
+            text-align: center;
+            background-color: var(--bg-light);
+            border-radius: 0.5rem;
+        }
+
+        /* Styling for markdown section summaries with voting */
+        .markdown-section summary {
+            padding: 0.75rem;
+            background: var(--bg-light);
+            border-radius: 0.5rem;
+            margin-bottom: 0.5rem;
+        }
+
+        .markdown-section summary:hover {
+            background: #e5e7eb;
+        }
+
+        .markdown-section summary .vote-buttons {
+            margin-left: auto;
+        }
+
+        .deep-research-section {
+            margin-bottom: 1rem;
+            border: 1px solid #c7d2fe;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8faff;
+        }
+
+        .deep-research-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .deep-research-section summary h3 {
+            margin: 0;
+            color: #3730a3;
+            font-size: 1.1rem;
+        }
+
+        .report-meta {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin: 0.75rem 0 1rem;
+            align-items: center;
+        }
+
+        .report-badge {
+            display: inline-flex;
+            align-items: center;
+            border: 1px solid #c7d2fe;
+            border-radius: 999px;
+            background: #eef2ff;
+            color: #4338ca;
+            font-size: 0.78rem;
+            font-weight: 600;
+            padding: 0.2rem 0.6rem;
+        }
+
+        .report-meta-text {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+        }
+
+        .artifact-list {
+            display: grid;
+            gap: 0.75rem;
+            margin: 0.75rem 0 1rem;
+        }
+
+        .artifact-link {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+            margin-top: 0.5rem;
+            word-break: break-word;
+        }
+
+        @media print {
+            body {
+                padding: 1rem;
+            }
+
+            .collapsible:after {
+                display: none;
+            }
+
+            .collapsed + .collapse-content {
+                max-height: none !important;
+            }
+        }
+
+        @media (max-width: 768px) {
+            body {
+                padding: 1rem;
+            }
+
+            h1 {
+                font-size: 2rem;
+            }
+
+            .annotations-table {
+                font-size: 0.875rem;
+            }
+
+            .annotations-table th,
+            .annotations-table td {
+                padding: 0.5rem;
+            }
+        }
+    </style>
+</head>
+<body>
+    <div class="header">
+        <h1>wzm</h1>
+        <div class="gene-info">
+
+            <div class="info-item">
+
+                <span class="info-label">UniProt ID:</span>
+                <span>
+                    <a href="https://www.uniprot.org/uniprotkb/Q9HTB8" target="_blank" class="term-link">
+                        Q9HTB8
+                    </a>
+                </span>
+
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Organism:</span>
+                <span>Pseudomonas aeruginosa (strain ATCC 15692 / DSM 22644 / CIP 104116 / JCM 14847 / LMG 12228 / 1C / PRS 101 / PAO1)</span>
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Review Status:</span>
+                <span class="status-badge status-complete">
+                    COMPLETE
+                </span>
+            </div>
+
+
+        </div>
+        <div style="margin-top: 1rem; text-align: center;">
+            <a id="feedback-form-link"
+               href="#"
+               target="_blank"
+               style="display: inline-block; padding: 10px 20px; background-color: #4CAF50; color: white; text-decoration: none; border-radius: 5px; font-weight: 600;">
+                📝 Provide Detailed Feedback
+            </a>
+            <script>
+                // Construct the form URL with proper encoding
+                // Extract organism code from the current page path (e.g., /genes/ARATH/APO1/ -> ARATH)
+                const pathParts = window.location.pathname.split('/');
+                const genesIndex = pathParts.indexOf('genes');
+                let organism = '';
+                if (genesIndex !== -1 && pathParts[genesIndex + 1]) {
+                    organism = pathParts[genesIndex + 1].toUpperCase();
+                }
+                const geneSymbol = "wzm";
+                const speciesGene = organism + ' ' + geneSymbol;
+                const formBaseUrl = 'https://docs.google.com/forms/d/e/1FAIpQLSdTot9L6GVkkZYgLQT0E8ZdAJv8RiN5ZgOVkgWNcKSbYvxxzQ/viewform';
+                const entryId = '1226477767'; // Correct entry ID for Species/Gene field
+                const formUrl = formBaseUrl + '?entry.' + entryId + '=' + encodeURIComponent(speciesGene);
+                const feedbackLink = document.getElementById('feedback-form-link');
+                feedbackLink.href = formUrl;
+                // Add tooltip showing the pre-filled value
+                feedbackLink.title = 'Opens form with pre-filled: ' + speciesGene;
+            </script>
+        </div>
+    </div>
+
+
+    <div class="description-card">
+        <div style="display: flex; justify-content: space-between; align-items: center;">
+            <h2>Gene Description</h2>
+            <span class="vote-buttons" data-g="Q9HTB8" data-a="DESCRIPTION: Wzm is the polytopic inner-membrane permease (tran..." data-r="" data-act="DESCRIPTION">
+                <button class="vote-btn" data-v="up" title="Agree with this description">👍</button>
+                <button class="vote-btn" data-v="down" title="Disagree with this description">👎</button>
+            </span>
+        </div>
+        <p>Wzm is the polytopic inner-membrane permease (transmembrane domain, TMD) subunit of the Wzm-Wzt ATP-binding cassette (ABC) transporter that exports the A-band common polysaccharide antigen (CPA), a D-rhamnan homopolymer, across the cytoplasmic (inner) membrane during ABC-transporter-dependent lipopolysaccharide O-antigen assembly in Pseudomonas aeruginosa. The polysaccharide is synthesized in the cytoplasm and translocated to the periplasm by this transporter; Wzm provides the transmembrane conduit while the peripheral cytoplasmic Wzt subunit supplies ATP binding and hydrolysis. Wzm has six predicted transmembrane helices and belongs to the ABC-2 integral membrane protein family. Loss of wzm (or wzt) blocks surface expression of A-band polysaccharide and causes it to accumulate in the cytoplasm, without affecting the Wzx/Wzy-dependent B-band O antigen. Wzm assembles as a homotetramer that, together with a Wzt tetramer, forms a hetero-octameric transporter complex.</p>
+    </div>
+
+
+
+
+
+
+
+    <div class="section">
+        <h2 class="section-title">Existing Annotations Review</h2>
+        <table class="annotations-table">
+            <thead>
+                <tr>
+                    <th>GO Term</th>
+                    <th>Evidence</th>
+                    <th>Action</th>
+                    <th>Reason</th>
+                </tr>
+            </thead>
+            <tbody>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0015920" target="_blank" class="term-link">
+                                    GO:0015920
+                                </a>
+                            </span>
+                            <span class="term-label">lipopolysaccharide transport</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9HTB8" data-a="GO:0015920" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Phylogenetically-inferred role in lipopolysaccharide/O-antigen transport, consistent with Wzm&#39;s role as the ABC-transporter permease that exports the A-band polysaccharide across the inner membrane.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> This is the correct core biological process for the Wzm/Wzt ABC exporter and is directly supported by experimental loss-of-function data in P. aeruginosa (PMID:9244257). The IBA propagation across the ABC-2 permease family (PTHR30413) is appropriate and at the right level of specificity.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/9244257" target="_blank" class="term-link">
+                                        PMID:9244257
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">transport of the polymer to the cell surface was inhibited. The inability of the polymer to cross the inner membrane resulted in the accumulation of cytoplasmic A-band polysaccharide.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:PSEAE/Q9HTB8/Q9HTB8-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">This D-rhamnan polymer is assembled on the cytoplasmic face of the inner membrane on a lipid carrier (UndPP), and Wzm–Wzt transports the completed polymer across the membrane to the periplasmic face</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005886" target="_blank" class="term-link">
+                                    GO:0005886
+                                </a>
+                            </span>
+                            <span class="term-label">plasma membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000044
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9HTB8" data-a="GO:0005886" data-r="GO_REF:0000044" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Localization to the cytoplasmic (inner/plasma) membrane, from UniProt subcellular location mapping; Wzm is a multi-pass inner-membrane protein.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct and informative cellular component. Wzm is a polytopic inner-membrane protein with six predicted transmembrane helices (UniProt), consistent with its role as the membrane conduit of the ABC transporter.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/23223798" target="_blank" class="term-link">
+                                        PMID:23223798
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">an ATP-binding cassette (ABC) transporter consisting of a transmembrane protein, Wzm, and a cytoplasmic nucleotide-binding protein, Wzt.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016020" target="_blank" class="term-link">
+                                    GO:0016020
+                                </a>
+                            </span>
+                            <span class="term-label">membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000120
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="Q9HTB8" data-a="GO:0016020" data-r="GO_REF:0000120" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Generic membrane localization from InterPro/UniRule electronic mapping.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Not incorrect, but a high-level parent that is subsumed by the more informative plasma membrane (inner membrane) annotation. Retain as a non-core, uninformative generalization rather than a core statement of localization.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0043190" target="_blank" class="term-link">
+                                    GO:0043190
+                                </a>
+                            </span>
+                            <span class="term-label">ATP-binding cassette (ABC) transporter complex</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000120
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9HTB8" data-a="GO:0043190" data-r="GO_REF:0000120" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Wzm is a subunit of the ABC transporter complex; this complex membership is supported experimentally by the demonstration that Wzm and Wzt form a hetero-oligomeric ABC transporter.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Wzm is a bona-fide component of the Wzm-Wzt ABC transporter; the complex-level annotation is correct and is corroborated by direct structural evidence that Wzm forms a homotetramer that assembles with a Wzt tetramer into the functional transporter (PMID:23223798).
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/23223798" target="_blank" class="term-link">
+                                        PMID:23223798
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Wzm forms a square-shaped homo-tetramer both in the presence and absence of Wzt</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0055085" target="_blank" class="term-link">
+                                    GO:0055085
+                                </a>
+                            </span>
+                            <span class="term-label">transmembrane transport</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000002
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="Q9HTB8" data-a="GO:0055085" data-r="GO_REF:0000002" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Generic transmembrane transport from InterPro mapping.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct but a high-level parent of the specific lipopolysaccharide transport process. Retain as non-core; the specific GO:0015920 annotation captures the biology.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0140359" target="_blank" class="term-link">
+                                    GO:0140359
+                                </a>
+                            </span>
+                            <span class="term-label">ABC-type transporter activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000002
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9HTB8" data-a="GO:0140359" data-r="GO_REF:0000002" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> ABC-type (ATP-driven) transporter molecular function inferred from the ABC-2 transmembrane domain signature.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Appropriate molecular function for the transporter. Strictly, Wzm is the transmembrane (permease) subunit and contributes to the ABC-type transporter activity of the Wzm-Wzt complex rather than enabling it independently (ATP hydrolysis is provided by Wzt), but at this granularity the term correctly captures Wzm&#39;s function as part of the transporter. Captured more precisely in core_functions via contributes_to.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/23223798" target="_blank" class="term-link">
+                                        PMID:23223798
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">an ATP-binding cassette (ABC) transporter consisting of a transmembrane protein, Wzm, and a cytoplasmic nucleotide-binding protein, Wzt.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0009243" target="_blank" class="term-link">
+                                    GO:0009243
+                                </a>
+                            </span>
+                            <span class="term-label">O antigen biosynthetic process</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IMP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/9244257" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:9244257
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Identification and functional characterization of an ABC tra...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9HTB8" data-a="GO:0009243" data-r="PMID:9244257" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Experimental (mutant phenotype) support for a role in O-antigen/A-band LPS assembly; wzm mutants fail to export A-band polysaccharide to the cell surface.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Wzm-mediated export across the inner membrane is a required step in ABC-transporter-dependent O-antigen (A-band CPA) assembly. Chromosomal wzm mutants still synthesize the A-band polysaccharide but cannot deliver it to the surface, directly implicating Wzm in the biosynthetic/assembly pathway (PMID:9244257).
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/9244257" target="_blank" class="term-link">
+                                        PMID:9244257
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">the wzm and wzt mutants were able to synthesize A-band polysaccharide, although transport of the polymer to the cell surface was inhibited.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0015920" target="_blank" class="term-link">
+                                    GO:0015920
+                                </a>
+                            </span>
+                            <span class="term-label">lipopolysaccharide transport</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IMP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/9244257" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:9244257
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Identification and functional characterization of an ABC tra...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9HTB8" data-a="GO:0015920" data-r="PMID:9244257" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Direct experimental (gene-replacement mutant) evidence that Wzm is required to transport the A-band polysaccharide across the inner membrane to the cell surface.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> This is the core, experimentally-supported function of Wzm. Chromosomal wzm mutants accumulate A-band polysaccharide in the cytoplasm because the polymer cannot cross the inner membrane, demonstrating a direct transport role (PMID:9244257).
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/9244257" target="_blank" class="term-link">
+                                        PMID:9244257
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">The inability of the polymer to cross the inner membrane resulted in the accumulation of cytoplasmic A-band polysaccharide.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0055085" target="_blank" class="term-link">
+                                    GO:0055085
+                                </a>
+                            </span>
+                            <span class="term-label">transmembrane transport</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">ISS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/9244257" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:9244257
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Identification and functional characterization of an ABC tra...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="Q9HTB8" data-a="GO:0055085" data-r="PMID:9244257" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Sequence-similarity-based generic transmembrane transport annotation (from UniProtKB:Q48478).
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct but a high-level parent, redundant with the specific lipopolysaccharide transport annotations. Retain as non-core rather than as a core statement of function.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0070258" target="_blank" class="term-link">
+                                    GO:0070258
+                                </a>
+                            </span>
+                            <span class="term-label">inner membrane pellicle complex</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">EXP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/23223798" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:23223798
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Determination of the quaternary structure of a bacterial ATP...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-remove">
+                            REMOVE
+                        </span>
+                        <span class="vote-buttons" data-g="Q9HTB8" data-a="GO:0070258" data-r="PMID:23223798" data-act="REMOVE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Localization to an &#34;inner membrane pellicle complex&#34; — but GO:0070258 is defined as a structure of the apicomplexan-parasite pellicle, which is taxonomically inappropriate for a bacterium.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> GO:0070258 is defined as &#34;A membrane structure formed of two closely aligned lipid bilayers that lie beneath the plasma membrane and form part of the pellicle surrounding an apicomplexan parasite cell.&#34; This is a taxon-inappropriate term for a Pseudomonas (bacterial) protein and is an erroneous mapping. The cited paper (PMID:23223798) actually characterizes the Wzm-Wzt ABC transporter located in the bacterial inner membrane; the intended concepts (inner-membrane ABC transporter complex) are already correctly captured by GO:0043190 (ABC transporter complex) and GO:0005886 (plasma/inner membrane). Recommend removal of this mis-annotation.
+                        </div>
+
+
+
+                        <div style="margin-top: 0.5rem;">
+                            <strong>Proposed replacements:</strong>
+
+                            <span class="badge">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0043190" target="_blank" class="term-link">
+                                    ATP-binding cassette (ABC) transporter complex
+                                </a>
+                            </span>
+
+                        </div>
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/23223798" target="_blank" class="term-link">
+                                        PMID:23223798
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">an ATP-binding cassette (ABC) transporter consisting of a transmembrane protein, Wzm, and a cytoplasmic nucleotide-binding protein, Wzt.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0015221" target="_blank" class="term-link">
+                                    GO:0015221
+                                </a>
+                            </span>
+                            <span class="term-label">lipopolysaccharide transmembrane transporter activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IMP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/9244257" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:9244257
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Identification and functional characterization of an ABC tra...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-new">
+                            NEW
+                        </span>
+                        <span class="vote-buttons" data-g="Q9HTB8" data-a="GO:0015221" data-r="PMID:9244257" data-act="NEW">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Proposed more-specific molecular function for Wzm as the transmembrane conduit of the ABC transporter that moves the A-band polysaccharide across the inner membrane.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> The existing GOA molecular-function annotation (GO:0140359, ABC-type transporter activity) is correct but generic. Wzm is the transmembrane (permease) subunit that forms the channel through which the A-band lipopolysaccharide polysaccharide is translocated; loss of wzm blocks passage of the polymer across the inner membrane (PMID:9244257), supporting a specific lipopolysaccharide transmembrane transporter activity. Recorded as a subunit-level activity that contributes to the ABC-type transporter activity of the Wzm-Wzt complex.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/9244257" target="_blank" class="term-link">
+                                        PMID:9244257
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">The inability of the polymer to cross the inner membrane resulted in the accumulation of cytoplasmic A-band polysaccharide.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+            </tbody>
+        </table>
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Core Functions</h2>
+
+        <div class="core-function-card">
+
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+                <h3>Transmembrane permease (TMD) subunit of the Wzm-Wzt ABC transporter that exports the A-band common polysaccharide antigen (D-rhamnan) across the inner membrane during O-antigen/LPS assembly. The subunit-specific molecular_function (GO:0015221) reflects Wzm&#39;s intrinsic role as the transmembrane channel/conduit that forms the translocation pathway for the polysaccharide; the full ATP-driven ABC-type transporter activity (GO:0140359) is a complex-level function that additionally requires the Wzt ATPase, and is therefore recorded under contributes_to_molecular_function.</h3>
+                <span class="vote-buttons" data-g="Q9HTB8" data-a="FUNCTION: Transmembrane permease (TMD) subunit of the Wzm-Wz..." data-r="" data-act="CORE_FUNCTION">
+                    <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
+                    <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
+                </span>
+            </div>
+
+
+            <div class="core-function-terms">
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Molecular Function:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0015221" target="_blank" class="term-link">
+                            lipopolysaccharide transmembrane transporter activity
+                        </a>
+                    </span>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Directly Involved In:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0015920" target="_blank" class="term-link">
+                                lipopolysaccharide transport
+                            </a>
+                        </span>
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0009243" target="_blank" class="term-link">
+                                O antigen biosynthetic process
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Cellular Locations:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005886" target="_blank" class="term-link">
+                                plasma membrane
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">In Complex:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0043190" target="_blank" class="term-link">
+                            ATP-binding cassette (ABC) transporter complex
+                        </a>
+                    </span>
+                </div>
+
+
+
+            </div>
+
+
+            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
+                <strong>Supporting Evidence:</strong>
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/9244257" target="_blank" class="term-link">
+                                PMID:9244257
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">The inability of the polymer to cross the inner membrane resulted in the accumulation of cytoplasmic A-band polysaccharide.</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/23223798" target="_blank" class="term-link">
+                                PMID:23223798
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">an ATP-binding cassette (ABC) transporter consisting of a transmembrane protein, Wzm, and a cytoplasmic nucleotide-binding protein, Wzt.</div>
+
+                    </li>
+
+                </ul>
+            </div>
+
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title collapsible">References</h2>
+        <div class="collapse-content">
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000002.md" target="_blank" class="term-link">
+                            GO_REF:0000002
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Gene Ontology annotation through association of InterPro records with GO terms</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000033.md" target="_blank" class="term-link">
+                            GO_REF:0000033
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Annotation inferences using phylogenetic trees</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000044.md" target="_blank" class="term-link">
+                            GO_REF:0000044
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location vocabulary mapping, accompanied by conservative changes to GO terms applied by UniProt</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000120.md" target="_blank" class="term-link">
+                            GO_REF:0000120
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Combined Automated Annotation using Multiple IEA Methods</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        file:PSEAE/Q9HTB8/Q9HTB8-deep-research-falcon.md
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Deep research report (falcon/Edison) for wzm (Q9HTB8) in P. aeruginosa PAO1</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">Wzm is the transmembrane-domain (permease) subunit of the Wzm-Wzt ABC transporter that exports the UndPP-linked common polysaccharide antigen (CPA; A-band, a D-rhamnan homopolymer) from the cytoplasmic to the periplasmic face of the inner membrane; loss of wzm blocks export but not polymer synthesis.</div>
+
+                        <div class="finding-text">"This D-rhamnan polymer is assembled on the cytoplasmic face of the inner membrane on a lipid carrier (UndPP), and Wzm–Wzt transports the completed polymer across the membrane to the periplasmic face"</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/23223798" target="_blank" class="term-link">
+                            PMID:23223798
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Determination of the quaternary structure of a bacterial ATP-binding cassette (ABC) transporter in living cells.</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">The A-band LPS polysaccharide is synthesized in the cytoplasm and translocated to the periplasm by an ABC transporter composed of the transmembrane protein Wzm and the cytoplasmic nucleotide-binding protein Wzt.</div>
+
+                        <div class="finding-text">"The polysaccharides in A-band LPSs are synthesized in the cytoplasm and translocated into the periplasm via an ATP-binding cassette (ABC) transporter consisting of a transmembrane protein, Wzm, and a cytoplasmic nucleotide-binding protein, Wzt."</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <div class="finding-statement">Wzm forms a homotetramer that assembles with a Wzt tetramer into a hetero-octameric transporter complex.</div>
+
+                        <div class="finding-text">"Wzm forms a square-shaped homo-tetramer both in the presence and absence of Wzt"</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/9244257" target="_blank" class="term-link">
+                            PMID:9244257
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Identification and functional characterization of an ABC transport system involved in polysaccharide export of A-band lipopolysaccharide in Pseudomonas aeruginosa.</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">Wzm is an integral inner-membrane protein with six potential membrane-spanning domains and, with the ATP-binding protein Wzt, forms an ABC transport system.</div>
+
+                        <div class="finding-text">"Wzm is an integral membrane protein with six potential membrane-spanning domains, while Wzt is an ATP-binding protein containing a highly conserved ATP-binding motif."</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <div class="finding-statement">Chromosomal wzm mutants still synthesize A-band polysaccharide but fail to export it to the cell surface, so the polymer accumulates in the cytoplasm; B-band LPS synthesis is unaffected.</div>
+
+                        <div class="finding-text">"the wzm and wzt mutants were able to synthesize A-band polysaccharide, although transport of the polymer to the cell surface was inhibited. The inability of the polymer to cross the inner membrane resulted in the accumulation of cytoplasmic A-band polysaccharide."</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+        </div>
+    </div>
+
+
+
+
+    <div class="section">
+        <h2 class="section-title">Suggested Questions for Experts</h2>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> What is the precise substrate specificity and stoichiometry of the Wzm channel during D-rhamnan (A-band CPA) translocation, and does Wzm recognize the polymer directly or only via Wzt?</p>
+
+                </div>
+                <span class="vote-buttons" data-g="Q9HTB8" data-a="Q: What is the precise substrate specificity and stoi..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> Does Wzm contribute to substrate recognition/gating, or is its role limited to forming the transmembrane conduit while Wzt provides both energy and polysaccharide binding?</p>
+
+                </div>
+                <span class="vote-buttons" data-g="Q9HTB8" data-a="Q: Does Wzm contribute to substrate recognition/gatin..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Suggested Experiments</h2>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> Determine a high-resolution structure (cryo-EM) of the intact P. aeruginosa Wzm-Wzt transporter with and without bound D-rhamnan substrate to define the translocation pathway and the Wzm homotetramer architecture in a native lipid environment.</p>
+
+
+
+                </div>
+                <span class="vote-buttons" data-g="Q9HTB8" data-a="EXPERIMENT: Determine a high-resolution structure (cryo-EM) of..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> Perform site-directed mutagenesis of predicted pore-lining residues in Wzm followed by in vivo A-band CPA surface-export assays (Western blot / immuno-EM with A-band-specific monoclonal antibodies) to map residues required for polysaccharide translocation.</p>
+
+
+
+                </div>
+                <span class="vote-buttons" data-g="Q9HTB8" data-a="EXPERIMENT: Perform site-directed mutagenesis of predicted por..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+    </div>
+
+
+
+
+
+
+    <!-- Computational Predictions Section -->
+
+
+    <!-- Deep Research Sections -->
+
+    <div class="section">
+        <h2 class="section-title">Deep Research</h2>
+
+        <details class="deep-research-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; gap: 1rem;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Asta</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(Q9HTB8-deep-research-asta.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="Q9HTB8" data-a="DEEP_RESEARCH: Asta" data-r="" data-act="DEEP_RESEARCH" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This deep research is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This deep research needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+
+                <div class="report-meta">
+
+                    <span class="report-meta-text">Asta Literature Retrieval: Gene Research for Functional Annotation ⚠️ CRITICAL: Gene/Protein Identification Context BEFORE YOU BEGIN RESEARCH: Y...</span>
+
+
+                    <span class="report-badge">Asta</span>
+
+
+                    <span class="report-badge">Asta Scientific Corpus Retrieval</span>
+
+
+                    <span class="report-badge">20 citations</span>
+
+
+
+                    <span class="report-meta-text">2026-07-03T23:34:34.443840</span>
+
+
+
+                </div>
+
+
+                <h1 id="asta-literature-retrieval-gene-research-for-functional-annotation-critical-geneprotein-identification-context-before-you-begin-research-y">Asta Literature Retrieval: Gene Research for Functional Annotation ⚠️ CRITICAL: Gene/Protein Identification Context BEFORE YOU BEGIN RESEARCH: Y...</h1>
+<p>This report is retrieval-only and is generated directly from Asta results.</p>
+<ul>
+<li>Papers retrieved: 20</li>
+<li>Snippets retrieved: 20</li>
+</ul>
+<h2 id="relevant-papers">Relevant Papers</h2>
+<h3 id="1-lmpd-lipid-maps-proteome-database">[1] LMPD: LIPID MAPS proteome database</h3>
+<ul>
+<li>Authors: Dawn Cotter, A. Maer, C. Guda, Brian Saunders, S. Subramaniam</li>
+<li>Year: 2005</li>
+<li>Venue: Nucleic Acids Research</li>
+<li>URL: https://www.semanticscholar.org/paper/265c37b45326b7927e396484751e84e4aeff92d5</li>
+<li>DOI: 10.1093/nar/gkj122</li>
+<li>PMID: 16381922</li>
+<li>PMCID: 1347484</li>
+<li>Citations: 92</li>
+<li>Influential citations: 2</li>
+<li>Summary: The initial release of the LIPID MAPS Proteome Database contains 2959 records, representing human and mouse proteins involved in lipid metabolism, and this LMPD protein list was enhanced with annotations from UniProt, EntrezGene, ENZYME, GO, KEGG and other public resources.</li>
+<li>Evidence snippets:</li>
+<li>Snippet 1 (score: 0.802)<br />
+    &gt; For each record selected from the results summary, all LMPD data relevant to that protein are displayed, with external database IDs linked to their respective resources.<br />
+    &gt; Annotations are organized by category: Record Overview, Gene/GO/KEGG Information, UniProt Annotations, and Related Proteins. The record overview contains LMPD_ID, species, description, gene symbols, lipid categories, EC number, molecular weight, sequence length and protein sequence. Gene information includes Entrez Gene ID, chromosome, map location, primary name, primary symbol and alternate names and symbols; Gene Ontology (GO) IDs and descriptions, and KEGG pathway IDs and descriptions. UniProt annotations include primary accession number, entry name and comments such as catalytic activity, enzyme regulation, function and similarity. For related proteins and splice variants, we display source database, database ID, sequence length, and title.</li>
+</ul>
+<h3 id="2-avian-immunome-db-an-example-of-a-user-friendly-interface-for-extracting-genetic-information">[2] Avian Immunome DB: an example of a user-friendly interface for extracting genetic information</h3>
+<ul>
+<li>Authors: Ralf C. Mueller, Nicolai Mallig, Jacqueline Smith, Lél Eöry, Richard I. Kuo et al.</li>
+<li>Year: 2020</li>
+<li>Venue: BMC Bioinformatics</li>
+<li>URL: https://www.semanticscholar.org/paper/b894d9ca8ea2d653bf1711a0c67dab71d054487c</li>
+<li>DOI: 10.1186/s12859-020-03764-3</li>
+<li>PMID: 33176685</li>
+<li>PMCID: 7661159</li>
+<li>Citations: 6</li>
+<li>Summary: The Avian Immunome DB (Avimm) for easy gene property extraction as exemplified by avian immune genes is presented and described, which contains 1170 distinct avian immune genes with canonical gene symbols and 612 synonyms across 363 bird species.</li>
+<li>Evidence snippets:</li>
+<li>Snippet 1 (score: 0.751)<br />
+    &gt; Ever since the advent of commercial next-generation sequencing platforms in the early 2000s with its associated decrease in sequencing costs [1], the number of DNA sequences increased considerably [2]. Generally, these data become publicly accessible in databases provided by projects focussing on different aspects of biological sequence information [3,4]. Ensembl [5] and NCBI [6] for instance, have a strong focus on genome annotation with the help of RNA transcript information while UniProt has a pronounced emphasis on protein-coding genes and biological function of proteins. UniProt's records are either based on manually annotated, non-redundant protein sequences (SwissProt) or on highquality computationally analysed records, which are enriched with automatic annotation (TrEMBL) [7]. Relying on accurate genome annotations and protein descriptions, Gene Ontology (GO) [8,9] categorises gene products and fits them into a computational model of biological systems. Their assignment deploys a controlled vocabulary, so-called GO terms, to link genes and gene products to biological processes, cellular components, or molecular functions.<br />
+    &gt; However, genome annotation is not standardised, and each service provider uses their own custom-built annotation pipelines. As a consequence, this often leads to ambiguity in gene names during genome annotation with different gene symbols being given to the same gene or the same gene symbol being given to different, but similar genes. Additionally, since the pre-existing wealth of sequencing information relies on model organisms like human and mouse, there is a strong bias in gene symbols towards those chosen for these species. Particularly for model species, this issue has been partially addressed, for example by the Human Genome Organisation (HUGO) Gene Nomenclature Committee (HGNC) [10], the Vertebrate Gene Nomenclature Committee (VGNC) [11], or the Chicken Gene Nomenclature Consortium [12]. However, this neither guarantees that gene names are harmonised among these consortia, nor does it keep researchers from assigning alternative gene symbols in their annotations, especially when working with non-model species.</li>
+</ul>
+<h3 id="3-identifying-orthologs-with-oma-a-primer">[3] Identifying orthologs with OMA: A primer</h3>
+<ul>
+<li>Authors: Monique Zahn-Zabal, C. Dessimoz, Natasha M. Glover</li>
+<li>Year: 2020</li>
+<li>Venue: F1000Research</li>
+<li>URL: https://www.semanticscholar.org/paper/3b77eadcdd6979352c81d0876b0ed3a3ef4215d6</li>
+<li>DOI: 10.12688/f1000research.21508.1</li>
+<li>PMID: 32089838</li>
+<li>PMCID: 7014581</li>
+<li>Citations: 40</li>
+<li>Summary: This Primer is organized in two parts and provides all the necessary background information to understand the concepts of orthology, how to infer them and the different subtypes of Orthology in OMA, as well as what types of analyses they should be used for.</li>
+<li>Evidence snippets:</li>
+<li>Snippet 1 (score: 0.750)<br />
+    &gt; Get more information about your gene. After searching for your gene, you will be taken to the gene's page, which provides some external information. You can also find this by clicking on the Information tab. The information for our example gene, which corresponds to the human protein S100 calcium binding protein P, is shown in Figure 5. The information page includes the OMA ID, description, organism, locus, other IDs and cross-reference, domain architectures, and Gene Ontology annotations.</li>
+</ul>
+<h3 id="4-construction-of-an-ortholog-database-using-the-semantic-web-technology-for-integrative-analysis-of-genomic-data">[4] Construction of an Ortholog Database Using the Semantic Web Technology for Integrative Analysis of Genomic Data</h3>
+<ul>
+<li>Authors: H. Chiba, Hiroyo Nishide, I. Uchiyama</li>
+<li>Year: 2015</li>
+<li>Venue: PLoS ONE</li>
+<li>URL: https://www.semanticscholar.org/paper/7cc805575c642aa8efdc1204383a7662965fbb60</li>
+<li>DOI: 10.1371/journal.pone.0122802</li>
+<li>PMID: 25875762</li>
+<li>PMCID: 4395280</li>
+<li>Citations: 14</li>
+<li>Summary: The ortholog database using the Semantic Web technology can contribute to biological knowledge discovery through integrative data analysis and examples demonstrate that the ortholog information described in RDF can be used to link various biological data such as taxonomy information and Gene Ontology.</li>
+<li>Evidence snippets:</li>
+<li>Snippet 1 (score: 0.750)<br />
+    &gt; A typical use of an ortholog database is transferring functional annotations from known genes in model organisms to genes of unknown function in other organisms, on the basis of the conjecture that orthologs are usually functionally conserved. To demonstrate such an application in our database, we showed a query to retrieve ortholog information of a specified protein.<br />
+    &gt; Here, we specified a UniProt ID to obtain ortholog information. For describing functional categories of genes, we used Gene Ontology (GO) [24]. The UniProt GO Annotation (UniProt-GOA) database [25] (http://www.ebi.ac.uk/GOA) provides GO term assignment to proteins with evidence codes (http://www.geneontology.org/GO.evidence.shtml). We created an ontology for GO annotation (GOA-O, Table 1, http://purl.jp/bio/11/goa) and described UniProt-GOA data in RDF using it (Table 2). If some model organisms have experimentally verified GO annotations, we can transfer such a validated annotation to orthologs of other organisms.</li>
+</ul>
+<h3 id="5-cronos-the-cross-reference-navigation-server">[5] CRONOS: the cross-reference navigation server</h3>
+<ul>
+<li>Authors: Brigitte Waegele, I. Dunger, G. Fobo, Corinna Montrone, H. Mewes et al.</li>
+<li>Year: 2008</li>
+<li>Venue: Bioinformatics</li>
+<li>URL: https://www.semanticscholar.org/paper/8c05b3aa0ba01c41ee97c2dc98ea7b5b14ce0e9c</li>
+<li>DOI: 10.1093/bioinformatics/btn590</li>
+<li>PMID: 19010804</li>
+<li>PMCID: 2638938</li>
+<li>Citations: 20</li>
+<li>Summary: CRONOS, a cross-reference server that contains entries from five mammalian organisms presented by major gene and protein information resources, is developed, which shows that the cross-references are highly accurate.</li>
+<li>Evidence snippets:</li>
+<li>Snippet 1 (score: 0.745)<br />
+    &gt; In order to detect gene and protein names which are assigned to products of different genes and thus result in erroneous cross-references, dedicated lists are created for each organism separately. Organism-specific lists are necessary, since terms that are ambiguous in one organism might be explicit in another. For example, ADORA2 is an ambiguous gene name in Homo sapiens but not in mouse, and GALT in mouse but not in H.sapiens.<br />
+    &gt; In a first step, ambiguous names within the databases were extracted. If a name occurs in at least two entries describing different genes or proteins (splice variants count as one gene/protein), this particular name is marked as ambiguous and is excluded from the mapping process. In a second step, corresponding gene names occurring in the manually annotated sections of RefSeq as well as in UniProt were analyzed. Entries containing the same gene product name and having a one-to-many or many-to-many relation (e.g. one Swiss-Prot entry maps to many RefSeq entries) were scrutinized for misleading annotation. This process is done manually by inspecting additional information like sequence similarity or functional information about the involved entries. In most of the cases, the exclusion of the ambiguous gene names resulted in correct one-to-one relations.<br />
+    &gt; As statistical analysis revealed (Supplementary Material S2) that gene names with less than four letters are exceptionally error-prone, only gene names with at least four letters are kept for mapping purposes. However, gene names with less than four letters can be queried, e.g. a search for the tumor suppressor 'p53' reveals the respective entries with the official gene name 'TP53'. Organism-specific lists of ambiguous gene and protein names are available for download on the CRONOS home page.</li>
+</ul>
+<h3 id="6-structure-aware-mycobacterium-tuberculosis-functional-annotation-uncloaks-resistance-metabolic-and-virulence-genes">[6] Structure-Aware Mycobacterium tuberculosis Functional Annotation Uncloaks Resistance, Metabolic, and Virulence Genes</h3>
+<ul>
+<li>Authors: Samuel J. Modlin, A. Elghraoui, Deepika Gunasekaran, Alyssa M Zlotnicki, N. Dillon et al.</li>
+<li>Year: 2021</li>
+<li>Venue: mSystems</li>
+<li>URL: https://www.semanticscholar.org/paper/76ff9a62b36b32cc10e46e71ffd4dd90344e4706</li>
+<li>DOI: 10.1128/mSystems.00673-21</li>
+<li>PMID: 34726489</li>
+<li>PMCID: 8562490</li>
+<li>Citations: 15</li>
+<li>Summary: This work systematically updates the functional genome annotation of Mycobacterium tuberculosis virulent type strain H37Rv and identifies hundreds of high-confidence candidates for mechanisms of antibiotic resistance, virulence factors, and basic metabolism and other functions key in clinical and basic tuberculosis research.</li>
+<li>Evidence snippets:</li>
+<li>Snippet 1 (score: 0.740)<br />
+    &gt; 3. Fig. S2B -match/mismatch colours mixed up? (I think match should be teal and mismatch -red?) 4. Line 162-163: Rv1430 is in UniProt (EC 3.1.1.-) and has been present in Uniprot since version 45 of the gene record: https://www.uniprot.org/uniprot/L7N697. I presume you had conducted your literature analysis before the UniProt entry was updated to include the EC code, so maybe you can add the dates when the data was retrieved from UniProt and other databases you used in the Materials and Methods section? 5. Supplementary text, p. 9, first paragraph. I believe that an unrelated fragment of text was copy-pasted into the second sentence of the paragraph ("Many mutations that altered bacterial clearance...") 6. Supplementary text, p. 12, final paragraph. It should be Rv1191, not Rv1191c. Could you also add a short explanation why you believe it should be classified as a cathepsin (what protein did you transfer this annotation from)?<br />
+    &gt; Reviewer #3 (Comments for the Author):<br />
+    &gt; In this manuscript, Modlin et al., attempt to tackle the problem of assigning functions to ~1700 hypothetical and/or underannotated genes in the Mycobacterium tuberculosis H37Rv (Mtb) genome. Rapid and accurate annotation of microbial genomes is indeed a very critical and under appreciated part of microbial ecophysiology. This step is especially crucial for pathogenic organisms such as Mtb where accurate functional annotation of these hypothetical proteins could unravel mechanisms which could act as drug targets. The authors employed a two-pronged strategy to define a set of these unannotated or under-annotated genes and to then provide possible functions for many of these genes. First, they undertook a large-scale manual curation of literature to assign functions (including EC numbers for enzymatic functions) to ~575 genes.</li>
+</ul>
+<h3 id="7-role-of-histone-lysine-n-methyltransferase-2d-kmt2d-in-mek-erk-signaling-mediated-epigenetic-regulation-a-phosphoproteomics-perspective">[7] Role of histone-lysine N-methyltransferase 2D (KMT2D) in MEK-ERK signaling-mediated epigenetic regulation: a phosphoproteomics perspective</h3>
+<ul>
+<li>Authors: Sreeshma Ravindran Kammarambath, Leona Dcunha, Athira Perunelly Gopalakrishnan, Amal Fahma, N. Krishna et al.</li>
+<li>Year: 2025</li>
+<li>Venue: Frontiers in Bioinformatics</li>
+<li>URL: https://www.semanticscholar.org/paper/0ac0729148aff3d839e6a15984e11532e9e740f9</li>
+<li>DOI: 10.3389/fbinf.2025.1683469</li>
+<li>PMID: 41341998</li>
+<li>PMCID: 12669113</li>
+<li>Citations: 3</li>
+<li>Summary: The phosphoregulatory network of Histone-lysine N-methyltransferase 2D is delineated, positioning it as a dynamic epigenetic effector modulated by MEK-ERK signaling, with broader implications for cancer and developmental disorders.</li>
+<li>Evidence snippets:</li>
+<li>Snippet 1 (score: 0.739)<br />
+    &gt; Each protein was mapped to its corresponding gene symbol based on the HGNC (downloaded on 30.05.2023) and to its corresponding UniProt (13.04.2023) (UniProt, 2023) accessions using our in-built mapping tool to ensure consistent and standardized annotation. We conducted the analysis using the methodologies outlined in (Sanjeev et al., 2024). The overall workflow used in this study is outlined in Figure 1.</li>
+</ul>
+<h3 id="8-genetools-application-for-functional-annotation-and-statistical-hypothesis-testing">[8] GeneTools – application for functional annotation and statistical hypothesis testing</h3>
+<ul>
+<li>Authors: V. Beisvåg, Frode K. R. Jünge, Hallgeir Bergum, Lars Jølsum, S. Lydersen et al.</li>
+<li>Year: 2006</li>
+<li>Venue: BMC Bioinformatics</li>
+<li>URL: https://www.semanticscholar.org/paper/1d9e0c2f67acd5bf64c659f1f3f8624325b6be8a</li>
+<li>DOI: 10.1186/1471-2105-7-470</li>
+<li>PMID: 17062145</li>
+<li>PMCID: 1630634</li>
+<li>Citations: 105</li>
+<li>Influential citations: 11</li>
+<li>Summary: GeneTools is the first "all in one" annotation tool, providing users with a rapid extraction of highly relevant gene annotation data for e.g. thousands of genes or clones at once.</li>
+<li>Evidence snippets:</li>
+<li>Snippet 1 (score: 0.728)<br />
+    &gt; The database enables searching by gene symbols/names, GenBank accession numbers, UniGene cluster IDs, Swiss-Prot entry names and several unique clone IDs (IMAGE clone IDs, University of Iowa clone IDs, Operon oligo IDs, TAIR IDs and a subset of selected Affymetrix and Agilent IDs).<br />
+    &gt; The names and symbols of genes/proteins may be highly ambiguous [20]. We therefore recommend using primary gene IDs, like GeneBank accession numbers or specific probe IDs when querying the database. However, if gene names or symbols are used, caution is advised because only official names/symbols associated with UniProt knowledgebase will be recognized. The underlying database is updated on a weekly basis with annotation information from several external databases including UniGene, Swiss-Prot, Entrez Gene and GO. User data are submitted to the database as text files of gene reporters and analysis of the annotation data can be performed through three user interfaces: the NMC Annotation Tool, the GO Annotator Tool and eGOn. Analysis results and annotation data can be exported in various formats.</li>
+</ul>
+<h3 id="9-network-pharmacology-based-strategic-prediction-and-target-identification-of-apocarotenoids-and-carotenoids-from-standardized-kashmir-saffron-crocus-sativus-l-extract-against-polycystic-ovary-syndrome">[9] Network pharmacology-based strategic prediction and target identification of apocarotenoids and carotenoids from standardized Kashmir saffron (Crocus sativus L.) extract against polycystic ovary syndrome</h3>
+<ul>
+<li>Authors: Anshul Tiwari, Siddharth J Modi, A. Girme, L. Hingorani</li>
+<li>Year: 2023</li>
+<li>Venue: Medicine</li>
+<li>URL: https://www.semanticscholar.org/paper/3e3253804574634d1968a0fd5b65dd1674bff6c6</li>
+<li>DOI: 10.1097/MD.0000000000034514</li>
+<li>PMID: 37565925</li>
+<li>PMCID: 10419424</li>
+<li>Citations: 2</li>
+<li>Summary: A network pharmacology-based method to determine the potential therapeutic pathways of phytoconstituents of UHPLC-PDA standardized stigma-based Crocus sativus extract for the management of PCOS revealed that the apocarotenoids and carotenoidal could act on various targets to regulate multiple pathways related to PCOS.</li>
+<li>Evidence snippets:</li>
+<li>Snippet 1 (score: 0.725)<br />
+    &gt; The target protein name of the active ingredient was converted to the standard target gene name using the UniProt Knowledge Base (UniProtKB). UniProt KB is the central hub for the collection of functional information on proteins, with accurate, consistent, and rich annotation. The target protein names were uploaded into UniProtKB, with the organism restricted to "Homo sapiens," eventually gaining the official symbol. The potential targets obtained from the UniproKB are depicted in Figures 3 and 4.</li>
+</ul>
+<h3 id="10-phosphositeplus-a-comprehensive-resource-for-investigating-the-structure-and-function-of-experimentally-determined-post-translational-modifications-in-man-and-mouse">[10] PhosphoSitePlus: a comprehensive resource for investigating the structure and function of experimentally determined post-translational modifications in man and mouse</h3>
+<ul>
+<li>Authors: P. Hornbeck, J. Kornhauser, S. Tkachev, Bin Zhang, E. Skrzypek et al.</li>
+<li>Year: 2011</li>
+<li>Venue: Nucleic Acids Research</li>
+<li>URL: https://www.semanticscholar.org/paper/93e4acf4ba3bca1b379ae8292e73dddb344abd90</li>
+<li>DOI: 10.1093/nar/gkr1122</li>
+<li>PMID: 22135298</li>
+<li>PMCID: 3245126</li>
+<li>Citations: 1602</li>
+<li>Influential citations: 155</li>
+<li>Summary: PhosphoSitePlus (http://www.phosphosite.org) is an open, comprehensive, manually curated and interactive resource for studying experimentally observed post-translational modifications, primarily of human and mouse proteins. It encompasses 1 30 000 non-redundant modification sites, primarily phosphorylation, ubiquitinylation and acetylation. The interface is designed for clarity and ease of navigation. From the home page, users can launch simple or complex searches and browse high-throughput d...</li>
+<li>Evidence snippets:</li>
+<li>Snippet 1 (score: 0.723)<br />
+    &gt; Accession numbers from UniPROT KB, NCBI and Ensembl (24)(25)(26), as well as gene symbols from HGNC (27), are curated for all proteins when possible. Basic protein descriptions include information parsed from UniPROT KB (24), and may include additional information from the literature. Descriptions are updated in bulk occasionally. Gene Ontology (28) annotations are parsed from NCBI (25). Editors assign protein types.</li>
+</ul>
+<h3 id="11-meiosisonline-a-manually-curated-database-for-tracking-and-predicting-genes-associated-with-meiosis">[11] MeiosisOnline: A Manually Curated Database for Tracking and Predicting Genes Associated With Meiosis</h3>
+<ul>
+<li>Authors: Xiaohua Jiang, Daren Zhao, Asim Ali, Bo Xu, Wei Liu et al.</li>
+<li>Year: 2021</li>
+<li>Venue: Frontiers in Cell and Developmental Biology</li>
+<li>URL: https://www.semanticscholar.org/paper/aeb08368a5540685473578345739bb569103bd46</li>
+<li>DOI: 10.3389/fcell.2021.673073</li>
+<li>PMID: 34485275</li>
+<li>PMCID: 8415030</li>
+<li>Citations: 6</li>
+<li>Summary: The developed MeiosisOnline provides the most updated and detailed information of experimental verified and predicted genes in meiosis, and will greatly help researchers in studying meiosis in an easy and efficient way.</li>
+<li>Evidence snippets:</li>
+<li>Snippet 1 (score: 0.722)<br />
+    &gt; Annotation information for each gene in MeiosisOnline contains "basic information, " "function annotation and classification, " "protein-protein interaction (PPI) and gene expression."<br />
+    &gt; (1) Basic information: gene name/synonyms, nucleotide sequences, etc., were extracted from GenBank3 and UniProt Knowledgebase.4 (2) Function annotation and classification: detailed functional information is also manually collected from literature reports. (i) Which meiotic stage is the gene involved? (ii) Did the gene function in one sex or both sexes? (iii) Whether deletion or mutation of the gene in model organism has a phenotype in fertility? (iv) Which protein complex of the gene is involved? (v) The cellular location and expression pattern in tissues or cell lines.<br />
+    &gt; (vi) Experimental methods used for functional analysis.<br />
+    &gt; (vii) The information of related literature and figures for illustrating the function of protein/gene. (viii) Gene ontology annotation for collected genes.<br />
+    &gt; (3) Protein-protein interaction and gene expression: both verified and predicted PPI information were provided. Gene expression pattern in reproductive system was also provided graphically.</li>
+</ul>
+<h3 id="12-revisiting-the-plasmodium-falciparum-druggable-genome-using-predicted-structures-and-data-mining">[12] Revisiting the Plasmodium falciparum druggable genome using predicted structures and data mining</h3>
+<ul>
+<li>Authors: Karla P. Godinez-Macias, Daisy Chen, J. L. Wallis, Miles G. Siegel, Anna Adam et al.</li>
+<li>Year: 2024</li>
+<li>Venue: Research Square</li>
+<li>URL: https://www.semanticscholar.org/paper/795b2985fdc3cf1cfbd5fda1b3c0502eb4dfe866</li>
+<li>DOI: 10.21203/rs.3.rs-5412515/v1</li>
+<li>PMID: 39649165</li>
+<li>PMCID: 11623766</li>
+<li>Citations: 3</li>
+<li>Summary: This study systematically assessed the Plasmodium falciparum genome for proteins amenable to target-based drug discovery, identifying 867 candidate targets with evidence of small molecule binding and blood stage essentiality and implements a generalizable framework for systematically evaluating and prioritizing novel pathogenic disease targets.</li>
+<li>Evidence snippets:</li>
+<li>Snippet 1 (score: 0.719)<br />
+    &gt; List of genes and genomic features (GFF) for Plasmodium falciparum 3D7 genome (PlasmoDB release 66) was downloaded and protein coding genes were extracted along with their gene annotations and genomic location. Additional genomic annotations were obtained by querying PlasmoDB to extract UniProt and Entrez ID(s), ortholog group (OrthoMCL), protein features (CDS and protein length, molecular weight, isoelectric point), domain annotations (InterPro, PFam, Superfamily), number of transmembrane (TM) domains, and enzyme commission (EC) numbers. Gene function (Gene Ontology; components, functions and processes) was extracted by either PlasmoDB or by querying the InterPro ID under InterPro2GO mapping tool from EMBL-EBI services. Gene essentiality data was obtained for P.<br />
+    &gt; falciparum 29 and P. berghei 30,31 parasites that were mapped to their falciparum ortholog using OrthoMCL orthology group IDs. Protein Data Bank (PDB) IDs of crystal structures were obtained by searching either gene symbols, UniProt IDs associated with each gene, or by typing "Plasmodium" in the PDB website search box. A report with gene identi er, organism, accession number, method for structure determination and publication information was extracted for the search hits.<br />
+    &gt; Mapping genes to associated literature publications A download from the NCBI FTP site was performed for gene2pubmed.gz (version 2024-02-21) containing taxonomy ID, gene ID (Entrez) and PubMed ID. Gene IDs were mapped to the P. falciparum 3D7 annotation set, and PMIDs matching the criteria were extracted. To include literature references associated with gene symbols, we queried each gene symbol in PubMed using the Eutils 81 efetch function from NCBI; additional information for each publication was obtained pragmatically using the same tool, retrieving title, authors and DOI (digital object identi er).</li>
+</ul>
+<h3 id="13-revisiting-the-plasmodium-falciparum-druggable-genome-using-predicted-structures-and-data-mining">[13] Revisiting the Plasmodium falciparum druggable genome using predicted structures and data mining</h3>
+<ul>
+<li>Authors: Karla P. Godinez-Macias, Daisy Chen, J. L. Wallis, Miles G. Siegel, Anna Adam et al.</li>
+<li>Year: 2025</li>
+<li>Venue: Npj Drug Discovery</li>
+<li>URL: https://www.semanticscholar.org/paper/000083b7bd96cff5b3d1891b00ad332eed7d9add</li>
+<li>DOI: 10.1038/s44386-025-00006-5</li>
+<li>PMID: 40066064</li>
+<li>PMCID: 11892419</li>
+<li>Citations: 4</li>
+<li>Summary: This study systematically assessed the Plasmodium falciparum genome and identified 867 candidate protein targets with evidence of small-molecule binding and blood-stage essentiality, providing a genome-wide data resource for P. falciparum and implements a generalizable framework for systematically evaluating and prioritizing novel pathogenic disease targets.</li>
+<li>Evidence snippets:</li>
+<li>Snippet 1 (score: 0.714)<br />
+    &gt; List of genes and genomic features (GFF) for Plasmodium falciparum 3D7 genome (PlasmoDB release 66) was downloaded and protein-coding genes were extracted along with their gene annotations and genomic location. Additional genomic annotations were obtained by querying PlasmoDB to extract UniProt and Entrez ID(s), ortholog group (OrthoMCL), protein features (CDS and protein length, molecular weight, isoelectric point), domain annotations (InterPro, Pfam, and Superfamily), number of transmembrane (TM) domains, and enzyme commission (EC) numbers. Gene function (Gene Ontology components, functions, and processes) was extracted either from PlasmoDB or by querying the InterPro ID with the InterPro2GO mapping tool from EMBL-EBI. Gene essentiality data was obtained for P. falciparum 20 and P. berghei 21,22 parasites mapped to their falciparum orthologs using OrthoMCL orthology group IDs. Protein Data Bank (PDB) IDs of crystal structures were obtained by searching either gene symbols, UniProt IDs associated with each gene, or the term "Plasmodium". A report with gene identifier, organism, accession number, method for structure determination and publication information was extracted for the search hits.<br />
+    &gt; Mapping genes to associated literature publications A download from the NCBI FTP site was performed for gene2pubmed.gz (version 2024-02-21) containing taxonomy ID, gene ID (Entrez) and PubMed ID information. Gene IDs were mapped to the P. falciparum 3D7 annotation set, and corresponding PMIDs were extracted. To include literature references associated with gene symbols, we queried each symbol in PubMed using the Eutils 77 efetch function from NCBI; additional information for each publication was obtained pragmatically using the same tool, namely title, authors and digital object identifier (DOI). Literature references from gene nomenclature extraction were manually reviewed and filtered for unrelated records (e.g., same name but different meaning across organisms/diseases).</li>
+</ul>
+<h3 id="14-the-surface-proteome-of-bovine-unsexed-and-sexed-spermatozoa">[14] The Surface Proteome of Bovine Unsexed and Sexed Spermatozoa</h3>
+<ul>
+<li>Authors: P. Pinto-Pinho, Joana Quelhas, Francis Impens, Sara Dufour, Delphi Van Haver et al.</li>
+<li>Year: 2025</li>
+<li>Venue: Animals : an Open Access Journal from MDPI</li>
+<li>URL: https://www.semanticscholar.org/paper/66496158140e8f55a2c2ca8965bd298300ce9ab0</li>
+<li>DOI: 10.3390/ani15040484</li>
+<li>PMID: 40002966</li>
+<li>PMCID: 11852025</li>
+<li>Citations: 2</li>
+<li>Summary: Differences in surface proteins between X- and Y-chromosome-bearing bovine spermatozoa are explored to identify potential targets for sperm sexing by LC-MS/MS analysis, with 5 transmembrane proteins showing promise as markers for X-sperm.</li>
+<li>Evidence snippets:</li>
+<li>Snippet 1 (score: 0.713)<br />
+    &gt; The protein sequences were functionally annotated by combining information retrieved from the UniProt database ( [25], accessed on 9 June 2022) and one-to-one fast orthology assignments using the eggNOG-mapper v.2.1.7 tool ( [26], accessed on 9 June 2022), as described in [27]. Briefly, the gene name, protein name, length, Gene Ontology (GO) IDs, and chromosome associated with each protein entry were obtained from UniProt using the retrieve/ID mapping tool. Additionally, gene names, descriptions, and experimentally validated GO IDs were obtained from eggNOG, with consideration given to a taxonomic scope auto-adjusted per query, a minimum hit bit-score of 60, and thresholds of 80% for identity, minimum query coverage, and minimum subject coverage.<br />
+    &gt; Out of the 130 detected proteins, 71 (54.6%) had information manually verified by UniProt curators (Supplementary Spreadsheet S1.5). Utilizing the eggNOG-mapper v2.1.7 tool, a total of 122 entries were scanned (Supplementary Spreadsheet S1.6). By combining data from both tools, a total of 123 proteins were characterized with a gene name, and 127 had GO information. However, 2 proteins still lacked information on a descrip-tion, protein, gene, and preferred names. Figure 1 provides a summary of the functional annotation results.<br />
+    &gt; tool, a total of 122 entries were scanned (Supplementary Spreadsheet S1.6). By combining data from both tools, a total of 123 proteins were characterized with a gene name, and 127 had GO information. However, 2 proteins still lacked information on a description, protein, gene, and preferred names. Figure 1 provides a summary of the functional annotation results.</li>
+</ul>
+<h3 id="15-functional-annotation-of-parasitic-worm-genomes-by-assigning-protein-names-and-go-terms">[15] Functional annotation of parasitic worm genomes, by assigning protein names and GO terms</h3>
+<ul>
+<li>Authors: Avril Coghlan, M. Berriman</li>
+<li>Year: 2018</li>
+<li>Venue: Unknown venue</li>
+<li>URL: https://www.semanticscholar.org/paper/583c74a2e225dbff5fca04d36298e5b690491e82</li>
+<li>DOI: 10.1038/protex.2018.055</li>
+<li>Citations: 1</li>
+<li>Summary: A computational pipeline for assigning protein names and GO terms to predicted proteins in parasitic worm (nematode and platyhelminth) genomes, which transfers names and Go terms from orthologues in other species.</li>
+<li>Evidence snippets:</li>
+<li>Snippet 1 (score: 0.710)<br />
+    &gt; Given a set of predicted protein-coding genes for a newly sequenced genome, functional annotation involves assigning putative functions to the predicted genes. Two ways in which this can be done are assigning protein names and Gene Ontology (GO;Gene Ontology Consortium, 2010) terms to the predicted proteins. Here we describe a computational pipeline for assigning protein names and GO terms to predicted proteins in parasitic worm (nematode and platyhelminth) genomes, which transfers names and GO terms from orthologues in other species.<br />
+    &gt; When assigning protein names, UniProt protein naming rules (www.uniprot.org/docs/nameprot) are followed where possible. This recommends that a good and stable name for a protein is "as neutral as possible"; that a protein name "should be, as far as possible, unique and attributed to all orthologs"; and a protein name "should not contain a specific characteristic of the protein, and in particular it should not reflect the function or role of the protein, nor its subcellular location, its domain structure, its tissue specificity, its molecular weight or its species of origin".<br />
+    &gt; In our protocol, a protein name is assigned to each predicted protein based on curated names in UniProt (Bairoch &amp; Apweiler, 2000) for human, zebrafish, Drosophila melanogaster, Caenorhabditis elegans, and Schistosoma mansoni orthologues identified from a database of gene families (e.g. built using Ensembl Compara; Vilella et al. 2009), or (if no information is found from orthologues) based on InterPro (Hunter et al. 2012) domains. Figure 1 shows an example of using our protein naming pipeline for four Strongyloides ratti genes that belong to the tubulin polyglutamylase family (underlined in pink), where four different protein names were assigned to them (in pink), based on names of their C. elegans or human orthologues.<br />
+    &gt; Since each of the S. ratti genes belonged to a different subfamily of the tubulin polyglutamylase family, they were assigned different names.</li>
+</ul>
+<h3 id="16-protein-localization-analysis-of-essential-genes-in-prokaryotes">[16] Protein Localization Analysis of Essential Genes in Prokaryotes</h3>
+<ul>
+<li>Authors: Chong Peng, Feng Gao</li>
+<li>Year: 2014</li>
+<li>Venue: Scientific Reports</li>
+<li>URL: https://www.semanticscholar.org/paper/69181762648fd77a085b2f93618a71b43b62cf76</li>
+<li>DOI: 10.1038/srep06001</li>
+<li>PMID: 25105358</li>
+<li>PMCID: 4126397</li>
+<li>Citations: 27</li>
+<li>Summary: A comprehensive protein localization analysis of essential genes in 27 prokaryotes including 24 bacteria, 2 mycoplasmas and 1 archaeon has been performed and shows that proteins encoded by essential genes are enriched in internal location sites, while exist in cell envelope with a lower proportion compared with non-essential ones.</li>
+<li>Evidence snippets:</li>
+<li>Snippet 1 (score: 0.703)<br />
+    &gt; Bioinformatics Databases. DEG is a database of essential genes (http://www. essentialgene.org/). The newly released DEG 10 has been developed to accommodate the quantitative and qualitative advancements brought by the progressive identification methods. Currently available records of both essential and nonessential genes among a wide range of organisms can be downloaded from DEG 10, making it possible to compare the two different types of genes in many aspects 21 .<br />
+    &gt; 27 prokaryotic organisms including 24 bacteria, 2 mycoplasmas and Methanococcus maripaludis S2, the only record of the Archaea domain were selected to analyze the protein localization and GO distribution of the essential and nonessential genes. There are 31 bacterial records corresponding to 27 organisms in the database in total and 26 sets of data were selected in the current study. Streptococcus pneumonia was not chosen for the lack of non-essential genes. Since the essential genes were not genome-widely identified, it's not reasonable to regard the complementary set of essential genes as non-essential genes in Streptococcus pneumonia 29,30 . In the case of multiple records for one organism, the one with the most convincing experimental methods was chosen. The non-essential genes in Methanococcus maripaludis S2 and 13 bacteria such as Escherichia coli MG1655 are obtained based on the original literatures, while non-essential genes in other 12 organisms such as Bacillus subtilis 168 are the complementary set of essential genes. The information of the organisms used in the current study are displayed in Table 1.<br />
+    &gt; The three model genomes' subcellular location information and the Gene Ontology (GO) terms used for the analysis in the current study were downloaded from the Universal Protein Resource (UniProt; http://www.uniprot.org). Maintained by the UniProt Consortium, UniProt is committed to providing biologists with a comprehensive, high-quality and freely accessible resource of protein sequences and functional annotation 27 . Among the wealth of annotation data, detailed GO annotation statements are included.</li>
+</ul>
+<h3 id="17-a-genome-wide-association-study-identifying-novel-genetic-markers-of-response-to-treatment-with-interleukin-23-inhibitors-in-psoriasis">[17] A Genome-Wide Association Study Identifying Novel Genetic Markers of Response to Treatment with Interleukin-23 Inhibitors in Psoriasis</h3>
+<ul>
+<li>Authors: Sophia Zachari, K. Liadaki, Angeliki Planaki, E. Zafiriou, Olga Kouvarou et al.</li>
+<li>Year: 2025</li>
+<li>Venue: Genes</li>
+<li>URL: https://www.semanticscholar.org/paper/d5f656311b54e222e7487ea32a061869b30178a1</li>
+<li>DOI: 10.3390/genes16101195</li>
+<li>PMID: 41153410</li>
+<li>PMCID: 12564705</li>
+<li>Summary: These findings provide promising pharmacogenetic markers which, upon validation in larger, independent cohorts, will enable the translation of a patient’s genotype into a response phenotype, thereby guiding clinical decisions and improving drug effectiveness.</li>
+<li>Evidence snippets:</li>
+<li>Snippet 1 (score: 0.700)<br />
+    &gt; The UniProt knowledgebase (www.uniprot.org/uniprotkb/), (accessed on 20 June 2025), the central hub for the collection of functional information on proteins, with accurate and rich annotation [33], was used to retrieve the approved human gene and protein names and symbols.</li>
+</ul>
+<h3 id="18-the-autophagy-database-an-all-inclusive-information-resource-on-autophagy-that-provides-nourishment-for-research">[18] The Autophagy Database: an all-inclusive information resource on autophagy that provides nourishment for research</h3>
+<ul>
+<li>Authors: Keiichi Homma, Koji Suzuki, H. Sugawara</li>
+<li>Year: 2010</li>
+<li>Venue: Nucleic Acids Research</li>
+<li>URL: https://www.semanticscholar.org/paper/946ad0a62c6da7c1b288f58b48b6ce015835c176</li>
+<li>DOI: 10.1093/nar/gkq995</li>
+<li>PMID: 20972215</li>
+<li>PMCID: 3013813</li>
+<li>Citations: 106</li>
+<li>Influential citations: 4</li>
+<li>Summary: The Autophagy database is built to provide basics, up-to-date information on relevant literature, and a list of autophagy-related proteins and their homologs in 41 eukaryotes to give impetus to further research on autophagic by providing basic and specialized data on the subject.</li>
+<li>Evidence snippets:</li>
+<li>Snippet 1 (score: 0.700)<br />
+    &gt; The list of proteins of each species can be viewed in the 'Protein List section'. The user can get the cluster number, synonyms, the gene name, the Entrez gene ID, the GI number of National Center for Biotechnology Information (NCBI), the NCBI Protein Accession number together with the version, description and the PDB IDs. Clicking the symbol column opens a new window displaying detailed functions, UniProt accession number(s), UniGene ID of NCBI, related paper(s) and protein sequence as well as other information. Gene ID, GI, Protein Accession number, PDB IDs are also clickable and are linked to the relevant data.</li>
+</ul>
+<h3 id="19-identifier-mapping-in-cytoscape-idmapper">[19] Identifier Mapping in Cytoscape: idmapper</h3>
+<ul>
+<li>Authors: Adam Treister, Alexander R. Pico</li>
+<li>Year: 2018</li>
+<li>Venue: F1000Research</li>
+<li>URL: https://www.semanticscholar.org/paper/c97ebea942d97f5336dd1a1a189c665ae83753ec</li>
+<li>DOI: 10.12688/f1000research.14807.1</li>
+<li>PMID: 30079244</li>
+<li>PMCID: 6053696</li>
+<li>Citations: 7</li>
+<li>Influential citations: 2</li>
+<li>Summary: The idmapper app for Cytoscape simplifies identifier mapping for genes and proteins in the context of common biological networks by providing a unified interface to different identifier resources accessible through a right-click on the table's column header.</li>
+<li>Evidence snippets:</li>
+<li>Snippet 1 (score: 0.698)<br />
+    &gt; (RCy3): mapTableColumn(column="name", species="Yeast", map.from="Ensembl", map.to="Entrez Gene") (py2cytoscape): cyclient.idmapper.map_column(source_column="name", species="Yeast", source_selection="Ensembl", target_selection="Entrez Gene")<br />
+    &gt; Case 2: From proteins to genes When working with protein interaction networks, for example those from the STRING database (see http:// apps.cytoscape.org/apps/stringapp), you may want to translate protein identifiers (e.g., Uniprot-TrEMBL) to gene identifiers. The idmapper app supports this case as well, but one should be aware of the assumptions involved when making this translation. Since most genes encode for many proteins, you may have many-to-one mappings in your results. For all human networks imported from STRING using the StringApp 5 , the following commands will perform an ID mapping from Uniprot-TrEMBL (proteins) to Ensembl (genes):<br />
+    &gt; (RCy3): mapTableColumn(column="canonical name", species="Human", map.from="Uniprot-TrEMBL", map.to="Ensembl") (py2cytoscape): cyclient.idmapper.map_column(source_column="canonical name", species="Human", source_selection="Uniprot-TrEMBL", target_selection="Ensembl")<br />
+    &gt; Case 3: Identifiers and symbols In contrast to gene names and symbols, identifiers provide a more reliable means of specifying a particular gene.<br />
+    &gt; All data integration should be performed using identifiers as keys. Nevertheless, names and symbols play an important role in making results easier to read and understand. The idmapper app is primarily concerned with identifiers. However, relying on a subset of commonly used sources from BridgeDb (Table 1) it does provide one exception.</li>
+</ul>
+<h3 id="20-geneset2mirna-finding-the-signature-of-cooperative-mirna-activities-in-the-gene-lists">[20] GeneSet2miRNA: finding the signature of cooperative miRNA activities in the gene lists</h3>
+<ul>
+<li>Authors: A. Antonov, S. Dietmann, Philip Wong, D. Lutter, H. Mewes</li>
+<li>Year: 2009</li>
+<li>Venue: Nucleic Acids Research</li>
+<li>URL: https://www.semanticscholar.org/paper/90ebadc70236638e9499c1200097725327469ea3</li>
+<li>DOI: 10.1093/nar/gkp313</li>
+<li>PMID: 19420064</li>
+<li>PMCID: 2703952</li>
+<li>Citations: 52</li>
+<li>Influential citations: 5</li>
+<li>Summary: GeneSet2miRNA is the first web-based tool which is able to identify whether or not a gene list has a signature of miRNA-regulatory activity.</li>
+<li>Evidence snippets:</li>
+<li>Snippet 1 (score: 0.697)<br />
+    &gt; As input GeneSet2miRNA accepts several types of gene or protein identifiers. For example, for the human genome GeneSet2miRNA supports identifiers from 'Entrez Gene' (24), 'UniProt/Swiss-Prot', 'Gene Symbol' (24,25), 'UniGene' (24), 'Ensembl' (26), 'RefSeq Protein ID', 'RefSeq Transcript ID' ( 27) and 'Affymetrix probe codes' (28). Additionally a mixture of several identifier types is possible. In the first step user supplied gene Ids are mapped to 'Entrez Gene' identifiers. For this purpose files from NCBI and Affymetrix web sites are used. Detailed information on data sources used by GeneSet2miRNA is in Table 1.<br />
+    &gt; The user gets full information on the mapping of the supplied gene ids. We would like to point out that protein and gene identifiers can be highly ambiguous (29) with multiple synonymous variants. For this reason the quality of the retrieved annotation can be different for different types of identifiers. To escape multiple mapping issues we recommend submitting 'Entrez Gene' identifies to GeneSet2miRNA.</li>
+</ul>
+<h2 id="notes">Notes</h2>
+<ul>
+<li>This provider combines <code>search_papers_by_relevance</code> with <code>snippet_search</code>.</li>
+<li>No synthesis or second-stage model call is performed.</li>
+</ul>
+<h2 id="citations">Citations</h2>
+<ol>
+<li>Dawn Cotter, A. Maer, C. Guda, Brian Saunders, S. Subramaniam (2005). LMPD: LIPID MAPS proteome database. Nucleic Acids Research. https://www.semanticscholar.org/paper/265c37b45326b7927e396484751e84e4aeff92d5</li>
+<li>Ralf C. Mueller, Nicolai Mallig, Jacqueline Smith, Lél Eöry, Richard I. Kuo et al. (2020). Avian Immunome DB: an example of a user-friendly interface for extracting genetic information. BMC Bioinformatics. https://www.semanticscholar.org/paper/b894d9ca8ea2d653bf1711a0c67dab71d054487c</li>
+<li>Monique Zahn-Zabal, C. Dessimoz, Natasha M. Glover (2020). Identifying orthologs with OMA: A primer. F1000Research. https://www.semanticscholar.org/paper/3b77eadcdd6979352c81d0876b0ed3a3ef4215d6</li>
+<li>H. Chiba, Hiroyo Nishide, I. Uchiyama (2015). Construction of an Ortholog Database Using the Semantic Web Technology for Integrative Analysis of Genomic Data. PLoS ONE. https://www.semanticscholar.org/paper/7cc805575c642aa8efdc1204383a7662965fbb60</li>
+<li>Brigitte Waegele, I. Dunger, G. Fobo, Corinna Montrone, H. Mewes et al. (2008). CRONOS: the cross-reference navigation server. Bioinformatics. https://www.semanticscholar.org/paper/8c05b3aa0ba01c41ee97c2dc98ea7b5b14ce0e9c</li>
+<li>Samuel J. Modlin, A. Elghraoui, Deepika Gunasekaran, Alyssa M Zlotnicki, N. Dillon et al. (2021). Structure-Aware Mycobacterium tuberculosis Functional Annotation Uncloaks Resistance, Metabolic, and Virulence Genes. mSystems. https://www.semanticscholar.org/paper/76ff9a62b36b32cc10e46e71ffd4dd90344e4706</li>
+<li>Sreeshma Ravindran Kammarambath, Leona Dcunha, Athira Perunelly Gopalakrishnan, Amal Fahma, N. Krishna et al. (2025). Role of histone-lysine N-methyltransferase 2D (KMT2D) in MEK-ERK signaling-mediated epigenetic regulation: a phosphoproteomics perspective. Frontiers in Bioinformatics. https://www.semanticscholar.org/paper/0ac0729148aff3d839e6a15984e11532e9e740f9</li>
+<li>V. Beisvåg, Frode K. R. Jünge, Hallgeir Bergum, Lars Jølsum, S. Lydersen et al. (2006). GeneTools – application for functional annotation and statistical hypothesis testing. BMC Bioinformatics. https://www.semanticscholar.org/paper/1d9e0c2f67acd5bf64c659f1f3f8624325b6be8a</li>
+<li>Anshul Tiwari, Siddharth J Modi, A. Girme, L. Hingorani (2023). Network pharmacology-based strategic prediction and target identification of apocarotenoids and carotenoids from standardized Kashmir saffron (Crocus sativus L.) extract against polycystic ovary syndrome. Medicine. https://www.semanticscholar.org/paper/3e3253804574634d1968a0fd5b65dd1674bff6c6</li>
+<li>P. Hornbeck, J. Kornhauser, S. Tkachev, Bin Zhang, E. Skrzypek et al. (2011). PhosphoSitePlus: a comprehensive resource for investigating the structure and function of experimentally determined post-translational modifications in man and mouse. Nucleic Acids Research. https://www.semanticscholar.org/paper/93e4acf4ba3bca1b379ae8292e73dddb344abd90</li>
+<li>Xiaohua Jiang, Daren Zhao, Asim Ali, Bo Xu, Wei Liu et al. (2021). MeiosisOnline: A Manually Curated Database for Tracking and Predicting Genes Associated With Meiosis. Frontiers in Cell and Developmental Biology. https://www.semanticscholar.org/paper/aeb08368a5540685473578345739bb569103bd46</li>
+<li>Karla P. Godinez-Macias, Daisy Chen, J. L. Wallis, Miles G. Siegel, Anna Adam et al. (2024). Revisiting the Plasmodium falciparum druggable genome using predicted structures and data mining. Research Square. https://www.semanticscholar.org/paper/795b2985fdc3cf1cfbd5fda1b3c0502eb4dfe866</li>
+<li>Karla P. Godinez-Macias, Daisy Chen, J. L. Wallis, Miles G. Siegel, Anna Adam et al. (2025). Revisiting the Plasmodium falciparum druggable genome using predicted structures and data mining. Npj Drug Discovery. https://www.semanticscholar.org/paper/000083b7bd96cff5b3d1891b00ad332eed7d9add</li>
+<li>P. Pinto-Pinho, Joana Quelhas, Francis Impens, Sara Dufour, Delphi Van Haver et al. (2025). The Surface Proteome of Bovine Unsexed and Sexed Spermatozoa. Animals : an Open Access Journal from MDPI. https://www.semanticscholar.org/paper/66496158140e8f55a2c2ca8965bd298300ce9ab0</li>
+<li>Avril Coghlan, M. Berriman (2018). Functional annotation of parasitic worm genomes, by assigning protein names and GO terms. https://www.semanticscholar.org/paper/583c74a2e225dbff5fca04d36298e5b690491e82</li>
+<li>Chong Peng, Feng Gao (2014). Protein Localization Analysis of Essential Genes in Prokaryotes. Scientific Reports. https://www.semanticscholar.org/paper/69181762648fd77a085b2f93618a71b43b62cf76</li>
+<li>Sophia Zachari, K. Liadaki, Angeliki Planaki, E. Zafiriou, Olga Kouvarou et al. (2025). A Genome-Wide Association Study Identifying Novel Genetic Markers of Response to Treatment with Interleukin-23 Inhibitors in Psoriasis. Genes. https://www.semanticscholar.org/paper/d5f656311b54e222e7487ea32a061869b30178a1</li>
+<li>Keiichi Homma, Koji Suzuki, H. Sugawara (2010). The Autophagy Database: an all-inclusive information resource on autophagy that provides nourishment for research. Nucleic Acids Research. https://www.semanticscholar.org/paper/946ad0a62c6da7c1b288f58b48b6ce015835c176</li>
+<li>Adam Treister, Alexander R. Pico (2018). Identifier Mapping in Cytoscape: idmapper. F1000Research. https://www.semanticscholar.org/paper/c97ebea942d97f5336dd1a1a189c665ae83753ec</li>
+<li>A. Antonov, S. Dietmann, Philip Wong, D. Lutter, H. Mewes (2009). GeneSet2miRNA: finding the signature of cooperative miRNA activities in the gene lists. Nucleic Acids Research. https://www.semanticscholar.org/paper/90ebadc70236638e9499c1200097725327469ea3</li>
+</ol>
+            </div>
+        </details>
+
+        <details class="deep-research-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; gap: 1rem;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Falcon</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(Q9HTB8-deep-research-falcon.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="Q9HTB8" data-a="DEEP_RESEARCH: Falcon" data-r="" data-act="DEEP_RESEARCH" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This deep research is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This deep research needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+
+                <div class="report-meta">
+
+                    <span class="report-meta-text">Comprehensive Research Report: Wzm (PA5451) in *Pseudomonas aeruginosa* PAO1</span>
+
+
+                    <span class="report-badge">Falcon</span>
+
+
+                    <span class="report-badge">Edison Scientific Literature</span>
+
+
+                    <span class="report-badge">31 citations</span>
+
+
+                    <span class="report-badge">2 artifacts</span>
+
+
+                    <span class="report-meta-text">2026-07-03T23:34:16.355059</span>
+
+
+
+                </div>
+
+
+                <div class="artifact-list">
+
+
+
+                    <div class="artifact-link">
+                        <a href="Q9HTB8-deep-research-falcon_artifacts/artifact-00.md" class="term-link">Edison artifact artifact-00</a>
+                        <span>(text/markdown)</span>
+                    </div>
+
+
+
+
+                    <div class="artifact-link">
+                        <a href="Q9HTB8-deep-research-falcon_artifacts/artifact-01.md" class="term-link">Edison artifact artifact-01</a>
+                        <span>(text/markdown)</span>
+                    </div>
+
+
+                </div>
+
+                <p>The research report should be a detailed narrative explaining the function, biological processes, and localization of the gene product. Citations should be given for all claims.</p>
+<p>You should prioritize authoritative reviews and primary scientific literature when conducting research. You can supplement<br />
+this with annotations you find in gene/protein databases, but these can be outdated or inaccurate.</p>
+<p>We are specifically interested in the primary function of the gene - for enzymes, what reaction is catalyzed, and what is the substrate specificity? For transporters, what is the substrate? For structural proteins or adapters, what is the broader structural role? For signaling molecules, what is the role in the pathway.</p>
+<p>We are interested in where in or outside the cell the gene product carries out its function.</p>
+<p>We are also interested in the signaling or biochemical pathways in which the gene functions. We are less interested in broad pleiotropic effects, except where these elucidate the precise role.</p>
+<p>Include evidence where possible. We are interested in both experimental evidence as well as inference from structure, evolution, or bioinformatic analysis. Precise studies should be prioritized over high-throughput, where available.</p>
+<h1 id="comprehensive-research-report-wzm-pa5451-in-pseudomonas-aeruginosa-pao1">Comprehensive Research Report: Wzm (PA5451) in <em>Pseudomonas aeruginosa</em> PAO1</h1>
+<h2 id="1-gene-and-protein-identity">1. Gene and Protein Identity</h2>
+<p>The gene <strong>wzm</strong> (ordered locus name <strong>PA5451</strong>) in <em>Pseudomonas aeruginosa</em> strain PAO1 (UniProt accession Q9HTB8) encodes a <strong>transport permease protein</strong> belonging to the <strong>ABC-2 integral membrane protein family</strong> (InterPro domains: IPR013525, IPR047817, IPR000412; Pfam: PF01061). Wzm functions as the <strong>transmembrane domain (TMD)</strong> component of the Wzm–Wzt ATP-binding cassette (ABC) transporter, which is essential for the export of the common polysaccharide antigen (CPA) O-polysaccharide across the inner membrane of <em>P. aeruginosa</em> (king2009reviewlipopolysaccharidebiosynthesis pages 25-27, rocchetta1999geneticsofoantigen pages 14-15).</p>
+<p>The following table summarizes the key properties of Wzm:</p>
+<table>
+<thead>
+<tr>
+<th>Property</th>
+<th>Details</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>Gene name/locus</td>
+<td><strong>wzm</strong>; ordered locus <strong>PA5451</strong> in <em>Pseudomonas aeruginosa</em> PAO1 (from the target UniProt record; gene-function linkage to CPA export supported in <em>P. aeruginosa</em>) (king2009reviewlipopolysaccharidebiosynthesis pages 25-27, rocchetta1999geneticsofoantigen pages 14-15)</td>
+</tr>
+<tr>
+<td>UniProt ID</td>
+<td><strong>Q9HTB8</strong> (target UniProt accession provided by user)</td>
+</tr>
+<tr>
+<td>Protein name</td>
+<td>Transport permease protein; functionally the <strong>integral membrane permease (TMD) subunit</strong> of the Wzm-Wzt ABC transporter for O-polysaccharide export (king2009reviewlipopolysaccharidebiosynthesis pages 25-27, rocchetta1999geneticsofoantigen pages 14-15)</td>
+</tr>
+<tr>
+<td>Protein family</td>
+<td><strong>ABC-2 integral membrane protein family</strong> / O-antigen polysaccharide ABC transporter permease; Wzm is the membrane component of a two-subunit ABC exporter (valvano2003exportofospecific pages 8-9, king2009reviewlipopolysaccharidebiosynthesis pages 25-27)</td>
+</tr>
+<tr>
+<td>Organism</td>
+<td><em>Pseudomonas aeruginosa</em> strain PAO1 (ATCC 15692 / DSM 22644 / CIP 104116 / JCM 14847 / LMG 12228 / 1C / PRS 101)</td>
+</tr>
+<tr>
+<td>Substrate transported</td>
+<td><strong>UndPP-linked common polysaccharide antigen (CPA; formerly A-band)</strong>, a <strong>D-rhamnose homopolymer/rhamnan O-polysaccharide</strong> assembled on the cytosolic face of the inner membrane before export to the periplasmic side (lam2011geneticandfunctional pages 8-9, king2009reviewlipopolysaccharidebiosynthesis pages 25-27, king2009reviewlipopolysaccharidebiosynthesis pages 21-23)</td>
+</tr>
+<tr>
+<td>Transport partner</td>
+<td><strong>Wzt</strong>, the cytosolic ATP-binding/nucleotide-binding domain partner; together Wzm-Wzt form the ABC transporter required for CPA export (king2009reviewlipopolysaccharidebiosynthesis pages 25-27, rocchetta1999geneticsofoantigen pages 14-15, caffalette2021cryoemstructureof pages 1-2)</td>
+</tr>
+<tr>
+<td>Localization</td>
+<td><strong>Inner membrane</strong> integral membrane protein; exports substrate from the <strong>cytoplasmic side</strong> to the <strong>periplasmic side</strong> for subsequent ligation to lipid A-core (king2009reviewlipopolysaccharidebiosynthesis pages 25-27, caffalette2021cryoemstructureof pages 1-2, king2009reviewlipopolysaccharidebiosynthesis pages 21-23)</td>
+</tr>
+<tr>
+<td>Topology (number of TM helices)</td>
+<td>Wzm homologs form the transporter TMD with <strong>6 transmembrane helices per protomer</strong>, plus an N-terminal amphipathic/interface helix and periplasmic gate helices in structural studies of homologous Wzm-Wzt systems (bi2018architectureofa pages 1-2, bi2018architectureofa pages 2-3, caffalette2021cryoemstructureof pages 2-2)</td>
+</tr>
+<tr>
+<td>Biosynthetic pathway</td>
+<td><strong>ABC transporter-dependent CPA/A-band O-antigen biosynthesis pathway</strong>; distinct from the <strong>Wzy-dependent</strong> pathway used for O-specific antigen (OSA/B-band). CPA is synthesized on a lipid carrier in the cytoplasm, exported by Wzm-Wzt, then ligated to lipid A-core in the periplasm (king2009reviewlipopolysaccharidebiosynthesis pages 20-21, king2009reviewlipopolysaccharidebiosynthesis pages 21-23)</td>
+</tr>
+<tr>
+<td>Biological function</td>
+<td>Required for <strong>export of CPA to the cell surface</strong>. Loss of <strong>wzm</strong> blocks export and core ligation but not polymer synthesis, causing CPA to accumulate intracellularly on lipid carrier and preventing surface display (king2009reviewlipopolysaccharidebiosynthesis pages 25-27, rocchetta1999geneticsofoantigen pages 14-15)</td>
+</tr>
+<tr>
+<td>Key structural features (gate helices, aromatic belt, channel)</td>
+<td>Structural studies of Wzm-Wzt homologs show Wzm forms a <strong>continuous transmembrane channel</strong> wide enough for linear polysaccharides; contains <strong>cytosolic and periplasmic gate helices</strong>, <strong>aromatic residues/aromatic belt</strong> near the periplasmic exit, and channel-lining aromatic/hydrophilic residues that coordinate the polymer during translocation (bi2018architectureofa pages 1-2, caffalette2021cryoemstructureof pages 1-2, caffalette2021cryoemstructureof pages 2-4)</td>
+</tr>
+<tr>
+<td>Transport mechanism</td>
+<td>Best-supported current model is an <strong>ATP-driven processive channel mechanism</strong>, not classical alternating access: the lipid-linked O-polysaccharide is recruited, loaded into a continuous Wzm channel, and moved stepwise across the membrane as ATP binding/hydrolysis at Wzt drives conformational changes (spellmon2022molecularbasisfor pages 9-11, bi2018architectureofa pages 4-5, caffalette2021cryoemstructureof pages 4-6, bi2018architectureofa pages 1-2)</td>
+</tr>
+</tbody>
+</table>
+<p><em>Table: This table summarizes the core identity, function, localization, substrate, and mechanism of the Wzm permease encoded by PA5451 in </em>Pseudomonas aeruginosa<em> PAO1. It is useful as a compact reference linking the PAO1 gene to the CPA/A-band O-antigen export pathway and to modern structural models of Wzm-Wzt transport.</em></p>
+<h2 id="2-primary-function-abc-transporter-permease-for-cpa-o-antigen-export">2. Primary Function: ABC Transporter Permease for CPA O-Antigen Export</h2>
+<h3 id="21-substrate-specificity">2.1 Substrate Specificity</h3>
+<p>Wzm is the <strong>integral membrane permease</strong> subunit of the Wzm–Wzt ABC transporter. Its substrate is the <strong>undecaprenyl-pyrophosphate (UndPP)-linked common polysaccharide antigen (CPA)</strong>, also historically referred to as the <strong>A-band O-polysaccharide</strong> (king2009reviewlipopolysaccharidebiosynthesis pages 25-27, lam2011geneticandfunctional pages 8-9). The CPA is a <strong>neutral homopolymer of D-rhamnose (D-Rha)</strong>, consisting of a trisaccharide repeating unit with the structure [→3)-α-D-Rha-(1→3)-α-D-Rha-(1→2)-α-D-Rha-(1→]ₙ (lam2011geneticandfunctional pages 8-9, king2009reviewlipopolysaccharidebiosynthesis pages 23-24). This D-rhamnan polymer is assembled on the cytoplasmic face of the inner membrane on a lipid carrier (UndPP), and Wzm–Wzt transports the completed polymer across the membrane to the periplasmic face (king2009reviewlipopolysaccharidebiosynthesis pages 21-23, king2009reviewlipopolysaccharidebiosynthesis pages 25-27).</p>
+<h3 id="22-transport-function">2.2 Transport Function</h3>
+<p>Wzm works in obligate partnership with <strong>Wzt</strong>, the cytosolic <strong>ATP-binding/nucleotide-binding domain (NBD)</strong> subunit. Together, Wzm (TMD) and Wzt (NBD) form a functional ABC transporter heterodimer that mediates the energy-dependent export of lipid-linked CPA from the cytoplasm to the periplasm (king2009reviewlipopolysaccharidebiosynthesis pages 25-27, rocchetta1999geneticsofoantigen pages 14-15, caffalette2021cryoemstructureof pages 1-2). The Wzm protein contains approximately six transmembrane domains and is responsible for forming the polysaccharide translocation channel (valvano2003exportofospecific pages 8-9, bi2018architectureofa pages 1-2).</p>
+<p>Experimental evidence directly demonstrates the essential role of Wzm: <strong>allele replacement mutagenesis</strong> of <em>wzm</em> in <em>P. aeruginosa</em> prevents export of CPA to the cell surface, although the polysaccharide is still synthesized intracellularly and remains attached to its isoprenyl-pyrophosphate lipid carrier in the cytoplasm (king2009reviewlipopolysaccharidebiosynthesis pages 25-27, rocchetta1999geneticsofoantigen pages 14-15). This intracellular accumulation can be detected by immunoelectron microscopy (rocchetta1999geneticsofoantigen pages 14-15). The inability to export CPA prevents its ligation to lipid A-core, which normally occurs only in the periplasm (rocchetta1999geneticsofoantigen pages 14-15, king2009reviewlipopolysaccharidebiosynthesis pages 25-27).</p>
+<h2 id="3-subcellular-localization">3. Subcellular Localization</h2>
+<p>Wzm is an <strong>integral inner membrane protein</strong> of <em>P. aeruginosa</em>. It is embedded in the cytoplasmic (inner) membrane with its transmembrane helices spanning the lipid bilayer, forming a translocation channel that connects the cytoplasmic and periplasmic faces of the membrane (king2009reviewlipopolysaccharidebiosynthesis pages 25-27, caffalette2021cryoemstructureof pages 1-2, bi2018architectureofa pages 1-2). The transporter exports its substrate from the <strong>cytoplasmic side</strong> to the <strong>periplasmic side</strong> of the inner membrane, where the CPA polymer is subsequently ligated to the lipid A-core oligosaccharide by the O-antigen ligase WaaL (king2009reviewlipopolysaccharidebiosynthesis pages 21-23).</p>
+<h2 id="4-biosynthetic-pathway-abc-transporter-dependent-cpa-biosynthesis">4. Biosynthetic Pathway: ABC Transporter-Dependent CPA Biosynthesis</h2>
+<h3 id="41-pathway-overview">4.1 Pathway Overview</h3>
+<p><em>P. aeruginosa</em> produces two structurally and serologically distinct O-antigen polysaccharides on its lipopolysaccharide (LPS): the <strong>CPA (A-band)</strong>, a D-rhamnose homopolymer, and the <strong>O-specific antigen (OSA, B-band)</strong>, a heteropolymer that varies between serotypes (king2009reviewlipopolysaccharidebiosynthesis pages 20-21, rocchetta1999geneticsofoantigen pages 6-8). These two O-antigens are synthesized through fundamentally different pathways. The CPA is produced via the <strong>ABC transporter-dependent pathway</strong> (Wzy-independent), whereas the OSA follows the <strong>Wzy-dependent pathway</strong> (rocchetta1999geneticsofoantigen pages 14-15, king2009reviewlipopolysaccharidebiosynthesis pages 20-21).</p>
+<p>In the ABC transporter-dependent pathway, the CPA polymer is fully assembled on the cytoplasmic face of the inner membrane on an UndPP lipid anchor. After complete assembly, the entire lipid-linked polymer is exported across the inner membrane by the Wzm–Wzt ABC transporter, and then ligated to lipid A-core in the periplasm (king2009reviewlipopolysaccharidebiosynthesis pages 21-23, lam2011geneticandfunctional pages 8-9).</p>
+<h3 id="42-gene-cluster-and-enzymatic-steps">4.2 Gene Cluster and Enzymatic Steps</h3>
+<p>The CPA biosynthesis genes are organized in a cluster. The following table summarizes the roles of the key genes in this pathway:</p>
+<table>
+<thead>
+<tr>
+<th>Gene</th>
+<th>PA locus (PAO1)</th>
+<th>Function</th>
+<th>Role in CPA pathway</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>wbpL</td>
+<td>PA3146</td>
+<td>Undecaprenyl-phosphate HexNAc-1-phosphate transferase that initiates O-polysaccharide assembly on the lipid carrier</td>
+<td>Initiates CPA synthesis on the cytoplasmic face of the inner membrane by adding the first sugar-phosphate to UndP; also required for initiation of OSA synthesis (king2009reviewlipopolysaccharidebiosynthesis pages 21-23)</td>
+</tr>
+<tr>
+<td>algC</td>
+<td>not specified in retrieved evidence</td>
+<td>Phosphomannomutase/phosphoglucomutase contributing precursor formation for GDP-D-rhamnose biosynthesis</td>
+<td>Supplies mannose-1-phosphate precursor used upstream in GDP-D-rhamnose production for CPA assembly (lam2011geneticandfunctional pages 8-9)</td>
+</tr>
+<tr>
+<td>wbpW</td>
+<td>not specified in retrieved evidence</td>
+<td>Phosphomannose isomerase</td>
+<td>Converts fructose-6-phosphate to mannose-6-phosphate in the precursor pathway leading to GDP-D-rhamnose for CPA biosynthesis (lam2011geneticandfunctional pages 8-9, king2009reviewlipopolysaccharidebiosynthesis pages 23-24)</td>
+</tr>
+<tr>
+<td>gmd</td>
+<td>not specified in retrieved evidence</td>
+<td>GDP-mannose 4,6-dehydratase</td>
+<td>Converts GDP-mannose toward GDP-4-keto-6-deoxymannose in the GDP-D-rhamnose biosynthetic pathway that supplies CPA sugar donor (lam2011geneticandfunctional pages 8-9, king2009reviewlipopolysaccharidebiosynthesis pages 23-24)</td>
+</tr>
+<tr>
+<td>rmd</td>
+<td>not specified in retrieved evidence</td>
+<td>GDP-4-keto-6-deoxymannose reductase</td>
+<td>Completes GDP-D-rhamnose synthesis, generating the activated sugar donor required for the D-rhamnan CPA polymer (lam2011geneticandfunctional pages 8-9, king2009reviewlipopolysaccharidebiosynthesis pages 23-24)</td>
+</tr>
+<tr>
+<td>wbpX</td>
+<td>not specified in retrieved evidence</td>
+<td>Rhamnosyltransferase</td>
+<td>Adds D-rhamnose residues during assembly of the CPA trisaccharide repeat/polymer on the lipid carrier (lam2011geneticandfunctional pages 8-9, king2009reviewlipopolysaccharidebiosynthesis pages 25-27)</td>
+</tr>
+<tr>
+<td>wbpY</td>
+<td>not specified in retrieved evidence</td>
+<td>Rhamnosyltransferase</td>
+<td>Adds D-rhamnose residues during assembly of the CPA trisaccharide repeat/polymer on the lipid carrier (lam2011geneticandfunctional pages 8-9, king2009reviewlipopolysaccharidebiosynthesis pages 25-27)</td>
+</tr>
+<tr>
+<td>wbpZ</td>
+<td>not specified in retrieved evidence</td>
+<td>Rhamnosyltransferase</td>
+<td>Adds D-rhamnose residues during assembly of the CPA trisaccharide repeat/polymer on the lipid carrier; together with WbpX/WbpY builds the characteristic α-linked D-rhamnan structure (lam2011geneticandfunctional pages 8-9, king2009reviewlipopolysaccharidebiosynthesis pages 25-27)</td>
+</tr>
+<tr>
+<td>wzm</td>
+<td>PA5451</td>
+<td>ABC transporter permease / transmembrane domain (TMD) subunit</td>
+<td>Exports completed UndPP-linked CPA across the inner membrane to the periplasmic face for ligation to lipid A-core; loss blocks export but not polymer synthesis (king2009reviewlipopolysaccharidebiosynthesis pages 25-27, rocchetta1999geneticsofoantigen pages 14-15)</td>
+</tr>
+<tr>
+<td>wzt</td>
+<td>not specified in retrieved evidence</td>
+<td>ABC transporter ATP-binding cassette ATPase / nucleotide-binding domain (NBD) subunit</td>
+<td>Provides ATP-driven energy for Wzm-Wzt-mediated export of completed CPA across the inner membrane; loss phenocopies wzm mutants with intracellular accumulation of lipid-linked CPA (king2009reviewlipopolysaccharidebiosynthesis pages 25-27, rocchetta1999geneticsofoantigen pages 14-15)</td>
+</tr>
+</tbody>
+</table>
+<p><em>Table: This table summarizes the core genes requested for CPA/A-band O-antigen biosynthesis in P. aeruginosa PAO1, linking each gene to its enzymatic or transport role in the pathway. It is useful for mapping Wzm into the broader precursor synthesis, polymer assembly, and export steps of CPA production.</em></p>
+<p>The biosynthetic pathway proceeds through: (1) synthesis of GDP-D-rhamnose from central metabolic precursors via AlgC, WbpW, Gmd, and Rmd; (2) initiation of polymer assembly on UndP by WbpL; (3) polymerization of the D-rhamnose trisaccharide repeating units by rhamnosyltransferases WbpX, WbpY, and WbpZ; (4) <strong>export of the completed UndPP-linked polymer by the Wzm–Wzt ABC transporter</strong>; and (5) ligation to lipid A-core in the periplasm (lam2011geneticandfunctional pages 8-9, king2009reviewlipopolysaccharidebiosynthesis pages 25-27, king2009reviewlipopolysaccharidebiosynthesis pages 21-23). Additional genes (PA5455–PA5459) encoding methyltransferases and acetyltransferases are also required for CPA biosynthesis (lam2011geneticandfunctional pages 9-10).</p>
+<h2 id="5-structural-biology-of-the-wzmwzt-transporter">5. Structural Biology of the Wzm–Wzt Transporter</h2>
+<p>While structural studies have not been performed directly on <em>P. aeruginosa</em> Wzm, extensive structural characterization of homologous Wzm–Wzt transporters from <em>Aquifex aeolicus</em> and <em>Mycobacterium abscessus</em> provides detailed insight into the architecture of this transporter family, which is directly relevant to understanding the <em>P. aeruginosa</em> protein.</p>
+<h3 id="51-transmembrane-architecture">5.1 Transmembrane Architecture</h3>
+<p>The crystal structure of the <em>A. aeolicus</em> Wzm–Wzt homolog revealed that <strong>each Wzm protomer contains six transmembrane helices (TM1–TM6)</strong>, preceded by an N-terminal amphipathic interface helix (bi2018architectureofa pages 1-2, bi2018architectureofa pages 2-3, caffalette2021cryoemstructureof pages 2-2). Two Wzm protomers interact closely through TM1 and TM5 to form a <strong>large continuous transmembrane channel</strong> spanning the entire membrane width, which is sufficiently wide (accessible to a ~3.5 Å radius probe) to accommodate linear polysaccharide chains (bi2018architectureofa pages 2-3). The channel features three layers of aromatic residues that coordinate the polysaccharide substrate through CH–π stacking interactions (bi2018architectureofa pages 2-3).</p>
+<h3 id="52-gate-helices-and-aromatic-belt">5.2 Gate Helices and Aromatic Belt</h3>
+<p>Key structural features include <strong>gate helices</strong> at both the cytosolic and periplasmic membrane interfaces, which serve as substrate entry and exit points, respectively (bi2018architectureofa pages 1-2). The periplasmic gate helices (PG1 and PG2) are formed by the TM5/TM6 loop, while the cytosolic gate helix is contributed by the Wzt NBD and packs against the Wzm protomer interface (bi2018architectureofa pages 1-2, caffalette2021cryoemstructureof pages 2-2). An <strong>aromatic belt</strong> near the periplasmic channel exit, composed of conserved residues such as Tyr39, Phe180, and Trp181, seals the transporter in its resting ATP-bound state (caffalette2021cryoemstructureof pages 1-2, caffalette2021cryoemstructureof pages 2-4). These aromatic residues dilate during substrate translocation to form the open channel (spellmon2022molecularbasisfor pages 7-8).</p>
+<h3 id="53-conformational-states">5.3 Conformational States</h3>
+<p>Cryo-EM structures have revealed multiple conformational states of the transporter. In the ATP-bound resting state, the channel is closed with an asymmetric architecture showing one open and one closed portal at both cytosolic and periplasmic sides (caffalette2021cryoemstructureof pages 1-2). The nucleotide-free (apo) state shows the widest channel diameter, suggesting that conformational cycling between these states drives polysaccharide translocation (caffalette2021cryoemstructureof pages 4-6). Recent cryo-EM studies of the mycobacterial Wzm–Wzt homolog have confirmed that the cytosolic gate helix plays a key functional role in polysaccharide transport, and that the hydrophobic polyprenyl lipid moiety is translocated first, followed by the polysaccharide chain (garaeva2026structuralbasisof pages 2-3).</p>
+<h2 id="6-transport-mechanism">6. Transport Mechanism</h2>
+<h3 id="61-processive-channel-mechanism">6.1 Processive Channel Mechanism</h3>
+<p>The Wzm–Wzt transporter operates through a <strong>processive channel-forming mechanism</strong> that is distinct from the classical alternating access mechanism used by most ABC transporters (bi2018architectureofa pages 1-2, spellmon2022molecularbasisfor pages 9-11). This mechanism is better suited for translocating high-molecular-mass polysaccharides. The transporter forms a continuous transmembrane channel, and the polysaccharide is ratcheted through this channel at the expense of <strong>ATP hydrolysis</strong> (spellmon2022molecularbasisfor pages 9-11, caffalette2021cryoemstructureof pages 4-6).</p>
+<h3 id="62-role-of-atp-hydrolysis">6.2 Role of ATP Hydrolysis</h3>
+<p>ATP hydrolysis at the Wzt NBDs drives repeated cycles of conformational changes in the Wzm TMDs that energize processive polymer translocation (bi2018architectureofa pages 4-5, caffalette2021cryoemstructureof pages 4-6). ATP-induced NBD closure triggers rigid-body movements of the Wzm protomers around a central helix axis, modulating channel width and facilitating stepwise translocation (caffalette2021cryoemstructureof pages 4-6). Notably, studies on the <em>A. aeolicus</em> system showed that O-antigen cap binding to the carbohydrate-binding domain (CBD) of Wzt causes <strong>stalling of ATPase activity</strong>, which may position the lipid moiety at the channel entrance before the transport cycle begins (spellmon2022molecularbasisfor pages 9-11). Multiple rounds of ATP hydrolysis then drive the actual polymer translocation process (spellmon2022molecularbasisfor pages 9-11).</p>
+<h3 id="63-substrate-recognition-via-the-carbohydrate-binding-domain">6.3 Substrate Recognition via the Carbohydrate-Binding Domain</h3>
+<p>In many Wzm–Wzt systems, the Wzt subunit possesses a <strong>carbohydrate-binding domain (CBD)</strong> that recognizes the chemically modified nonreducing terminus of the O-antigen polymer (spellmon2022molecularbasisfor pages 9-11). In <em>P. aeruginosa</em>, the CPA polymer appears to have modifications at its nonreducing terminal residue, likely methylation, which may serve as a signal for recognition and translocation competency (king2009reviewlipopolysaccharidebiosynthesis pages 25-27). The CBD recruits the lipid-linked substrate to the transporter, increasing local concentration and facilitating channel loading (spellmon2022molecularbasisfor pages 9-11).</p>
+<h2 id="7-biological-significance-and-role-in-pathogenesis">7. Biological Significance and Role in Pathogenesis</h2>
+<h3 id="71-cpa-in-chronic-infection">7.1 CPA in Chronic Infection</h3>
+<p>CPA is produced by the majority of <em>P. aeruginosa</em> isolates and is particularly significant in chronic infections. In cystic fibrosis (CF) patients with chronic <em>P. aeruginosa</em> lung infections, clinical isolates characteristically <strong>maintain CPA expression while losing B-band (OSA) O-antigen expression</strong> (rocchetta1999geneticsofoantigen pages 3-4). A study of 250 CF patient isolates found that 68% expressed A-band LPS but none expressed B-band O-antigen (rocchetta1999geneticsofoantigen pages 3-4). This selective enrichment of CPA during chronic CF infection suggests it provides a survival advantage in the host environment (lam2011geneticandfunctional pages 9-10).</p>
+<h3 id="72-cpa-and-bacterial-adherence">7.2 CPA and Bacterial Adherence</h3>
+<p>CPA contributes to <strong>bacterial adherence to human epithelial cells</strong>. A CPA-deficient mutant (<em>rmd</em> knockout, defective in GDP-D-rhamnose synthesis) showed significantly reduced efficiency in adhering to cultured human bronchial epithelial cells, with mutant bacteria attaching as isolated bacteria rather than forming microcolonies (king2009reviewlipopolysaccharidebiosynthesis pages 4-5, lam2011geneticandfunctional pages 9-10).</p>
+<h3 id="73-cpa-and-immune-modulation">7.3 CPA and Immune Modulation</h3>
+<p>Unlike B-band O-antigen, CPA alone <strong>does not confer serum resistance</strong> or protect against complement-mediated lysis (rocchetta1999geneticsofoantigen pages 3-4). Antibodies against A-band LPS are not protective in animal models, in contrast to anti-B-band antibodies that are highly protective (rocchetta1999geneticsofoantigen pages 3-4). However, CPA serves as a <strong>receptor for bacteriophage A7</strong>, indicating its significance as a cell surface determinant co-evolving with phage predation (lam2011geneticandfunctional pages 8-9).</p>
+<h3 id="74-cpa-and-virulence-regulation">7.4 CPA and Virulence Regulation</h3>
+<p>Interestingly, when both OSA and CPA are absent from <em>P. aeruginosa</em>, there are pronounced increases in expression of type III secretion system (T3SS) effector genes (<em>exoS</em>, <em>exoT</em>) and associated regulatory genes (<em>exsA</em>, <em>pcrV</em>), along with increased cytotoxicity in both <em>in vitro</em> and <em>in vivo</em> models (lam2011geneticandfunctional pages 18-19). This suggests that the presence of CPA on the cell surface functions as a <strong>negative modulator of T3SS-mediated virulence</strong> (lam2011geneticandfunctional pages 18-19).</p>
+<h2 id="8-evolutionary-context">8. Evolutionary Context</h2>
+<p>The Wzm–Wzt transporter system is broadly conserved across Gram-negative and Gram-positive bacteria for the export of diverse cell surface glycoconjugates. Homologous systems have been characterized in <em>Escherichia coli</em>, <em>Klebsiella pneumoniae</em>, <em>Rhizobium etli</em>, <em>Myxococcus xanthus</em>, and <em>Mycobacterium</em> species, where they transport structurally diverse polysaccharides including O-antigens, capsular polysaccharides, and arabinogalactan precursors (valvano2003exportofospecific pages 8-9, garaeva2026structuralbasisof pages 2-3). The functional interchangeability of Wzm components between different bacterial species has been demonstrated, underscoring the conservation of this transport mechanism (king2009reviewlipopolysaccharidebiosynthesis pages 25-27). The ABC-2 family classification of Wzm proteins reflects their shared evolutionary origin and conserved structural architecture across diverse bacterial lineages.</p>
+<h2 id="9-summary">9. Summary</h2>
+<p>Wzm (PA5451) in <em>P. aeruginosa</em> PAO1 is an essential <strong>inner membrane ABC transporter permease</strong> that exports the <strong>UndPP-linked D-rhamnose homopolymer (CPA/A-band O-antigen)</strong> from the cytoplasm to the periplasm. It functions as a homodimeric transmembrane channel in partnership with the Wzt ATPase, using a <strong>processive, ATP-driven channel mechanism</strong> to translocate the polysaccharide substrate. Structural studies of homologs reveal a channel formed by six transmembrane helices per protomer, with gate helices and an aromatic belt controlling substrate access. CPA export by Wzm–Wzt is essential for surface display of A-band LPS, which plays roles in epithelial cell adherence, chronic infection maintenance in cystic fibrosis, and modulation of virulence factor expression in <em>P. aeruginosa</em>.</p>
+<p>References</p>
+<ol>
+<li>
+<p>(king2009reviewlipopolysaccharidebiosynthesis pages 25-27): Jerry D. King, Dana Kocíncová, Erin L. Westman, and Joseph S. Lam. Review: lipopolysaccharide biosynthesis in pseudomonas aeruginosa. Innate Immunity, 15:261-312, Aug 2009. URL: https://doi.org/10.1177/1753425909106436, doi:10.1177/1753425909106436. This article has 451 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(rocchetta1999geneticsofoantigen pages 14-15): H. L. Rocchetta, L. L. Burrows, and J. S. Lam. Genetics of o-antigen biosynthesis inpseudomonas aeruginosa. Microbiology and Molecular Biology Reviews, 63:523-553, Sep 1999. URL: https://doi.org/10.1128/mmbr.63.3.523-553.1999, doi:10.1128/mmbr.63.3.523-553.1999. This article has 488 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(valvano2003exportofospecific pages 8-9): Miguel A Valvano. Export of o-specific lipopolysaccharide. Frontiers in bioscience : a journal and virtual library, 8:s452-71, May 2003. URL: https://doi.org/10.2741/1079, doi:10.2741/1079. This article has 194 citations.</p>
+</li>
+<li>
+<p>(lam2011geneticandfunctional pages 8-9): Joseph S. Lam, Véronique L. Taylor, Salim T. Islam, Youai Hao, and Dana Kocíncová. Genetic and functional diversity of pseudomonas aeruginosa lipopolysaccharide. Frontiers in Microbiology, Apr 2011. URL: https://doi.org/10.3389/fmicb.2011.00118, doi:10.3389/fmicb.2011.00118. This article has 386 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(king2009reviewlipopolysaccharidebiosynthesis pages 21-23): Jerry D. King, Dana Kocíncová, Erin L. Westman, and Joseph S. Lam. Review: lipopolysaccharide biosynthesis in pseudomonas aeruginosa. Innate Immunity, 15:261-312, Aug 2009. URL: https://doi.org/10.1177/1753425909106436, doi:10.1177/1753425909106436. This article has 451 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(caffalette2021cryoemstructureof pages 1-2): Christopher A. Caffalette and Jochen Zimmer. Cryo-em structure of the full-length wzmwzt abc transporter required for lipid-linked o antigen transport. Dec 2021. URL: https://doi.org/10.1073/pnas.2016144118, doi:10.1073/pnas.2016144118. This article has 32 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(bi2018architectureofa pages 1-2): Yunchen Bi, Evan Mann, Chris Whitfield, and Jochen Zimmer. Architecture of a channel-forming o-antigen polysaccharide abc transporter. Jan 2018. URL: https://doi.org/10.1038/nature25190, doi:10.1038/nature25190. This article has 118 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(bi2018architectureofa pages 2-3): Yunchen Bi, Evan Mann, Chris Whitfield, and Jochen Zimmer. Architecture of a channel-forming o-antigen polysaccharide abc transporter. Jan 2018. URL: https://doi.org/10.1038/nature25190, doi:10.1038/nature25190. This article has 118 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(caffalette2021cryoemstructureof pages 2-2): Christopher A. Caffalette and Jochen Zimmer. Cryo-em structure of the full-length wzmwzt abc transporter required for lipid-linked o antigen transport. Dec 2021. URL: https://doi.org/10.1073/pnas.2016144118, doi:10.1073/pnas.2016144118. This article has 32 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(king2009reviewlipopolysaccharidebiosynthesis pages 20-21): Jerry D. King, Dana Kocíncová, Erin L. Westman, and Joseph S. Lam. Review: lipopolysaccharide biosynthesis in pseudomonas aeruginosa. Innate Immunity, 15:261-312, Aug 2009. URL: https://doi.org/10.1177/1753425909106436, doi:10.1177/1753425909106436. This article has 451 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(caffalette2021cryoemstructureof pages 2-4): Christopher A. Caffalette and Jochen Zimmer. Cryo-em structure of the full-length wzmwzt abc transporter required for lipid-linked o antigen transport. Dec 2021. URL: https://doi.org/10.1073/pnas.2016144118, doi:10.1073/pnas.2016144118. This article has 32 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(spellmon2022molecularbasisfor pages 9-11): Nicholas Spellmon, Artur Muszyński, Ireneusz Górniak, Jiri Vlach, David Hahn, Parastoo Azadi, and Jochen Zimmer. Molecular basis for polysaccharide recognition and modulated atp hydrolysis by the o antigen abc transporter. Nature Communications, Sep 2022. URL: https://doi.org/10.1038/s41467-022-32597-2, doi:10.1038/s41467-022-32597-2. This article has 20 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(bi2018architectureofa pages 4-5): Yunchen Bi, Evan Mann, Chris Whitfield, and Jochen Zimmer. Architecture of a channel-forming o-antigen polysaccharide abc transporter. Jan 2018. URL: https://doi.org/10.1038/nature25190, doi:10.1038/nature25190. This article has 118 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(caffalette2021cryoemstructureof pages 4-6): Christopher A. Caffalette and Jochen Zimmer. Cryo-em structure of the full-length wzmwzt abc transporter required for lipid-linked o antigen transport. Dec 2021. URL: https://doi.org/10.1073/pnas.2016144118, doi:10.1073/pnas.2016144118. This article has 32 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(king2009reviewlipopolysaccharidebiosynthesis pages 23-24): Jerry D. King, Dana Kocíncová, Erin L. Westman, and Joseph S. Lam. Review: lipopolysaccharide biosynthesis in pseudomonas aeruginosa. Innate Immunity, 15:261-312, Aug 2009. URL: https://doi.org/10.1177/1753425909106436, doi:10.1177/1753425909106436. This article has 451 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(rocchetta1999geneticsofoantigen pages 6-8): H. L. Rocchetta, L. L. Burrows, and J. S. Lam. Genetics of o-antigen biosynthesis inpseudomonas aeruginosa. Microbiology and Molecular Biology Reviews, 63:523-553, Sep 1999. URL: https://doi.org/10.1128/mmbr.63.3.523-553.1999, doi:10.1128/mmbr.63.3.523-553.1999. This article has 488 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(lam2011geneticandfunctional pages 9-10): Joseph S. Lam, Véronique L. Taylor, Salim T. Islam, Youai Hao, and Dana Kocíncová. Genetic and functional diversity of pseudomonas aeruginosa lipopolysaccharide. Frontiers in Microbiology, Apr 2011. URL: https://doi.org/10.3389/fmicb.2011.00118, doi:10.3389/fmicb.2011.00118. This article has 386 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(spellmon2022molecularbasisfor pages 7-8): Nicholas Spellmon, Artur Muszyński, Ireneusz Górniak, Jiri Vlach, David Hahn, Parastoo Azadi, and Jochen Zimmer. Molecular basis for polysaccharide recognition and modulated atp hydrolysis by the o antigen abc transporter. Nature Communications, Sep 2022. URL: https://doi.org/10.1038/s41467-022-32597-2, doi:10.1038/s41467-022-32597-2. This article has 20 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(garaeva2026structuralbasisof pages 2-3): Alisa A. Garaeva, Viktória Fabianová, Karin Savková, Stanislav Huszár, Xiaochao Xue, Todd L. Lowary, Katarína Mikušová, and Markus A. Seeger. Structural basis of lipid-linked galactan export by the mycobacterial abc transporter wzm-wzt. Nature Communications, Mar 2026. URL: https://doi.org/10.1038/s41467-026-70429-9, doi:10.1038/s41467-026-70429-9. This article has 0 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(rocchetta1999geneticsofoantigen pages 3-4): H. L. Rocchetta, L. L. Burrows, and J. S. Lam. Genetics of o-antigen biosynthesis inpseudomonas aeruginosa. Microbiology and Molecular Biology Reviews, 63:523-553, Sep 1999. URL: https://doi.org/10.1128/mmbr.63.3.523-553.1999, doi:10.1128/mmbr.63.3.523-553.1999. This article has 488 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(king2009reviewlipopolysaccharidebiosynthesis pages 4-5): Jerry D. King, Dana Kocíncová, Erin L. Westman, and Joseph S. Lam. Review: lipopolysaccharide biosynthesis in pseudomonas aeruginosa. Innate Immunity, 15:261-312, Aug 2009. URL: https://doi.org/10.1177/1753425909106436, doi:10.1177/1753425909106436. This article has 451 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(lam2011geneticandfunctional pages 18-19): Joseph S. Lam, Véronique L. Taylor, Salim T. Islam, Youai Hao, and Dana Kocíncová. Genetic and functional diversity of pseudomonas aeruginosa lipopolysaccharide. Frontiers in Microbiology, Apr 2011. URL: https://doi.org/10.3389/fmicb.2011.00118, doi:10.3389/fmicb.2011.00118. This article has 386 citations and is from a peer-reviewed journal.</p>
+</li>
+</ol>
+<h2 id="artifacts">Artifacts</h2>
+<ul>
+<li><a href="Q9HTB8-deep-research-falcon_artifacts/artifact-00.md">Edison artifact artifact-00</a></li>
+<li><a href="Q9HTB8-deep-research-falcon_artifacts/artifact-01.md">Edison artifact artifact-01</a></li>
+</ul>
+<h2 id="citations">Citations</h2>
+<ol>
+<li>rocchetta1999geneticsofoantigen pages 14-15</li>
+<li>king2009reviewlipopolysaccharidebiosynthesis pages 21-23</li>
+<li>lam2011geneticandfunctional pages 8-9</li>
+<li>lam2011geneticandfunctional pages 9-10</li>
+<li>bi2018architectureofa pages 2-3</li>
+<li>bi2018architectureofa pages 1-2</li>
+<li>spellmon2022molecularbasisfor pages 7-8</li>
+<li>caffalette2021cryoemstructureof pages 1-2</li>
+<li>caffalette2021cryoemstructureof pages 4-6</li>
+<li>garaeva2026structuralbasisof pages 2-3</li>
+<li>spellmon2022molecularbasisfor pages 9-11</li>
+<li>king2009reviewlipopolysaccharidebiosynthesis pages 25-27</li>
+<li>rocchetta1999geneticsofoantigen pages 3-4</li>
+<li>lam2011geneticandfunctional pages 18-19</li>
+<li>valvano2003exportofospecific pages 8-9</li>
+<li>caffalette2021cryoemstructureof pages 2-2</li>
+<li>king2009reviewlipopolysaccharidebiosynthesis pages 20-21</li>
+<li>caffalette2021cryoemstructureof pages 2-4</li>
+<li>bi2018architectureofa pages 4-5</li>
+<li>king2009reviewlipopolysaccharidebiosynthesis pages 23-24</li>
+<li>rocchetta1999geneticsofoantigen pages 6-8</li>
+<li>king2009reviewlipopolysaccharidebiosynthesis pages 4-5</li>
+<li>→3)-α-D-Rha-(1→3)-α-D-Rha-(1→2)-α-D-Rha-(1→</li>
+<li>https://doi.org/10.1177/1753425909106436,</li>
+<li>https://doi.org/10.1128/mmbr.63.3.523-553.1999,</li>
+<li>https://doi.org/10.2741/1079,</li>
+<li>https://doi.org/10.3389/fmicb.2011.00118,</li>
+<li>https://doi.org/10.1073/pnas.2016144118,</li>
+<li>https://doi.org/10.1038/nature25190,</li>
+<li>https://doi.org/10.1038/s41467-022-32597-2,</li>
+<li>https://doi.org/10.1038/s41467-026-70429-9,</li>
+</ol>
+            </div>
+        </details>
+
+    </div>
+
+
+    <!-- Additional Documentation Sections -->
+
+    <div class="section">
+        <h2 class="section-title">📚 Additional Documentation</h2>
+
+        <details class="markdown-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; cursor: pointer;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Notes</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(Q9HTB8-notes.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="Q9HTB8" data-a="DOC: Notes" data-r="" data-act="DOCUMENTATION" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This documentation is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This documentation needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+                <h1 id="wzm-q9htb8_pseae-pa5451-review-notes">wzm (Q9HTB8_PSEAE / PA5451) — review notes</h1>
+<h2 id="identity">Identity</h2>
+<ul>
+<li><strong>Gene</strong>: <code>wzm</code>, ordered locus <code>PA5451</code>, <em>Pseudomonas aeruginosa</em> PAO1 (taxon 208964).</li>
+<li><strong>Protein</strong>: Transport permease protein, 265 aa, ~29.5 kDa; polytopic inner-membrane protein.<br />
+  UniProt lists 6 predicted transmembrane helices and one "ABC transmembrane type-2" domain<br />
+  (PROSITE PS51012). TrEMBL (unreviewed), PE=3 (inferred from homology).</li>
+<li><strong>Family</strong>: ABC-2 integral membrane protein family (ARBA/RuleBase); PANTHER PTHR30413<br />
+  (INNER MEMBRANE TRANSPORT PERMEASE); Pfam PF01061 (ABC2_membrane); InterPro IPR000412<br />
+  (ABC_2_transport), IPR013525 / IPR047817 (ABC2_TM). TCDB 3.A.1.103.6 (ABC superfamily).</li>
+</ul>
+<h2 id="core-function-synthesis">Core function (synthesis)</h2>
+<p>Wzm is the <strong>transmembrane permease (TMD) subunit of the Wzm–Wzt ABC transporter</strong> that<br />
+<strong>exports the A-band common polysaccharide antigen (CPA; a D-rhamnan homopolymer) across the<br />
+inner (cytoplasmic) membrane</strong> during ABC-transporter-dependent LPS O-antigen assembly in<br />
+<em>P. aeruginosa</em>. Wzm provides the transmembrane conduit; the cytoplasmic Wzt subunit supplies<br />
+ATP binding/hydrolysis (NBD). It is the classic Wzm/Wzt (ABC-transporter-dependent) O-antigen<br />
+export pathway, as opposed to the Wzx/Wzy flippase/polymerase pathway used for B-band O antigen.</p>
+<h2 id="key-primary-evidence">Key primary evidence</h2>
+<ul>
+<li><strong>PMID:9244257</strong> (Rocchetta &amp; Lam, J Bacteriol 1997) — <em>identification &amp; functional<br />
+  characterization</em> of wzm and wzt in the A-band LPS biosynthesis/export cluster.</li>
+<li>"we report the characterization of two genes within the cluster, designated wzm and wzt.<br />
+    The Wzm and Wzt proteins have predicted sizes of 29.5 and 47.2 kDa … homologous to a number<br />
+    of proteins that comprise ABC (ATP-binding cassette) transport systems."</li>
+<li>"Wzm is an integral membrane protein with six potential membrane-spanning domains, while Wzt<br />
+    is an ATP-binding protein containing a highly conserved ATP-binding motif."</li>
+<li>Chromosomal wzm/wzt mutants: "were able to synthesize A-band polysaccharide, although<br />
+    transport of the polymer to the cell surface was inhibited. The inability of the polymer to<br />
+    cross the inner membrane resulted in the accumulation of cytoplasmic A-band polysaccharide."</li>
+<li>"Chromosomal mutations in wzm and wzt were found to have no effect on B-band LPS synthesis."</li>
+<li>
+<p>Note: cache is <strong>abstract-only</strong> (<code>full_text_available: false</code>); full text likely contains<br />
+    additional detail. Supports IMP annotations for LPS/O-antigen transport (loss-of-function →<br />
+    cytoplasmic accumulation, blocked surface export).</p>
+</li>
+<li>
+<p><strong>PMID:23223798</strong> (Singh et al., Integr Biol 2013) — quaternary structure of the Wzm–Wzt ABC<br />
+  transporter (FRET in living cells; heterologous expression in CHO cells).</p>
+</li>
+<li>"The polysaccharides in A-band LPSs are synthesized in the cytoplasm and translocated into<br />
+    the periplasm via an ATP-binding cassette (ABC) transporter consisting of a transmembrane<br />
+    protein, Wzm, and a cytoplasmic nucleotide-binding protein, Wzt."</li>
+<li>"Wzm forms a square-shaped homo-tetramer both in the presence and absence of Wzt"; Wzt forms<br />
+    a rhombus→square tetramer with Wzm; propose a hetero-octameric double-tetramer model.</li>
+<li>"Wzm is thought to provide a passage for PS during the translocation."</li>
+<li>Supports: Wzm is a subunit of the ABC transporter complex; oligomerizes; TMD role.</li>
+</ul>
+<h2 id="annotation-review-reasoning">Annotation review reasoning</h2>
+<p>Existing GOA annotations (10):<br />
+1. GO:0015920 lipopolysaccharide transport — IBA (GO_REF:0000033) — involved_in → <strong>ACCEPT</strong> (core; matches ABC-2 permease phylogeny + experimental data).<br />
+2. GO:0005886 plasma membrane — IEA (SubCell) — located_in → <strong>ACCEPT</strong> (bacterial inner/plasma membrane; multipass).<br />
+3. GO:0016020 membrane — IEA (InterPro/UniRule) — located_in → <strong>KEEP_AS_NON_CORE / MODIFY</strong> (too general; plasma membrane is more informative and already present).<br />
+4. GO:0043190 ABC transporter complex — IEA (InterPro/UniRule) — part_of → <strong>ACCEPT</strong> (Wzm is a bona-fide subunit; supported experimentally by PMID:23223798).<br />
+5. GO:0055085 transmembrane transport — IEA (InterPro) — involved_in → <strong>KEEP_AS_NON_CORE</strong> (correct but generic parent of LPS transport).<br />
+6. GO:0140359 ABC-type transporter activity — IEA (InterPro) — enables → <strong>ACCEPT</strong> (MF for the transporter; Wzm is the TMD subunit — contributes_to; acceptable at this granularity).<br />
+7. GO:0009243 O antigen biosynthetic process — IMP (PMID:9244257) — involved_in → <strong>ACCEPT</strong> (A-band CPA export is part of O-antigen/LPS assembly; mutant phenotype supports).<br />
+8. GO:0015920 lipopolysaccharide transport — IMP (PMID:9244257) — involved_in → <strong>ACCEPT</strong> (direct experimental support; this is the core BP).<br />
+9. GO:0055085 transmembrane transport — ISS (PMID:9244257, from Q48478) — involved_in → <strong>KEEP_AS_NON_CORE</strong> (generic; redundant with LPS transport).<br />
+10. GO:0070258 <strong>inner membrane pellicle complex</strong> — EXP (PMID:23223798) — located_in → <strong>REMOVE</strong>.<br />
+    - GO:0070258 def: "A membrane structure formed of two closely aligned lipid bilayers that lie<br />
+      beneath the plasma membrane and form part of the <strong>pellicle surrounding an apicomplexan<br />
+      parasite cell</strong>." This is a taxon-inappropriate term for a <em>Pseudomonas</em> (bacterial)<br />
+      protein — an obvious mis-mapping. The paper describes the Wzm–Wzt ABC transporter in the<br />
+      bacterial <strong>inner membrane</strong>; the intended concept is the ABC transporter complex /<br />
+      plasma membrane, already captured by GO:0043190 and GO:0005886. → REMOVE (mis-annotation).</p>
+<h2 id="candidate-more-specific-mf-for-core_functions-consideration">Candidate more-specific MF (for core_functions consideration)</h2>
+<ul>
+<li>GO:0015221 lipopolysaccharide transmembrane transporter activity — more specific than the<br />
+  generic GO:0140359; but Wzm is the membrane channel subunit (contributes_to the ABC transporter).</li>
+<li>No dedicated "O-antigen/CPA ABC exporter permease" MF term found; ABC-type transporter activity<br />
+  (GO:0140359) + LPS transmembrane transporter activity (GO:0015221) span the function.</li>
+</ul>
+<h2 id="notes-caveats">Notes / caveats</h2>
+<ul>
+<li>A-band CPA is a <strong>D-rhamnan homopolymer</strong> ("common polysaccharide antigen"); B-band = serotype-<br />
+  specific O antigen exported by the Wzx/Wzy pathway (not Wzm/Wzt).</li>
+<li>No RB-TnSeq/FEBA fitness dataset fetch command available in this repo for PSEAE; step skipped.</li>
+</ul>
+            </div>
+        </details>
+
+    </div>
+
+
+    <!-- YAML Preview Section -->
+    <div class="section">
+        <details class="yaml-preview">
+            <summary>
+                <h2 style="display: inline;">📄 View Raw YAML</h2>
+            </summary>
+            <div class="yaml-content">
+                <pre><code>id: Q9HTB8
+gene_symbol: wzm
+product_type: PROTEIN
+status: COMPLETE
+taxon:
+  id: NCBITaxon:208964
+  label: Pseudomonas aeruginosa (strain ATCC 15692 / DSM 22644 / CIP 104116 / JCM
+    14847 / LMG 12228 / 1C / PRS 101 / PAO1)
+description: Wzm is the polytopic inner-membrane permease (transmembrane domain, TMD)
+  subunit of the Wzm-Wzt ATP-binding cassette (ABC) transporter that exports the A-band
+  common polysaccharide antigen (CPA), a D-rhamnan homopolymer, across the cytoplasmic
+  (inner) membrane during ABC-transporter-dependent lipopolysaccharide O-antigen assembly
+  in Pseudomonas aeruginosa. The polysaccharide is synthesized in the cytoplasm and
+  translocated to the periplasm by this transporter; Wzm provides the transmembrane
+  conduit while the peripheral cytoplasmic Wzt subunit supplies ATP binding and hydrolysis.
+  Wzm has six predicted transmembrane helices and belongs to the ABC-2 integral membrane
+  protein family. Loss of wzm (or wzt) blocks surface expression of A-band polysaccharide
+  and causes it to accumulate in the cytoplasm, without affecting the Wzx/Wzy-dependent
+  B-band O antigen. Wzm assembles as a homotetramer that, together with a Wzt tetramer,
+  forms a hetero-octameric transporter complex.
+existing_annotations:
+- term:
+    id: GO:0015920
+    label: lipopolysaccharide transport
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: involved_in
+  review:
+    summary: Phylogenetically-inferred role in lipopolysaccharide/O-antigen transport,
+      consistent with Wzm&#39;s role as the ABC-transporter permease that exports the A-band
+      polysaccharide across the inner membrane.
+    action: ACCEPT
+    reason: This is the correct core biological process for the Wzm/Wzt ABC exporter
+      and is directly supported by experimental loss-of-function data in P. aeruginosa
+      (PMID:9244257). The IBA propagation across the ABC-2 permease family (PTHR30413)
+      is appropriate and at the right level of specificity.
+    supported_by:
+    - reference_id: PMID:9244257
+      supporting_text: transport of the polymer to the cell surface was inhibited. The
+        inability of the polymer to cross the inner membrane resulted in the accumulation
+        of cytoplasmic A-band polysaccharide.
+    - reference_id: file:PSEAE/Q9HTB8/Q9HTB8-deep-research-falcon.md
+      supporting_text: This D-rhamnan polymer is assembled on the cytoplasmic face of
+        the inner membrane on a lipid carrier (UndPP), and Wzm–Wzt transports the completed
+        polymer across the membrane to the periplasmic face
+- term:
+    id: GO:0005886
+    label: plasma membrane
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000044
+  qualifier: located_in
+  review:
+    summary: Localization to the cytoplasmic (inner/plasma) membrane, from UniProt subcellular
+      location mapping; Wzm is a multi-pass inner-membrane protein.
+    action: ACCEPT
+    reason: Correct and informative cellular component. Wzm is a polytopic inner-membrane
+      protein with six predicted transmembrane helices (UniProt), consistent with its
+      role as the membrane conduit of the ABC transporter.
+    supported_by:
+    - reference_id: PMID:23223798
+      supporting_text: an ATP-binding cassette (ABC) transporter consisting of a transmembrane
+        protein, Wzm, and a cytoplasmic nucleotide-binding protein, Wzt.
+- term:
+    id: GO:0016020
+    label: membrane
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000120
+  qualifier: located_in
+  review:
+    summary: Generic membrane localization from InterPro/UniRule electronic mapping.
+    action: KEEP_AS_NON_CORE
+    reason: Not incorrect, but a high-level parent that is subsumed by the more informative
+      plasma membrane (inner membrane) annotation. Retain as a non-core, uninformative
+      generalization rather than a core statement of localization.
+- term:
+    id: GO:0043190
+    label: ATP-binding cassette (ABC) transporter complex
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000120
+  qualifier: part_of
+  review:
+    summary: Wzm is a subunit of the ABC transporter complex; this complex membership
+      is supported experimentally by the demonstration that Wzm and Wzt form a hetero-oligomeric
+      ABC transporter.
+    action: ACCEPT
+    reason: Wzm is a bona-fide component of the Wzm-Wzt ABC transporter; the complex-level
+      annotation is correct and is corroborated by direct structural evidence that Wzm
+      forms a homotetramer that assembles with a Wzt tetramer into the functional transporter
+      (PMID:23223798).
+    supported_by:
+    - reference_id: PMID:23223798
+      supporting_text: Wzm forms a square-shaped homo-tetramer both in the presence and
+        absence of Wzt
+- term:
+    id: GO:0055085
+    label: transmembrane transport
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000002
+  qualifier: involved_in
+  review:
+    summary: Generic transmembrane transport from InterPro mapping.
+    action: KEEP_AS_NON_CORE
+    reason: Correct but a high-level parent of the specific lipopolysaccharide transport
+      process. Retain as non-core; the specific GO:0015920 annotation captures the biology.
+- term:
+    id: GO:0140359
+    label: ABC-type transporter activity
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000002
+  qualifier: enables
+  review:
+    summary: ABC-type (ATP-driven) transporter molecular function inferred from the ABC-2
+      transmembrane domain signature.
+    action: ACCEPT
+    reason: Appropriate molecular function for the transporter. Strictly, Wzm is the
+      transmembrane (permease) subunit and contributes to the ABC-type transporter activity
+      of the Wzm-Wzt complex rather than enabling it independently (ATP hydrolysis is
+      provided by Wzt), but at this granularity the term correctly captures Wzm&#39;s function
+      as part of the transporter. Captured more precisely in core_functions via contributes_to.
+    supported_by:
+    - reference_id: PMID:23223798
+      supporting_text: an ATP-binding cassette (ABC) transporter consisting of a transmembrane
+        protein, Wzm, and a cytoplasmic nucleotide-binding protein, Wzt.
+- term:
+    id: GO:0009243
+    label: O antigen biosynthetic process
+  evidence_type: IMP
+  original_reference_id: PMID:9244257
+  qualifier: involved_in
+  review:
+    summary: Experimental (mutant phenotype) support for a role in O-antigen/A-band LPS
+      assembly; wzm mutants fail to export A-band polysaccharide to the cell surface.
+    action: ACCEPT
+    reason: Wzm-mediated export across the inner membrane is a required step in ABC-transporter-dependent
+      O-antigen (A-band CPA) assembly. Chromosomal wzm mutants still synthesize the A-band
+      polysaccharide but cannot deliver it to the surface, directly implicating Wzm in
+      the biosynthetic/assembly pathway (PMID:9244257).
+    supported_by:
+    - reference_id: PMID:9244257
+      supporting_text: the wzm and wzt mutants were able to synthesize A-band polysaccharide,
+        although transport of the polymer to the cell surface was inhibited.
+- term:
+    id: GO:0015920
+    label: lipopolysaccharide transport
+  evidence_type: IMP
+  original_reference_id: PMID:9244257
+  qualifier: involved_in
+  review:
+    summary: Direct experimental (gene-replacement mutant) evidence that Wzm is required
+      to transport the A-band polysaccharide across the inner membrane to the cell surface.
+    action: ACCEPT
+    reason: This is the core, experimentally-supported function of Wzm. Chromosomal wzm
+      mutants accumulate A-band polysaccharide in the cytoplasm because the polymer cannot
+      cross the inner membrane, demonstrating a direct transport role (PMID:9244257).
+    supported_by:
+    - reference_id: PMID:9244257
+      supporting_text: The inability of the polymer to cross the inner membrane resulted
+        in the accumulation of cytoplasmic A-band polysaccharide.
+- term:
+    id: GO:0055085
+    label: transmembrane transport
+  evidence_type: ISS
+  original_reference_id: PMID:9244257
+  qualifier: involved_in
+  review:
+    summary: Sequence-similarity-based generic transmembrane transport annotation (from
+      UniProtKB:Q48478).
+    action: KEEP_AS_NON_CORE
+    reason: Correct but a high-level parent, redundant with the specific lipopolysaccharide
+      transport annotations. Retain as non-core rather than as a core statement of function.
+- term:
+    id: GO:0070258
+    label: inner membrane pellicle complex
+  evidence_type: EXP
+  original_reference_id: PMID:23223798
+  qualifier: located_in
+  review:
+    summary: Localization to an &#34;inner membrane pellicle complex&#34; — but GO:0070258 is
+      defined as a structure of the apicomplexan-parasite pellicle, which is taxonomically
+      inappropriate for a bacterium.
+    action: REMOVE
+    reason: &#39;GO:0070258 is defined as &#34;A membrane structure formed of two closely aligned
+      lipid bilayers that lie beneath the plasma membrane and form part of the pellicle
+      surrounding an apicomplexan parasite cell.&#34; This is a taxon-inappropriate term
+      for a Pseudomonas (bacterial) protein and is an erroneous mapping. The cited paper
+      (PMID:23223798) actually characterizes the Wzm-Wzt ABC transporter located in the
+      bacterial inner membrane; the intended concepts (inner-membrane ABC transporter
+      complex) are already correctly captured by GO:0043190 (ABC transporter complex)
+      and GO:0005886 (plasma/inner membrane). Recommend removal of this mis-annotation.&#39;
+    proposed_replacement_terms:
+    - id: GO:0043190
+      label: ATP-binding cassette (ABC) transporter complex
+    supported_by:
+    - reference_id: PMID:23223798
+      supporting_text: an ATP-binding cassette (ABC) transporter consisting of a transmembrane
+        protein, Wzm, and a cytoplasmic nucleotide-binding protein, Wzt.
+- term:
+    id: GO:0015221
+    label: lipopolysaccharide transmembrane transporter activity
+  evidence_type: IMP
+  original_reference_id: PMID:9244257
+  qualifier: enables
+  review:
+    summary: Proposed more-specific molecular function for Wzm as the transmembrane conduit
+      of the ABC transporter that moves the A-band polysaccharide across the inner membrane.
+    action: NEW
+    reason: The existing GOA molecular-function annotation (GO:0140359, ABC-type transporter
+      activity) is correct but generic. Wzm is the transmembrane (permease) subunit that
+      forms the channel through which the A-band lipopolysaccharide polysaccharide is
+      translocated; loss of wzm blocks passage of the polymer across the inner membrane
+      (PMID:9244257), supporting a specific lipopolysaccharide transmembrane transporter
+      activity. Recorded as a subunit-level activity that contributes to the ABC-type
+      transporter activity of the Wzm-Wzt complex.
+    supported_by:
+    - reference_id: PMID:9244257
+      supporting_text: The inability of the polymer to cross the inner membrane resulted
+        in the accumulation of cytoplasmic A-band polysaccharide.
+core_functions:
+- description: Transmembrane permease (TMD) subunit of the Wzm-Wzt ABC transporter that
+    exports the A-band common polysaccharide antigen (D-rhamnan) across the inner membrane
+    during O-antigen/LPS assembly. The subunit-specific molecular_function (GO:0015221)
+    reflects Wzm&#39;s intrinsic role as the transmembrane channel/conduit that forms the
+    translocation pathway for the polysaccharide; the full ATP-driven ABC-type transporter
+    activity (GO:0140359) is a complex-level function that additionally requires the Wzt
+    ATPase, and is therefore recorded under contributes_to_molecular_function.
+  molecular_function:
+    id: GO:0015221
+    label: lipopolysaccharide transmembrane transporter activity
+  contributes_to_molecular_function:
+    id: GO:0140359
+    label: ABC-type transporter activity
+  directly_involved_in:
+  - id: GO:0015920
+    label: lipopolysaccharide transport
+  - id: GO:0009243
+    label: O antigen biosynthetic process
+  locations:
+  - id: GO:0005886
+    label: plasma membrane
+  in_complex:
+    id: GO:0043190
+    label: ATP-binding cassette (ABC) transporter complex
+  supported_by:
+  - reference_id: PMID:9244257
+    supporting_text: The inability of the polymer to cross the inner membrane resulted
+      in the accumulation of cytoplasmic A-band polysaccharide.
+  - reference_id: PMID:23223798
+    supporting_text: an ATP-binding cassette (ABC) transporter consisting of a transmembrane
+      protein, Wzm, and a cytoplasmic nucleotide-binding protein, Wzt.
+suggested_questions:
+- question: What is the precise substrate specificity and stoichiometry of the Wzm channel
+    during D-rhamnan (A-band CPA) translocation, and does Wzm recognize the polymer directly
+    or only via Wzt?
+- question: Does Wzm contribute to substrate recognition/gating, or is its role limited
+    to forming the transmembrane conduit while Wzt provides both energy and polysaccharide
+    binding?
+suggested_experiments:
+- description: Determine a high-resolution structure (cryo-EM) of the intact P. aeruginosa
+    Wzm-Wzt transporter with and without bound D-rhamnan substrate to define the translocation
+    pathway and the Wzm homotetramer architecture in a native lipid environment.
+- description: Perform site-directed mutagenesis of predicted pore-lining residues in
+    Wzm followed by in vivo A-band CPA surface-export assays (Western blot / immuno-EM
+    with A-band-specific monoclonal antibodies) to map residues required for polysaccharide
+    translocation.
+references:
+- id: GO_REF:0000002
+  title: Gene Ontology annotation through association of InterPro records with GO
+    terms
+  findings: []
+- id: GO_REF:0000033
+  title: Annotation inferences using phylogenetic trees
+  findings: []
+- id: GO_REF:0000044
+  title: Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location
+    vocabulary mapping, accompanied by conservative changes to GO terms applied by
+    UniProt
+  findings: []
+- id: GO_REF:0000120
+  title: Combined Automated Annotation using Multiple IEA Methods
+  findings: []
+- id: file:PSEAE/Q9HTB8/Q9HTB8-deep-research-falcon.md
+  title: Deep research report (falcon/Edison) for wzm (Q9HTB8) in P. aeruginosa PAO1
+  findings:
+  - statement: Wzm is the transmembrane-domain (permease) subunit of the Wzm-Wzt ABC
+      transporter that exports the UndPP-linked common polysaccharide antigen (CPA;
+      A-band, a D-rhamnan homopolymer) from the cytoplasmic to the periplasmic face of
+      the inner membrane; loss of wzm blocks export but not polymer synthesis.
+    supporting_text: This D-rhamnan polymer is assembled on the cytoplasmic face of
+      the inner membrane on a lipid carrier (UndPP), and Wzm–Wzt transports the completed
+      polymer across the membrane to the periplasmic face
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: Provider-generated (falcon/Edison) literature synthesis; its core claims
+      (TMD permease subunit, D-rhamnan/CPA substrate, inner-membrane export, wzm-mutant
+      phenotype) are consistent with and corroborated by the primary literature
+      (PMID:9244257, PMID:23223798). Used as supporting context, not as a primary source.
+- id: PMID:23223798
+  title: Determination of the quaternary structure of a bacterial ATP-binding cassette
+    (ABC) transporter in living cells.
+  findings:
+  - statement: The A-band LPS polysaccharide is synthesized in the cytoplasm and translocated
+      to the periplasm by an ABC transporter composed of the transmembrane protein Wzm
+      and the cytoplasmic nucleotide-binding protein Wzt.
+    supporting_text: The polysaccharides in A-band LPSs are synthesized in the cytoplasm
+      and translocated into the periplasm via an ATP-binding cassette (ABC) transporter
+      consisting of a transmembrane protein, Wzm, and a cytoplasmic nucleotide-binding
+      protein, Wzt.
+  - statement: Wzm forms a homotetramer that assembles with a Wzt tetramer into a hetero-octameric
+      transporter complex.
+    supporting_text: Wzm forms a square-shaped homo-tetramer both in the presence and
+      absence of Wzt
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: PMC full text available; abstract and full text describe the Wzm-Wzt
+      ABC transporter and its quaternary structure. Note the experiments used heterologous
+      expression (CHO cells) for FRET; supports complex membership and TMD role, but the
+      inner-membrane-pellicle-complex GOA mapping derived from it (GO:0070258) is erroneous.
+- id: PMID:9244257
+  title: Identification and functional characterization of an ABC transport system
+    involved in polysaccharide export of A-band lipopolysaccharide in Pseudomonas
+    aeruginosa.
+  findings:
+  - statement: Wzm is an integral inner-membrane protein with six potential membrane-spanning
+      domains and, with the ATP-binding protein Wzt, forms an ABC transport system.
+    supporting_text: Wzm is an integral membrane protein with six potential membrane-spanning
+      domains, while Wzt is an ATP-binding protein containing a highly conserved ATP-binding
+      motif.
+  - statement: Chromosomal wzm mutants still synthesize A-band polysaccharide but fail
+      to export it to the cell surface, so the polymer accumulates in the cytoplasm; B-band
+      LPS synthesis is unaffected.
+    supporting_text: the wzm and wzt mutants were able to synthesize A-band polysaccharide,
+      although transport of the polymer to the cell surface was inhibited. The inability
+      of the polymer to cross the inner membrane resulted in the accumulation of cytoplasmic
+      A-band polysaccharide.
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: PubMed-verified; the defining functional characterization of wzm/wzt
+      in P. aeruginosa. Cache is abstract-only (full_text_available false), but the abstract
+      alone directly supports the IMP transport and O-antigen-biosynthesis annotations.
+</code></pre>
+            </div>
+        </details>
+    </div>
+
+    <!-- Pathway Visualization Link -->
+
+
+    <style>
+        /* Markdown Section Styles */
+        .markdown-section {
+            margin-bottom: 1rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .markdown-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .markdown-section summary h3 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.1rem;
+        }
+
+        .markdown-section summary:hover h3 {
+            color: #007bff;
+        }
+
+        .markdown-section[open] {
+            background-color: #fff;
+        }
+
+        .markdown-content {
+            margin-top: 1rem;
+            padding: 1rem;
+            border-top: 1px solid #dee2e6;
+        }
+
+        /* Markdown content styling */
+        .markdown-content h1 { font-size: 1.5rem; margin-top: 1.5rem; }
+        .markdown-content h2 { font-size: 1.3rem; margin-top: 1.3rem; }
+        .markdown-content h3 { font-size: 1.1rem; margin-top: 1.1rem; }
+        .markdown-content h4 { font-size: 1rem; margin-top: 1rem; }
+
+        .markdown-content pre {
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .markdown-content code {
+            background-color: #f8f9fa;
+            padding: 0.2rem 0.4rem;
+            border-radius: 3px;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+        }
+
+        .markdown-content pre code {
+            background: none;
+            padding: 0;
+        }
+
+        .markdown-content table {
+            border-collapse: collapse;
+            width: 100%;
+            margin: 1rem 0;
+        }
+
+        .markdown-content table th,
+        .markdown-content table td {
+            border: 1px solid #dee2e6;
+            padding: 0.5rem;
+            text-align: left;
+        }
+
+        .markdown-content table th {
+            background-color: #f8f9fa;
+            font-weight: bold;
+        }
+
+        .markdown-content blockquote {
+            border-left: 4px solid #007bff;
+            padding-left: 1rem;
+            margin-left: 0;
+            color: #666;
+        }
+
+        /* YAML Preview Styles */
+        .yaml-preview {
+            margin-top: 2rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .yaml-preview summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .yaml-preview summary h2 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.3rem;
+        }
+
+        .yaml-preview summary:hover h2 {
+            color: #007bff;
+        }
+
+        .yaml-preview[open] {
+            background-color: #fff;
+        }
+
+        .yaml-content {
+            margin-top: 1rem;
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .yaml-content pre {
+            margin: 0;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+            line-height: 1.4;
+        }
+
+        .yaml-content code {
+            color: #333;
+            background: none;
+            padding: 0;
+        }
+
+        /* Pathway Link Styles */
+        .pathway-link {
+            margin: 1rem 0;
+        }
+
+        .btn-link {
+            display: inline-block;
+            padding: 0.5rem 1rem;
+            background-color: #007bff;
+            color: white !important;
+            text-decoration: none;
+            border-radius: 4px;
+            font-weight: 500;
+            transition: background-color 0.2s;
+        }
+
+        .btn-link:hover {
+            background-color: #0056b3;
+            text-decoration: none;
+        }
+
+        /* Voting buttons */
+        .vote-buttons {
+            display: inline-block;
+            margin-left: 0.5rem;
+        }
+
+        .vote-btn {
+            background: none;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 2px 6px;
+            margin: 0 2px;
+            cursor: pointer;
+            font-size: 0.9rem;
+            transition: all 0.2s;
+            opacity: 0.6;
+        }
+
+        .vote-btn:hover {
+            opacity: 1;
+            transform: scale(1.1);
+        }
+
+        .vote-btn.voted {
+            opacity: 1;
+            border-color: #28a745;
+            background-color: #d4edda;
+        }
+
+        .vote-btn.voted-down {
+            border-color: #dc3545;
+            background-color: #f8d7da;
+        }
+
+        .vote-btn-small {
+            font-size: 0.7rem;
+            padding: 1px 4px;
+            margin: 0 1px;
+        }
+    </style>
+
+    <script>
+        // Add collapsible functionality
+        document.querySelectorAll('.collapsible').forEach(element => {
+            element.addEventListener('click', function() {
+                this.classList.toggle('collapsed');
+            });
+        });
+
+        // Voting functionality
+        const VOTE_URL = 'https://script.google.com/macros/s/AKfycbwPKH7d3seuPNBtB0ugVjqGeTiByyOGD5vkqB_Ck6K8eOcPQYbJqBOuz6GFgXHKBNWK/exec';
+
+        // Get or create session ID
+        let sessionId = localStorage.getItem('review_session_id');
+        if (!sessionId) {
+            sessionId = 's' + Date.now() + '_' + Math.random().toString(36).substr(2, 9);
+            localStorage.setItem('review_session_id', sessionId);
+        }
+
+        // Show previous votes on page load
+        document.addEventListener('DOMContentLoaded', function() {
+            document.querySelectorAll('.vote-buttons').forEach(container => {
+                const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+                const previousVote = localStorage.getItem(key);
+                if (previousVote) {
+                    const btn = container.querySelector(`[data-v="${previousVote}"]`);
+                    if (btn) btn.classList.add(previousVote === 'up' ? 'voted' : 'voted-down');
+                }
+            });
+        });
+
+        // Handle vote clicks - Simple image beacon approach
+        document.addEventListener('click', function(e) {
+            if (!e.target.classList.contains('vote-btn')) return;
+
+            // Prevent the click from bubbling to parent elements (like summary)
+            e.preventDefault();
+            e.stopPropagation();
+
+            const btn = e.target;
+            const container = btn.closest('.vote-buttons');
+            if (!container) return;
+
+            const voteType = btn.dataset.v;
+
+            // Check if already voted (locally)
+            const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+            const previousVote = localStorage.getItem(key);
+
+            if (previousVote === voteType) {
+                // Same vote - do nothing
+                btn.style.animation = 'shake 0.5s';
+                setTimeout(() => btn.style.animation = '', 500);
+                return;
+            }
+
+            // Build URL
+            const params = new URLSearchParams({
+                gene_id: container.dataset.g,
+                annotation_id: container.dataset.a,
+                ref_id: container.dataset.r || '',
+                action: container.dataset.act,
+                vote: voteType,
+                session_id: sessionId,
+                ua: navigator.userAgent.substring(0, 100)
+            });
+
+            // Clear previous vote styling
+            container.querySelectorAll('.vote-btn').forEach(b => {
+                b.classList.remove('voted', 'voted-down');
+            });
+
+            // Apply new vote styling immediately (optimistic UI)
+            btn.classList.add(voteType === 'up' ? 'voted' : 'voted-down');
+
+            // Store locally
+            localStorage.setItem(key, voteType);
+
+            // Send vote using fetch with no-cors mode (fire and forget)
+            const fullUrl = VOTE_URL + '?' + params;
+            console.log('Sending vote to:', fullUrl);
+
+            // Use fetch in no-cors mode - we won't get a response but the request will be sent
+            fetch(fullUrl, {
+                mode: 'no-cors',
+                method: 'GET'
+            }).then(() => {
+                console.log('Vote request sent (no response due to no-cors mode)');
+            }).catch(err => {
+                console.warn('Vote may not have been recorded, but saved locally:', err);
+
+                // Fallback: try image beacon as well
+                const img = new Image();
+                img.src = fullUrl;
+            });
+        });
+
+        // Optional: Add shake animation for feedback
+        const style = document.createElement('style');
+        style.textContent = `
+            @keyframes shake {
+                0%, 100% { transform: translateX(0); }
+                25% { transform: translateX(-5px); }
+                75% { transform: translateX(5px); }
+            }
+        `;
+        document.head.appendChild(style);
+    </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary

Automated regeneration of static assets after gene review or template changes.

## Generated Assets

| Asset | Count/Status |
|-------|--------------|
| Gene review YAML files | 2854 |
| Gene review HTML pages | 2854 |
| Project pages | 1095 |
| Module pages | 87 |
| Browser app (data.js) | Updated |
| Validation report | Updated |

## Trigger

This PR was triggered by changes to:
- genes/**/*.yaml - gene review data files
- src/ai_gene_review/schema/** - LinkML schema files
- src/ai_gene_review/templates/** - Jinja2 templates
- src/ai_gene_review/render.py - rendering code
- src/ai_gene_review/render_modules.py - module rendering code
- src/ai_gene_review/export/** - export code
- src/ai_gene_review/browser/** - browser app assets
- src/ai_gene_review/tools/minify_linkml_browser_data.py - browser data compaction
- projects/*.md - project definitions
- modules/**/*.yaml - module definitions
- project.justfile - just recipes used by CI
- .github/workflows/generate-pages.yaml - workflow definition

## Review

- [ ] Spot-check a few gene review HTML pages render correctly
- [ ] Spot-check module tree browser pages render correctly
- [ ] Verify browser app loads and filters work
- [ ] Check validation report for new issues
