### PR TITLE
Regenerate pages and browser app

### DIFF
--- a/genes/worm/dyf-1/dyf-1-ai-review.html
+++ b/genes/worm/dyf-1/dyf-1-ai-review.html
@@ -1,0 +1,3380 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>dyf-1 - AI Gene Review</title>
+    <style>
+        :root {
+            --color-accept: #22c55e;
+            --color-remove: #ef4444;
+            --color-modify: #f97316;
+            --color-keep-non-core: #3b82f6;
+            --color-undecided: #6b7280;
+            --color-new: #8b5cf6;
+            --color-mark-over: #eab308;
+            --bg-light: #f9fafb;
+            --border-color: #e5e7eb;
+            --text-muted: #6b7280;
+            --text-primary: #111827;
+        }
+
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+            line-height: 1.6;
+            color: var(--text-primary);
+            background-color: #ffffff;
+            padding: 2rem;
+            max-width: 1400px;
+            margin: 0 auto;
+        }
+
+        .header {
+            border-bottom: 2px solid var(--border-color);
+            padding-bottom: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        h1 {
+            font-size: 2.5rem;
+            font-weight: 700;
+            margin-bottom: 0.5rem;
+            color: #1f2937;
+        }
+
+        .gene-info {
+            display: flex;
+            gap: 2rem;
+            flex-wrap: wrap;
+            margin-top: 1rem;
+        }
+
+        .info-item {
+            display: flex;
+            gap: 0.5rem;
+        }
+
+        .info-label {
+            font-weight: 600;
+            color: var(--text-muted);
+        }
+
+        .aliases {
+            display: flex;
+            gap: 0.5rem;
+            flex-wrap: wrap;
+        }
+
+        .badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.875rem;
+            font-weight: 500;
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+        }
+
+        .status-badge {
+            padding: 0.375rem 0.875rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .status-initialized {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fde68a;
+        }
+
+        .status-in-progress {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+        }
+
+        .status-draft {
+            background-color: #fce7f3;
+            color: #831843;
+            border: 1px solid #fbcfe8;
+        }
+
+        .status-complete {
+            background-color: #d1fae5;
+            color: #065f46;
+            border: 1px solid #a7f3d0;
+        }
+
+        .description-card {
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        .description-card h2 {
+            font-size: 1.25rem;
+            margin-bottom: 1rem;
+            color: #374151;
+        }
+
+        .section {
+            margin-bottom: 2.5rem;
+        }
+
+        .section-title {
+            font-size: 1.5rem;
+            font-weight: 600;
+            margin-bottom: 1.5rem;
+            color: #1f2937;
+            border-bottom: 1px solid var(--border-color);
+            padding-bottom: 0.5rem;
+        }
+
+        .annotations-table {
+            width: 100%;
+            border-collapse: collapse;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            overflow: hidden;
+        }
+
+        .annotations-table thead {
+            background-color: var(--bg-light);
+        }
+
+        .annotations-table th {
+            text-align: left;
+            padding: 1rem;
+            font-weight: 600;
+            border-bottom: 2px solid var(--border-color);
+            font-size: 0.875rem;
+            text-transform: uppercase;
+            letter-spacing: 0.05em;
+            color: var(--text-muted);
+        }
+
+        .annotations-table td {
+            padding: 1rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .annotations-table tbody tr:hover {
+            background-color: #f9fafb;
+        }
+
+        .action-badge {
+            display: inline-block;
+            padding: 0.375rem 0.75rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .action-accept {
+            background-color: var(--color-accept);
+            color: white;
+        }
+
+        .action-remove {
+            background-color: var(--color-remove);
+            color: white;
+        }
+
+        .action-modify {
+            background-color: var(--color-modify);
+            color: white;
+        }
+
+        .action-keep_as_non_core {
+            background-color: var(--color-keep-non-core);
+            color: white;
+        }
+
+        .action-undecided {
+            background-color: var(--color-undecided);
+            color: white;
+        }
+
+        .action-new {
+            background-color: var(--color-new);
+            color: white;
+        }
+
+        .action-mark_as_over_annotated {
+            background-color: var(--color-mark-over);
+            color: white;
+        }
+
+        .term-info {
+            display: flex;
+            flex-direction: column;
+            gap: 0.25rem;
+        }
+
+        .term-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .term-label {
+            font-weight: 500;
+        }
+
+        .evidence-code {
+            font-family: monospace;
+            background-color: var(--bg-light);
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .not-badge {
+            display: inline-block;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-weight: 600;
+            margin-left: 0.25rem;
+        }
+
+        .isoform-badge {
+            display: inline-block;
+            background-color: #eff6ff;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            margin-top: 0.25rem;
+        }
+
+        .core-function-card {
+            background-color: white;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 1rem;
+        }
+
+        .core-function-card h3 {
+            font-size: 1.125rem;
+            margin-bottom: 1rem;
+            color: #1f2937;
+        }
+
+        .core-function-statement {
+            margin-bottom: 1rem;
+            padding: 0.75rem;
+            background-color: var(--bg-light);
+            border-left: 4px solid var(--color-accept);
+            border-radius: 0.25rem;
+        }
+
+        .function-annotations {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin-top: 1rem;
+        }
+
+        .reference-item {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+        }
+
+        .reference-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: start;
+            margin-bottom: 0.75rem;
+        }
+
+        .reference-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #2563eb;
+        }
+
+        .supported-by {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f3f4f6;
+            border-left: 3px solid #3b82f6;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .supported-by-title {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .support-item {
+            margin-bottom: 0.5rem;
+        }
+
+        .support-ref {
+            font-weight: 500;
+            color: #2563eb;
+        }
+
+        .support-text {
+            color: #6b7280;
+            font-style: italic;
+            margin-left: 1rem;
+        }
+
+        .propagation-review {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f8fafc;
+            border-left: 3px solid #64748b;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .propagation-title {
+            font-weight: 600;
+            color: #334155;
+            margin-bottom: 0.25rem;
+        }
+
+        .propagation-row {
+            margin-top: 0.25rem;
+        }
+
+        .propagation-source {
+            margin-top: 0.5rem;
+            padding-top: 0.5rem;
+            border-top: 1px solid #e5e7eb;
+        }
+
+        .propagation-source-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #1d4ed8;
+        }
+
+        .propagation-comment {
+            color: #4b5563;
+            margin-left: 1rem;
+        }
+
+        a.term-link {
+            color: #2563eb;
+            text-decoration: none;
+        }
+
+        a.term-link:hover {
+            text-decoration: underline;
+        }
+
+        .core-function-terms {
+            margin-top: 1rem;
+        }
+
+        .function-term-group {
+            margin-bottom: 1rem;
+        }
+
+        .function-term-label {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .reference-title {
+            font-weight: 500;
+            margin-bottom: 0.5rem;
+        }
+
+        .findings-list {
+            margin-top: 1rem;
+            padding-left: 1.5rem;
+        }
+
+        .finding-item {
+            margin-bottom: 0.75rem;
+        }
+
+        .finding-statement {
+            font-weight: 500;
+            margin-bottom: 0.25rem;
+        }
+
+        .finding-text {
+            color: var(--text-muted);
+            font-size: 0.95rem;
+            font-style: italic;
+        }
+
+        .proposed-term {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #fef3c7;
+        }
+
+        .question-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #dbeafe;
+        }
+
+        .experiment-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #f3e8ff;
+        }
+
+        .prediction-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: white;
+        }
+
+        .prediction-card .prediction-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+        }
+
+        .prediction-source {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+        }
+
+        .assessment-badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.8rem;
+            font-weight: 600;
+            text-transform: uppercase;
+        }
+
+        .assessment-cor { background-color: #dcfce7; color: #166534; }
+        .assessment-cnn { background-color: #dbeafe; color: #1e40af; }
+        .assessment-lsp { background-color: #fef9c3; color: #854d0e; }
+        .assessment-unc { background-color: #f3f4f6; color: #374151; }
+        .assessment-pli { background-color: #fee2e2; color: #991b1b; }
+        .assessment-npi { background-color: #fecaca; color: #7f1d1d; }
+        .assessment-rep { background-color: #fde68a; color: #92400e; }
+
+        .confidence-score {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+            margin-left: 0.5rem;
+        }
+
+        .error-type-badge {
+            font-size: 0.75rem;
+            padding: 0.125rem 0.5rem;
+            border-radius: 0.25rem;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+        }
+
+        .isoforms-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fill, minmax(400px, 1fr));
+            gap: 1rem;
+        }
+
+        .isoform-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            background-color: white;
+            transition: box-shadow 0.2s;
+        }
+
+        .isoform-card:hover {
+            box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+        }
+
+        .functional-isoform-type {
+            display: inline-block;
+            padding: 0.2rem 0.5rem;
+            border-radius: 0.25rem;
+            font-size: 0.7rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.03em;
+        }
+
+        .type-SPLICE_VARIANT, .type-SPLICE_CLASS {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #93c5fd;
+        }
+
+        .type-CLEAVAGE_PRODUCT {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fcd34d;
+        }
+
+        .type-MODIFICATION_STATE {
+            background-color: #f3e8ff;
+            color: #6b21a8;
+            border: 1px solid #c4b5fd;
+        }
+
+        .type-CONFORMATIONAL_STATE {
+            background-color: #dcfce7;
+            color: #166534;
+            border: 1px solid #86efac;
+        }
+
+        .functional-isoform-mappings {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+            font-size: 0.85rem;
+        }
+
+        .functional-isoform-mappings .mapping-type {
+            font-weight: 600;
+            color: var(--text-muted);
+            font-size: 0.75rem;
+        }
+
+        .functional-isoform-go {
+            margin-top: 0.5rem;
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.25rem;
+        }
+
+        .go-chip {
+            display: inline-block;
+            padding: 0.15rem 0.4rem;
+            background-color: #ecfdf5;
+            color: #047857;
+            border: 1px solid #a7f3d0;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-family: monospace;
+        }
+
+        .isoform-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+            padding-bottom: 0.5rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .isoform-name {
+            font-weight: 600;
+            font-size: 1.1rem;
+            color: #1f2937;
+        }
+
+        .isoform-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .isoform-sequence-note {
+            font-size: 0.875rem;
+            color: var(--text-muted);
+            margin-bottom: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+        }
+
+        .isoform-description {
+            font-size: 0.95rem;
+            line-height: 1.5;
+        }
+
+        .collapsible {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .collapsible:after {
+            content: ' ▼';
+            font-size: 0.75rem;
+        }
+
+        .collapsible.collapsed:after {
+            content: ' ►';
+        }
+
+        .collapse-content {
+            transition: max-height 0.3s ease;
+            overflow: hidden;
+        }
+
+        .collapsed + .collapse-content {
+            max-height: 0;
+        }
+
+        .no-data {
+            color: var(--text-muted);
+            font-style: italic;
+            padding: 1rem;
+            text-align: center;
+            background-color: var(--bg-light);
+            border-radius: 0.5rem;
+        }
+
+        /* Styling for markdown section summaries with voting */
+        .markdown-section summary {
+            padding: 0.75rem;
+            background: var(--bg-light);
+            border-radius: 0.5rem;
+            margin-bottom: 0.5rem;
+        }
+
+        .markdown-section summary:hover {
+            background: #e5e7eb;
+        }
+
+        .markdown-section summary .vote-buttons {
+            margin-left: auto;
+        }
+
+        .deep-research-section {
+            margin-bottom: 1rem;
+            border: 1px solid #c7d2fe;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8faff;
+        }
+
+        .deep-research-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .deep-research-section summary h3 {
+            margin: 0;
+            color: #3730a3;
+            font-size: 1.1rem;
+        }
+
+        .report-meta {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin: 0.75rem 0 1rem;
+            align-items: center;
+        }
+
+        .report-badge {
+            display: inline-flex;
+            align-items: center;
+            border: 1px solid #c7d2fe;
+            border-radius: 999px;
+            background: #eef2ff;
+            color: #4338ca;
+            font-size: 0.78rem;
+            font-weight: 600;
+            padding: 0.2rem 0.6rem;
+        }
+
+        .report-meta-text {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+        }
+
+        .artifact-list {
+            display: grid;
+            gap: 0.75rem;
+            margin: 0.75rem 0 1rem;
+        }
+
+        .artifact-link {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+            margin-top: 0.5rem;
+            word-break: break-word;
+        }
+
+        @media print {
+            body {
+                padding: 1rem;
+            }
+
+            .collapsible:after {
+                display: none;
+            }
+
+            .collapsed + .collapse-content {
+                max-height: none !important;
+            }
+        }
+
+        @media (max-width: 768px) {
+            body {
+                padding: 1rem;
+            }
+
+            h1 {
+                font-size: 2rem;
+            }
+
+            .annotations-table {
+                font-size: 0.875rem;
+            }
+
+            .annotations-table th,
+            .annotations-table td {
+                padding: 0.5rem;
+            }
+        }
+    </style>
+</head>
+<body>
+    <div class="header">
+        <h1>dyf-1</h1>
+        <div class="gene-info">
+
+            <div class="info-item">
+
+                <span class="info-label">UniProt ID:</span>
+                <span>
+                    <a href="https://www.uniprot.org/uniprotkb/Q8I7G4" target="_blank" class="term-link">
+                        Q8I7G4
+                    </a>
+                </span>
+
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Organism:</span>
+                <span>Caenorhabditis elegans</span>
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Review Status:</span>
+                <span class="status-badge status-complete">
+                    COMPLETE
+                </span>
+            </div>
+
+
+        </div>
+        <div style="margin-top: 1rem; text-align: center;">
+            <a id="feedback-form-link"
+               href="#"
+               target="_blank"
+               style="display: inline-block; padding: 10px 20px; background-color: #4CAF50; color: white; text-decoration: none; border-radius: 5px; font-weight: 600;">
+                📝 Provide Detailed Feedback
+            </a>
+            <script>
+                // Construct the form URL with proper encoding
+                // Extract organism code from the current page path (e.g., /genes/ARATH/APO1/ -> ARATH)
+                const pathParts = window.location.pathname.split('/');
+                const genesIndex = pathParts.indexOf('genes');
+                let organism = '';
+                if (genesIndex !== -1 && pathParts[genesIndex + 1]) {
+                    organism = pathParts[genesIndex + 1].toUpperCase();
+                }
+                const geneSymbol = "dyf-1";
+                const speciesGene = organism + ' ' + geneSymbol;
+                const formBaseUrl = 'https://docs.google.com/forms/d/e/1FAIpQLSdTot9L6GVkkZYgLQT0E8ZdAJv8RiN5ZgOVkgWNcKSbYvxxzQ/viewform';
+                const entryId = '1226477767'; // Correct entry ID for Species/Gene field
+                const formUrl = formBaseUrl + '?entry.' + entryId + '=' + encodeURIComponent(speciesGene);
+                const feedbackLink = document.getElementById('feedback-form-link');
+                feedbackLink.href = formUrl;
+                // Add tooltip showing the pre-filled value
+                feedbackLink.title = 'Opens form with pre-filled: ' + speciesGene;
+            </script>
+        </div>
+    </div>
+
+
+    <div class="description-card">
+        <div style="display: flex; justify-content: space-between; align-items: center;">
+            <h2>Gene Description</h2>
+            <span class="vote-buttons" data-g="Q8I7G4" data-a="DESCRIPTION: DYF-1 is a tetratricopeptide-repeat (TPR) protein ..." data-r="" data-act="DESCRIPTION">
+                <button class="vote-btn" data-v="up" title="Agree with this description">👍</button>
+                <button class="vote-btn" data-v="down" title="Disagree with this description">👎</button>
+            </span>
+        </div>
+        <p>DYF-1 is a tetratricopeptide-repeat (TPR) protein and a subunit of intraflagellar transport (IFT) complex B, the anterograde IFT module that builds and maintains cilia. It is the Caenorhabditis elegans ortholog of human TTC30A/TTC30B and of the ciliate/algal IFT70, and its name reflects the abnormal dye-filling (Dyf) phenotype of its mutants. DYF-1 is expressed in ciliated sensory neurons and localizes to the ciliary basal body and the axoneme, moving processively along the axoneme as part of IFT trains. Its central role is to act as an obligatory activator/adaptor for the homodimeric kinesin-2 motor OSM-3 (the KIF17 ortholog): DYF-1 is specifically required for OSM-3 to dock onto and move IFT particles, and in its absence OSM-3 is inactive so that IFT trains are carried by heterotrimeric kinesin-II alone and the distal singlet segments of amphid and phasmid cilia fail to form. As an IFT-B component DYF-1 is required for normal ciliogenesis and for delivery of ciliary cargo, and DYF-1/IFT70 is additionally required for polyglutamylation of the axonemal tubulin of sensory cilia.</p>
+    </div>
+
+
+
+
+
+
+
+    <div class="section">
+        <h2 class="section-title">Existing Annotations Review</h2>
+        <table class="annotations-table">
+            <thead>
+                <tr>
+                    <th>GO Term</th>
+                    <th>Evidence</th>
+                    <th>Action</th>
+                    <th>Reason</th>
+                </tr>
+            </thead>
+            <tbody>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0030992" target="_blank" class="term-link">
+                                    GO:0030992
+                                </a>
+                            </span>
+                            <span class="term-label">intraciliary transport particle B</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q8I7G4" data-a="GO:0030992" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> DYF-1 is a subunit of intraflagellar transport complex B (IFT-B). This IBA transfer is strongly corroborated experimentally: DYF-1 was identified in the C. elegans IFT-B complex by mass spectrometry (PMID:28479320; ComplexPortal CPX-1290).
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Core cellular-component identity of DYF-1. Phylogenetically inferred and independently confirmed by biochemical identification of DYF-1 in worm IFT-B.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/28479320" target="_blank" class="term-link">
+                                        PMID:28479320
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">intraflagellar transport (IFT)-B complex abolishes dynein-2&#39;s ciliary localization</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0042073" target="_blank" class="term-link">
+                                    GO:0042073
+                                </a>
+                            </span>
+                            <span class="term-label">intraciliary transport</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q8I7G4" data-a="GO:0042073" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> DYF-1 functions in intraflagellar (intraciliary) transport as an IFT-B subunit and OSM-3 kinesin activator. IBA is well supported by the C. elegans experimental data.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Core biological process. Confirmed experimentally in worm (PMID:16049494): DYF-1 is required for OSM-3 to move IFT particles.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/16049494" target="_blank" class="term-link">
+                                        PMID:16049494
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">specifically required for OSM-3 kinesin to dock onto and move IFT particles</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005879" target="_blank" class="term-link">
+                                    GO:0005879
+                                </a>
+                            </span>
+                            <span class="term-label">axonemal microtubule</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q8I7G4" data-a="GO:0005879" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> DYF-1 acts along axonemal microtubules, where IFT trains move. The is_active_in qualifier is appropriate for an IFT motor-associated protein that translocates along the axoneme; corroborated by the experimental IDA localization (PMID:16049494).
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Consistent with DYF-1&#39;s role as an axoneme-associated IFT-B component that undergoes IFT along ciliary microtubules.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0120170" target="_blank" class="term-link">
+                                    GO:0120170
+                                </a>
+                            </span>
+                            <span class="term-label">intraciliary transport particle B binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q8I7G4" data-a="GO:0120170" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> DYF-1 binds the IFT-B particle as one of its subunits. This is the most informative molecular-function term available for DYF-1 and is preferable to generic protein binding.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Captures DYF-1&#39;s molecular function as an IFT-B-associated protein. Note this binding term does not express DYF-1&#39;s distinctive OSM-3-kinesin-activation activity, which has no dedicated GO MF term (see knowledge_gaps).
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/28479320" target="_blank" class="term-link">
+                                        PMID:28479320
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">intraflagellar transport (IFT)-B complex abolishes dynein-2&#39;s ciliary localization</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005929" target="_blank" class="term-link">
+                                    GO:0005929
+                                </a>
+                            </span>
+                            <span class="term-label">cilium</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000044
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q8I7G4" data-a="GO:0005929" data-r="GO_REF:0000044" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> DYF-1 localizes to the cilium. Electronic mapping from the UniProt Cilium subcellular keyword; redundant with the experimental IDA cilium annotation.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct location, independently supported by experimental evidence (PMID:16049494).
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005929" target="_blank" class="term-link">
+                                    GO:0005929
+                                </a>
+                            </span>
+                            <span class="term-label">cilium</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">NAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/28479320" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:28479320
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Dynein-Driven Retrograde Intraflagellar Transport Is Triphas...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q8I7G4" data-a="GO:0005929" data-r="PMID:28479320" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> DYF-1 localizes to the cilium as an IFT-B component (ComplexPortal NAS from PMID:28479320).
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct ciliary localization; consistent with IFT-B membership and IDA evidence.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0030992" target="_blank" class="term-link">
+                                    GO:0030992
+                                </a>
+                            </span>
+                            <span class="term-label">intraciliary transport particle B</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">NAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/28479320" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:28479320
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Dynein-Driven Retrograde Intraflagellar Transport Is Triphas...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q8I7G4" data-a="GO:0030992" data-r="PMID:28479320" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> DYF-1 is part of IFT complex B, identified by mass spectrometry in C. elegans (PMID:28479320) and curated by ComplexPortal (CPX-1290).
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Direct experimental/curated support for IFT-B membership; the strongest evidence for this core cellular-component identity.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/28479320" target="_blank" class="term-link">
+                                        PMID:28479320
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">intraflagellar transport (IFT)-B complex abolishes dynein-2&#39;s ciliary localization</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0042073" target="_blank" class="term-link">
+                                    GO:0042073
+                                </a>
+                            </span>
+                            <span class="term-label">intraciliary transport</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">NAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/28479320" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:28479320
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Dynein-Driven Retrograde Intraflagellar Transport Is Triphas...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q8I7G4" data-a="GO:0042073" data-r="PMID:28479320" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> DYF-1 participates in intraciliary transport as an IFT-B subunit (ComplexPortal NAS from PMID:28479320).
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Core biological process; concordant with the IBA and IMP intraciliary-transport rows.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0060271" target="_blank" class="term-link">
+                                    GO:0060271
+                                </a>
+                            </span>
+                            <span class="term-label">cilium assembly</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">NAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/28479320" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:28479320
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Dynein-Driven Retrograde Intraflagellar Transport Is Triphas...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q8I7G4" data-a="GO:0060271" data-r="PMID:28479320" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> As an IFT-B component required for anterograde transport, DYF-1 is required for cilium assembly; the distal singlet segments of amphid/phasmid cilia fail to form in dyf-1 mutants (via loss of OSM-3 activity).
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> IFT-B is essential for ciliogenesis; this NAS annotation is well grounded in DYF-1&#39;s role in building the distal ciliary segment.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/28479320" target="_blank" class="term-link">
+                                        PMID:28479320
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">essential for cilium formation and maintenance</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0072659" target="_blank" class="term-link">
+                                    GO:0072659
+                                </a>
+                            </span>
+                            <span class="term-label">protein localization to plasma membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IMP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/16049494" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:16049494
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Functional coordination of intraflagellar transport motors.
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-undecided">
+                            UNDECIDED
+                        </span>
+                        <span class="vote-buttons" data-g="Q8I7G4" data-a="GO:0072659" data-r="PMID:16049494" data-act="UNDECIDED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> This IMP is attributed to PMID:16049494 (Ou et al. 2005), whose cached abstract is entirely about coordination of the kinesin-II and OSM-3 IFT motors and does not address localization of any plasma-membrane/ciliary-membrane protein. The generic term protein localization to plasma membrane is also imprecise for a ciliary IFT role (ciliary membrane rather than bulk plasma membrane).
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Cannot verify the supporting evidence: the cached publication is abstract-only and the abstract does not mention membrane-protein localization, and no specific mislocalized cargo can be identified from the accessible text. Per review guidelines, marked UNDECIDED rather than removed, since the curator may have used full-text/supplementary data not available here.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0036064" target="_blank" class="term-link">
+                                    GO:0036064
+                                </a>
+                            </span>
+                            <span class="term-label">ciliary basal body</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/22922713" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:22922713
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    The BBSome controls IFT assembly and turnaround in cilia.
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q8I7G4" data-a="GO:0036064" data-r="PMID:22922713" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> DYF-1 localizes to the ciliary basal body (ciliary base), the docking/loading zone where IFT trains assemble. Basal-body localization is a defining feature of IFT-B proteins, which build and load onto IFT trains at the ciliary base.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Experimental IDA (assigned_by MGI) consistent with DYF-1&#39;s role as an IFT-B subunit that docks at the ciliary base. DYF-1 is not named in the cached main text of PMID:22922713 (which foregrounds dyf-2/bbs-1); per review guidelines the experimental annotation is retained and deferred to the curator rather than removed, and the citation is flagged UNVERIFIED in reference_review.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005879" target="_blank" class="term-link">
+                                    GO:0005879
+                                </a>
+                            </span>
+                            <span class="term-label">axonemal microtubule</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/16049494" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:16049494
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Functional coordination of intraflagellar transport motors.
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q8I7G4" data-a="GO:0005879" data-r="PMID:16049494" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> DYF-1::GFP localizes along the ciliary axoneme and undergoes IFT (Ou et al. 2005), consistent with an axonemal-microtubule location.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Experimental localization supporting DYF-1&#39;s presence along axonemal microtubules; concordant with the IBA is_active_in axonemal-microtubule row.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005929" target="_blank" class="term-link">
+                                    GO:0005929
+                                </a>
+                            </span>
+                            <span class="term-label">cilium</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/16049494" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:16049494
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Functional coordination of intraflagellar transport motors.
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q8I7G4" data-a="GO:0005929" data-r="PMID:16049494" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> DYF-1 is directly observed in the cilium (Ou et al. 2005). UniProt records the subcellular location Cell projection, cilium from this study.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Experimental (IDA) ciliary localization; the best-supported location annotation.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0018095" target="_blank" class="term-link">
+                                    GO:0018095
+                                </a>
+                            </span>
+                            <span class="term-label">protein polyglutamylation</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IMP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/16049494" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:16049494
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Functional coordination of intraflagellar transport motors.
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="Q8I7G4" data-a="GO:0018095" data-r="PMID:16049494" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> DYF-1/IFT70 is required for tubulin polyglutamylation of the ciliary axoneme. This is a genuine, literature-established function of dyf-1 shown directly in C. elegans by Pathak et al. 2007 (PMID:17761526), although GOA cites it here to PMID:16049494, whose abstract does not address polyglutamylation. It is a downstream/indirect role, not DYF-1&#39;s core molecular activity.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Real but non-core: DYF-1 is not itself a glutamylase; polyglutamylation loss is a consequence of DYF-1 dysfunction (whether via failed IFT-delivery of a glutamylase or via the B-tubule/axoneme structural defect is unresolved; see knowledge_gaps). Retained because the function is well supported; supporting text drawn from the definitive paper (PMID:17761526) rather than the GOA-cited PMID:16049494.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/17761526" target="_blank" class="term-link">
+                                        PMID:17761526
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">dyf-1, is also required for tubulin polyglutamylation in sensory neuron cilia</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0042073" target="_blank" class="term-link">
+                                    GO:0042073
+                                </a>
+                            </span>
+                            <span class="term-label">intraciliary transport</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IMP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/16049494" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:16049494
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Functional coordination of intraflagellar transport motors.
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q8I7G4" data-a="GO:0042073" data-r="PMID:16049494" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Direct experimental evidence (IMP): in dyf-1 mutants OSM-3 is inactive and IFT particles are moved by kinesin-II alone, so distal singlet ciliary segments are not built. This is the primary experimental support for DYF-1&#39;s role in intraciliary transport.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Strongest experimental evidence for DYF-1&#39;s core function in anterograde IFT via OSM-3 activation.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/16049494" target="_blank" class="term-link">
+                                        PMID:16049494
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">specifically required for OSM-3 kinesin to dock onto and move IFT particles</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/16049494" target="_blank" class="term-link">
+                                        PMID:16049494
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">an OSM-3 kinesin activator in the formation of two IFT pathways</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0035720" target="_blank" class="term-link">
+                                    GO:0035720
+                                </a>
+                            </span>
+                            <span class="term-label">intraciliary anterograde transport</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IMP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/16049494" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:16049494
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Functional coordination of intraflagellar transport motors.
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-new">
+                            NEW
+                        </span>
+                        <span class="vote-buttons" data-g="Q8I7G4" data-a="GO:0035720" data-r="PMID:16049494" data-act="NEW">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> NEW (proposed, more specific). DYF-1 acts specifically in ANTEROGRADE intraciliary transport: it is required for the anterograde kinesin-2 motor OSM-3 to dock onto and move IFT particles, building the distal singlet segment of amphid/phasmid cilia. The current GOA rows use the generic parent term intraciliary transport (GO:0042073); the anterograde-specific child term more precisely captures DYF-1&#39;s role.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> DYF-1&#39;s function is anterograde-specific (OSM-3 activation), so intraciliary anterograde transport (GO:0035720) is more informative than the generic GO:0042073 already annotated by GOA.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/16049494" target="_blank" class="term-link">
+                                        PMID:16049494
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">specifically required for OSM-3 kinesin to dock onto and move IFT particles</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+            </tbody>
+        </table>
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Core Functions</h2>
+
+        <div class="core-function-card">
+
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+                <h3>DYF-1 is a tetratricopeptide-repeat subunit of intraflagellar transport complex B that acts as the obligatory activator/adaptor coupling the homodimeric kinesin-2 motor OSM-3 to anterograde IFT trains. DYF-1 is specifically required for OSM-3 to dock onto and move IFT particles; in its absence OSM-3 is inactive, IFT trains are moved by heterotrimeric kinesin-II alone, and the distal singlet segments of amphid/phasmid sensory cilia fail to form. It functions at the ciliary basal body (train assembly/loading) and along axonemal microtubules, and is required for ciliogenesis of sensory cilia.</h3>
+                <span class="vote-buttons" data-g="Q8I7G4" data-a="FUNCTION: DYF-1 is a tetratricopeptide-repeat subunit of int..." data-r="" data-act="CORE_FUNCTION">
+                    <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
+                    <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
+                </span>
+            </div>
+
+
+            <div class="core-function-terms">
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Molecular Function:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0120170" target="_blank" class="term-link">
+                            intraciliary transport particle B binding
+                        </a>
+                    </span>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Directly Involved In:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0035720" target="_blank" class="term-link">
+                                intraciliary anterograde transport
+                            </a>
+                        </span>
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0060271" target="_blank" class="term-link">
+                                cilium assembly
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Cellular Locations:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0036064" target="_blank" class="term-link">
+                                ciliary basal body
+                            </a>
+                        </span>
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005879" target="_blank" class="term-link">
+                                axonemal microtubule
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">In Complex:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0030992" target="_blank" class="term-link">
+                            intraciliary transport particle B
+                        </a>
+                    </span>
+                </div>
+
+
+
+            </div>
+
+
+            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
+                <strong>Supporting Evidence:</strong>
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/16049494" target="_blank" class="term-link">
+                                PMID:16049494
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">specifically required for OSM-3 kinesin to dock onto and move IFT particles</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/28479320" target="_blank" class="term-link">
+                                PMID:28479320
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">intraflagellar transport (IFT)-B complex abolishes dynein-2&#39;s ciliary localization</div>
+
+                    </li>
+
+                </ul>
+            </div>
+
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title collapsible">References</h2>
+        <div class="collapse-content">
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000033.md" target="_blank" class="term-link">
+                            GO_REF:0000033
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Annotation inferences using phylogenetic trees</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000044.md" target="_blank" class="term-link">
+                            GO_REF:0000044
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location vocabulary mapping, accompanied by conservative changes to GO terms applied by UniProt</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/16049494" target="_blank" class="term-link">
+                            PMID:16049494
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Functional coordination of intraflagellar transport motors.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/17761526" target="_blank" class="term-link">
+                            PMID:17761526
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">The zebrafish fleer gene encodes an essential regulator of cilia tubulin polyglutamylation.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/22922713" target="_blank" class="term-link">
+                            PMID:22922713
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">The BBSome controls IFT assembly and turnaround in cilia.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/28479320" target="_blank" class="term-link">
+                            PMID:28479320
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Dynein-Driven Retrograde Intraflagellar Transport Is Triphasic in C. elegans Sensory Cilia.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/15916950" target="_blank" class="term-link">
+                            PMID:15916950
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Functional genomics of the cilium, a sensory organelle.</div>
+
+
+            </div>
+
+        </div>
+    </div>
+
+
+
+
+    <div class="section">
+        <h2 class="section-title">Suggested Questions for Experts</h2>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> Does DYF-1 bind OSM-3 directly, and does it activate the motor by relieving OSM-3 autoinhibition or by tethering OSM-3 to the IFT-B core?</p>
+
+                </div>
+                <span class="vote-buttons" data-g="Q8I7G4" data-a="Q: Does DYF-1 bind OSM-3 directly, and does it activa..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> Is the polyglutamylation defect in dyf-1 mutants a direct consequence of failed IFT delivery of a tubulin glutamylase, or an indirect result of the B-tubule structural defect?</p>
+
+                </div>
+                <span class="vote-buttons" data-g="Q8I7G4" data-a="Q: Is the polyglutamylation defect in dyf-1 mutants a..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Suggested Experiments</h2>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> Reconstitute purified OSM-3 with DYF-1 and IFT-B and measure single-molecule motility and ATPase activity +/- DYF-1; map the DYF-1-OSM-3 interaction by crosslinking/MS or cryo-EM, and test separation-of-function dyf-1 alleles in vivo for IFT-B binding vs OSM-3 activation.</p>
+
+
+                    <p style="margin-top: 0.5rem;"><em>Hypothesis: DYF-1 activates OSM-3 by direct binding that relieves OSM-3 motor autoinhibition and docks it onto IFT-B.</em></p>
+
+
+                    <p style="margin-top: 0.5rem;">Type: in vitro reconstitution / single-molecule motility / structural biology</p>
+
+                </div>
+                <span class="vote-buttons" data-g="Q8I7G4" data-a="EXPERIMENT: Reconstitute purified OSM-3 with DYF-1 and IFT-B a..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> Image candidate TTLL glutamylases for IFT-dependent ciliary transport and co-movement with DYF-1/IFT-B; test whether glutamylase ciliary entry and axonemal polyglutamylation are lost in dyf-1 mutants while scoring axonemal ultrastructure across an allelic series.</p>
+
+
+                    <p style="margin-top: 0.5rem;"><em>Hypothesis: DYF-1/IFT-B is required to transport a tubulin polyglutamylase (or its substrate) into the cilium.</em></p>
+
+
+                    <p style="margin-top: 0.5rem;">Type: live-cell IFT imaging / genetics</p>
+
+                </div>
+                <span class="vote-buttons" data-g="Q8I7G4" data-a="EXPERIMENT: Image candidate TTLL glutamylases for IFT-dependen..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Knowledge Gaps</h2>
+        <p style="color: #555; font-size: 0.92rem; margin-top: -0.3rem;">
+            What is <em>not</em> known — curated, literature-grounded statements of the open
+            unknowns (the inverse of core functions).
+        </p>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> How DYF-1 activates OSM-3 kinesin at the molecular level is unknown: whether it binds the motor directly, relieves OSM-3 autoinhibition, or bridges OSM-3 to the IFT-B core, and which OSM-3 surface it engages, are undetermined. There is also no GO molecular-function term that expresses a kinesin-2 docking/activation-factor activity, so the gene reads as MF-dark despite a well-defined cellular role.</p>
+            <p style="margin-top: 0.4rem;">
+                <span class="badge">OPEN</span>
+                <span class="badge">BIOLOGY</span><span class="badge">ONTOLOGY</span>
+                <span class="badge">MF_DARK</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> DYF-1 is an IFT complex B subunit localizing to the ciliary base and axoneme that is genetically and specifically required for OSM-3 to dock onto and move IFT particles; loss inactivates OSM-3 and prevents assembly of the distal singlet ciliary segment. Its only informative MF term is intraciliary transport particle B binding (GO:0120170).</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Significance:</strong> This is the step that selectively couples the OSM-3/KIF17 motor to anterograde IFT and builds the distal ciliary segment; the mechanism is conserved to human TTC30A/TTC30B and the ciliate/algal IFT70, and is central to how two anterograde kinesins are coordinated on a shared IFT train.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>What would resolve it:</strong> Reconstitute OSM-3 motility with purified DYF-1 and IFT-B in vitro; determine a DYF-1-OSM-3 structure/interface; isolate separation-of-function dyf-1 alleles that uncouple IFT-B binding from OSM-3 activation; propose a molecular-function term for kinesin docking/activation-factor activity.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Provenance (the field's own admissions):</strong></p>
+            <ul style="margin-top: 0.2rem;">
+
+                <li><em>"specifically required for OSM-3 kinesin to dock onto and move IFT particles"</em> — PMID:16049494</li>
+
+                <li><em>"an OSM-3 kinesin activator in the formation of two IFT pathways"</em> — PMID:16049494</li>
+
+            </ul>
+
+
+        </div>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> Whether DYF-1/IFT70 promotes axonemal tubulin polyglutamylation directly (for example by IFT-dependent delivery of a TTLL glutamylase or its tubulin substrate) or indirectly as a downstream consequence of the B-tubule/axoneme structural defect is unresolved, and the responsible glutamylase in the dyf-1 pathway is not identified.</p>
+            <p style="margin-top: 0.4rem;">
+                <span class="badge">OPEN</span>
+                <span class="badge">BIOLOGY</span>
+                <span class="badge">RESIDUAL_SUBGAP</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> Loss of the DYF-1/fleer ortholog dramatically reduces ciliary polyglutamylated tubulin and causes B-tubule ultrastructural defects, and C. elegans dyf-1 is likewise required for tubulin polyglutamylation in sensory-neuron cilia; the mechanistic link between IFT-B function and the polyglutamylation machinery has not been defined.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Significance:</strong> Tubulin polyglutamylation is required for cilium structure and, in motile cilia, motility across species; distinguishing a direct IFT-transport role from an indirect structural consequence would clarify how IFT-B controls axonemal post-translational modification.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>What would resolve it:</strong> Test whether a TTLL glutamylase or its substrate is an IFT-B/DYF-1 cargo (IFT co-transport imaging, proximity proteomics); quantify polyglutamylation vs axonemal ultrastructure across a dyf-1 allelic series to separate cause from consequence.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Provenance (the field's own admissions):</strong></p>
+            <ul style="margin-top: 0.2rem;">
+
+                <li><em>"novel modulator of tubulin polyglutamylation"</em> — PMID:17761526</li>
+
+                <li><em>"dyf-1, is also required for tubulin polyglutamylation in sensory neuron cilia"</em> — PMID:17761526</li>
+
+            </ul>
+
+
+        </div>
+
+    </div>
+
+
+
+
+    <!-- Computational Predictions Section -->
+
+
+    <!-- Deep Research Sections -->
+
+
+    <!-- Additional Documentation Sections -->
+
+    <div class="section">
+        <h2 class="section-title">📚 Additional Documentation</h2>
+
+        <details class="markdown-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; cursor: pointer;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Notes</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(dyf-1-notes.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="Q8I7G4" data-a="DOC: Notes" data-r="" data-act="DOCUMENTATION" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This documentation is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This documentation needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+                <h1 id="dyf-1-c-elegans-research-notes">dyf-1 (C. elegans) — Research Notes</h1>
+<p>UniProt: Q8I7G4 (TTC30_CAEEL) · WormBase: WBGene00001117 / F54C1.5 · Gene: dyf-1<br />
+("abnormal <strong>dy</strong>e <strong>f</strong>illing protein 1"). Member of the CAEEL_CILIOPATHY / IFT flagship<br />
+project (anterograde IFT-B).</p>
+<h2 id="provenance-note-automated-deep-research-unavailable">Provenance note: automated deep research unavailable</h2>
+<p>Automated deep research did not complete for this gene. <code>just deep-research-falcon worm dyf-1
+--fallback perplexity-lite</code> ran but <strong>both</strong> providers failed: falcon (Edison) <strong>timed out</strong><br />
+after 600 s ("Verbose Edison response has no answer. Status: in progress"), and the<br />
+perplexity-lite fallback returned <strong>HTTP 401 – insufficient_quota</strong> ("You exceeded your current<br />
+quota"). No <code>-deep-research-*.md</code> file was generated, and none was fabricated. This review is<br />
+therefore grounded directly in the UniProt entry, the GOA table, and the cached primary<br />
+publications (PMID:16049494, PMID:28479320, PMID:22922713, PMID:17761526, PMID:15916950), with<br />
+every <code>supporting_text</code> verbatim-verified against those cached publications.</p>
+<h2 id="summary-standalone-picture">Summary / standalone picture</h2>
+<p>DYF-1 is a ~656-aa tetratricopeptide-repeat (TPR) protein (9 TPR repeats; TTC30/DYF-1/fleer<br />
+family; ortholog of human TTC30A/TTC30B and the algal/ciliate IFT70/FAP259) that is a subunit<br />
+of intraflagellar transport (IFT) complex B (IFT-B). It is expressed specifically in ciliated<br />
+sensory neurons and localizes to the ciliary base (basal body), the axoneme (axonemal<br />
+microtubules), and undergoes IFT along the cilium. Its best-defined role is as an obligatory<br />
+activator/adaptor for the homodimeric kinesin-2 motor OSM-3 (KIF17 ortholog): DYF-1 is<br />
+specifically required for OSM-3 to dock onto and move IFT particles. In <em>dyf-1</em> mutants OSM-3<br />
+is inactive, IFT particles are carried by heterotrimeric kinesin-II alone, the distal singlet<br />
+segments of the amphid/phasmid cilia are not built, and the animals are dye-filling defective<br />
+(Dyf). DYF-1/IFT70 is also required for tubulin polyglutamylation of the ciliary axoneme in<br />
+sensory neurons.</p>
+<h2 id="molecular-identity">Molecular identity</h2>
+<ul>
+<li>656 aa; 9 TPR repeats (UniProt features REPEAT 1–9); TPR-like all-α solenoid<br />
+  (IPR011990/IPR019734; PANTHER PTHR20931 "TETRATRICOPEPTIDE REPEAT PROTEIN 30"; InterPro TT30<br />
+  IPR039941). Two alternatively spliced isoforms (a = Q8I7G4-1 displayed; b = Q8I7G4-2 lacks<br />
+  residues 1–59) [file:worm/dyf-1/dyf-1-uniprot.txt].</li>
+<li>SIMILARITY: "Belongs to the TTC30/dfy-1/fleer family." [file:worm/dyf-1/dyf-1-uniprot.txt].</li>
+<li>Orthologs: human TTC30A/TTC30B; zebrafish <em>fleer</em> (flr); <em>Chlamydomonas</em>/<em>Tetrahymena</em> IFT70.<br />
+  The zebrafish fleer paper cloned "a tetratricopeptide repeat protein homologous to the<br />
+  Caenorhabditis elegans protein DYF1" <a href="https://pubmed.ncbi.nlm.nih.gov/17761526" title="Positional cloning flr identified a   tetratricopeptide repeat protein homologous to the Caenorhabditis elegans protein DYF1 that   was highly expressed in ciliated cells.">PMID:17761526</a>.</li>
+</ul>
+<h2 id="core-function-1-osm-3-kinesin-2-activator-within-anterograde-ift">Core function 1 — OSM-3 kinesin-2 activator within anterograde IFT</h2>
+<p>The defining C. elegans finding (Ou et al. 2005, Nature): the amphid/phasmid channel cilia are<br />
+built by two anterograde IFT motors — heterotrimeric kinesin-II (builds the middle doublet<br />
+segment) and homodimeric OSM-3 (extends the distal singlet segment) — which normally move the<br />
+same IFT particles cooperatively. DYF-1 is the factor that couples OSM-3 to the IFT train:</p>
+<ul>
+<li><a href="https://pubmed.ncbi.nlm.nih.gov/16049494" title="A conserved ciliary protein, DYF-1, is specifically required for OSM-3 kinesin   to dock onto and move IFT particles">PMID:16049494</a>.</li>
+<li><a href="https://pubmed.ncbi.nlm.nih.gov/16049494" title="OSM-3 kinesin is inactive and intact IFT particles are moved by kinesin-II   alone in dyf-1 mutants">PMID:16049494</a>.</li>
+<li>Consequence: distal singlet segments fail to assemble, dye filling fails<br />
+  [PMID:16049494 disruption phenotype: "Sensory neurons are unable to take up a fluorescent dye<br />
+  from the media, a phenotype that is often associated with aberrant sensory cilia."].</li>
+</ul>
+<p>The same study established DYF-1's ciliary localization and IFT behavior (basis of the<br />
+axonemal-microtubule / cilium IDA localization annotations). UniProt FUNCTION synthesizes:<br />
+"Specifically required for the kinesin osm-3 to dock onto and move the IFT particles which<br />
+contain these precursors." [file:worm/dyf-1/dyf-1-uniprot.txt].</p>
+<h2 id="core-function-2-ift-b-structural-subunit-cilium-assembly-cargo-transport">Core function 2 — IFT-B structural subunit (cilium assembly / cargo transport)</h2>
+<p>DYF-1 is a bona fide IFT complex B subunit, identified biochemically by mass spectrometry:<br />
+- UniProt SUBUNIT: "Component of the IFT complex B composed of at least che-2, che-13, dyf-1,<br />
+  dyf-3, dyf-6, dyf-11, dyf-13, ift-20, ift-74, ift-81, ifta-2, osm-1, osm-5 and osm-6."<br />
+  [file:worm/dyf-1/dyf-1-uniprot.txt]; ComplexPortal CPX-1290 (IFT complex B).<br />
+- Yi et al. 2017 (Curr Biol) identified DYF-1 in IFT-B by mass spectrometry and showed IFT-B is<br />
+  required for ciliary entry of the retrograde motor dynein-2:<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/28479320" title="Disruption of the dynein-2 tail domain, light intermediate chain, or   intraflagellar transport (IFT)-B complex abolishes dynein-2's ciliary localization, revealing   their important roles in ciliary entry of dynein-2.">PMID:28479320</a>. This is the NAS source (ComplexPortal)<br />
+  for the cilium / IFT particle B / intraciliary transport / cilium-assembly annotations.</p>
+<p>As an IFT-B subunit DYF-1 localizes to the ciliary basal body (docking/loading zone) — IDA<br />
+localization to GO:0036064 ciliary basal body is from PMID:22922713 (a C. elegans IFT study).</p>
+<h2 id="core-function-3-required-for-axonemal-tubulin-polyglutamylation">Core function 3 — required for axonemal tubulin polyglutamylation</h2>
+<p>The DYF-1/fleer family is required for cilia tubulin polyglutamylation, shown in zebrafish and<br />
+confirmed directly in C. elegans dyf-1:<br />
+- <a href="https://pubmed.ncbi.nlm.nih.gov/17761526" title="flr cilia showed a dramatic reduction in cilia polyglutamylated tubulin,   indicating that flr encodes a novel modulator of tubulin polyglutamylation.">PMID:17761526</a><br />
+- <a href="https://pubmed.ncbi.nlm.nih.gov/17761526" title="We also found that the C. elegans flr homologue, dyf-1, is also required for   tubulin polyglutamylation in sensory neuron cilia.">PMID:17761526</a><br />
+- Loss is accompanied by B-tubule ultrastructural defects <a href="https://pubmed.ncbi.nlm.nih.gov/17761526" title="flr cilia exhibited   ultrastructural defects in microtubule B-tubules, similar to axonemes that lack tubulin   posttranslational modifications (polyglutamylation or polyglycylation).">PMID:17761526</a>.</p>
+<p>Note: the GOA <code>protein polyglutamylation</code> (GO:0018095) IMP annotation is attributed to<br />
+PMID:16049494 (Ou 2005), whose abstract is entirely about IFT-motor coordination and does not<br />
+itself mention polyglutamylation; the function is definitively established for dyf-1 in<br />
+PMID:17761526. Treated as a real but non-core (downstream) role; supporting text drawn from<br />
+PMID:17761526.</p>
+<h2 id="expression-regulation">Expression / regulation</h2>
+<ul>
+<li>Ciliated-sensory-neuron-specific: "Expressed in most amphid, both phasmid and several<br />
+  labial-quadrant neurons." [file:worm/dyf-1/dyf-1-uniprot.txt, from PMID:15916950].</li>
+<li>PMID:15916950 (Blacque et al. 2005, "Functional genomics of the cilium") is the SAGE / DAF-19<br />
+  X-box ciliary-transcriptome screen that placed dyf-1 among ciliated-cell genes (tissue<br />
+  specificity reference).</li>
+</ul>
+<h2 id="what-is-not-known-knowledge-gap-candidates">What is NOT known (knowledge-gap candidates)</h2>
+<ol>
+<li>
+<p><strong>Molecular mechanism of OSM-3 activation (MF-dark / ontology gap).</strong> DYF-1 is genetically<br />
+<em>required</em> for OSM-3 to dock onto and move IFT particles, but the biochemical activity is<br />
+   undefined: does DYF-1 bind OSM-3 directly, relieve OSM-3 autoinhibition, or bridge OSM-3 to<br />
+   the IFT-B core? No GO molecular-function term expresses "kinesin-2 docking/activation factor";<br />
+   the only informative MF available is <code>intraciliary transport particle B binding</code> (GO:0120170),<br />
+   which captures IFT-B membership, not the OSM-3-activation activity.<br />
+   Provenance: <a href="https://pubmed.ncbi.nlm.nih.gov/16049494" title="DYF-1, is specifically required for OSM-3 kinesin to dock onto and    move IFT particles, because OSM-3 kinesin is inactive">PMID:16049494</a> — establishes requirement, never a<br />
+   biochemical activity/interaction.</p>
+</li>
+<li>
+<p><strong>Cause vs consequence of the polyglutamylation defect.</strong> Whether DYF-1/IFT70 promotes tubulin<br />
+   polyglutamylation directly (e.g. by IFT-dependent delivery of a TTLL glutamylase or its<br />
+   substrate) or indirectly (as a downstream consequence of the B-tubule/axoneme structural<br />
+   defect) is unresolved. The zebrafish study frames flr as a "novel modulator of tubulin<br />
+   polyglutamylation" <a href="https://pubmed.ncbi.nlm.nih.gov/17761526">PMID:17761526</a> without a molecular mechanism, and did not distinguish<br />
+   these possibilities.</p>
+</li>
+<li>
+<p><strong><code>protein localization to plasma membrane</code> (GO:0072659) evidence.</strong> The basis of this IMP<br />
+   annotation (cited to PMID:16049494, abstract-only in our cache) cannot be verified from the<br />
+   available text; the abstract concerns IFT-motor coordination, not membrane-protein<br />
+   localization. Which ciliary/plasma-membrane cargo protein (if any) mislocalizes in dyf-1 is<br />
+   not established from the accessible evidence.</p>
+</li>
+</ol>
+<h2 id="annotation-review-disposition-planned">Annotation-review disposition (planned)</h2>
+<ul>
+<li>IFT-B membership / IFT / cilium / axonemal MT / basal body / IFT-B binding / cilium assembly:<br />
+  ACCEPT (well supported by IBA + experimental IDA/NAS; core IFT-B identity).</li>
+<li>intraciliary transport (IMP + IBA + NAS): ACCEPT (core; OSM-3 coupling directly shown).</li>
+<li>protein polyglutamylation (GO:0018095, IMP/PMID:16049494): KEEP_AS_NON_CORE — real but<br />
+  downstream; definitive evidence is PMID:17761526.</li>
+<li>protein localization to plasma membrane (GO:0072659, IMP/PMID:16049494): UNDECIDED — cannot<br />
+  verify supporting evidence from abstract-only cache; term is imprecise for a ciliary IFT role.<br />
+</content></li>
+</ul>
+            </div>
+        </details>
+
+    </div>
+
+
+    <!-- YAML Preview Section -->
+    <div class="section">
+        <details class="yaml-preview">
+            <summary>
+                <h2 style="display: inline;">📄 View Raw YAML</h2>
+            </summary>
+            <div class="yaml-content">
+                <pre><code>id: Q8I7G4
+gene_symbol: dyf-1
+product_type: PROTEIN
+status: COMPLETE
+taxon:
+  id: NCBITaxon:6239
+  label: Caenorhabditis elegans
+description: &gt;-
+  DYF-1 is a tetratricopeptide-repeat (TPR) protein and a subunit of intraflagellar
+  transport (IFT) complex B, the anterograde IFT module that builds and maintains cilia.
+  It is the Caenorhabditis elegans ortholog of human TTC30A/TTC30B and of the
+  ciliate/algal IFT70, and its name reflects the abnormal dye-filling (Dyf) phenotype of
+  its mutants. DYF-1 is expressed in ciliated sensory neurons and localizes to the ciliary
+  basal body and the axoneme, moving processively along the axoneme as part of IFT trains.
+  Its central role is to act as an obligatory activator/adaptor for the homodimeric
+  kinesin-2 motor OSM-3 (the KIF17 ortholog): DYF-1 is specifically required for OSM-3 to
+  dock onto and move IFT particles, and in its absence OSM-3 is inactive so that IFT trains
+  are carried by heterotrimeric kinesin-II alone and the distal singlet segments of amphid
+  and phasmid cilia fail to form. As an IFT-B component DYF-1 is required for normal
+  ciliogenesis and for delivery of ciliary cargo, and DYF-1/IFT70 is additionally required
+  for polyglutamylation of the axonemal tubulin of sensory cilia.
+alternative_products:
+- name: a
+  id: Q8I7G4-1
+- name: b
+  id: Q8I7G4-2
+  sequence_note: VSP_033490
+references:
+- id: GO_REF:0000033
+  title: Annotation inferences using phylogenetic trees
+  findings: []
+  reference_review:
+    relevance: MEDIUM
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Standard GO_Central IBA pipeline. The phylogenetic inferences (IFT complex B
+      membership, intraciliary transport, IFT-B binding, axonemal microtubule) are all
+      corroborated by C. elegans experimental data, so the IBA transfers are sound.
+- id: GO_REF:0000044
+  title: Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location
+    vocabulary mapping, accompanied by conservative changes to GO terms applied by
+    UniProt
+  findings: []
+  reference_review:
+    relevance: LOW
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Electronic mapping of the UniProt &#34;Cilium&#34; subcellular-location keyword to
+      GO:0005929; redundant with the experimental IDA cilium annotation but not incorrect.
+- id: PMID:16049494
+  title: Functional coordination of intraflagellar transport motors.
+  findings: []
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Founding functional paper for dyf-1 (Ou et al. 2005, Nature). The abstract directly
+      establishes that DYF-1 is specifically required for OSM-3 kinesin to dock onto and
+      move IFT particles and that OSM-3 is inactive in dyf-1 mutants. Correctly supports the
+      intraciliary-transport and OSM-3-activation core function. The same PMID is also the
+      GOA citation for the protein-polyglutamylation and plasma-membrane-localization IMP
+      rows, which its abstract does not itself address (see those annotations).
+- id: PMID:17761526
+  title: The zebrafish fleer gene encodes an essential regulator of cilia tubulin
+    polyglutamylation.
+  findings: []
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Pathak et al. 2007. Establishes the DYF-1/fleer family role in cilia tubulin
+      polyglutamylation and states explicitly that C. elegans dyf-1 is also required for
+      tubulin polyglutamylation in sensory-neuron cilia; also confirms fleer/DYF1 orthology.
+      This is the definitive supporting reference for the protein-polyglutamylation
+      annotation (which GOA cites to PMID:16049494 instead).
+- id: PMID:22922713
+  title: The BBSome controls IFT assembly and turnaround in cilia.
+  findings: []
+  reference_review:
+    relevance: LOW
+    correctness: UNVERIFIED
+    review_notes: &gt;-
+      Wei et al. 2012. A C. elegans IFT paper whose main text (cached) concerns dyf-2 and
+      bbs-1 IFT turnaround; DYF-1 is not named in the cached main text (dyf-2/bbs-1 are the
+      subjects). It is the assigned reference for the ciliary-basal-body IDA (assigned_by
+      MGI); the basal-body localization is biologically expected for any IFT-B protein, but
+      the dyf-1-specific evidence could not be verbatim-verified here (may reside in a
+      supplement). Deferred to the experimental curator; retained as ACCEPT on biological
+      grounds.
+- id: PMID:28479320
+  title: Dynein-Driven Retrograde Intraflagellar Transport Is Triphasic in C. elegans
+    Sensory Cilia.
+  findings: []
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Yi et al. 2017. Identifies DYF-1 as a component of IFT complex B by mass spectrometry
+      (basis of ComplexPortal CPX-1290 and the UniProt SUBUNIT list) and shows IFT-B is
+      required for ciliary entry of dynein-2. Supports the IFT-B membership, intraciliary
+      transport, cilium-localization and cilium-assembly (NAS) annotations.
+- id: PMID:15916950
+  title: Functional genomics of the cilium, a sensory organelle.
+  findings: []
+  reference_review:
+    relevance: MEDIUM
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Blacque et al. 2005 SAGE/DAF-19 ciliary-transcriptome screen; source of the UniProt
+      tissue-specificity statement that dyf-1 is expressed in amphid, phasmid and
+      labial-quadrant sensory neurons. Background/expression context, not an annotation
+      source.
+existing_annotations:
+- term:
+    id: GO:0030992
+    label: intraciliary transport particle B
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: part_of
+  review:
+    summary: &gt;-
+      DYF-1 is a subunit of intraflagellar transport complex B (IFT-B). This IBA transfer is
+      strongly corroborated experimentally: DYF-1 was identified in the C. elegans IFT-B
+      complex by mass spectrometry (PMID:28479320; ComplexPortal CPX-1290).
+    action: ACCEPT
+    reason: &gt;-
+      Core cellular-component identity of DYF-1. Phylogenetically inferred and independently
+      confirmed by biochemical identification of DYF-1 in worm IFT-B.
+    supported_by:
+    - reference_id: PMID:28479320
+      supporting_text: intraflagellar transport (IFT)-B complex abolishes dynein-2&#39;s ciliary
+        localization
+      reference_section_type: ABSTRACT
+- term:
+    id: GO:0042073
+    label: intraciliary transport
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      DYF-1 functions in intraflagellar (intraciliary) transport as an IFT-B subunit and
+      OSM-3 kinesin activator. IBA is well supported by the C. elegans experimental data.
+    action: ACCEPT
+    reason: &gt;-
+      Core biological process. Confirmed experimentally in worm (PMID:16049494): DYF-1 is
+      required for OSM-3 to move IFT particles.
+    supported_by:
+    - reference_id: PMID:16049494
+      supporting_text: specifically required for OSM-3 kinesin to dock onto and move IFT
+        particles
+      reference_section_type: ABSTRACT
+- term:
+    id: GO:0005879
+    label: axonemal microtubule
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: is_active_in
+  review:
+    summary: &gt;-
+      DYF-1 acts along axonemal microtubules, where IFT trains move. The is_active_in
+      qualifier is appropriate for an IFT motor-associated protein that translocates along
+      the axoneme; corroborated by the experimental IDA localization (PMID:16049494).
+    action: ACCEPT
+    reason: &gt;-
+      Consistent with DYF-1&#39;s role as an axoneme-associated IFT-B component that undergoes
+      IFT along ciliary microtubules.
+- term:
+    id: GO:0120170
+    label: intraciliary transport particle B binding
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: enables
+  review:
+    summary: &gt;-
+      DYF-1 binds the IFT-B particle as one of its subunits. This is the most informative
+      molecular-function term available for DYF-1 and is preferable to generic protein
+      binding.
+    action: ACCEPT
+    reason: &gt;-
+      Captures DYF-1&#39;s molecular function as an IFT-B-associated protein. Note this binding
+      term does not express DYF-1&#39;s distinctive OSM-3-kinesin-activation activity, which has
+      no dedicated GO MF term (see knowledge_gaps).
+    supported_by:
+    - reference_id: PMID:28479320
+      supporting_text: intraflagellar transport (IFT)-B complex abolishes dynein-2&#39;s ciliary
+        localization
+      reference_section_type: ABSTRACT
+- term:
+    id: GO:0005929
+    label: cilium
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000044
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      DYF-1 localizes to the cilium. Electronic mapping from the UniProt Cilium subcellular
+      keyword; redundant with the experimental IDA cilium annotation.
+    action: ACCEPT
+    reason: &gt;-
+      Correct location, independently supported by experimental evidence (PMID:16049494).
+- term:
+    id: GO:0005929
+    label: cilium
+  evidence_type: NAS
+  original_reference_id: PMID:28479320
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      DYF-1 localizes to the cilium as an IFT-B component (ComplexPortal NAS from
+      PMID:28479320).
+    action: ACCEPT
+    reason: Correct ciliary localization; consistent with IFT-B membership and IDA evidence.
+- term:
+    id: GO:0030992
+    label: intraciliary transport particle B
+  evidence_type: NAS
+  original_reference_id: PMID:28479320
+  qualifier: part_of
+  review:
+    summary: &gt;-
+      DYF-1 is part of IFT complex B, identified by mass spectrometry in C. elegans
+      (PMID:28479320) and curated by ComplexPortal (CPX-1290).
+    action: ACCEPT
+    reason: &gt;-
+      Direct experimental/curated support for IFT-B membership; the strongest evidence for
+      this core cellular-component identity.
+    supported_by:
+    - reference_id: PMID:28479320
+      supporting_text: intraflagellar transport (IFT)-B complex abolishes dynein-2&#39;s ciliary
+        localization
+      reference_section_type: ABSTRACT
+- term:
+    id: GO:0042073
+    label: intraciliary transport
+  evidence_type: NAS
+  original_reference_id: PMID:28479320
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      DYF-1 participates in intraciliary transport as an IFT-B subunit (ComplexPortal NAS
+      from PMID:28479320).
+    action: ACCEPT
+    reason: Core biological process; concordant with the IBA and IMP intraciliary-transport rows.
+- term:
+    id: GO:0060271
+    label: cilium assembly
+  evidence_type: NAS
+  original_reference_id: PMID:28479320
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      As an IFT-B component required for anterograde transport, DYF-1 is required for cilium
+      assembly; the distal singlet segments of amphid/phasmid cilia fail to form in dyf-1
+      mutants (via loss of OSM-3 activity).
+    action: ACCEPT
+    reason: &gt;-
+      IFT-B is essential for ciliogenesis; this NAS annotation is well grounded in DYF-1&#39;s
+      role in building the distal ciliary segment.
+    supported_by:
+    - reference_id: PMID:28479320
+      supporting_text: essential for cilium formation and maintenance
+      reference_section_type: ABSTRACT
+- term:
+    id: GO:0072659
+    label: protein localization to plasma membrane
+  evidence_type: IMP
+  original_reference_id: PMID:16049494
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      This IMP is attributed to PMID:16049494 (Ou et al. 2005), whose cached abstract is
+      entirely about coordination of the kinesin-II and OSM-3 IFT motors and does not
+      address localization of any plasma-membrane/ciliary-membrane protein. The generic term
+      protein localization to plasma membrane is also imprecise for a ciliary IFT role
+      (ciliary membrane rather than bulk plasma membrane).
+    action: UNDECIDED
+    reason: &gt;-
+      Cannot verify the supporting evidence: the cached publication is abstract-only and the
+      abstract does not mention membrane-protein localization, and no specific mislocalized
+      cargo can be identified from the accessible text. Per review guidelines, marked
+      UNDECIDED rather than removed, since the curator may have used full-text/supplementary
+      data not available here.
+- term:
+    id: GO:0036064
+    label: ciliary basal body
+  evidence_type: IDA
+  original_reference_id: PMID:22922713
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      DYF-1 localizes to the ciliary basal body (ciliary base), the docking/loading zone
+      where IFT trains assemble. Basal-body localization is a defining feature of IFT-B
+      proteins, which build and load onto IFT trains at the ciliary base.
+    action: ACCEPT
+    reason: &gt;-
+      Experimental IDA (assigned_by MGI) consistent with DYF-1&#39;s role as an IFT-B subunit
+      that docks at the ciliary base. DYF-1 is not named in the cached main text of
+      PMID:22922713 (which foregrounds dyf-2/bbs-1); per review guidelines the experimental
+      annotation is retained and deferred to the curator rather than removed, and the
+      citation is flagged UNVERIFIED in reference_review.
+- term:
+    id: GO:0005879
+    label: axonemal microtubule
+  evidence_type: IDA
+  original_reference_id: PMID:16049494
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      DYF-1::GFP localizes along the ciliary axoneme and undergoes IFT (Ou et al. 2005),
+      consistent with an axonemal-microtubule location.
+    action: ACCEPT
+    reason: &gt;-
+      Experimental localization supporting DYF-1&#39;s presence along axonemal microtubules;
+      concordant with the IBA is_active_in axonemal-microtubule row.
+- term:
+    id: GO:0005929
+    label: cilium
+  evidence_type: IDA
+  original_reference_id: PMID:16049494
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      DYF-1 is directly observed in the cilium (Ou et al. 2005). UniProt records the
+      subcellular location Cell projection, cilium from this study.
+    action: ACCEPT
+    reason: Experimental (IDA) ciliary localization; the best-supported location annotation.
+- term:
+    id: GO:0018095
+    label: protein polyglutamylation
+  evidence_type: IMP
+  original_reference_id: PMID:16049494
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      DYF-1/IFT70 is required for tubulin polyglutamylation of the ciliary axoneme. This is
+      a genuine, literature-established function of dyf-1 shown directly in C. elegans by
+      Pathak et al. 2007 (PMID:17761526), although GOA cites it here to PMID:16049494, whose
+      abstract does not address polyglutamylation. It is a downstream/indirect role, not
+      DYF-1&#39;s core molecular activity.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      Real but non-core: DYF-1 is not itself a glutamylase; polyglutamylation loss is a
+      consequence of DYF-1 dysfunction (whether via failed IFT-delivery of a glutamylase or
+      via the B-tubule/axoneme structural defect is unresolved; see knowledge_gaps). Retained
+      because the function is well supported; supporting text drawn from the definitive paper
+      (PMID:17761526) rather than the GOA-cited PMID:16049494.
+    supported_by:
+    - reference_id: PMID:17761526
+      supporting_text: dyf-1, is also required for tubulin polyglutamylation in sensory
+        neuron cilia
+      reference_section_type: ABSTRACT
+- term:
+    id: GO:0042073
+    label: intraciliary transport
+  evidence_type: IMP
+  original_reference_id: PMID:16049494
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Direct experimental evidence (IMP): in dyf-1 mutants OSM-3 is inactive and IFT
+      particles are moved by kinesin-II alone, so distal singlet ciliary segments are not
+      built. This is the primary experimental support for DYF-1&#39;s role in intraciliary
+      transport.
+    action: ACCEPT
+    reason: &gt;-
+      Strongest experimental evidence for DYF-1&#39;s core function in anterograde IFT via
+      OSM-3 activation.
+    supported_by:
+    - reference_id: PMID:16049494
+      supporting_text: specifically required for OSM-3 kinesin to dock onto and move IFT
+        particles
+      reference_section_type: ABSTRACT
+    - reference_id: PMID:16049494
+      supporting_text: an OSM-3 kinesin activator in the formation of two IFT pathways
+      reference_section_type: ABSTRACT
+- term:
+    id: GO:0035720
+    label: intraciliary anterograde transport
+  evidence_type: IMP
+  original_reference_id: PMID:16049494
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      NEW (proposed, more specific). DYF-1 acts specifically in ANTEROGRADE intraciliary
+      transport: it is required for the anterograde kinesin-2 motor OSM-3 to dock onto and
+      move IFT particles, building the distal singlet segment of amphid/phasmid cilia. The
+      current GOA rows use the generic parent term intraciliary transport (GO:0042073); the
+      anterograde-specific child term more precisely captures DYF-1&#39;s role.
+    action: NEW
+    reason: &gt;-
+      DYF-1&#39;s function is anterograde-specific (OSM-3 activation), so intraciliary anterograde
+      transport (GO:0035720) is more informative than the generic GO:0042073 already annotated
+      by GOA.
+    supported_by:
+    - reference_id: PMID:16049494
+      supporting_text: specifically required for OSM-3 kinesin to dock onto and move IFT
+        particles
+      reference_section_type: ABSTRACT
+core_functions:
+- description: &gt;-
+    DYF-1 is a tetratricopeptide-repeat subunit of intraflagellar transport complex B that
+    acts as the obligatory activator/adaptor coupling the homodimeric kinesin-2 motor OSM-3
+    to anterograde IFT trains. DYF-1 is specifically required for OSM-3 to dock onto and move
+    IFT particles; in its absence OSM-3 is inactive, IFT trains are moved by heterotrimeric
+    kinesin-II alone, and the distal singlet segments of amphid/phasmid sensory cilia fail to
+    form. It functions at the ciliary basal body (train assembly/loading) and along axonemal
+    microtubules, and is required for ciliogenesis of sensory cilia.
+  molecular_function:
+    id: GO:0120170
+    label: intraciliary transport particle B binding
+  in_complex:
+    id: GO:0030992
+    label: intraciliary transport particle B
+  directly_involved_in:
+  - id: GO:0035720
+    label: intraciliary anterograde transport
+  - id: GO:0060271
+    label: cilium assembly
+  locations:
+  - id: GO:0036064
+    label: ciliary basal body
+  - id: GO:0005879
+    label: axonemal microtubule
+  supported_by:
+  - reference_id: PMID:16049494
+    supporting_text: specifically required for OSM-3 kinesin to dock onto and move IFT
+      particles
+    reference_section_type: ABSTRACT
+  - reference_id: PMID:28479320
+    supporting_text: intraflagellar transport (IFT)-B complex abolishes dynein-2&#39;s ciliary
+      localization
+    reference_section_type: ABSTRACT
+knowledge_gaps:
+- gap_statement: &gt;-
+    How DYF-1 activates OSM-3 kinesin at the molecular level is unknown: whether it binds the
+    motor directly, relieves OSM-3 autoinhibition, or bridges OSM-3 to the IFT-B core, and
+    which OSM-3 surface it engages, are undetermined. There is also no GO molecular-function
+    term that expresses a kinesin-2 docking/activation-factor activity, so the gene reads as
+    MF-dark despite a well-defined cellular role.
+  boundary: &gt;-
+    DYF-1 is an IFT complex B subunit localizing to the ciliary base and axoneme that is
+    genetically and specifically required for OSM-3 to dock onto and move IFT particles;
+    loss inactivates OSM-3 and prevents assembly of the distal singlet ciliary segment. Its
+    only informative MF term is intraciliary transport particle B binding (GO:0120170).
+  gap_kind:
+  - BIOLOGY
+  - ONTOLOGY
+  dark_aspect: MF_DARK
+  status: OPEN
+  significance: &gt;-
+    This is the step that selectively couples the OSM-3/KIF17 motor to anterograde IFT and
+    builds the distal ciliary segment; the mechanism is conserved to human TTC30A/TTC30B and
+    the ciliate/algal IFT70, and is central to how two anterograde kinesins are coordinated
+    on a shared IFT train.
+  resolution: &gt;-
+    Reconstitute OSM-3 motility with purified DYF-1 and IFT-B in vitro; determine a
+    DYF-1-OSM-3 structure/interface; isolate separation-of-function dyf-1 alleles that
+    uncouple IFT-B binding from OSM-3 activation; propose a molecular-function term for
+    kinesin docking/activation-factor activity.
+  provenance:
+  - reference_id: PMID:16049494
+    supporting_text: specifically required for OSM-3 kinesin to dock onto and move IFT
+      particles
+    reference_section_type: ABSTRACT
+  - reference_id: PMID:16049494
+    supporting_text: an OSM-3 kinesin activator in the formation of two IFT pathways
+    reference_section_type: ABSTRACT
+- gap_statement: &gt;-
+    Whether DYF-1/IFT70 promotes axonemal tubulin polyglutamylation directly (for example by
+    IFT-dependent delivery of a TTLL glutamylase or its tubulin substrate) or indirectly as a
+    downstream consequence of the B-tubule/axoneme structural defect is unresolved, and the
+    responsible glutamylase in the dyf-1 pathway is not identified.
+  boundary: &gt;-
+    Loss of the DYF-1/fleer ortholog dramatically reduces ciliary polyglutamylated tubulin
+    and causes B-tubule ultrastructural defects, and C. elegans dyf-1 is likewise required
+    for tubulin polyglutamylation in sensory-neuron cilia; the mechanistic link between IFT-B
+    function and the polyglutamylation machinery has not been defined.
+  gap_kind:
+  - BIOLOGY
+  dark_aspect: RESIDUAL_SUBGAP
+  status: OPEN
+  significance: &gt;-
+    Tubulin polyglutamylation is required for cilium structure and, in motile cilia,
+    motility across species; distinguishing a direct IFT-transport role from an indirect
+    structural consequence would clarify how IFT-B controls axonemal post-translational
+    modification.
+  resolution: &gt;-
+    Test whether a TTLL glutamylase or its substrate is an IFT-B/DYF-1 cargo (IFT
+    co-transport imaging, proximity proteomics); quantify polyglutamylation vs axonemal
+    ultrastructure across a dyf-1 allelic series to separate cause from consequence.
+  provenance:
+  - reference_id: PMID:17761526
+    supporting_text: novel modulator of tubulin polyglutamylation
+    reference_section_type: ABSTRACT
+  - reference_id: PMID:17761526
+    supporting_text: dyf-1, is also required for tubulin polyglutamylation in sensory neuron
+      cilia
+    reference_section_type: ABSTRACT
+suggested_questions:
+- question: &gt;-
+    Does DYF-1 bind OSM-3 directly, and does it activate the motor by relieving OSM-3
+    autoinhibition or by tethering OSM-3 to the IFT-B core?
+  experts: []
+- question: &gt;-
+    Is the polyglutamylation defect in dyf-1 mutants a direct consequence of failed IFT
+    delivery of a tubulin glutamylase, or an indirect result of the B-tubule structural
+    defect?
+  experts: []
+suggested_experiments:
+- hypothesis: &gt;-
+    DYF-1 activates OSM-3 by direct binding that relieves OSM-3 motor autoinhibition and
+    docks it onto IFT-B.
+  description: &gt;-
+    Reconstitute purified OSM-3 with DYF-1 and IFT-B and measure single-molecule motility and
+    ATPase activity +/- DYF-1; map the DYF-1-OSM-3 interaction by crosslinking/MS or
+    cryo-EM, and test separation-of-function dyf-1 alleles in vivo for IFT-B binding vs
+    OSM-3 activation.
+  experiment_type: in vitro reconstitution / single-molecule motility / structural biology
+- hypothesis: &gt;-
+    DYF-1/IFT-B is required to transport a tubulin polyglutamylase (or its substrate) into
+    the cilium.
+  description: &gt;-
+    Image candidate TTLL glutamylases for IFT-dependent ciliary transport and co-movement
+    with DYF-1/IFT-B; test whether glutamylase ciliary entry and axonemal polyglutamylation
+    are lost in dyf-1 mutants while scoring axonemal ultrastructure across an allelic series.
+  experiment_type: live-cell IFT imaging / genetics
+</code></pre>
+            </div>
+        </details>
+    </div>
+
+    <!-- Pathway Visualization Link -->
+
+
+    <style>
+        /* Markdown Section Styles */
+        .markdown-section {
+            margin-bottom: 1rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .markdown-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .markdown-section summary h3 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.1rem;
+        }
+
+        .markdown-section summary:hover h3 {
+            color: #007bff;
+        }
+
+        .markdown-section[open] {
+            background-color: #fff;
+        }
+
+        .markdown-content {
+            margin-top: 1rem;
+            padding: 1rem;
+            border-top: 1px solid #dee2e6;
+        }
+
+        /* Markdown content styling */
+        .markdown-content h1 { font-size: 1.5rem; margin-top: 1.5rem; }
+        .markdown-content h2 { font-size: 1.3rem; margin-top: 1.3rem; }
+        .markdown-content h3 { font-size: 1.1rem; margin-top: 1.1rem; }
+        .markdown-content h4 { font-size: 1rem; margin-top: 1rem; }
+
+        .markdown-content pre {
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .markdown-content code {
+            background-color: #f8f9fa;
+            padding: 0.2rem 0.4rem;
+            border-radius: 3px;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+        }
+
+        .markdown-content pre code {
+            background: none;
+            padding: 0;
+        }
+
+        .markdown-content table {
+            border-collapse: collapse;
+            width: 100%;
+            margin: 1rem 0;
+        }
+
+        .markdown-content table th,
+        .markdown-content table td {
+            border: 1px solid #dee2e6;
+            padding: 0.5rem;
+            text-align: left;
+        }
+
+        .markdown-content table th {
+            background-color: #f8f9fa;
+            font-weight: bold;
+        }
+
+        .markdown-content blockquote {
+            border-left: 4px solid #007bff;
+            padding-left: 1rem;
+            margin-left: 0;
+            color: #666;
+        }
+
+        /* YAML Preview Styles */
+        .yaml-preview {
+            margin-top: 2rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .yaml-preview summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .yaml-preview summary h2 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.3rem;
+        }
+
+        .yaml-preview summary:hover h2 {
+            color: #007bff;
+        }
+
+        .yaml-preview[open] {
+            background-color: #fff;
+        }
+
+        .yaml-content {
+            margin-top: 1rem;
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .yaml-content pre {
+            margin: 0;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+            line-height: 1.4;
+        }
+
+        .yaml-content code {
+            color: #333;
+            background: none;
+            padding: 0;
+        }
+
+        /* Pathway Link Styles */
+        .pathway-link {
+            margin: 1rem 0;
+        }
+
+        .btn-link {
+            display: inline-block;
+            padding: 0.5rem 1rem;
+            background-color: #007bff;
+            color: white !important;
+            text-decoration: none;
+            border-radius: 4px;
+            font-weight: 500;
+            transition: background-color 0.2s;
+        }
+
+        .btn-link:hover {
+            background-color: #0056b3;
+            text-decoration: none;
+        }
+
+        /* Voting buttons */
+        .vote-buttons {
+            display: inline-block;
+            margin-left: 0.5rem;
+        }
+
+        .vote-btn {
+            background: none;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 2px 6px;
+            margin: 0 2px;
+            cursor: pointer;
+            font-size: 0.9rem;
+            transition: all 0.2s;
+            opacity: 0.6;
+        }
+
+        .vote-btn:hover {
+            opacity: 1;
+            transform: scale(1.1);
+        }
+
+        .vote-btn.voted {
+            opacity: 1;
+            border-color: #28a745;
+            background-color: #d4edda;
+        }
+
+        .vote-btn.voted-down {
+            border-color: #dc3545;
+            background-color: #f8d7da;
+        }
+
+        .vote-btn-small {
+            font-size: 0.7rem;
+            padding: 1px 4px;
+            margin: 0 1px;
+        }
+    </style>
+
+    <script>
+        // Add collapsible functionality
+        document.querySelectorAll('.collapsible').forEach(element => {
+            element.addEventListener('click', function() {
+                this.classList.toggle('collapsed');
+            });
+        });
+
+        // Voting functionality
+        const VOTE_URL = 'https://script.google.com/macros/s/AKfycbwPKH7d3seuPNBtB0ugVjqGeTiByyOGD5vkqB_Ck6K8eOcPQYbJqBOuz6GFgXHKBNWK/exec';
+
+        // Get or create session ID
+        let sessionId = localStorage.getItem('review_session_id');
+        if (!sessionId) {
+            sessionId = 's' + Date.now() + '_' + Math.random().toString(36).substr(2, 9);
+            localStorage.setItem('review_session_id', sessionId);
+        }
+
+        // Show previous votes on page load
+        document.addEventListener('DOMContentLoaded', function() {
+            document.querySelectorAll('.vote-buttons').forEach(container => {
+                const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+                const previousVote = localStorage.getItem(key);
+                if (previousVote) {
+                    const btn = container.querySelector(`[data-v="${previousVote}"]`);
+                    if (btn) btn.classList.add(previousVote === 'up' ? 'voted' : 'voted-down');
+                }
+            });
+        });
+
+        // Handle vote clicks - Simple image beacon approach
+        document.addEventListener('click', function(e) {
+            if (!e.target.classList.contains('vote-btn')) return;
+
+            // Prevent the click from bubbling to parent elements (like summary)
+            e.preventDefault();
+            e.stopPropagation();
+
+            const btn = e.target;
+            const container = btn.closest('.vote-buttons');
+            if (!container) return;
+
+            const voteType = btn.dataset.v;
+
+            // Check if already voted (locally)
+            const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+            const previousVote = localStorage.getItem(key);
+
+            if (previousVote === voteType) {
+                // Same vote - do nothing
+                btn.style.animation = 'shake 0.5s';
+                setTimeout(() => btn.style.animation = '', 500);
+                return;
+            }
+
+            // Build URL
+            const params = new URLSearchParams({
+                gene_id: container.dataset.g,
+                annotation_id: container.dataset.a,
+                ref_id: container.dataset.r || '',
+                action: container.dataset.act,
+                vote: voteType,
+                session_id: sessionId,
+                ua: navigator.userAgent.substring(0, 100)
+            });
+
+            // Clear previous vote styling
+            container.querySelectorAll('.vote-btn').forEach(b => {
+                b.classList.remove('voted', 'voted-down');
+            });
+
+            // Apply new vote styling immediately (optimistic UI)
+            btn.classList.add(voteType === 'up' ? 'voted' : 'voted-down');
+
+            // Store locally
+            localStorage.setItem(key, voteType);
+
+            // Send vote using fetch with no-cors mode (fire and forget)
+            const fullUrl = VOTE_URL + '?' + params;
+            console.log('Sending vote to:', fullUrl);
+
+            // Use fetch in no-cors mode - we won't get a response but the request will be sent
+            fetch(fullUrl, {
+                mode: 'no-cors',
+                method: 'GET'
+            }).then(() => {
+                console.log('Vote request sent (no response due to no-cors mode)');
+            }).catch(err => {
+                console.warn('Vote may not have been recorded, but saved locally:', err);
+
+                // Fallback: try image beacon as well
+                const img = new Image();
+                img.src = fullUrl;
+            });
+        });
+
+        // Optional: Add shake animation for feedback
+        const style = document.createElement('style');
+        style.textContent = `
+            @keyframes shake {
+                0%, 100% { transform: translateX(0); }
+                25% { transform: translateX(-5px); }
+                75% { transform: translateX(5px); }
+            }
+        `;
+        document.head.appendChild(style);
+    </script>
+</body>
+</html>

--- a/pages/projects/CAEEL_CILIOPATHY.html
+++ b/pages/projects/CAEEL_CILIOPATHY.html
@@ -388,7 +388,7 @@
 - <strong>osm-6</strong> - IFT52 ortholog<br />
 - <strong><a href="../../genes/worm/che-2/che-2-ai-review.html">che-2</a></strong> - IFT80 ortholog<br />
 - <strong>che-13</strong> - IFT57 ortholog<br />
-- <strong>dyf-1</strong> - Required for <a href="../../genes/worm/osm-3/osm-3-ai-review.html">osm-3</a> function<br />
+- <strong><a href="../../genes/worm/dyf-1/dyf-1-ai-review.html">dyf-1</a></strong> - Required for <a href="../../genes/worm/osm-3/osm-3-ai-review.html">osm-3</a> function<br />
 - <strong>dyf-3</strong> - IFT54 ortholog<br />
 - <strong>dyf-6</strong> - IFT46 ortholog<br />
 - <strong>dyf-11</strong> - IFT54 ortholog<br />


### PR DESCRIPTION
## Summary

Automated regeneration of static assets after gene review or template changes.

## Generated Assets

| Asset | Count/Status |
|-------|--------------|
| Gene review YAML files | 2856 |
| Gene review HTML pages | 2856 |
| Project pages | 1095 |
| Module pages | 87 |
| Browser app (data.js) | Updated |
| Validation report | Updated |

## Trigger

This PR was triggered by changes to:
- genes/**/*.yaml - gene review data files
- src/ai_gene_review/schema/** - LinkML schema files
- src/ai_gene_review/templates/** - Jinja2 templates
- src/ai_gene_review/render.py - rendering code
- src/ai_gene_review/render_modules.py - module rendering code
- src/ai_gene_review/export/** - export code
- src/ai_gene_review/browser/** - browser app assets
- src/ai_gene_review/tools/minify_linkml_browser_data.py - browser data compaction
- projects/*.md - project definitions
- modules/**/*.yaml - module definitions
- project.justfile - just recipes used by CI
- .github/workflows/generate-pages.yaml - workflow definition

## Review

- [ ] Spot-check a few gene review HTML pages render correctly
- [ ] Spot-check module tree browser pages render correctly
- [ ] Verify browser app loads and filters work
- [ ] Check validation report for new issues
