### PR TITLE
Regenerate pages and browser app

### DIFF
--- a/genes/worm/hsp-3/hsp-3-ai-review.html
+++ b/genes/worm/hsp-3/hsp-3-ai-review.html
@@ -1,0 +1,4977 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>hsp-3 - AI Gene Review</title>
+    <style>
+        :root {
+            --color-accept: #22c55e;
+            --color-remove: #ef4444;
+            --color-modify: #f97316;
+            --color-keep-non-core: #3b82f6;
+            --color-undecided: #6b7280;
+            --color-new: #8b5cf6;
+            --color-mark-over: #eab308;
+            --bg-light: #f9fafb;
+            --border-color: #e5e7eb;
+            --text-muted: #6b7280;
+            --text-primary: #111827;
+        }
+
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+            line-height: 1.6;
+            color: var(--text-primary);
+            background-color: #ffffff;
+            padding: 2rem;
+            max-width: 1400px;
+            margin: 0 auto;
+        }
+
+        .header {
+            border-bottom: 2px solid var(--border-color);
+            padding-bottom: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        h1 {
+            font-size: 2.5rem;
+            font-weight: 700;
+            margin-bottom: 0.5rem;
+            color: #1f2937;
+        }
+
+        .gene-info {
+            display: flex;
+            gap: 2rem;
+            flex-wrap: wrap;
+            margin-top: 1rem;
+        }
+
+        .info-item {
+            display: flex;
+            gap: 0.5rem;
+        }
+
+        .info-label {
+            font-weight: 600;
+            color: var(--text-muted);
+        }
+
+        .aliases {
+            display: flex;
+            gap: 0.5rem;
+            flex-wrap: wrap;
+        }
+
+        .badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.875rem;
+            font-weight: 500;
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+        }
+
+        .status-badge {
+            padding: 0.375rem 0.875rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .status-initialized {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fde68a;
+        }
+
+        .status-in-progress {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+        }
+
+        .status-draft {
+            background-color: #fce7f3;
+            color: #831843;
+            border: 1px solid #fbcfe8;
+        }
+
+        .status-complete {
+            background-color: #d1fae5;
+            color: #065f46;
+            border: 1px solid #a7f3d0;
+        }
+
+        .description-card {
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        .description-card h2 {
+            font-size: 1.25rem;
+            margin-bottom: 1rem;
+            color: #374151;
+        }
+
+        .section {
+            margin-bottom: 2.5rem;
+        }
+
+        .section-title {
+            font-size: 1.5rem;
+            font-weight: 600;
+            margin-bottom: 1.5rem;
+            color: #1f2937;
+            border-bottom: 1px solid var(--border-color);
+            padding-bottom: 0.5rem;
+        }
+
+        .annotations-table {
+            width: 100%;
+            border-collapse: collapse;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            overflow: hidden;
+        }
+
+        .annotations-table thead {
+            background-color: var(--bg-light);
+        }
+
+        .annotations-table th {
+            text-align: left;
+            padding: 1rem;
+            font-weight: 600;
+            border-bottom: 2px solid var(--border-color);
+            font-size: 0.875rem;
+            text-transform: uppercase;
+            letter-spacing: 0.05em;
+            color: var(--text-muted);
+        }
+
+        .annotations-table td {
+            padding: 1rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .annotations-table tbody tr:hover {
+            background-color: #f9fafb;
+        }
+
+        .action-badge {
+            display: inline-block;
+            padding: 0.375rem 0.75rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .action-accept {
+            background-color: var(--color-accept);
+            color: white;
+        }
+
+        .action-remove {
+            background-color: var(--color-remove);
+            color: white;
+        }
+
+        .action-modify {
+            background-color: var(--color-modify);
+            color: white;
+        }
+
+        .action-keep_as_non_core {
+            background-color: var(--color-keep-non-core);
+            color: white;
+        }
+
+        .action-undecided {
+            background-color: var(--color-undecided);
+            color: white;
+        }
+
+        .action-new {
+            background-color: var(--color-new);
+            color: white;
+        }
+
+        .action-mark_as_over_annotated {
+            background-color: var(--color-mark-over);
+            color: white;
+        }
+
+        .term-info {
+            display: flex;
+            flex-direction: column;
+            gap: 0.25rem;
+        }
+
+        .term-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .term-label {
+            font-weight: 500;
+        }
+
+        .evidence-code {
+            font-family: monospace;
+            background-color: var(--bg-light);
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .not-badge {
+            display: inline-block;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-weight: 600;
+            margin-left: 0.25rem;
+        }
+
+        .isoform-badge {
+            display: inline-block;
+            background-color: #eff6ff;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            margin-top: 0.25rem;
+        }
+
+        .core-function-card {
+            background-color: white;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 1rem;
+        }
+
+        .core-function-card h3 {
+            font-size: 1.125rem;
+            margin-bottom: 1rem;
+            color: #1f2937;
+        }
+
+        .core-function-statement {
+            margin-bottom: 1rem;
+            padding: 0.75rem;
+            background-color: var(--bg-light);
+            border-left: 4px solid var(--color-accept);
+            border-radius: 0.25rem;
+        }
+
+        .function-annotations {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin-top: 1rem;
+        }
+
+        .reference-item {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+        }
+
+        .reference-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: start;
+            margin-bottom: 0.75rem;
+        }
+
+        .reference-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #2563eb;
+        }
+
+        .supported-by {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f3f4f6;
+            border-left: 3px solid #3b82f6;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .supported-by-title {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .support-item {
+            margin-bottom: 0.5rem;
+        }
+
+        .support-ref {
+            font-weight: 500;
+            color: #2563eb;
+        }
+
+        .support-text {
+            color: #6b7280;
+            font-style: italic;
+            margin-left: 1rem;
+        }
+
+        .propagation-review {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f8fafc;
+            border-left: 3px solid #64748b;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .propagation-title {
+            font-weight: 600;
+            color: #334155;
+            margin-bottom: 0.25rem;
+        }
+
+        .propagation-row {
+            margin-top: 0.25rem;
+        }
+
+        .propagation-source {
+            margin-top: 0.5rem;
+            padding-top: 0.5rem;
+            border-top: 1px solid #e5e7eb;
+        }
+
+        .propagation-source-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #1d4ed8;
+        }
+
+        .propagation-comment {
+            color: #4b5563;
+            margin-left: 1rem;
+        }
+
+        a.term-link {
+            color: #2563eb;
+            text-decoration: none;
+        }
+
+        a.term-link:hover {
+            text-decoration: underline;
+        }
+
+        .core-function-terms {
+            margin-top: 1rem;
+        }
+
+        .function-term-group {
+            margin-bottom: 1rem;
+        }
+
+        .function-term-label {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .reference-title {
+            font-weight: 500;
+            margin-bottom: 0.5rem;
+        }
+
+        .findings-list {
+            margin-top: 1rem;
+            padding-left: 1.5rem;
+        }
+
+        .finding-item {
+            margin-bottom: 0.75rem;
+        }
+
+        .finding-statement {
+            font-weight: 500;
+            margin-bottom: 0.25rem;
+        }
+
+        .finding-text {
+            color: var(--text-muted);
+            font-size: 0.95rem;
+            font-style: italic;
+        }
+
+        .proposed-term {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #fef3c7;
+        }
+
+        .question-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #dbeafe;
+        }
+
+        .experiment-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #f3e8ff;
+        }
+
+        .prediction-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: white;
+        }
+
+        .prediction-card .prediction-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+        }
+
+        .prediction-source {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+        }
+
+        .assessment-badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.8rem;
+            font-weight: 600;
+            text-transform: uppercase;
+        }
+
+        .assessment-cor { background-color: #dcfce7; color: #166534; }
+        .assessment-cnn { background-color: #dbeafe; color: #1e40af; }
+        .assessment-lsp { background-color: #fef9c3; color: #854d0e; }
+        .assessment-unc { background-color: #f3f4f6; color: #374151; }
+        .assessment-pli { background-color: #fee2e2; color: #991b1b; }
+        .assessment-npi { background-color: #fecaca; color: #7f1d1d; }
+        .assessment-rep { background-color: #fde68a; color: #92400e; }
+
+        .confidence-score {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+            margin-left: 0.5rem;
+        }
+
+        .error-type-badge {
+            font-size: 0.75rem;
+            padding: 0.125rem 0.5rem;
+            border-radius: 0.25rem;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+        }
+
+        .isoforms-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fill, minmax(400px, 1fr));
+            gap: 1rem;
+        }
+
+        .isoform-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            background-color: white;
+            transition: box-shadow 0.2s;
+        }
+
+        .isoform-card:hover {
+            box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+        }
+
+        .functional-isoform-type {
+            display: inline-block;
+            padding: 0.2rem 0.5rem;
+            border-radius: 0.25rem;
+            font-size: 0.7rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.03em;
+        }
+
+        .type-SPLICE_VARIANT, .type-SPLICE_CLASS {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #93c5fd;
+        }
+
+        .type-CLEAVAGE_PRODUCT {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fcd34d;
+        }
+
+        .type-MODIFICATION_STATE {
+            background-color: #f3e8ff;
+            color: #6b21a8;
+            border: 1px solid #c4b5fd;
+        }
+
+        .type-CONFORMATIONAL_STATE {
+            background-color: #dcfce7;
+            color: #166534;
+            border: 1px solid #86efac;
+        }
+
+        .functional-isoform-mappings {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+            font-size: 0.85rem;
+        }
+
+        .functional-isoform-mappings .mapping-type {
+            font-weight: 600;
+            color: var(--text-muted);
+            font-size: 0.75rem;
+        }
+
+        .functional-isoform-go {
+            margin-top: 0.5rem;
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.25rem;
+        }
+
+        .go-chip {
+            display: inline-block;
+            padding: 0.15rem 0.4rem;
+            background-color: #ecfdf5;
+            color: #047857;
+            border: 1px solid #a7f3d0;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-family: monospace;
+        }
+
+        .isoform-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+            padding-bottom: 0.5rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .isoform-name {
+            font-weight: 600;
+            font-size: 1.1rem;
+            color: #1f2937;
+        }
+
+        .isoform-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .isoform-sequence-note {
+            font-size: 0.875rem;
+            color: var(--text-muted);
+            margin-bottom: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+        }
+
+        .isoform-description {
+            font-size: 0.95rem;
+            line-height: 1.5;
+        }
+
+        .collapsible {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .collapsible:after {
+            content: ' ▼';
+            font-size: 0.75rem;
+        }
+
+        .collapsible.collapsed:after {
+            content: ' ►';
+        }
+
+        .collapse-content {
+            transition: max-height 0.3s ease;
+            overflow: hidden;
+        }
+
+        .collapsed + .collapse-content {
+            max-height: 0;
+        }
+
+        .no-data {
+            color: var(--text-muted);
+            font-style: italic;
+            padding: 1rem;
+            text-align: center;
+            background-color: var(--bg-light);
+            border-radius: 0.5rem;
+        }
+
+        /* Styling for markdown section summaries with voting */
+        .markdown-section summary {
+            padding: 0.75rem;
+            background: var(--bg-light);
+            border-radius: 0.5rem;
+            margin-bottom: 0.5rem;
+        }
+
+        .markdown-section summary:hover {
+            background: #e5e7eb;
+        }
+
+        .markdown-section summary .vote-buttons {
+            margin-left: auto;
+        }
+
+        .deep-research-section {
+            margin-bottom: 1rem;
+            border: 1px solid #c7d2fe;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8faff;
+        }
+
+        .deep-research-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .deep-research-section summary h3 {
+            margin: 0;
+            color: #3730a3;
+            font-size: 1.1rem;
+        }
+
+        .report-meta {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin: 0.75rem 0 1rem;
+            align-items: center;
+        }
+
+        .report-badge {
+            display: inline-flex;
+            align-items: center;
+            border: 1px solid #c7d2fe;
+            border-radius: 999px;
+            background: #eef2ff;
+            color: #4338ca;
+            font-size: 0.78rem;
+            font-weight: 600;
+            padding: 0.2rem 0.6rem;
+        }
+
+        .report-meta-text {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+        }
+
+        .artifact-list {
+            display: grid;
+            gap: 0.75rem;
+            margin: 0.75rem 0 1rem;
+        }
+
+        .artifact-link {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+            margin-top: 0.5rem;
+            word-break: break-word;
+        }
+
+        @media print {
+            body {
+                padding: 1rem;
+            }
+
+            .collapsible:after {
+                display: none;
+            }
+
+            .collapsed + .collapse-content {
+                max-height: none !important;
+            }
+        }
+
+        @media (max-width: 768px) {
+            body {
+                padding: 1rem;
+            }
+
+            h1 {
+                font-size: 2rem;
+            }
+
+            .annotations-table {
+                font-size: 0.875rem;
+            }
+
+            .annotations-table th,
+            .annotations-table td {
+                padding: 0.5rem;
+            }
+        }
+    </style>
+</head>
+<body>
+    <div class="header">
+        <h1>hsp-3</h1>
+        <div class="gene-info">
+
+            <div class="info-item">
+
+                <span class="info-label">UniProt ID:</span>
+                <span>
+                    <a href="https://www.uniprot.org/uniprotkb/P27420" target="_blank" class="term-link">
+                        P27420
+                    </a>
+                </span>
+
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Organism:</span>
+                <span>Caenorhabditis elegans</span>
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Review Status:</span>
+                <span class="status-badge status-complete">
+                    COMPLETE
+                </span>
+            </div>
+
+
+        </div>
+        <div style="margin-top: 1rem; text-align: center;">
+            <a id="feedback-form-link"
+               href="#"
+               target="_blank"
+               style="display: inline-block; padding: 10px 20px; background-color: #4CAF50; color: white; text-decoration: none; border-radius: 5px; font-weight: 600;">
+                📝 Provide Detailed Feedback
+            </a>
+            <script>
+                // Construct the form URL with proper encoding
+                // Extract organism code from the current page path (e.g., /genes/ARATH/APO1/ -> ARATH)
+                const pathParts = window.location.pathname.split('/');
+                const genesIndex = pathParts.indexOf('genes');
+                let organism = '';
+                if (genesIndex !== -1 && pathParts[genesIndex + 1]) {
+                    organism = pathParts[genesIndex + 1].toUpperCase();
+                }
+                const geneSymbol = "hsp-3";
+                const speciesGene = organism + ' ' + geneSymbol;
+                const formBaseUrl = 'https://docs.google.com/forms/d/e/1FAIpQLSdTot9L6GVkkZYgLQT0E8ZdAJv8RiN5ZgOVkgWNcKSbYvxxzQ/viewform';
+                const entryId = '1226477767'; // Correct entry ID for Species/Gene field
+                const formUrl = formBaseUrl + '?entry.' + entryId + '=' + encodeURIComponent(speciesGene);
+                const feedbackLink = document.getElementById('feedback-form-link');
+                feedbackLink.href = formUrl;
+                // Add tooltip showing the pre-filled value
+                feedbackLink.title = 'Opens form with pre-filled: ' + speciesGene;
+            </script>
+        </div>
+    </div>
+
+
+    <div class="description-card">
+        <div style="display: flex; justify-content: space-between; align-items: center;">
+            <h2>Gene Description</h2>
+            <span class="vote-buttons" data-g="P27420" data-a="DESCRIPTION: HSP-3 is one of the two endoplasmic reticulum (ER)..." data-r="" data-act="DESCRIPTION">
+                <button class="vote-btn" data-v="up" title="Agree with this description">👍</button>
+                <button class="vote-btn" data-v="down" title="Disagree with this description">👎</button>
+            </span>
+        </div>
+        <p>HSP-3 is one of the two endoplasmic reticulum (ER)-resident HSP70/BiP (GRP78/KAR2) chaperones of Caenorhabditis elegans; the other is its close paralog HSP-4. HSP-3 is a soluble ER-lumen protein bearing an N-terminal signal peptide and a C-terminal KDEL-type ER-retention motif, with the canonical HSP70 nucleotide-binding and substrate-binding domain architecture. It acts as an ATP-dependent molecular chaperone that assists folding, refolding and assembly of nascent secretory and membrane proteins in the ER lumen. Like other BiP orthologs, HSP-3 also participates in the ER unfolded protein response (UPR): it (with HSP-4) associates with the three UPR stress sensors IRE-1, ATF-6 and PEK-1 to hold them inactive, and its own transcription is modestly induced by ER stress in an ire-1/xbp-1-dependent manner. HSP-3 is generally the more constitutively expressed of the two worm BiP paralogs, whereas HSP-4 is the strongly stress-inducible one. HSP-3 is a direct substrate of the FIC-1 AMPylase and contributes to tolerance of chronic ER stress and to innate immunity.</p>
+    </div>
+
+
+
+
+
+
+
+    <div class="section">
+        <h2 class="section-title">Existing Annotations Review</h2>
+        <table class="annotations-table">
+            <thead>
+                <tr>
+                    <th>GO Term</th>
+                    <th>Evidence</th>
+                    <th>Action</th>
+                    <th>Reason</th>
+                </tr>
+            </thead>
+            <tbody>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005737" target="_blank" class="term-link">
+                                    GO:0005737
+                                </a>
+                            </span>
+                            <span class="term-label">cytoplasm</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="P27420" data-a="GO:0005737" data-r="GO_REF:0000033" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> IBA annotation propagated across the broad HSP70 phylogenetic tree, which contains cytosolic and nuclear members. HSP-3 is a dedicated ER-lumenal BiP with a cleaved signal peptide and a C-terminal KDEL ER-retention motif; its functional compartment is the ER lumen, not the cytoplasm.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Over-propagation from the pan-HSP70 family tree. HSP-3 is directly reported to be retained within the ER lumen and carries a signal peptide plus ER-retention motif, so a general cytoplasm annotation does not represent its site of action.
+                        </div>
+
+
+
+                        <div class="propagation-review">
+                            <div class="propagation-title">Propagation Review</div>
+                            <div class="propagation-row">
+                                <strong>Root cause:</strong>
+                                <span class="badge">PROPAGATION BAD</span>
+                            </div>
+
+                            <div class="propagation-row">
+                                <strong>Failure modes:</strong>
+
+                                <span class="badge">COMPARTMENT OR COMPLEX MISMATCH</span>
+
+                            </div>
+
+
+                            <div class="propagation-source">
+                                <strong>Sources checked:</strong>
+
+                                <div class="propagation-row">
+                                    <span class="propagation-source-id">PANTHER:PTN002321897</span>
+
+
+                                    <span class="badge">SUPPORTS SOURCE BUT NOT TARGET</span>
+
+
+                                    <div class="propagation-comment">GO_Central IBA propagated across the broad HSP70 tree, which contains cytosolic/nuclear members; HSP-3 is a signal-peptide-bearing, KDEL-retained ER-lumenal BiP, so the cytosolic localization does not transfer to it.</div>
+
+                                </div>
+
+                            </div>
+
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/27138431" target="_blank" class="term-link">
+                                        PMID:27138431
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">HSP-1 is predominantly cytosolic, whereas HSP-3 is retained within the ER lumen.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    UniProt:P27420
+
+                                </span>
+
+                                <div class="support-text">SUBCELLULAR LOCATION: Endoplasmic reticulum lumen</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005788" target="_blank" class="term-link">
+                                    GO:0005788
+                                </a>
+                            </span>
+                            <span class="term-label">endoplasmic reticulum lumen</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P27420" data-a="GO:0005788" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> The ER lumen is the primary functional location of HSP-3, consistent with its signal peptide, KDEL retention motif, and direct experimental localization.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Core localization of HSP-3/BiP. UniProt records ER lumen localization and the FIC-1 study directly reports HSP-3 retention in the ER lumen.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    UniProt:P27420
+
+                                </span>
+
+                                <div class="support-text">SUBCELLULAR LOCATION: Endoplasmic reticulum lumen</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/27138431" target="_blank" class="term-link">
+                                        PMID:27138431
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">HSP-1 is predominantly cytosolic, whereas HSP-3 is retained within the ER lumen.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016887" target="_blank" class="term-link">
+                                    GO:0016887
+                                </a>
+                            </span>
+                            <span class="term-label">ATP hydrolysis activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P27420" data-a="GO:0016887" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> HSP-3/BiP is an ATPase; ATP hydrolysis drives the allosteric chaperone cycle of substrate binding and release. This is a conserved core molecular function of the HSP70 family.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> ATP hydrolysis is essential to the HSP70/BiP chaperone cycle. UniProt annotates this activity (ISS to yeast KAR2), and it is a defining feature of the family.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    UniProt:P27420
+
+                                </span>
+
+                                <div class="support-text">GO:0016887; F:ATP hydrolysis activity; ISS:WormBase</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    UniProt:P27420
+
+                                </span>
+
+                                <div class="support-text">Belongs to the heat shock protein 70 family</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0044183" target="_blank" class="term-link">
+                                    GO:0044183
+                                </a>
+                            </span>
+                            <span class="term-label">protein folding chaperone</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P27420" data-a="GO:0044183" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> HSP-3 is an ER-resident molecular chaperone that assists folding and assembly of client proteins in the ER lumen, the core molecular function of BiP orthologs.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> This is the core molecular function of HSP-3. UniProt describes a role in facilitating assembly of multimeric protein complexes in the ER, and the FIC-1 study frames HSP-3 and HSP-4 as cross-compensating ER-resident chaperones.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    UniProt:P27420
+
+                                </span>
+
+                                <div class="support-text">Probably plays a role in facilitating the assembly of</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/27138431" target="_blank" class="term-link">
+                                        PMID:27138431
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">elegans encodes two Grp78/BiP homologues, hsp-3 and hsp-4, assumed to cross-compensate for each other in their roles as ER-residing protein chaperones</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:worm/hsp-3/hsp-3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">primarily responsible for de novo protein folding and the refolding of misfolded proteins within the ER lumen</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005634" target="_blank" class="term-link">
+                                    GO:0005634
+                                </a>
+                            </span>
+                            <span class="term-label">nucleus</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="P27420" data-a="GO:0005634" data-r="GO_REF:0000033" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> IBA annotation propagated from nuclear/cytosolic HSP70 family members. HSP-3 is an ER-lumenal BiP and is not a nuclear protein.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Over-propagation from the broad HSP70 tree. HSP-3 has a signal peptide and a KDEL ER-retention motif and is directly reported to reside in the ER lumen; nuclear localization does not represent its function.
+                        </div>
+
+
+
+                        <div class="propagation-review">
+                            <div class="propagation-title">Propagation Review</div>
+                            <div class="propagation-row">
+                                <strong>Root cause:</strong>
+                                <span class="badge">PROPAGATION BAD</span>
+                            </div>
+
+                            <div class="propagation-row">
+                                <strong>Failure modes:</strong>
+
+                                <span class="badge">COMPARTMENT OR COMPLEX MISMATCH</span>
+
+                            </div>
+
+
+                            <div class="propagation-source">
+                                <strong>Sources checked:</strong>
+
+                                <div class="propagation-row">
+                                    <span class="propagation-source-id">PANTHER:PTN001834223</span>
+
+
+                                    <span class="badge">SUPPORTS SOURCE BUT NOT TARGET</span>
+
+
+                                    <div class="propagation-comment">Nuclear localization is contributed by nuclear/cytosolic HSP70 members of the family tree; it does not transfer to the ER-lumenal BiP HSP-3.</div>
+
+                                </div>
+
+                            </div>
+
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/27138431" target="_blank" class="term-link">
+                                        PMID:27138431
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">HSP-1 is predominantly cytosolic, whereas HSP-3 is retained within the ER lumen.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    UniProt:P27420
+
+                                </span>
+
+                                <div class="support-text">SUBCELLULAR LOCATION: Endoplasmic reticulum lumen</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0031072" target="_blank" class="term-link">
+                                    GO:0031072
+                                </a>
+                            </span>
+                            <span class="term-label">heat shock protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P27420" data-a="GO:0031072" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> HSP70/BiP chaperones cooperate with co-chaperones (J-domain/Hsp40 proteins and nucleotide-exchange factors) that regulate the ATPase cycle and substrate handling; this is captured by heat shock protein binding.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> A defensible family-level function that is more informative than generic protein binding: it reflects the co-chaperone interactions central to the HSP70 mechanism. Retained as a supporting (non-defining) molecular function.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    UniProt:P27420
+
+                                </span>
+
+                                <div class="support-text">Belongs to the heat shock protein 70 family</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0036503" target="_blank" class="term-link">
+                                    GO:0036503
+                                </a>
+                            </span>
+                            <span class="term-label">ERAD pathway</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P27420" data-a="GO:0036503" data-r="GO_REF:0000033" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> BiP orthologs recognize and retain misfolded ER proteins destined for ER-associated degradation. This is a genuine BiP-family role, but there is no hsp-3-specific experimental evidence in C. elegans and it is peripheral to the constitutive folding role.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Plausible by orthology (BiP participates in ERAD substrate recognition) but not the primary, directly demonstrated function of HSP-3; retained as a non-core role pending worm-specific evidence.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    UniProt:P27420
+
+                                </span>
+
+                                <div class="support-text">Belongs to the heat shock protein 70 family</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016020" target="_blank" class="term-link">
+                                    GO:0016020
+                                </a>
+                            </span>
+                            <span class="term-label">membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="P27420" data-a="GO:0016020" data-r="GO_REF:0000033" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> HSP-3 is a soluble ER-lumen protein, not a membrane-embedded protein. It may transiently associate with membrane-bound clients or the translocon, but is not an integral membrane protein.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Overly broad and imprecise for a soluble ER-lumenal BiP with a KDEL retention motif. The specific location endoplasmic reticulum lumen (GO:0005788) is more appropriate.
+                        </div>
+
+
+
+                        <div class="propagation-review">
+                            <div class="propagation-title">Propagation Review</div>
+                            <div class="propagation-row">
+                                <strong>Root cause:</strong>
+                                <span class="badge">TERM SCOPING PROBLEM</span>
+                            </div>
+
+                            <div class="propagation-row">
+                                <strong>Failure modes:</strong>
+
+                                <span class="badge">GRANULARITY MISMATCH</span>
+
+                                <span class="badge">COMPARTMENT OR COMPLEX MISMATCH</span>
+
+                            </div>
+
+
+                            <div class="propagation-source">
+                                <strong>Sources checked:</strong>
+
+                                <div class="propagation-row">
+                                    <span class="propagation-source-id">PANTHER:PTN001834223</span>
+
+
+                                    <span class="badge">SUPPORTS SOURCE BUT NOT TARGET</span>
+
+
+                                    <div class="propagation-comment">The generic membrane term reflects membrane-associated HSP70 family members; HSP-3 is a soluble ER-lumen protein, so ER lumen (GO:0005788) is the correct scoped location.</div>
+
+                                </div>
+
+                            </div>
+
+                        </div>
+
+
+                        <div style="margin-top: 0.5rem;">
+                            <strong>Proposed replacements:</strong>
+
+                            <span class="badge">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005788" target="_blank" class="term-link">
+                                    endoplasmic reticulum lumen
+                                </a>
+                            </span>
+
+                        </div>
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    UniProt:P27420
+
+                                </span>
+
+                                <div class="support-text">SUBCELLULAR LOCATION: Endoplasmic reticulum lumen</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0042026" target="_blank" class="term-link">
+                                    GO:0042026
+                                </a>
+                            </span>
+                            <span class="term-label">protein refolding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P27420" data-a="GO:0042026" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> HSP70/BiP chaperones iteratively bind and release substrates through the ATP-driven cycle to promote (re)folding of unfolded or misfolded ER clients.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Refolding/folding of ER clients is a core activity of HSP-3/BiP, driven by its ATPase cycle. Consistent with UniProt and the family-level chaperone role.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    UniProt:P27420
+
+                                </span>
+
+                                <div class="support-text">Probably plays a role in facilitating the assembly of</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    UniProt:P27420
+
+                                </span>
+
+                                <div class="support-text">Belongs to the heat shock protein 70 family</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0034663" target="_blank" class="term-link">
+                                    GO:0034663
+                                </a>
+                            </span>
+                            <span class="term-label">endoplasmic reticulum chaperone complex</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P27420" data-a="GO:0034663" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> HSP-3 functions within the ER chaperone machinery, cooperating with co-chaperones and other ER quality-control factors, and it physically associates with the UPR stress sensors in the ER membrane.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> HSP-3/BiP is a component of the ER chaperone complex. This is supported both by phylogenetic inference and by the direct demonstration that HSP-3 forms a complex with IRE-1, ATF-6 and PEK-1.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/27138431" target="_blank" class="term-link">
+                                        PMID:27138431
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">form a complex with IRE-1, ATF-6 and PEK-1, to preclude activation of UPR-related signaling events</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0030968" target="_blank" class="term-link">
+                                    GO:0030968
+                                </a>
+                            </span>
+                            <span class="term-label">endoplasmic reticulum unfolded protein response</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P27420" data-a="GO:0030968" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> HSP-3/BiP is both a UPR effector and a target. It binds the UPR sensors to keep them inactive under basal conditions, and its transcription is induced by ER stress in an ire-1/xbp-1-dependent manner.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Involvement in the ER UPR is a core BiP function. HSP-3 directly participates in the sensor-repressive complex and is a modestly xbp-1-dependent UPR target gene.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/27138431" target="_blank" class="term-link">
+                                        PMID:27138431
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">form a complex with IRE-1, ATF-6 and PEK-1, to preclude activation of UPR-related signaling events</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/12186849" target="_blank" class="term-link">
+                                        PMID:12186849
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">in C. elegans, the ire-1 and xbp-1 pathway has retained its essential role in upregulating expression of many UPR target genes that are similarly upregulated by the homologous pathway in yeast</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005524" target="_blank" class="term-link">
+                                    GO:0005524
+                                </a>
+                            </span>
+                            <span class="term-label">ATP binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000002
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P27420" data-a="GO:0005524" data-r="GO_REF:0000002" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> HSP-3 binds ATP through its nucleotide-binding domain; ATP binding and its allosteric coupling to the substrate-binding domain drive the chaperone cycle.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Core molecular function of HSP-3/BiP, supported by the conserved HSP70 nucleotide-binding domain and UniProt keyword annotation.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    UniProt:P27420
+
+                                </span>
+
+                                <div class="support-text">GO:0005524; F:ATP binding; IEA:UniProtKB-KW</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005788" target="_blank" class="term-link">
+                                    GO:0005788
+                                </a>
+                            </span>
+                            <span class="term-label">endoplasmic reticulum lumen</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000044
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P27420" data-a="GO:0005788" data-r="GO_REF:0000044" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> IEA localization from UniProt subcellular-location mapping, duplicating the IBA call from a different source. ER lumen is the established location of HSP-3.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct and well-supported localization; multiple independent evidence sources for the ER lumen are appropriate.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    UniProt:P27420
+
+                                </span>
+
+                                <div class="support-text">SUBCELLULAR LOCATION: Endoplasmic reticulum lumen</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016887" target="_blank" class="term-link">
+                                    GO:0016887
+                                </a>
+                            </span>
+                            <span class="term-label">ATP hydrolysis activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000002
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P27420" data-a="GO:0016887" data-r="GO_REF:0000002" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> IEA annotation from InterPro-to-GO mapping, duplicating the IBA ATP hydrolysis call. HSP-3 is an ATPase.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> ATP hydrolysis is a core function of HSP-3/BiP; multiple evidence sources are appropriate.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    UniProt:P27420
+
+                                </span>
+
+                                <div class="support-text">GO:0016887; F:ATP hydrolysis activity; ISS:WormBase</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0030968" target="_blank" class="term-link">
+                                    GO:0030968
+                                </a>
+                            </span>
+                            <span class="term-label">endoplasmic reticulum unfolded protein response</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000117
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P27420" data-a="GO:0030968" data-r="GO_REF:0000117" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> IEA annotation from ARBA machine-learning models, duplicating the UPR involvement supported by direct and expression evidence.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> HSP-3 involvement in the ER UPR is well-supported by direct interaction with the UPR sensors and by its xbp-1-dependent induction.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/27138431" target="_blank" class="term-link">
+                                        PMID:27138431
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">form a complex with IRE-1, ATF-6 and PEK-1, to preclude activation of UPR-related signaling events</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0036498" target="_blank" class="term-link">
+                                    GO:0036498
+                                </a>
+                            </span>
+                            <span class="term-label">IRE1-mediated unfolded protein response</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/11779465" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:11779465
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Complementary signaling pathways regulate the unfolded prote...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P27420" data-a="GO:0036498" data-r="PMID:11779465" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> IEP annotation based on expression pattern. Shen et al. (2001) established the ire-1/xbp-1 UPR pathway in C. elegans, which controls UPR target-gene transcription including the BiP genes.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> hsp-3 is induced by ER stress in an ire-1/xbp-1-dependent manner (see the Urano microarray, cosmid C15H9.6). The IEP call from the foundational UPR paper is defensible; the full text (read by the WormBase curator) is not cached, so the specific hsp-3 expression evidence is deferred to the curator.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/11779465" target="_blank" class="term-link">
+                                        PMID:11779465
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">C. elegans requires ire-1-mediated splicing of xbp-1 mRNA for UPR gene transcription and survival upon ER stress</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0036498" target="_blank" class="term-link">
+                                    GO:0036498
+                                </a>
+                            </span>
+                            <span class="term-label">IRE1-mediated unfolded protein response</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">HEP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/12186849" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:12186849
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    A survival pathway for Caenorhabditis elegans with a blocked...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P27420" data-a="GO:0036498" data-r="PMID:12186849" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> HEP annotation from the genome-wide ER-stress microarray. hsp-3 (cosmid C15H9.6) is among the tunicamycin-induced genes whose induction is attenuated in xbp-1 mutants, placing it downstream of the ire-1/xbp-1 (IRE1-mediated) UPR branch.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Directly supported: C15H9.6 (= hsp-3) appears in Table I of xbp-1-dependent, tunicamycin-induced genes (N2 log2 1.32, reduced to 0.68 in xbp-1), a modest but genuine IRE1/xbp-1-dependent induction.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/12186849" target="_blank" class="term-link">
+                                        PMID:12186849
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">in C. elegans, the ire-1 and xbp-1 pathway has retained its essential role in upregulating expression of many UPR target genes that are similarly upregulated by the homologous pathway in yeast</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0030968" target="_blank" class="term-link">
+                                    GO:0030968
+                                </a>
+                            </span>
+                            <span class="term-label">endoplasmic reticulum unfolded protein response</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/11779465" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:11779465
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Complementary signaling pathways regulate the unfolded prote...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P27420" data-a="GO:0030968" data-r="PMID:11779465" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> IEP annotation from the foundational C. elegans UPR study, based on the ER-stress expression program controlled by ire-1/xbp-1.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> hsp-3 is an ER-stress-responsive gene within the ire-1/xbp-1-controlled UPR program (see Urano microarray). Deferred to the WormBase curator for the specific full-text expression evidence.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/11779465" target="_blank" class="term-link">
+                                        PMID:11779465
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">C. elegans requires ire-1-mediated splicing of xbp-1 mRNA for UPR gene transcription and survival upon ER stress</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0030968" target="_blank" class="term-link">
+                                    GO:0030968
+                                </a>
+                            </span>
+                            <span class="term-label">endoplasmic reticulum unfolded protein response</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">HEP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/12186849" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:12186849
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    A survival pathway for Caenorhabditis elegans with a blocked...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P27420" data-a="GO:0030968" data-r="PMID:12186849" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> HEP annotation from the ER-stress microarray. hsp-3 (C15H9.6) is a tunicamycin- induced, xbp-1-dependent gene, marking it as part of the ER UPR transcriptional program.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Supported by Table I of Urano et al., where C15H9.6 (= hsp-3) is induced by ER stress and attenuated in xbp-1 mutants. Consistent with BiP being a canonical UPR target.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/12186849" target="_blank" class="term-link">
+                                        PMID:12186849
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">in C. elegans, the ire-1 and xbp-1 pathway has retained its essential role in upregulating expression of many UPR target genes that are similarly upregulated by the homologous pathway in yeast</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0034663" target="_blank" class="term-link">
+                                    GO:0034663
+                                </a>
+                            </span>
+                            <span class="term-label">endoplasmic reticulum chaperone complex</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">ISS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/11779465" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:11779465
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Complementary signaling pathways regulate the unfolded prote...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P27420" data-a="GO:0034663" data-r="PMID:11779465" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> ISS annotation (by similarity to human BiP, UniProtKB:P11021) placing HSP-3 in the ER chaperone complex. Corroborated by its physical association with the ER UPR sensors.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> HSP-3 is orthologous to mammalian BiP, a component of the ER chaperone machinery, and directly forms a complex with IRE-1/ATF-6/PEK-1 in the ER.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/27138431" target="_blank" class="term-link">
+                                        PMID:27138431
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">form a complex with IRE-1, ATF-6 and PEK-1, to preclude activation of UPR-related signaling events</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    UniProt:P27420
+
+                                </span>
+
+                                <div class="support-text">Belongs to the heat shock protein 70 family</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016887" target="_blank" class="term-link">
+                                    GO:0016887
+                                </a>
+                            </span>
+                            <span class="term-label">ATP hydrolysis activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">ISS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/2225768" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:2225768
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    The HSP70 multigene family of Caenorhabditis elegans.
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P27420" data-a="GO:0016887" data-r="PMID:2225768" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> ISS annotation (by similarity to yeast KAR2/BiP, UniProtKB:P16474) for the HSP70 ATPase activity. HSP-3 is an ER-resident HSP70 with conserved ATPase machinery.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> ATP hydrolysis is a conserved core function of ER HSP70/BiP proteins. The ISS to yeast KAR2 is appropriate given the strong sequence conservation of the HSP70 nucleotide-binding domain.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    UniProt:P27420
+
+                                </span>
+
+                                <div class="support-text">GO:0016887; F:ATP hydrolysis activity; ISS:WormBase</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    UniProt:P27420
+
+                                </span>
+
+                                <div class="support-text">Belongs to the heat shock protein 70 family</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006457" target="_blank" class="term-link">
+                                    GO:0006457
+                                </a>
+                            </span>
+                            <span class="term-label">protein folding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">NAS</span>
+
+
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-new">
+                            NEW
+                        </span>
+                        <span class="vote-buttons" data-g="P27420" data-a="GO:0006457" data-r="" data-act="NEW">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Added to align core_functions with existing_annotations. Protein folding is the biological process served by the HSP-3 chaperone/ATPase activities in the ER lumen.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Core process term not present among the GOA existing annotations; HSP-3/BiP is an ATP-dependent chaperone whose primary role is folding of ER client proteins.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    UniProt:P27420
+
+                                </span>
+
+                                <div class="support-text">Probably plays a role in facilitating the assembly of</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+            </tbody>
+        </table>
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Core Functions</h2>
+
+        <div class="core-function-card">
+
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+                <h3>HSP-3 is an ER-lumen-resident HSP70/BiP molecular chaperone that assists folding, refolding and assembly of nascent secretory and membrane client proteins in the ER lumen, using ATP-dependent cycles of substrate binding and release. It also participates in the ER unfolded protein response, both as a sensor-repressing chaperone and as a stress-inducible effector.</h3>
+                <span class="vote-buttons" data-g="P27420" data-a="FUNCTION: HSP-3 is an ER-lumen-resident HSP70/BiP molecular ..." data-r="" data-act="CORE_FUNCTION">
+                    <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
+                    <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
+                </span>
+            </div>
+
+
+            <div class="core-function-terms">
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Molecular Function:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0044183" target="_blank" class="term-link">
+                            protein folding chaperone
+                        </a>
+                    </span>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Directly Involved In:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006457" target="_blank" class="term-link">
+                                protein folding
+                            </a>
+                        </span>
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0030968" target="_blank" class="term-link">
+                                endoplasmic reticulum unfolded protein response
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Cellular Locations:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005788" target="_blank" class="term-link">
+                                endoplasmic reticulum lumen
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+
+
+            </div>
+
+
+            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
+                <strong>Supporting Evidence:</strong>
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            UniProt:P27420
+
+                        </span>
+
+                        <div class="finding-text">Probably plays a role in facilitating the assembly of</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/27138431" target="_blank" class="term-link">
+                                PMID:27138431
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">HSP-1 is predominantly cytosolic, whereas HSP-3 is retained within the ER lumen.</div>
+
+                    </li>
+
+                </ul>
+            </div>
+
+        </div>
+
+        <div class="core-function-card">
+
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+                <h3>ATP hydrolysis drives the HSP-3 chaperone cycle. Allosteric coupling between the nucleotide-binding and substrate-binding domains converts ATP turnover into regulated binding and release of client polypeptides.</h3>
+                <span class="vote-buttons" data-g="P27420" data-a="FUNCTION: ATP hydrolysis drives the HSP-3 chaperone cycle. A..." data-r="" data-act="CORE_FUNCTION">
+                    <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
+                    <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
+                </span>
+            </div>
+
+
+            <div class="core-function-terms">
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Molecular Function:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016887" target="_blank" class="term-link">
+                            ATP hydrolysis activity
+                        </a>
+                    </span>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Directly Involved In:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006457" target="_blank" class="term-link">
+                                protein folding
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Cellular Locations:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005788" target="_blank" class="term-link">
+                                endoplasmic reticulum lumen
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+
+
+            </div>
+
+
+            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
+                <strong>Supporting Evidence:</strong>
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            UniProt:P27420
+
+                        </span>
+
+                        <div class="finding-text">GO:0016887; F:ATP hydrolysis activity; ISS:WormBase</div>
+
+                    </li>
+
+                </ul>
+            </div>
+
+        </div>
+
+        <div class="core-function-card">
+
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+                <h3>HSP-3 binds ATP through its conserved HSP70 nucleotide-binding domain; nucleotide state allosterically controls substrate-binding affinity during the chaperone cycle.</h3>
+                <span class="vote-buttons" data-g="P27420" data-a="FUNCTION: HSP-3 binds ATP through its conserved HSP70 nucleo..." data-r="" data-act="CORE_FUNCTION">
+                    <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
+                    <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
+                </span>
+            </div>
+
+
+            <div class="core-function-terms">
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Molecular Function:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005524" target="_blank" class="term-link">
+                            ATP binding
+                        </a>
+                    </span>
+                </div>
+
+
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Cellular Locations:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005788" target="_blank" class="term-link">
+                                endoplasmic reticulum lumen
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+
+
+            </div>
+
+
+            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
+                <strong>Supporting Evidence:</strong>
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            UniProt:P27420
+
+                        </span>
+
+                        <div class="finding-text">GO:0005524; F:ATP binding; IEA:UniProtKB-KW</div>
+
+                    </li>
+
+                </ul>
+            </div>
+
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title collapsible">References</h2>
+        <div class="collapse-content">
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000002.md" target="_blank" class="term-link">
+                            GO_REF:0000002
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Gene Ontology annotation through association of InterPro records with GO terms</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000033.md" target="_blank" class="term-link">
+                            GO_REF:0000033
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Annotation inferences using phylogenetic trees</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000044.md" target="_blank" class="term-link">
+                            GO_REF:0000044
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location vocabulary mapping, accompanied by conservative changes to GO terms applied by UniProt</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000117.md" target="_blank" class="term-link">
+                            GO_REF:0000117
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Electronic Gene Ontology annotations created by ARBA machine learning models</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/11779465" target="_blank" class="term-link">
+                            PMID:11779465
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Complementary signaling pathways regulate the unfolded protein response and are required for C. elegans development.</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">Foundational study establishing that C. elegans uses ire-1-mediated splicing of xbp-1 mRNA for UPR gene transcription and survival upon ER stress.</div>
+
+                        <div class="finding-text">"C. elegans requires ire-1-mediated splicing of xbp-1 mRNA for UPR gene transcription and survival upon ER stress"</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/12186849" target="_blank" class="term-link">
+                            PMID:12186849
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">A survival pathway for Caenorhabditis elegans with a blocked unfolded protein response.</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">Genome-wide microarray of the C. elegans ER-stress response; hsp-3 (cosmid C15H9.6) is among the tunicamycin-induced genes whose induction is attenuated in xbp-1 mutants (Table I), establishing hsp-3 as an xbp-1-dependent UPR target.</div>
+
+                        <div class="finding-text">"in C. elegans, the ire-1 and xbp-1 pathway has retained its essential role in upregulating expression of many UPR target genes that are similarly upregulated by the homologous pathway in yeast"</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/2225768" target="_blank" class="term-link">
+                            PMID:2225768
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">The HSP70 multigene family of Caenorhabditis elegans.</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">Reviews the C. elegans HSP70 multigene family, including the ER-resident BiP-type members; used as the ISS source for ATP hydrolysis activity.</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/27138431" target="_blank" class="term-link">
+                            PMID:27138431
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">The Caenorhabditis elegans Protein FIC-1 Is an AMPylase That Covalently Modifies Heat-Shock 70 Family Proteins, Translation Elongation Factors and Histones.</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">HSP-3 is directly retained within the ER lumen (contrasted with the cytosolic HSP-1), confirming its ER-lumenal localization by direct study.</div>
+
+                        <div class="finding-text">"HSP-1 is predominantly cytosolic, whereas HSP-3 is retained within the ER lumen."</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <div class="finding-statement">HSP-3 is a direct in vivo AMPylation substrate of FIC-1, identified by mass spectrometry among the AMPylated protein fraction.</div>
+
+                        <div class="finding-text">"two classes of proteins over-represented amongst the AMPylated fraction of proteins: HSP 70 proteins (HSP-1, HSP-3)"</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <div class="finding-statement">HSP-3, with HSP-4, forms a complex with the three UPR sensors IRE-1, ATF-6 and PEK-1 to keep them inactive (the classical BiP brake on UPR signaling).</div>
+
+                        <div class="finding-text">"form a complex with IRE-1, ATF-6 and PEK-1, to preclude activation of UPR-related signaling events"</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <div class="finding-statement">HSP-3 contributes to tolerance of chronic ER stress and to innate immunity, based on hypersensitivity of hsp-3 animals to Pseudomonas aeruginosa.</div>
+
+                        <div class="finding-text">"highlighting a role for HSP-3 in the tolerance of chronic ER stress and innate immunity."</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <div class="finding-statement">The two worm BiP paralogs hsp-3 and hsp-4 are assumed to cross-compensate as ER-resident chaperones, framing their functional redundancy.</div>
+
+                        <div class="finding-text">"elegans encodes two Grp78/BiP homologues, hsp-3 and hsp-4, assumed to cross-compensate for each other in their roles as ER-residing protein chaperones"</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+        </div>
+    </div>
+
+
+
+
+    <div class="section">
+        <h2 class="section-title">Suggested Questions for Experts</h2>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> Which secretory/membrane client proteins specifically depend on HSP-3 (rather than HSP-4) for folding in the C. elegans ER, and in which tissues?</p>
+
+                </div>
+                <span class="vote-buttons" data-g="P27420" data-a="Q: Which secretory/membrane client proteins specifica..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> Does FIC-1-mediated AMPylation inhibit or otherwise tune HSP-3 chaperone activity in vivo, and is it dynamically regulated during ER-stress recovery?</p>
+
+                </div>
+                <span class="vote-buttons" data-g="P27420" data-a="Q: Does FIC-1-mediated AMPylation inhibit or otherwis..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> Is the BiP-mediated repression of the IRE-1/ATF-6/PEK-1 sensors exerted specifically by HSP-3, by HSP-4, or does it require both paralogs?</p>
+
+                </div>
+                <span class="vote-buttons" data-g="P27420" data-a="Q: Is the BiP-mediated repression of the IRE-1/ATF-6/..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Suggested Experiments</h2>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> Proximity labeling (TurboID/BioID) of endogenously tagged HSP-3 and HSP-4 under basal and tunicamycin/pathogen-induced ER stress, to define paralog-specific client and interactor repertoires.</p>
+
+
+                    <p style="margin-top: 0.5rem;"><em>Hypothesis: HSP-3 and HSP-4 have overlapping but distinct client and interactor sets.</em></p>
+
+
+                    <p style="margin-top: 0.5rem;">Type: proteomics</p>
+
+                </div>
+                <span class="vote-buttons" data-g="P27420" data-a="EXPERIMENT: Proximity labeling (TurboID/BioID) of endogenously..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> Generate non-AMPylatable HSP-3 knock-in alleles (mutating the FIC-1 target residue) and assay ER-stress tolerance, innate-immune resistance to P. aeruginosa, and chaperone-dependent folding reporters.</p>
+
+
+                    <p style="margin-top: 0.5rem;"><em>Hypothesis: AMPylation of HSP-3 modulates its chaperone activity and stress tolerance.</em></p>
+
+
+                    <p style="margin-top: 0.5rem;">Type: genetics / phenotyping</p>
+
+                </div>
+                <span class="vote-buttons" data-g="P27420" data-a="EXPERIMENT: Generate non-AMPylatable HSP-3 knock-in alleles (m..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> Paralog-specific depletion (hsp-3 vs hsp-4) combined with a UPR reporter and sensor activation assays to test which paralog restrains IRE-1/ATF-6/PEK-1 under basal conditions.</p>
+
+
+                    <p style="margin-top: 0.5rem;"><em>Hypothesis: HSP-3 and HSP-4 differ in their contribution to UPR-sensor repression.</em></p>
+
+
+                    <p style="margin-top: 0.5rem;">Type: genetics / reporter assay</p>
+
+                </div>
+                <span class="vote-buttons" data-g="P27420" data-a="EXPERIMENT: Paralog-specific depletion (hsp-3 vs hsp-4) combin..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Knowledge Gaps</h2>
+        <p style="color: #555; font-size: 0.92rem; margin-top: -0.3rem;">
+            What is <em>not</em> known — curated, literature-grounded statements of the open
+            unknowns (the inverse of core functions).
+        </p>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> The molecular basis of the division of labor between the two C. elegans BiP paralogs HSP-3 and HSP-4 is undetermined: which client proteins specifically require HSP-3 (versus HSP-4), and which tissue programs and signaling interfaces each paralog serves, are not established.</p>
+            <p style="margin-top: 0.4rem;">
+                <span class="badge">NARROWING</span>
+                <span class="badge">BIOLOGY</span>
+                <span class="badge">RESIDUAL_SUBGAP</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> Both are ER-lumen HSP70/BiP orthologs with canonical nucleotide- and substrate- binding domains that share &gt;70% sequence similarity, and recent paralog-resolved work indicates they are functionally diversified rather than strictly interchangeable (HSP-3 canonical folding; HSP-4 specialized for stress/ER-phagy signaling). What is undetermined is the paralog-specific clientele and mechanism.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Significance:</strong> Distinguishing HSP-3- from HSP-4-dependent clients is required to interpret loss-of- function phenotypes, to model human BiP (single-gene) biology in the two-paralog worm system, and to know which paralog controls a given secretory or stress phenotype.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>What would resolve it:</strong> Paralog-resolved interactome/client proteomics (e.g. proximity labeling of tagged endogenous HSP-3 vs HSP-4) under basal and ER-stress conditions, with reciprocal rescue and paralog-swap experiments.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Provenance (the field's own admissions):</strong></p>
+            <ul style="margin-top: 0.2rem;">
+
+                <li><em>"elegans encodes two Grp78/BiP homologues, hsp-3 and hsp-4, assumed to cross-compensate for each other in their roles as ER-residing protein chaperones"</em> — PMID:27138431</li>
+
+            </ul>
+
+
+        </div>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> The functional consequence of HSP-3 AMPylation by FIC-1 is unknown: whether, where, and under what conditions this modification alters HSP-3 ATPase or chaperone activity in vivo has not been determined.</p>
+            <p style="margin-top: 0.4rem;">
+                <span class="badge">OPEN</span>
+                <span class="badge">BIOLOGY</span>
+                <span class="badge">RESIDUAL_SUBGAP</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> HSP-3 is a confirmed in vivo AMPylation substrate of the sole C. elegans Fic protein FIC-1 (identified by mass spectrometry), and AMPylation is a reversible post-translational modification, but its regulatory effect on HSP-3 activity is not characterized.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Significance:</strong> AMPylation of BiP-family chaperones is a candidate mechanism for tuning ER chaperone capacity during stress and recovery; knowing its effect on HSP-3 would clarify how chaperone activity is post-translationally regulated in the worm ER.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>What would resolve it:</strong> Measure the ATPase/chaperone activity of AMPylated versus unmodified HSP-3 and phenotype non-AMPylatable HSP-3 knock-in animals under ER stress and pathogen challenge.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Provenance (the field's own admissions):</strong></p>
+            <ul style="margin-top: 0.2rem;">
+
+                <li><em>"results in diverse changes of their activities remains to be studied."</em> — PMID:27138431</li>
+
+                <li><em>"two classes of proteins over-represented amongst the AMPylated fraction of proteins"</em> — PMID:27138431</li>
+
+            </ul>
+
+
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Tags</h2>
+        <div class="aliases">
+
+            <span class="badge">caeel-proteostasis</span>
+
+            <span class="badge">caeel-upr-stress</span>
+
+        </div>
+    </div>
+
+
+    <!-- Computational Predictions Section -->
+
+
+    <!-- Deep Research Sections -->
+
+    <div class="section">
+        <h2 class="section-title">Deep Research</h2>
+
+        <details class="deep-research-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; gap: 1rem;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Falcon</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(hsp-3-deep-research-falcon.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="P27420" data-a="DEEP_RESEARCH: Falcon" data-r="" data-act="DEEP_RESEARCH" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This deep research is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This deep research needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+
+                <div class="report-meta">
+
+                    <span class="report-meta-text">Comprehensive Research Report: *C. elegans* HSP-3 (hsp-3 / C15H9.6) — An ER-Resident BiP/GRP78 Ortholog</span>
+
+
+                    <span class="report-badge">Falcon</span>
+
+
+                    <span class="report-badge">Edison Scientific Literature</span>
+
+
+                    <span class="report-badge">28 citations</span>
+
+
+                    <span class="report-badge">2 artifacts</span>
+
+
+                    <span class="report-meta-text">2026-07-03T20:29:19.454154</span>
+
+
+
+                </div>
+
+
+                <div class="artifact-list">
+
+
+
+                    <div class="artifact-link">
+                        <a href="hsp-3-deep-research-falcon_artifacts/artifact-00.md" class="term-link">Edison artifact artifact-00</a>
+                        <span>(text/markdown)</span>
+                    </div>
+
+
+
+
+                    <div class="artifact-link">
+                        <a href="hsp-3-deep-research-falcon_artifacts/artifact-01.md" class="term-link">Edison artifact artifact-01</a>
+                        <span>(text/markdown)</span>
+                    </div>
+
+
+                </div>
+
+                <p>The research report should be a detailed narrative explaining the function, biological processes, and localization of the gene product. Citations should be given for all claims.</p>
+<p>You should prioritize authoritative reviews and primary scientific literature when conducting research. You can supplement<br />
+this with annotations you find in gene/protein databases, but these can be outdated or inaccurate.</p>
+<p>We are specifically interested in the primary function of the gene - for enzymes, what reaction is catalyzed, and what is the substrate specificity? For transporters, what is the substrate? For structural proteins or adapters, what is the broader structural role? For signaling molecules, what is the role in the pathway.</p>
+<p>We are interested in where in or outside the cell the gene product carries out its function.</p>
+<p>We are also interested in the signaling or biochemical pathways in which the gene functions. We are less interested in broad pleiotropic effects, except where these elucidate the precise role.</p>
+<p>Include evidence where possible. We are interested in both experimental evidence as well as inference from structure, evolution, or bioinformatic analysis. Precise studies should be prioritized over high-throughput, where available.</p>
+<h1 id="comprehensive-research-report-c-elegans-hsp-3-hsp-3-c15h96-an-er-resident-bipgrp78-ortholog">Comprehensive Research Report: <em>C. elegans</em> HSP-3 (hsp-3 / C15H9.6) — An ER-Resident BiP/GRP78 Ortholog</h1>
+<h2 id="1-gene-identity-and-protein-overview">1. Gene Identity and Protein Overview</h2>
+<p>The <em>hsp-3</em> gene (also known as <em>hsp70c</em>, ORF name C15H9.6; UniProt P27420) encodes Heat Shock 70 kDa Protein C in <em>Caenorhabditis elegans</em>. HSP-3 is a member of the heat shock protein 70 (HSP70) family and is one of two <em>C. elegans</em> orthologs of mammalian BiP/GRP78 (the binding immunoglobulin protein), the other being HSP-4 (urban2025functionallydiversifiedcaenorhabditis pages 1-2, shen2001complementarysignalingpathways pages 2-3). While mammals possess a single BiP gene, <em>C. elegans</em> has undergone a gene duplication resulting in two functionally diversified BiP paralogs that share high sequence similarity but have distinct roles in endoplasmic reticulum (ER) proteostasis and organismal physiology (urban2025functionallydiversifiedcaenorhabditis pages 1-2, urban2025functionallydiversifiedbip pages 1-5).</p>
+<h2 id="2-primary-molecular-function">2. Primary Molecular Function</h2>
+<h3 id="21-er-chaperone-activity">2.1 ER Chaperone Activity</h3>
+<p>HSP-3 functions as a <strong>canonical ER-resident HSP70 chaperone</strong> primarily responsible for de novo protein folding and the refolding of misfolded proteins within the ER lumen (urban2025functionallydiversifiedbip pages 29-33, urban2025functionallydiversifiedcaenorhabditis pages 8-10). Like its mammalian counterpart BiP, HSP-3 contains an N-terminal ATPase/nucleotide-binding domain (NBD) and a C-terminal substrate-binding domain, consistent with its InterPro domain annotations (ATPase_NBD, BIP_NBD, HSP70_C_sf, HSP70_peptide-bd_sf). The protein cycles between ATP-bound (low-affinity, fast-exchange) and ADP-bound (high-affinity, slow-exchange) states to bind and release unfolded or misfolded client polypeptides translocated into the ER, thereby assisting their productive folding (urban2025functionallydiversifiedbip pages 29-33, truttmann2016thecaenorhabditiselegans pages 8-11).</p>
+<p>Recent work by Urban et al. (2025) has clarified that, compared to its paralog HSP-4, HSP-3 operates more directly as a <strong>protein refolding chaperone</strong>, while HSP-4 has become more specialized for interorganellar signaling, ER stress mitigation, and adaptive transcriptional programs (urban2025functionallydiversifiedbip pages 29-33, urban2025functionallydiversifiedcaenorhabditis pages 8-10). This functional diversification represents a significant conceptual advance in understanding how duplicated BiP genes partition ER proteostasis functions.</p>
+<h3 id="22-post-translational-regulation-by-ampylation">2.2 Post-Translational Regulation by AMPylation</h3>
+<p>HSP-3 is a direct substrate of the Fic-domain AMPylase FIC-1, the <em>C. elegans</em> ortholog of mammalian FICD/HYPE. Mass spectrometry identified <strong>threonine 176 (Thr176)</strong> within the nucleotide-binding domain as the specific AMPylation site, a modification that covalently attaches an AMP moiety to the protein (truttmann2016thecaenorhabditiselegans pages 13-14, truttmann2016thecaenorhabditiselegans pages 11-13, camara2022hypemediatedampylationas pages 37-41). Notably, this site differs from the mammalian BiP AMPylation sites (Ser365/Thr366 and Thr518), indicating species-specific regulatory mechanisms (camara2022hypemediatedampylationas pages 37-41). HSP-4, by contrast, was not identified as a FIC-1 AMPylation target, demonstrating selectivity among the two BiP paralogs (camara2022hypemediatedampylationas pages 37-41, chatterjee2021ficandnonfic pages 14-15). While the precise consequences of Thr176 AMPylation for HSP-3 chaperone activity remain to be fully elucidated, FIC-1 is proposed to act as a "soft" regulator of BiP-dependent ER proteostasis (truttmann2016thecaenorhabditiselegans pages 13-14, chatterjee2021ficandnonfic pages 14-15).</p>
+<h2 id="3-subcellular-localization">3. Subcellular Localization</h2>
+<p>HSP-3 is localized to the <strong>ER lumen</strong>, consistent with its possession of an N-terminal signal peptide (precursor) and a C-terminal <strong>KDEL ER-retention motif</strong> (couillault2012auprindependentinfectionspecific pages 7-8, shen2001complementarysignalingpathways pages 2-3). This distinguishes it from HSP-4, which carries an HDEL retention signal (shen2001complementarysignalingpathways pages 2-3). The ER-lumenal localization restricts HSP-3's direct access to cytosolic proteins, confining its primary chaperone activity to the secretory pathway (urban2025functionallydiversifiedbip pages 29-33). Fluorescent protein fusion reporters (HSP-3::wrmScarlet) with tags inserted immediately upstream of the XDEL motif confirmed functional ER localization and allowed visualization of tissue-specific expression patterns (urban2025functionallydiversifiedbip pages 14-18).</p>
+<h3 id="31-tissue-specific-expression">3.1 Tissue-Specific Expression</h3>
+<p>HSP-3 is broadly expressed throughout the worm body, with particularly high abundance in the <strong>intestine</strong> and <strong>neurons</strong> in early adulthood (urban2025functionallydiversifiedbip pages 18-21). Expression increases in response to ER stress predominantly in these tissues (urban2025functionallydiversifiedbip pages 18-21). Germline expression is also functionally important: germline-specific ablation of hsp-3 shortens lifespan (urban2025functionallydiversifiedcaenorhabditis pages 5-8, urban2025functionallydiversifiedbip pages 21-25). Intriguingly, intestine-specific loss of hsp-3 does not significantly alter lifespan, and pan-neuronal loss has modest effects, suggesting that the germline is a critical tissue for HSP-3-dependent longevity control (urban2025functionallydiversifiedcaenorhabditis pages 5-8).</p>
+<h3 id="32-temporal-expression-dynamics">3.2 Temporal Expression Dynamics</h3>
+<p>HSP-3 protein levels are notably higher than HSP-4 throughout larval development and in day 1 adults, peaking during the <strong>L3/L4 developmental stages</strong> (approximately 48 hours post-development) (urban2025functionallydiversifiedbip pages 14-18, urban2025functionallydiversifiedcaenorhabditis pages 1-2). HSP-3 abundance then decreases upon entry into adulthood, though it increases again later in life, with maximum adult levels around day 5 (urban2025functionallydiversifiedcaenorhabditis pages 1-2). This contrasts with HSP-4, whose levels are minimal during larval stages but rise substantially during adulthood, peaking around day 10 (urban2025functionallydiversifiedcaenorhabditis pages 1-2).</p>
+<h2 id="4-signaling-and-biochemical-pathways">4. Signaling and Biochemical Pathways</h2>
+<h3 id="41-unfolded-protein-response-uprer">4.1 Unfolded Protein Response (UPR^ER)</h3>
+<p>HSP-3 is both a <strong>target gene</strong> and a <strong>regulatory component</strong> of the ER unfolded protein response. The UPR^ER in <em>C. elegans</em> operates through three conserved sensor pathways: IRE-1/XBP-1, PEK-1 (PERK ortholog), and ATF-6.</p>
+<ul>
+<li><strong>Basal expression</strong>: HSP-3 requires <strong>IRE-1</strong> for its constitutive expression in unstressed conditions (urban2025functionallydiversifiedbip pages 18-21).</li>
+<li><strong>Stress-induced expression</strong>: Upon ER stress, hsp-3 transcription is upregulated through the <strong>IRE-1/XBP-1</strong> pathway. Both hsp-3 and hsp-4 promoters contain XBP-1 binding sites (shen2001complementarysignalingpathways pages 7-8). However, hsp-3 is more modestly stress-inducible than hsp-4: DTT treatment induces hsp-3 approximately 2-fold compared to 9-fold for hsp-4, reflecting hsp-3's higher basal expression (approximately 5-fold higher than hsp-4 under normal conditions) (shen2001complementarysignalingpathways pages 2-3).</li>
+<li><strong>Loss-of-function consequences</strong>: Loss of hsp-3 triggers distinct transcriptomic responses involving all three UPR sensors. In polyglutamine-expressing worms, compensatory protective responses to hsp-3 depletion require signaling through IRE-1, PEK-1, and ATF-6, with PEK-1 signaling through ATF-4 and eIF2A being particularly important for suppressing proteotoxicity (pelt2025lossoffic1mediated pages 1-2, pelt2025lossoffic1mediated pages 14-16).</li>
+</ul>
+<h3 id="42-fic-1ampylation-upr-crosstalk">4.2 FIC-1/AMPylation-UPR Crosstalk</h3>
+<p>The AMPylase FIC-1 modulates HSP-3 activity at the post-translational level. Genetic deletion of <em>fic-1</em> rescues the developmental arrest caused by hsp-3 depletion in polyglutamine-expressing animals, indicating that FIC-1-mediated AMPylation normally restrains compensatory proteostasis responses (pelt2025lossoffic1mediated pages 1-2, pelt2025lossoffic1mediated pages 2-4). In <em>fic-1</em>-deficient worms, loss of hsp-3 triggers upregulation of the cytosolic HSP70 chaperone F44E5.4 through UPR^ER signaling, which is sufficient to suppress polyQ toxicity. This requires both IRE-1 and ATF-6, as knockdown of either blocks F44E5.4 upregulation (pelt2025lossoffic1mediated pages 1-2, pelt2025lossoffic1mediated pages 14-16).</p>
+<h3 id="43-innate-immunity-upr-independent-signaling">4.3 Innate Immunity — UPR-Independent Signaling</h3>
+<p>A distinct and surprising function of HSP-3 was uncovered by Couillault et al. (2012): HSP-3 plays a <strong>UPR-independent, infection-specific role</strong> in the epidermal innate immune response to fungal infection by <em>Drechmeria coniospora</em> (couillault2012auprindependentinfectionspecific pages 7-8, couillault2012auprindependentinfectionspecific pages 5-7). Epistasis analysis placed HSP-3 genetically <strong>downstream of the Tribbles-like kinase NIPI-3</strong> and <strong>upstream of (or parallel to) the protein kinase C delta TPA-1</strong> in the regulation of the antimicrobial peptide gene <em>nlp-29</em> (couillault2012auprindependentinfectionspecific pages 5-7). This immune function is specific to infection and is not shared with HSP-4, nor does it involve the canonical UPR. HSP-3 does not affect nlp-29 induction by non-immune stressors such as wounding, salt stress, or PMA treatment (couillault2012auprindependentinfectionspecific pages 5-7). The precise mechanism by which an ER-resident chaperone signals in an infection-specific immune pathway remains an open question, with the authors suggesting that HSP-3 may function outside the ER in some contexts despite possessing a KDEL retention signal (couillault2012auprindependentinfectionspecific pages 7-8).</p>
+<h3 id="44-temperature-dependent-germline-sex-determination">4.4 Temperature-Dependent Germline Sex Determination</h3>
+<p>In an elegant 2024 study, Shi et al. identified BiP (encoded by hsp-3/hsp-4) as a <strong>temperature sensor</strong> mediating temperature-induced germline sex reversal in <em>C. elegans</em> (shi2024identificationofbip pages 9-10). At warmer temperatures (30°C), increased ER protein-folding demand sequesters BiP, reducing the pool of free BiP available in the germline. This reduction in available BiP leads to ERAD-dependent degradation of the oocyte fate-driving factor TRA-2, thereby promoting male (sperm) germline fate. The mechanism demonstrates that BiP transduces temperature information into a germline sex-governing signal, providing mechanistic insight into how genotypic and temperature-dependent sex determination can coexist (shi2024identificationofbip pages 9-10).</p>
+<h3 id="45-proteotoxic-stress-and-neurodegeneration-models">4.5 Proteotoxic Stress and Neurodegeneration Models</h3>
+<p>HSP-3 depletion has pronounced effects in <em>C. elegans</em> models of protein aggregation diseases. In polyglutamine (polyQ)-expressing worms, hsp-3 knockdown causes <strong>developmental arrest</strong> and worsens fitness and lifespan decline (pelt2025lossoffic1mediated pages 1-2, pelt2025lossoffic1mediated pages 2-4, pelt2025lossoffic1mediated pages 10-14). Transcriptomic analysis revealed that hsp-3 loss upregulates molecular chaperones (hsp-90, F44E5.4/F44E5.5, small HSPs), ERAD components, and glutathione S-transferases, while downregulating reproduction and lysosomal function genes (pelt2025lossoffic1mediated pages 14-16, pelt2025lossoffic1mediated pages 10-14). HSP-3 overexpression, however, does not increase paralysis in amyloid-β expressing worms, in contrast to HSP-4 overexpression, indicating compartmentalized functional roles in neurodegenerative contexts (urban2025functionallydiversifiedbip pages 29-33).</p>
+<h2 id="5-role-in-aging-and-lifespan-regulation">5. Role in Aging and Lifespan Regulation</h2>
+<p>A comprehensive analysis by Urban et al. (2025, <em>Nature Communications</em>) demonstrated that HSP-3 and HSP-4 have distinct roles in longevity (urban2025functionallydiversifiedcaenorhabditis pages 1-2, urban2025functionallydiversifiedcaenorhabditis pages 5-8, urban2025functionallydiversifiedbip pages 21-25):</p>
+<ul>
+<li><strong>Life-long depletion</strong> of either paralog reduces lifespan, with hsp-3 mutants being significantly shorter-lived than hsp-4 mutants (urban2025functionallydiversifiedcaenorhabditis pages 5-8).</li>
+<li><strong>HSP-3 overexpression uniquely improves longevity</strong> (urban2025functionallydiversifiedbip pages 1-5, urban2025functionallydiversifiedbip pages 21-25).</li>
+<li>HSP-3 is most critical during <strong>larval development</strong>: loss during this period has lasting negative effects on later-life health. HSP-4, by contrast, is essential throughout adulthood (urban2025functionallydiversifiedcaenorhabditis pages 5-8, urban2025functionallydiversifiedbip pages 21-25).</li>
+<li>HSP-3 and HSP-4 <strong>differentially regulate dietary restriction and reduced insulin signaling-mediated longevity</strong>. Intriguingly, hsp-3 loss can enhance lifespan in <em>daf-2</em> (insulin/IGF-1 receptor) mutants, suggesting a complex, non-linear interaction with the insulin signaling pathway (urban2025functionallydiversifiedcaenorhabditis pages 1-2, urban2025functionallydiversifiedcaenorhabditis pages 5-8).</li>
+<li>The authors propose a model in which aging-specific demands require a shift from direct chaperone-mediated protein refolding (the primary HSP-3 function) to broader transcriptional regulation, a role more aligned with HSP-4 (urban2025functionallydiversifiedcaenorhabditis pages 8-10).</li>
+</ul>
+<h2 id="6-functional-diversification-of-hsp-3-and-hsp-4">6. Functional Diversification of HSP-3 and HSP-4</h2>
+<p>The following table compares the two BiP orthologs across major functional dimensions:</p>
+<table>
+<thead>
+<tr>
+<th>Feature</th>
+<th>HSP-3</th>
+<th>HSP-4</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>Gene / ortholog identity</td>
+<td>BiP/GRP78-family ER-resident HSP70 chaperone encoded by <strong>hsp-3</strong>; one of two C. elegans BiP paralogs (urban2025functionallydiversifiedcaenorhabditis pages 1-2, shen2001complementarysignalingpathways pages 7-8)</td>
+<td>BiP/GRP78-family ER-resident HSP70 chaperone encoded by <strong>hsp-4</strong>; paralog of hsp-3 and canonical UPR reporter target in many studies (urban2025functionallydiversifiedcaenorhabditis pages 1-2, shen2001complementarysignalingpathways pages 7-8)</td>
+</tr>
+<tr>
+<td>ER retention motif</td>
+<td><strong>KDEL</strong> ER-retention motif reported for HSP-3 (couillault2012auprindependentinfectionspecific pages 7-8, shen2001complementarysignalingpathways pages 2-3)</td>
+<td><strong>HDEL</strong> ER-retention motif reported for HSP-4 (shen2001complementarysignalingpathways pages 2-3)</td>
+</tr>
+<tr>
+<td>Basal expression level</td>
+<td>Higher basal expression than HSP-4; hsp-3 has ~5-fold higher basal expression and HSP-3 protein exceeds HSP-4 through development and in day-1 adults (urban2025functionallydiversifiedbip pages 14-18, shen2001complementarysignalingpathways pages 2-3)</td>
+<td>Lower basal expression than HSP-3 during development; minimal in larval stages relative to HSP-3 (urban2025functionallydiversifiedbip pages 14-18, urban2025functionallydiversifiedcaenorhabditis pages 1-2)</td>
+</tr>
+<tr>
+<td>Stress inducibility</td>
+<td>Induced by ER stress, but more modestly than hsp-4; DTT induced hsp-3 ~2-fold in early UPR work (shen2001complementarysignalingpathways pages 2-3)</td>
+<td>Strongly stress inducible; DTT induced hsp-4 ~9-fold, making it the more classic inducible UPR target (shen2001complementarysignalingpathways pages 2-3)</td>
+</tr>
+<tr>
+<td>Primary function</td>
+<td>Functions as a more <strong>canonical ER HSP70 chaperone</strong> for de novo protein folding and misfolded protein refolding; especially important for developmental protein quality control (urban2025functionallydiversifiedbip pages 29-33, urban2025functionallydiversifiedcaenorhabditis pages 8-10)</td>
+<td>Shares ER folding function but appears more specialized for <strong>ER stress mitigation, signaling integration, and adaptive proteostasis programs</strong> rather than primarily direct refolding (urban2025functionallydiversifiedbip pages 18-21, urban2025functionallydiversifiedcaenorhabditis pages 8-10)</td>
+</tr>
+<tr>
+<td>Tissue-enriched expression</td>
+<td>Broadly expressed; in early adulthood HSP-3 is especially abundant in <strong>intestine and neurons</strong> (urban2025functionallydiversifiedbip pages 18-21)</td>
+<td>Also induced in intestine and neurons under ER stress; later-life expression becomes more prominent than during larval stages (urban2025functionallydiversifiedbip pages 18-21, urban2025functionallydiversifiedcaenorhabditis pages 1-2)</td>
+</tr>
+<tr>
+<td>Intestine-specific roles</td>
+<td>Intestine-specific loss of hsp-3 did <strong>not</strong> significantly alter lifespan in the 2025 study (urban2025functionallydiversifiedcaenorhabditis pages 5-8)</td>
+<td>Intestinal hsp-4 loss shortened lifespan and caused severe defects including early death/matricide, indicating a stronger intestinal homeostatic requirement (urban2025functionallydiversifiedcaenorhabditis pages 5-8, urban2025functionallydiversifiedbip pages 21-25)</td>
+</tr>
+<tr>
+<td>Germline-specific roles</td>
+<td>Germline-specific ablation shortens lifespan, showing a germline requirement for organismal aging control (urban2025functionallydiversifiedcaenorhabditis pages 5-8, urban2025functionallydiversifiedbip pages 21-25)</td>
+<td>Germline loss also shortens lifespan, in some analyses more severely than hsp-3 loss (urban2025functionallydiversifiedcaenorhabditis pages 5-8, urban2025functionallydiversifiedbip pages 21-25)</td>
+</tr>
+<tr>
+<td>Neuronal roles</td>
+<td>Pan-neuronal loss had little lifespan effect, but HSP-3 is strongly expressed in neurons and participates in neuronal/organismal ER proteostasis programs (urban2025functionallydiversifiedbip pages 18-21, urban2025functionallydiversifiedcaenorhabditis pages 5-8)</td>
+<td>Neuronal expression is also part of ER stress responses; hsp-4 is a major downstream effector in proteostasis-related neuronal disease models such as tauopathy rescue by XBP-1s (urban2025functionallydiversifiedbip pages 18-21)</td>
+</tr>
+<tr>
+<td>Age-dependent expression</td>
+<td>Peaks during <strong>L3/L4</strong> development, remains above HSP-4 in day-1 adults, then declines on entry into adulthood; later peaks around day 5 adults in the 2025 study (urban2025functionallydiversifiedbip pages 14-18, urban2025functionallydiversifiedcaenorhabditis pages 1-2)</td>
+<td>Low during larval development, rises strongly in adulthood, with peak abundance later than HSP-3 (around day 10 adults in the 2025 study) (urban2025functionallydiversifiedcaenorhabditis pages 1-2)</td>
+</tr>
+<tr>
+<td>Role in basal UPR regulation</td>
+<td>Basal expression requires <strong>IRE-1</strong>; during ER stress, upregulation depends strongly on <strong>IRE-1/XBP-1</strong> (urban2025functionallydiversifiedbip pages 18-21, shen2001complementarysignalingpathways pages 7-8)</td>
+<td>Basal expression also depends on <strong>IRE-1</strong>; stress-induced regulation is more complex, involving <strong>IRE-1</strong> and context-dependent input from <strong>ATF-6</strong>, while <strong>PEK-1</strong> can negatively regulate some HSP-4 responses (urban2025functionallydiversifiedbip pages 18-21)</td>
+</tr>
+<tr>
+<td>Differential engagement with UPR branches</td>
+<td>Loss of hsp-3 elicits UPR and stress-response transcription; in polyQ settings, protective compensation in fic-1 mutants requires <strong>IRE-1, ATF-6, and PEK-1 downstream signaling</strong> (pelt2025lossoffic1mediated pages 1-2, pelt2025lossoffic1mediated pages 14-16)</td>
+<td>Loss of hsp-4 more strongly resembles overt UPRER activation and is more tightly integrated with the broader three-sensor UPR network (urban2025functionallydiversifiedbip pages 18-21)</td>
+</tr>
+<tr>
+<td>Role in aging / lifespan</td>
+<td>Loss shortens lifespan more severely than hsp-4 loss; overexpression of HSP-3 extends lifespan; particularly critical during <strong>larval development</strong> for later-life health (urban2025functionallydiversifiedbip pages 1-5, urban2025functionallydiversifiedcaenorhabditis pages 5-8, urban2025functionallydiversifiedbip pages 21-25)</td>
+<td>Loss also shortens lifespan, but HSP-4 is more critical during <strong>adulthood</strong> and in intestine-centered longevity control (urban2025functionallydiversifiedcaenorhabditis pages 5-8, urban2025functionallydiversifiedbip pages 21-25)</td>
+</tr>
+<tr>
+<td>Relationship to dietary restriction / insulin-signaling longevity</td>
+<td>2025 work indicates HSP-3 and HSP-4 differentially regulate dietary-restriction and reduced-insulin-signaling longevity; hsp-3 loss can enhance lifespan in <strong>daf-2</strong> mutants, implying non-identical interaction with IIS (urban2025functionallydiversifiedcaenorhabditis pages 1-2, urban2025functionallydiversifiedcaenorhabditis pages 5-8)</td>
+<td>Also participates in DR/IIS longevity regulation, but with distinct tissue/time requirements from HSP-3 (urban2025functionallydiversifiedcaenorhabditis pages 1-2, urban2025functionallydiversifiedcaenorhabditis pages 5-8)</td>
+</tr>
+<tr>
+<td>FIC-1 AMPylation</td>
+<td><strong>Direct FIC-1 target</strong>; AMPylated at <strong>Thr176</strong> in the nucleotide-binding domain, indicating post-translational regulation of HSP-3 activity/state (truttmann2016thecaenorhabditiselegans pages 13-14, truttmann2016thecaenorhabditiselegans pages 11-13, chatterjee2021ficandnonfic pages 14-15)</td>
+<td>No comparable FIC-1 AMPylation evidence was identified in the cited studies; HSP-4 was not highlighted as the FIC-1-modified BiP paralog (camara2022hypemediatedampylationas pages 37-41, chatterjee2021ficandnonfic pages 14-15)</td>
+</tr>
+<tr>
+<td>Innate immunity role</td>
+<td>Has a distinct <strong>UPR-independent infection-specific role</strong> in epidermal antifungal signaling; acts genetically downstream of <strong>nipi-3</strong> and upstream of or parallel to <strong>tpa-1</strong> to regulate <strong>nlp-29</strong> induction (couillault2012auprindependentinfectionspecific pages 7-8, couillault2012auprindependentinfectionspecific pages 5-7)</td>
+<td>Does not share the same infection-specific immune role; can partly compensate in some contexts but was not assigned the same nlp-29 regulatory function (couillault2012auprindependentinfectionspecific pages 7-8, couillault2012auprindependentinfectionspecific pages 5-7)</td>
+</tr>
+<tr>
+<td>PolyQ / proteotoxic stress phenotypes</td>
+<td>hsp-3 depletion causes developmental arrest and worsens polyQ toxicity; fic-1 deletion can rescue this by activating UPRER-linked compensatory chaperone programs (pelt2025lossoffic1mediated pages 1-2, pelt2025lossoffic1mediated pages 2-4, pelt2025lossoffic1mediated pages 10-14)</td>
+<td>hsp-4 depletion also perturbs ER homeostasis, but transcriptomic and signaling consequences are distinct and complementary to hsp-3 loss (pelt2025lossoffic1mediated pages 1-2)</td>
+</tr>
+<tr>
+<td>ER-phagy / autophagy</td>
+<td>Participates in BiP-controlled ER proteostasis and ER-phagy-related phenotypes, but <strong>hsp-3 loss alone did not specifically induce autophagy</strong> in the 2025 work (urban2025functionallydiversifiedcaenorhabditis pages 1-2, urban2025functionallydiversifiedbip pages 33-36)</td>
+<td>More clearly linked to autophagy/ER-phagy control; <strong>hsp-4 knockdown specifically induced autophagy</strong> and HSP-4 was linked to ER-phagy signaling via IRE-1-associated programs (urban2025functionallydiversifiedcaenorhabditis pages 1-2, urban2025functionallydiversifiedcaenorhabditis pages 8-10)</td>
+</tr>
+<tr>
+<td>Overall interpretation</td>
+<td>Developmentally dominant, highly abundant, folding-centered BiP paralog with additional specialized roles in immunity and proteostasis buffering (urban2025functionallydiversifiedbip pages 29-33, couillault2012auprindependentinfectionspecific pages 7-8, urban2025functionallydiversifiedbip pages 21-25)</td>
+<td>More inducible, adulthood- and stress-oriented BiP paralog specialized for adaptive UPRER signaling, intestinal homeostasis, and autophagy/ER-phagy responses (urban2025functionallydiversifiedbip pages 18-21, urban2025functionallydiversifiedcaenorhabditis pages 5-8, urban2025functionallydiversifiedcaenorhabditis pages 8-10)</td>
+</tr>
+</tbody>
+</table>
+<p><em>Table: This table compares the two C. elegans BiP orthologs across localization, expression, stress regulation, pathway involvement, tissue roles, and aging phenotypes. It is useful for distinguishing the more developmentally abundant, folding-centered HSP-3 from the more stress-inducible, signaling-linked HSP-4.</em></p>
+<h2 id="7-summary-of-pathways-and-biological-processes">7. Summary of Pathways and Biological Processes</h2>
+<p>The following table provides a pathway-level summary of HSP-3 involvement:</p>
+<table>
+<thead>
+<tr>
+<th>Pathway/Process</th>
+<th>Role of HSP-3</th>
+<th>Key Interactors</th>
+<th>Evidence Type (genetic/biochemical/transcriptomic)</th>
+<th>Key Reference</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>ER protein folding / quality control</td>
+<td>Canonical ER-resident HSP70/BiP chaperone that supports de novo folding and refolding of misfolded secretory-pathway proteins; more developmentally abundant and folding-centered than HSP-4 (urban2025functionallydiversifiedbip pages 29-33, urban2025functionallydiversifiedcaenorhabditis pages 8-10)</td>
+<td>HSP-4, ER client proteins, ER proteostasis machinery (urban2025functionallydiversifiedbip pages 29-33, urban2025functionallydiversifiedcaenorhabditis pages 1-2)</td>
+<td>Genetic, expression/localization, functional inference from family/domain conservation (urban2025functionallydiversifiedbip pages 29-33, urban2025functionallydiversifiedbip pages 14-18)</td>
+<td>Urban et al., 2025 bioRxiv / Nature Communications (urban2025functionallydiversifiedbip pages 29-33, urban2025functionallydiversifiedcaenorhabditis pages 1-2)</td>
+</tr>
+<tr>
+<td>Unfolded Protein Response (IRE-1/XBP-1, PEK-1, ATF-6)</td>
+<td>UPR target and regulator: basal and stress-induced expression depends strongly on IRE-1/XBP-1; hsp-3 loss activates compensatory UPR programs and engages all three ER stress sensors in specific proteotoxic contexts (urban2025functionallydiversifiedbip pages 18-21, shen2001complementarysignalingpathways pages 7-8, pelt2025lossoffic1mediated pages 1-2, pelt2025lossoffic1mediated pages 14-16)</td>
+<td>IRE-1, XBP-1, PEK-1, ATF-6, ATF-4, eIF2A, HSP-4 (urban2025functionallydiversifiedbip pages 18-21, pelt2025lossoffic1mediated pages 1-2, pelt2025lossoffic1mediated pages 14-16)</td>
+<td>Genetic, reporter-based, transcriptomic (urban2025functionallydiversifiedbip pages 18-21, shen2001complementarysignalingpathways pages 7-8, pelt2025lossoffic1mediated pages 1-2)</td>
+<td>Shen et al., 2001 Cell; Van Pelt &amp; Truttmann, 2025 PLOS Genetics (shen2001complementarysignalingpathways pages 7-8, pelt2025lossoffic1mediated pages 1-2)</td>
+</tr>
+<tr>
+<td>FIC-1 / AMPylation regulation</td>
+<td>Direct substrate of the Fic AMPylase FIC-1; AMPylated at Thr176 in the nucleotide-binding domain, implying post-translational tuning of HSP-3/BiP state and ER proteostasis capacity (truttmann2016thecaenorhabditiselegans pages 13-14, truttmann2016thecaenorhabditiselegans pages 11-13, chatterjee2021ficandnonfic pages 14-15)</td>
+<td>FIC-1, ATP, Thr176 residue in HSP-3 NBD (truttmann2016thecaenorhabditiselegans pages 13-14, truttmann2016thecaenorhabditiselegans pages 11-13)</td>
+<td>Biochemical, mass spectrometry, genetic (truttmann2016thecaenorhabditiselegans pages 13-14, truttmann2016thecaenorhabditiselegans pages 11-13)</td>
+<td>Truttmann et al., 2016 PLOS Genetics; Chatterjee &amp; Truttmann, 2021 Open Biology (truttmann2016thecaenorhabditiselegans pages 13-14, chatterjee2021ficandnonfic pages 14-15)</td>
+</tr>
+<tr>
+<td>Innate immunity / antifungal signaling</td>
+<td>Has a UPR-independent, infection-specific role in epidermal antimicrobial peptide induction; acts downstream of NIPI-3 and upstream of or parallel to TPA-1 to promote nlp-29 expression after fungal infection (couillault2012auprindependentinfectionspecific pages 7-8, couillault2012auprindependentinfectionspecific pages 5-7)</td>
+<td>NIPI-3, TPA-1, nlp-29, HSP-4 (partial compensation context) (couillault2012auprindependentinfectionspecific pages 7-8, couillault2012auprindependentinfectionspecific pages 5-7)</td>
+<td>Genetic, epistasis, proteomic candidate follow-up (couillault2012auprindependentinfectionspecific pages 7-8, couillault2012auprindependentinfectionspecific pages 5-7)</td>
+<td>Couillault et al., 2012 Virulence (couillault2012auprindependentinfectionspecific pages 7-8, couillault2012auprindependentinfectionspecific pages 5-7)</td>
+</tr>
+<tr>
+<td>Temperature-dependent germline sex determination</td>
+<td>BiP pool encoded by hsp-3/hsp-4 functions as a temperature sensor; reduced available BiP under warmer conditions transduces ER folding demand into a signal promoting sperm fate upstream of TRA-2 (shi2024identificationofbip pages 9-10)</td>
+<td>HSP-4, TRA-2, ER folding load / ERAD-linked machinery (shi2024identificationofbip pages 9-10)</td>
+<td>Genetic, physiological, mechanistic inference (shi2024identificationofbip pages 9-10)</td>
+<td>Shi et al., 2024 EMBO Journal (shi2024identificationofbip pages 9-10)</td>
+</tr>
+<tr>
+<td>Polyglutamine / proteotoxic stress</td>
+<td>Loss of hsp-3 worsens ER homeostasis and causes developmental arrest in polyQ-expressing worms; fic-1 deletion rescues via UPRER activation and induction of cytosolic HSP70s, especially F44E5.4 (pelt2025lossoffic1mediated pages 1-2, pelt2025lossoffic1mediated pages 2-4, pelt2025lossoffic1mediated pages 10-14)</td>
+<td>FIC-1, IRE-1, ATF-6, PEK-1, F44E5.4, F44E5.5, small HSPs, glutathione transferases (pelt2025lossoffic1mediated pages 1-2, pelt2025lossoffic1mediated pages 14-16, pelt2025lossoffic1mediated pages 10-14)</td>
+<td>Genetic, transcriptomic, lifespan/developmental assays (pelt2025lossoffic1mediated pages 1-2, pelt2025lossoffic1mediated pages 2-4, pelt2025lossoffic1mediated pages 10-14)</td>
+<td>Van Pelt &amp; Truttmann, 2025 PLOS Genetics (pelt2025lossoffic1mediated pages 1-2, pelt2025lossoffic1mediated pages 2-4)</td>
+</tr>
+<tr>
+<td>Aging and lifespan regulation</td>
+<td>Required for normal lifespan with strong developmental-stage specificity; HSP-3 abundance is high during larval stages, loss shortens lifespan, and overexpression can extend lifespan; tissue-specific effects include germline dependence (urban2025functionallydiversifiedcaenorhabditis pages 1-2, urban2025functionallydiversifiedcaenorhabditis pages 5-8, urban2025functionallydiversifiedbip pages 21-25)</td>
+<td>HSP-4, germline, intestine, daf-2/reduced insulin signaling context (urban2025functionallydiversifiedcaenorhabditis pages 1-2, urban2025functionallydiversifiedcaenorhabditis pages 5-8)</td>
+<td>Genetic, temporal/tissue-specific knockdown, expression profiling (urban2025functionallydiversifiedcaenorhabditis pages 1-2, urban2025functionallydiversifiedcaenorhabditis pages 5-8, urban2025functionallydiversifiedbip pages 21-25)</td>
+<td>Urban et al., 2025 Nature Communications / bioRxiv (urban2025functionallydiversifiedcaenorhabditis pages 1-2, urban2025functionallydiversifiedbip pages 21-25)</td>
+</tr>
+<tr>
+<td>ER-phagy / ER homeostasis remodeling</td>
+<td>Participates in BiP-dependent ER proteostasis programs linked to ER-phagy, but appears less directly tied than HSP-4 to autophagy induction; contributes to maintaining ER quality during aging and stress (urban2025functionallydiversifiedcaenorhabditis pages 1-2, urban2025functionallydiversifiedbip pages 33-36, urban2025functionallydiversifiedcaenorhabditis pages 8-10)</td>
+<td>HSP-4, IRE-1, ER-phagy factors such as Sec-62/C18E9.2-linked pathways (urban2025functionallydiversifiedbip pages 33-36, urban2025functionallydiversifiedcaenorhabditis pages 8-10)</td>
+<td>Genetic, functional, transcriptomic inference (urban2025functionallydiversifiedcaenorhabditis pages 1-2, urban2025functionallydiversifiedcaenorhabditis pages 8-10)</td>
+<td>Urban et al., 2025 Nature Communications / bioRxiv (urban2025functionallydiversifiedcaenorhabditis pages 1-2, urban2025functionallydiversifiedbip pages 33-36)</td>
+</tr>
+<tr>
+<td>Neuron-glia communication</td>
+<td>HSP-3 is highly expressed in neurons and is implicated, together with HSP-4, in ER-stress-linked neuron-glia signaling during aging; evidence is currently stronger for a shared BiP/HSP-mediated IRE1-XBP1 axis than for an HSP-3-specific mechanism (urban2025functionallydiversifiedbip pages 18-21)</td>
+<td>HSP-4, neurons, glia, IRE1-XBP1 pathway (urban2025functionallydiversifiedbip pages 18-21)</td>
+<td>Expression/localization, emerging functional evidence (urban2025functionallydiversifiedbip pages 18-21)</td>
+<td>Urban et al., 2025 bioRxiv; related 2024 preprint literature noted in search context (urban2025functionallydiversifiedbip pages 18-21)</td>
+</tr>
+</tbody>
+</table>
+<p><em>Table: This table summarizes the major signaling pathways and biological processes involving C. elegans HSP-3, highlighting its role, interacting factors, evidence types, and key references. It is useful for quickly distinguishing HSP-3’s core ER chaperone function from its more specialized roles in immunity, proteotoxic stress, aging, and signaling.</em></p>
+<h2 id="8-evolutionary-and-structural-context">8. Evolutionary and Structural Context</h2>
+<p>HSP-3 shares greater than 80% sequence similarity with human BiP/GRP78 (truttmann2016thecaenorhabditiselegans pages 13-14). Its domain architecture — comprising an N-terminal ATPase/nucleotide-binding domain, a substrate-binding domain, and a C-terminal lid domain — is conserved across the HSP70 superfamily. The Thr176 AMPylation site lies within a strictly conserved sequence motif (AVVTVPAYFND) shared among BiP homologs, though the modification site itself is distinct from mammalian BiP AMPylation sites, reflecting species-specific evolution of regulatory mechanisms (truttmann2016thecaenorhabditiselegans pages 13-14, camara2022hypemediatedampylationas pages 37-41). The KDEL ER-retention motif on HSP-3 (versus HDEL on HSP-4) represents a further point of functional divergence that may influence ER retention efficiency and cycling between the ER and Golgi (couillault2012auprindependentinfectionspecific pages 7-8, shen2001complementarysignalingpathways pages 2-3).</p>
+<h2 id="9-conclusions">9. Conclusions</h2>
+<p>HSP-3 is a multifunctional ER-resident HSP70/BiP chaperone in <em>C. elegans</em> whose primary role is the ATP-dependent folding and refolding of client proteins within the ER lumen. It is distinguished from its paralog HSP-4 by higher basal expression, developmental stage-specificity (peaking at L3/L4), sensitivity to FIC-1-mediated AMPylation, and a unique UPR-independent role in epidermal innate immunity. HSP-3 participates in all three branches of the UPR^ER and is essential for developmental protein quality control, lifespan regulation, and stress resistance. Recent discoveries have further revealed its involvement in temperature-dependent germline sex determination and proteotoxic stress responses, making it a central node in <em>C. elegans</em> ER biology with implications for understanding conserved mechanisms of protein homeostasis, aging, and disease.</p>
+<p>References</p>
+<ol>
+<li>
+<p>(urban2025functionallydiversifiedcaenorhabditis pages 1-2): Nicholas D. Urban, Shannon M. Lacy, Kate M. Van Pelt, Benedict Abdon, Zachary Mattiola, Adam Klaiss, Sarah Tabler, Eric K. F. Donahue, Kristopher Burkewitz, and Matthias C. Truttmann. Functionally diversified caenorhabditis elegans bip orthologs control body growth, reproduction, stress resistance, aging, and autophagy. Nature Communications, Dec 2025. URL: https://doi.org/10.1038/s41467-025-65998-0, doi:10.1038/s41467-025-65998-0. This article has 4 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(shen2001complementarysignalingpathways pages 2-3): Xiaohua Shen, Ronald E. Ellis, Kyungho Lee, Chuan-Yin Liu, Kun Yang, Aaron Solomon, Hiderou Yoshida, Rick Morimoto, David M. Kurnit, Kazutoshi Mori, and Randal J. Kaufman. Complementary signaling pathways regulate the unfolded protein response and are required for c. elegans development. Cell, 107:893-903, Dec 2001. URL: https://doi.org/10.1016/s0092-8674(01)00612-2, doi:10.1016/s0092-8674(01)00612-2. This article has 905 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(urban2025functionallydiversifiedbip pages 1-5): Nicholas D. Urban, Shannon M. Lacy, Kate M. Van Pelt, Benedict Abdon, Zachary Mattiola, Adam Klaiss, Sarah Tabler, and Matthias C. Truttmann. Functionally diversified bip orthologs control body growth, reproduction, stress resistance, aging, and er-phagy in caenorhabditis elegans. bioRxiv, Jan 2025. URL: https://doi.org/10.1101/2025.01.14.633073, doi:10.1101/2025.01.14.633073. This article has 4 citations.</p>
+</li>
+<li>
+<p>(urban2025functionallydiversifiedbip pages 29-33): Nicholas D. Urban, Shannon M. Lacy, Kate M. Van Pelt, Benedict Abdon, Zachary Mattiola, Adam Klaiss, Sarah Tabler, and Matthias C. Truttmann. Functionally diversified bip orthologs control body growth, reproduction, stress resistance, aging, and er-phagy in caenorhabditis elegans. bioRxiv, Jan 2025. URL: https://doi.org/10.1101/2025.01.14.633073, doi:10.1101/2025.01.14.633073. This article has 4 citations.</p>
+</li>
+<li>
+<p>(urban2025functionallydiversifiedcaenorhabditis pages 8-10): Nicholas D. Urban, Shannon M. Lacy, Kate M. Van Pelt, Benedict Abdon, Zachary Mattiola, Adam Klaiss, Sarah Tabler, Eric K. F. Donahue, Kristopher Burkewitz, and Matthias C. Truttmann. Functionally diversified caenorhabditis elegans bip orthologs control body growth, reproduction, stress resistance, aging, and autophagy. Nature Communications, Dec 2025. URL: https://doi.org/10.1038/s41467-025-65998-0, doi:10.1038/s41467-025-65998-0. This article has 4 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(truttmann2016thecaenorhabditiselegans pages 8-11): Matthias C. Truttmann, Victor E. Cruz, Xuanzong Guo, Christoph Engert, Thomas U. Schwartz, and Hidde L. Ploegh. The caenorhabditis elegans protein fic-1 is an ampylase that covalently modifies heat-shock 70 family proteins, translation elongation factors and histones. May 2016. URL: https://doi.org/10.1371/journal.pgen.1006023, doi:10.1371/journal.pgen.1006023. This article has 63 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(truttmann2016thecaenorhabditiselegans pages 13-14): Matthias C. Truttmann, Victor E. Cruz, Xuanzong Guo, Christoph Engert, Thomas U. Schwartz, and Hidde L. Ploegh. The caenorhabditis elegans protein fic-1 is an ampylase that covalently modifies heat-shock 70 family proteins, translation elongation factors and histones. May 2016. URL: https://doi.org/10.1371/journal.pgen.1006023, doi:10.1371/journal.pgen.1006023. This article has 63 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(truttmann2016thecaenorhabditiselegans pages 11-13): Matthias C. Truttmann, Victor E. Cruz, Xuanzong Guo, Christoph Engert, Thomas U. Schwartz, and Hidde L. Ploegh. The caenorhabditis elegans protein fic-1 is an ampylase that covalently modifies heat-shock 70 family proteins, translation elongation factors and histones. May 2016. URL: https://doi.org/10.1371/journal.pgen.1006023, doi:10.1371/journal.pgen.1006023. This article has 63 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(camara2022hypemediatedampylationas pages 37-41): Ali Camara. Hype-mediated ampylation as a novel therapeutic for neurodegeneration. Text, Jan 2022. URL: https://doi.org/10.25394/pgs.20399142, doi:10.25394/pgs.20399142. This article has 0 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(chatterjee2021ficandnonfic pages 14-15): Bhaskar K. Chatterjee and Matthias C. Truttmann. Fic and non-fic ampylases: protein ampylation in metazoans. May 2021. URL: https://doi.org/10.1098/rsob.210009, doi:10.1098/rsob.210009. This article has 12 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(couillault2012auprindependentinfectionspecific pages 7-8): Carole Couillault, Patrick Fourquet, Matthieu Pophillat, and Jonathan J. Ewbank. A upr-independent infection-specific role for a bip/grp78 protein in the control of antimicrobial peptide expression in c. elegans epidermis. Virulence, 3:299-308, May 2012. URL: https://doi.org/10.4161/viru.20384, doi:10.4161/viru.20384. This article has 40 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(urban2025functionallydiversifiedbip pages 14-18): Nicholas D. Urban, Shannon M. Lacy, Kate M. Van Pelt, Benedict Abdon, Zachary Mattiola, Adam Klaiss, Sarah Tabler, and Matthias C. Truttmann. Functionally diversified bip orthologs control body growth, reproduction, stress resistance, aging, and er-phagy in caenorhabditis elegans. bioRxiv, Jan 2025. URL: https://doi.org/10.1101/2025.01.14.633073, doi:10.1101/2025.01.14.633073. This article has 4 citations.</p>
+</li>
+<li>
+<p>(urban2025functionallydiversifiedbip pages 18-21): Nicholas D. Urban, Shannon M. Lacy, Kate M. Van Pelt, Benedict Abdon, Zachary Mattiola, Adam Klaiss, Sarah Tabler, and Matthias C. Truttmann. Functionally diversified bip orthologs control body growth, reproduction, stress resistance, aging, and er-phagy in caenorhabditis elegans. bioRxiv, Jan 2025. URL: https://doi.org/10.1101/2025.01.14.633073, doi:10.1101/2025.01.14.633073. This article has 4 citations.</p>
+</li>
+<li>
+<p>(urban2025functionallydiversifiedcaenorhabditis pages 5-8): Nicholas D. Urban, Shannon M. Lacy, Kate M. Van Pelt, Benedict Abdon, Zachary Mattiola, Adam Klaiss, Sarah Tabler, Eric K. F. Donahue, Kristopher Burkewitz, and Matthias C. Truttmann. Functionally diversified caenorhabditis elegans bip orthologs control body growth, reproduction, stress resistance, aging, and autophagy. Nature Communications, Dec 2025. URL: https://doi.org/10.1038/s41467-025-65998-0, doi:10.1038/s41467-025-65998-0. This article has 4 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(urban2025functionallydiversifiedbip pages 21-25): Nicholas D. Urban, Shannon M. Lacy, Kate M. Van Pelt, Benedict Abdon, Zachary Mattiola, Adam Klaiss, Sarah Tabler, and Matthias C. Truttmann. Functionally diversified bip orthologs control body growth, reproduction, stress resistance, aging, and er-phagy in caenorhabditis elegans. bioRxiv, Jan 2025. URL: https://doi.org/10.1101/2025.01.14.633073, doi:10.1101/2025.01.14.633073. This article has 4 citations.</p>
+</li>
+<li>
+<p>(shen2001complementarysignalingpathways pages 7-8): Xiaohua Shen, Ronald E. Ellis, Kyungho Lee, Chuan-Yin Liu, Kun Yang, Aaron Solomon, Hiderou Yoshida, Rick Morimoto, David M. Kurnit, Kazutoshi Mori, and Randal J. Kaufman. Complementary signaling pathways regulate the unfolded protein response and are required for c. elegans development. Cell, 107:893-903, Dec 2001. URL: https://doi.org/10.1016/s0092-8674(01)00612-2, doi:10.1016/s0092-8674(01)00612-2. This article has 905 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(pelt2025lossoffic1mediated pages 1-2): Kate M. Van Pelt and Matthias C. Truttmann. Loss of fic-1-mediated ampylation activates the uprer and upregulates cytosolic hsp70 chaperones to suppress polyglutamine toxicity. Jun 2025. URL: https://doi.org/10.1371/journal.pgen.1011723, doi:10.1371/journal.pgen.1011723. This article has 11 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(pelt2025lossoffic1mediated pages 14-16): Kate M. Van Pelt and Matthias C. Truttmann. Loss of fic-1-mediated ampylation activates the uprer and upregulates cytosolic hsp70 chaperones to suppress polyglutamine toxicity. Jun 2025. URL: https://doi.org/10.1371/journal.pgen.1011723, doi:10.1371/journal.pgen.1011723. This article has 11 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(pelt2025lossoffic1mediated pages 2-4): Kate M. Van Pelt and Matthias C. Truttmann. Loss of fic-1-mediated ampylation activates the uprer and upregulates cytosolic hsp70 chaperones to suppress polyglutamine toxicity. Jun 2025. URL: https://doi.org/10.1371/journal.pgen.1011723, doi:10.1371/journal.pgen.1011723. This article has 11 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(couillault2012auprindependentinfectionspecific pages 5-7): Carole Couillault, Patrick Fourquet, Matthieu Pophillat, and Jonathan J. Ewbank. A upr-independent infection-specific role for a bip/grp78 protein in the control of antimicrobial peptide expression in c. elegans epidermis. Virulence, 3:299-308, May 2012. URL: https://doi.org/10.4161/viru.20384, doi:10.4161/viru.20384. This article has 40 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(shi2024identificationofbip pages 9-10): Jing Shi, Danli Sheng, Jie Guo, Fangyuan Zhou, Shaofeng Wu, and Hongyun Tang. Identification of bip as a temperature sensor mediating temperature-induced germline sex reversal in c. elegans. The EMBO Journal, 43:4020-4048, Aug 2024. URL: https://doi.org/10.1038/s44318-024-00197-z, doi:10.1038/s44318-024-00197-z. This article has 4 citations.</p>
+</li>
+<li>
+<p>(pelt2025lossoffic1mediated pages 10-14): Kate M. Van Pelt and Matthias C. Truttmann. Loss of fic-1-mediated ampylation activates the uprer and upregulates cytosolic hsp70 chaperones to suppress polyglutamine toxicity. Jun 2025. URL: https://doi.org/10.1371/journal.pgen.1011723, doi:10.1371/journal.pgen.1011723. This article has 11 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(urban2025functionallydiversifiedbip pages 33-36): Nicholas D. Urban, Shannon M. Lacy, Kate M. Van Pelt, Benedict Abdon, Zachary Mattiola, Adam Klaiss, Sarah Tabler, and Matthias C. Truttmann. Functionally diversified bip orthologs control body growth, reproduction, stress resistance, aging, and er-phagy in caenorhabditis elegans. bioRxiv, Jan 2025. URL: https://doi.org/10.1101/2025.01.14.633073, doi:10.1101/2025.01.14.633073. This article has 4 citations.</p>
+</li>
+</ol>
+<h2 id="artifacts">Artifacts</h2>
+<ul>
+<li><a href="hsp-3-deep-research-falcon_artifacts/artifact-00.md">Edison artifact artifact-00</a></li>
+<li><a href="hsp-3-deep-research-falcon_artifacts/artifact-01.md">Edison artifact artifact-01</a></li>
+</ul>
+<h2 id="citations">Citations</h2>
+<ol>
+<li>camara2022hypemediatedampylationas pages 37-41</li>
+<li>shen2001complementarysignalingpathways pages 2-3</li>
+<li>urban2025functionallydiversifiedbip pages 29-33</li>
+<li>urban2025functionallydiversifiedbip pages 14-18</li>
+<li>urban2025functionallydiversifiedbip pages 18-21</li>
+<li>urban2025functionallydiversifiedcaenorhabditis pages 5-8</li>
+<li>urban2025functionallydiversifiedcaenorhabditis pages 1-2</li>
+<li>shen2001complementarysignalingpathways pages 7-8</li>
+<li>couillault2012auprindependentinfectionspecific pages 5-7</li>
+<li>couillault2012auprindependentinfectionspecific pages 7-8</li>
+<li>shi2024identificationofbip pages 9-10</li>
+<li>urban2025functionallydiversifiedcaenorhabditis pages 8-10</li>
+<li>truttmann2016thecaenorhabditiselegans pages 13-14</li>
+<li>urban2025functionallydiversifiedbip pages 1-5</li>
+<li>truttmann2016thecaenorhabditiselegans pages 8-11</li>
+<li>truttmann2016thecaenorhabditiselegans pages 11-13</li>
+<li>chatterjee2021ficandnonfic pages 14-15</li>
+<li>urban2025functionallydiversifiedbip pages 21-25</li>
+<li>urban2025functionallydiversifiedbip pages 33-36</li>
+<li>https://doi.org/10.1038/s41467-025-65998-0,</li>
+<li>https://doi.org/10.1016/s0092-8674(01</li>
+<li>https://doi.org/10.1101/2025.01.14.633073,</li>
+<li>https://doi.org/10.1371/journal.pgen.1006023,</li>
+<li>https://doi.org/10.25394/pgs.20399142,</li>
+<li>https://doi.org/10.1098/rsob.210009,</li>
+<li>https://doi.org/10.4161/viru.20384,</li>
+<li>https://doi.org/10.1371/journal.pgen.1011723,</li>
+<li>https://doi.org/10.1038/s44318-024-00197-z,</li>
+</ol>
+            </div>
+        </details>
+
+    </div>
+
+
+    <!-- Additional Documentation Sections -->
+
+    <div class="section">
+        <h2 class="section-title">📚 Additional Documentation</h2>
+
+        <details class="markdown-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; cursor: pointer;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Notes</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(hsp-3-notes.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="P27420" data-a="DOC: Notes" data-r="" data-act="DOCUMENTATION" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This documentation is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This documentation needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+                <h1 id="hsp-3-c-elegans-research-notes">hsp-3 (C. elegans) — Research Notes</h1>
+<p>Gene: <strong>hsp-3</strong> / HSP70C / C15H9.6 / WBGene00002007<br />
+UniProt: <strong>P27420</strong> (HSP7C_CAEEL), 661 aa precursor<br />
+Taxon: NCBITaxon:6239 (Caenorhabditis elegans)</p>
+<h2 id="identity-one-line-summary">Identity / one-line summary</h2>
+<p>hsp-3 is one of the two <em>C. elegans</em> endoplasmic-reticulum (ER)-resident HSP70/BiP<br />
+(GRP78/KAR2) orthologs; the other is <strong>hsp-4</strong> (F43E2.8, WBGene00002008, P20163). HSP-3 is<br />
+an ATP-dependent chaperone of the ER lumen that assists folding/quality control of secretory<br />
+and membrane proteins. HSP-3 is generally regarded as the more <strong>constitutively expressed</strong><br />
+BiP paralog, whereas hsp-4 is the strongly <strong>stress-inducible</strong> paralog and the source of the<br />
+canonical <code>hsp-4::GFP</code> ER-stress reporter.</p>
+<h2 id="known-well-grounded">KNOWN (well-grounded)</h2>
+<h3 id="molecular-architecture-family">Molecular architecture / family</h3>
+<ul>
+<li>UniProt: <code>RecName: Full=Heat shock 70 kDa protein C; Flags: Precursor;</code> — belongs to the<br />
+  HSP70 family. Signal peptide 1–17; C-terminal ER-retention motif (residues 658–661,<br />
+<code>MOTIF ... "Prevents secretion from ER"</code>; the sequence ends <code>...DDKDEL</code>, so the functional<br />
+  retention tetrapeptide is <strong>KDEL</strong> — note HSP-4 instead uses HDEL). Canonical HSP70<br />
+  nucleotide-binding domain (NBD) + substrate-binding domain (SBD) architecture (InterPro<br />
+  BIP_NBD IPR042050; CDD <code>ASKHA_NBD_HSP70_BiP</code>). [UniProt:P27420]</li>
+<li>ATP binding / ATP hydrolysis are family-level MFs (UniProt KW ATP-binding, Nucleotide-binding;<br />
+  GOA IBA GO:0016887, IEA GO:0005524, ISS GO:0016887 by similarity to yeast KAR2 P16474).</li>
+</ul>
+<h3 id="localization">Localization</h3>
+<ul>
+<li>ER lumen. UniProt: <code>SUBCELLULAR LOCATION: Endoplasmic reticulum lumen</code>. Directly stated for<br />
+  HSP-3 in the FIC-1 paper: <a href="https://pubmed.ncbi.nlm.nih.gov/27138431" title="HSP-1 is predominantly cytosolic, whereas HSP-3 is   retained within the ER lumen.">PMID:27138431</a>. The signal peptide + <code>DDKDEL</code> retention motif are consistent.</li>
+<li>The pan-HSP70 IBA also propagated <code>cytoplasm</code>, <code>nucleus</code>, and <code>membrane</code> to HSP-3. These are<br />
+  ancestral/aspecific localizations of the broad HSP70 family (which includes cytosolic and<br />
+  nuclear members); for a dedicated ER-lumenal BiP with a cleaved signal peptide and DDKDEL<br />
+  motif, these are over-propagations, not the functional site.</li>
+</ul>
+<h3 id="function-er-protein-folding-chaperone">Function — ER protein folding chaperone</h3>
+<ul>
+<li>UniProt FUNCTION (by similarity): <code>Probably plays a role in facilitating the assembly of
+  multimeric protein complexes inside the ER.</code> [UniProt:P27420]</li>
+<li>The two worm BiPs are treated as chaperones that cross-compensate:<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/27138431" title="elegans encodes two Grp78/BiP homologues, hsp-3 and hsp-4, assumed to   cross-compensate for each other in their roles as ER-residing protein chaperones">PMID:27138431</a>.</li>
+<li>GOA: <code>protein folding chaperone</code> (GO:0044183, IBA), <code>protein refolding</code> (GO:0042026, IBA),<br />
+<code>ATP hydrolysis activity</code> (GO:0016887), <code>heat shock protein binding</code> (GO:0031072, co-chaperone<br />
+  interactions), <code>endoplasmic reticulum chaperone complex</code> (GO:0034663), <code>ERAD pathway</code><br />
+  (GO:0036503, IBA).</li>
+</ul>
+<h3 id="function-upr-er-stress">Function — UPR / ER stress</h3>
+<ul>
+<li>HSP-3 (with HSP-4) is part of the BiP-type repressive brake on the three UPR sensors:<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/27138431" title="HSP-3—together with its close homolog, HSP-4—form a complex with IRE-1, ATF-6   and PEK-1, to preclude activation of UPR-related signaling events by preventing either   oligomerization of IRE-1 and PEK-1 or proteolytic processing of ATF-6 in the golgi [23]">PMID:27138431</a>.</li>
+<li>hsp-3 is itself an ER-stress/UPR target. In the Urano et al. genome-wide microarray, the gene<br />
+<strong>C15H9.6 (= hsp-3)</strong> appears in Table I (genes whose tunicamycin induction is attenuated in<br />
+<code>xbp-1(zc12)</code> mutants): induction in N2 = 1.32 ± 0.06 (log2), reduced to 0.68 ± 0.05 in the<br />
+  xbp-1 mutant — i.e. hsp-3 IS ER-stress-inducible and xbp-1/ire-1-dependent, though more<br />
+  modestly than hsp-4 (F43E2.8; 1.92 → 0.44) and the sHSPs. [PMID:12186849 — Table I lists<br />
+<code>C15H9.6 ... 1.32 ± 0.06 ... 0.68 ± 0.05</code>; general framing: "in C. elegans, the ire-1 and<br />
+  xbp-1 pathway has retained its essential role in upregulating expression of many UPR target<br />
+  genes that are similarly upregulated by the homologous pathway in yeast"].<br />
+  NOTE (paralog caution): the extracted Urano Table I places the display label "HSP-4" next to<br />
+  cosmid C15H9.6, but C15H9.6 is unambiguously <strong>hsp-3</strong> per WormBase/UniProt ORFName; the GOA<br />
+  IEP/HEP annotation of hsp-3 to UPR is therefore based on the gene actually assayed, not a<br />
+  mislabel.</li>
+<li>GOA IEP GO:0030968 / GO:0036498 from Shen et al. 2001 <a href="https://pubmed.ncbi.nlm.nih.gov/11779465">PMID:11779465</a> (abstract-only in cache;<br />
+  curator read full text — the foundational C. elegans UPR paper that established<br />
+  ire-1/xbp-1-dependent UPR-target transcription). Defer to curator.</li>
+</ul>
+<h3 id="ptm">PTM</h3>
+<ul>
+<li>HSP-3 is a direct substrate of the FIC-1 AMPylase (covalent AMP addition). UniProt: <code>PTM:
+  AMPylated by fic-1. {ECO:0000269|PubMed:27138431}</code>. Direct MS evidence:<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/27138431" title="two classes of proteins over-represented amongst the AMPylated fraction of   proteins: HSP 70 proteins (HSP-1, HSP-3) as well as translation elongation factors ...">PMID:27138431</a>.</li>
+</ul>
+<h3 id="physiology-hsp-3-specific">Physiology (hsp-3-specific)</h3>
+<ul>
+<li>HSP-3 contributes to tolerance of chronic ER stress and innate immunity:<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/27138431" title="hsp-3 nematodes were very sensitive to P. aeruginosa exposure during early   development and only few reached adulthood, highlighting a role for HSP-3 in the tolerance of   chronic ER stress and innate immunity.">PMID:27138431</a>.</li>
+<li>Recent paralog-resolved work (Urban et al. 2025, Nat Commun 10.1038/s41467-025-65998-0; bioRxiv<br />
+  2025.01.14.633073) shows the two BiPs are <strong>functionally diversified</strong>: HSP-3 carries the more<br />
+  canonical ER-folding role while HSP-4 is specialized for interorganellar signaling / ER-phagy<br />
+  (Sec-62/C18E9.2) and ER-stress mitigation, together controlling body growth, reproduction,<br />
+  stress resistance, aging, and autophagy. (DOI-level; not in local PMID cache.)</li>
+</ul>
+<h2 id="not-known-gaps">NOT known / gaps</h2>
+<ul>
+<li>The molecular basis of the hsp-3 vs hsp-4 <strong>division of labor</strong> — differential client<br />
+  repertoire, tissue programs, and signaling interfaces — is unresolved; the paralogs are still<br />
+  largely "assumed to cross-compensate" <a href="https://pubmed.ncbi.nlm.nih.gov/27138431">PMID:27138431</a>. Which clients specifically require<br />
+  HSP-3 (vs HSP-4) is not established.</li>
+<li>The functional consequence of HSP-3 <strong>AMPylation</strong> by FIC-1 (does it inhibit/tune HSP-3<br />
+  chaperone/ATPase activity in vivo, and under what conditions?) is unknown:<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/27138431" title="Whether AMPylation of different—or even multiple—sites on Heat shock 70 family   proteins results in diverse changes of their activities remains to be studied.">PMID:27138431</a>; and<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/27138431" title="it remains to be tested which proteins may represent the primary in vivo   targets of FIC-1">PMID:27138431</a>.</li>
+<li>Whether the classic BiP→UPR-sensor repression mechanism is exerted specifically by HSP-3 (vs<br />
+  HSP-4, or requiring both) in worms is inferred from mammalian precedent (ref [23] in the FIC-1<br />
+  paper) rather than shown directly for HSP-3.</li>
+</ul>
+<h2 id="annotation-review-plan-21-goa-annotations">Annotation-review plan (21 GOA annotations)</h2>
+<p>MF/biology core (ACCEPT): GO:0005788 ER lumen (IBA+IEA); GO:0016887 ATP hydrolysis (IBA/IEA/ISS);<br />
+GO:0005524 ATP binding (IEA); GO:0044183 protein folding chaperone (IBA); GO:0042026 protein<br />
+refolding (IBA); GO:0031072 heat shock protein binding (IBA); GO:0034663 ER chaperone complex<br />
+(IBA+ISS).</p>
+<p>UPR (ACCEPT, hsp-3 assayed/part of machinery): GO:0030968 ER UPR (IBA/IEA/IEP×1/HEP×1);<br />
+GO:0036498 IRE1-mediated UPR (IEP+HEP).</p>
+<p>Non-core (KEEP_AS_NON_CORE): GO:0036503 ERAD pathway (IBA — genuine BiP QC role but no<br />
+hsp-3-specific evidence, peripheral to the constitutive folding role).</p>
+<p>Over-propagations from pan-HSP70 IBA (MARK_AS_OVER_ANNOTATED): GO:0005737 cytoplasm; GO:0005634<br />
+nucleus; GO:0016020 membrane — HSP-3 is a soluble ER-lumen protein (signal peptide + DDKDEL).</p>
+<h2 id="additional-findings-surfaced-by-falcon-deep-research-hsp-3-deep-research-falconmd">Additional findings surfaced by falcon deep research (hsp-3-deep-research-falcon.md)</h2>
+<p>The falcon report (real output, 28 citations; verified against primary sources where cached)<br />
+corroborates and extends the above. Notable additional, literature-grounded points (cited to<br />
+the report's own sources — not all are in the local PMID cache, so treated as context, not as<br />
+GOA-annotation evidence):<br />
+- AMPylation site mapped to <strong>Thr176</strong> in the NBD; consequences for HSP-3 chaperone activity<br />
+  "remain to be fully elucidated"; FIC-1 selectively AMPylates HSP-3 (not HSP-4)<br />
+  (truttmann2016; camara2022). Reinforces knowledge-gap 2.<br />
+- HSP-3 is ~5-fold more abundant than HSP-4 basally and only ~2-fold DTT-inducible (vs ~9-fold<br />
+  for hsp-4); <strong>IRE-1 is required for hsp-3 basal expression</strong> (urban2025; shen2001).<br />
+  Confirms hsp-3 = the constitutive paralog.<br />
+- <strong>UPR-independent, infection-specific immune role</strong>: Couillault et al. 2012 place HSP-3<br />
+  downstream of NIPI-3 / upstream of TPA-1 in epidermal nlp-29 antimicrobial-peptide control<br />
+  during <em>Drechmeria coniospora</em> fungal infection — not shared with HSP-4, not via canonical<br />
+  UPR. (Not in GOA; noted for completeness.)<br />
+- <strong>BiP as a temperature sensor</strong> (Shi et al. 2024): at 30°C, folding demand sequesters BiP<br />
+  (hsp-3/hsp-4), lowering free BiP and driving ERAD-dependent degradation of TRA-2 to promote<br />
+  male germline fate. Provides worm-specific ERAD context (kept hsp-3 ERAD as non-core since<br />
+  attributed to BiP collectively).<br />
+- Germline-specific hsp-3 ablation shortens lifespan; intestine-specific loss does not<br />
+  (urban2025) — tissue-specific physiology.</p>
+<h2 id="provenance-index-cached-publications-used">Provenance index (cached publications used)</h2>
+<ul>
+<li>PMID:27138431 — FIC-1 AMPylase paper (full text). HSP-3-specific: ER-lumen localization,<br />
+  AMPylation, UPR-sensor complex, ER-stress/immunity role. HIGH relevance.</li>
+<li>PMID:12186849 — Urano et al. 2002, JCB (full text). Microarray; C15H9.6/hsp-3 is an<br />
+  xbp-1-dependent UPR target (Table I). HIGH relevance.</li>
+<li>PMID:11779465 — Shen et al. 2001, Cell (abstract-only). Foundational C. elegans UPR paper;<br />
+  source of IEP UPR annotations. MEDIUM–HIGH relevance.</li>
+<li>PMID:2225768 — Heschl &amp; Baillie 1990, review (abstract-only). HSP70 multigene family; ISS<br />
+  source for ATP hydrolysis. LOW–MEDIUM relevance.<br />
+</content><br />
+</invoke></li>
+</ul>
+            </div>
+        </details>
+
+    </div>
+
+
+    <!-- YAML Preview Section -->
+    <div class="section">
+        <details class="yaml-preview">
+            <summary>
+                <h2 style="display: inline;">📄 View Raw YAML</h2>
+            </summary>
+            <div class="yaml-content">
+                <pre><code>id: P27420
+gene_symbol: hsp-3
+product_type: PROTEIN
+status: COMPLETE
+taxon:
+  id: NCBITaxon:6239
+  label: Caenorhabditis elegans
+description: &gt;-
+  HSP-3 is one of the two endoplasmic reticulum (ER)-resident HSP70/BiP (GRP78/KAR2)
+  chaperones of Caenorhabditis elegans; the other is its close paralog HSP-4. HSP-3 is
+  a soluble ER-lumen protein bearing an N-terminal signal peptide and a C-terminal
+  KDEL-type ER-retention motif, with the canonical HSP70 nucleotide-binding and
+  substrate-binding domain architecture. It acts as an ATP-dependent molecular chaperone
+  that assists folding, refolding and assembly of nascent secretory and membrane proteins
+  in the ER lumen. Like other BiP orthologs, HSP-3 also participates in the ER unfolded
+  protein response (UPR): it (with HSP-4) associates with the three UPR stress sensors
+  IRE-1, ATF-6 and PEK-1 to hold them inactive, and its own transcription is modestly
+  induced by ER stress in an ire-1/xbp-1-dependent manner. HSP-3 is generally the more
+  constitutively expressed of the two worm BiP paralogs, whereas HSP-4 is the strongly
+  stress-inducible one. HSP-3 is a direct substrate of the FIC-1 AMPylase and contributes
+  to tolerance of chronic ER stress and to innate immunity.
+references:
+  - id: GO_REF:0000002
+    title: Gene Ontology annotation through association of InterPro records with GO terms
+    findings: []
+  - id: GO_REF:0000033
+    title: Annotation inferences using phylogenetic trees
+    findings: []
+  - id: GO_REF:0000044
+    title: Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location
+      vocabulary mapping, accompanied by conservative changes to GO terms applied by
+      UniProt
+    findings: []
+  - id: GO_REF:0000117
+    title: Electronic Gene Ontology annotations created by ARBA machine learning models
+    findings: []
+  - id: PMID:11779465
+    title: Complementary signaling pathways regulate the unfolded protein response and
+      are required for C. elegans development.
+    findings:
+      - statement: Foundational study establishing that C. elegans uses ire-1-mediated
+          splicing of xbp-1 mRNA for UPR gene transcription and survival upon ER stress.
+        supporting_text: C. elegans requires ire-1-mediated splicing of xbp-1 mRNA for
+          UPR gene transcription and survival upon ER stress
+    reference_review:
+      relevance: MEDIUM
+      correctness: UNVERIFIED
+      review_notes: &gt;-
+        PubMed-verified as the foundational C. elegans UPR paper (Shen et al., Cell 2001)
+        and the source of the WormBase IEP UPR annotations for hsp-3. Only the abstract is
+        cached locally, so the hsp-3-specific expression data underlying the IEP call could
+        not be independently re-verified here; the experimental annotation is deferred to
+        the WormBase curator who read the full text.
+  - id: PMID:12186849
+    title: A survival pathway for Caenorhabditis elegans with a blocked unfolded protein
+      response.
+    findings:
+      - statement: Genome-wide microarray of the C. elegans ER-stress response; hsp-3
+          (cosmid C15H9.6) is among the tunicamycin-induced genes whose induction is
+          attenuated in xbp-1 mutants (Table I), establishing hsp-3 as an xbp-1-dependent
+          UPR target.
+        supporting_text: in C. elegans, the ire-1 and xbp-1 pathway has retained its
+          essential role in upregulating expression of many UPR target genes that are
+          similarly upregulated by the homologous pathway in yeast
+    reference_review:
+      relevance: HIGH
+      correctness: VERIFIED
+      review_notes: &gt;-
+        PubMed-verified (Urano et al., J Cell Biol 2002). hsp-3 is unambiguously cosmid
+        C15H9.6 (UniProt/WormBase ORFName); C15H9.6 appears in Table I of tunicamycin-
+        induced, xbp-1-dependent genes (N2 log2 1.32 +/- 0.06, reduced to 0.68 +/- 0.05 in
+        xbp-1), directly supporting the HEP UPR annotation on hsp-3.
+  - id: PMID:2225768
+    title: The HSP70 multigene family of Caenorhabditis elegans.
+    findings:
+      - statement: Reviews the C. elegans HSP70 multigene family, including the
+          ER-resident BiP-type members; used as the ISS source for ATP hydrolysis activity.
+    reference_review:
+      relevance: LOW
+      correctness: UNVERIFIED
+      review_notes: &gt;-
+        Review article (Heschl &amp; Baillie 1990); abstract-only in the local cache. Cited by
+        WormBase as the ISS basis (by similarity to yeast KAR2, UniProtKB:P16474) for the
+        HSP70 ATPase activity of hsp-3. Family-level context rather than direct hsp-3
+        functional data.
+  - id: PMID:27138431
+    title: The Caenorhabditis elegans Protein FIC-1 Is an AMPylase That Covalently
+      Modifies Heat-Shock 70 Family Proteins, Translation Elongation Factors and Histones.
+    findings:
+      - statement: HSP-3 is directly retained within the ER lumen (contrasted with the
+          cytosolic HSP-1), confirming its ER-lumenal localization by direct study.
+        supporting_text: HSP-1 is predominantly cytosolic, whereas HSP-3 is retained
+          within the ER lumen.
+      - statement: HSP-3 is a direct in vivo AMPylation substrate of FIC-1, identified by
+          mass spectrometry among the AMPylated protein fraction.
+        supporting_text: &#39;two classes of proteins over-represented amongst the AMPylated
+          fraction of proteins: HSP 70 proteins (HSP-1, HSP-3)&#39;
+      - statement: HSP-3, with HSP-4, forms a complex with the three UPR sensors IRE-1,
+          ATF-6 and PEK-1 to keep them inactive (the classical BiP brake on UPR signaling).
+        supporting_text: form a complex with IRE-1, ATF-6 and PEK-1, to preclude
+          activation of UPR-related signaling events
+      - statement: HSP-3 contributes to tolerance of chronic ER stress and to innate
+          immunity, based on hypersensitivity of hsp-3 animals to Pseudomonas aeruginosa.
+        supporting_text: highlighting a role for HSP-3 in the tolerance of chronic ER
+          stress and innate immunity.
+      - statement: The two worm BiP paralogs hsp-3 and hsp-4 are assumed to
+          cross-compensate as ER-resident chaperones, framing their functional redundancy.
+        supporting_text: elegans encodes two Grp78/BiP homologues, hsp-3 and hsp-4,
+          assumed to cross-compensate for each other in their roles as ER-residing protein
+          chaperones
+    reference_review:
+      relevance: HIGH
+      correctness: VERIFIED
+      review_notes: &gt;-
+        PubMed-verified (Truttmann et al., PLoS Genet 2016); full text cached. Provides the
+        strongest hsp-3-specific experimental data available: ER-lumen localization,
+        FIC-1 AMPylation, membership in the BiP-UPR-sensor repressive complex, and a role
+        in chronic ER-stress tolerance / innate immunity. Cited by UniProt P27420 for the
+        AMPylation PTM.
+existing_annotations:
+  - term:
+      id: GO:0005737
+      label: cytoplasm
+    evidence_type: IBA
+    original_reference_id: GO_REF:0000033
+    qualifier: is_active_in
+    review:
+      summary: &gt;-
+        IBA annotation propagated across the broad HSP70 phylogenetic tree, which contains
+        cytosolic and nuclear members. HSP-3 is a dedicated ER-lumenal BiP with a cleaved
+        signal peptide and a C-terminal KDEL ER-retention motif; its functional
+        compartment is the ER lumen, not the cytoplasm.
+      action: MARK_AS_OVER_ANNOTATED
+      reason: &gt;-
+        Over-propagation from the pan-HSP70 family tree. HSP-3 is directly reported to be
+        retained within the ER lumen and carries a signal peptide plus ER-retention motif,
+        so a general cytoplasm annotation does not represent its site of action.
+      supported_by:
+        - reference_id: PMID:27138431
+          supporting_text: HSP-1 is predominantly cytosolic, whereas HSP-3 is retained
+            within the ER lumen.
+        - reference_id: UniProt:P27420
+          supporting_text: &#39;SUBCELLULAR LOCATION: Endoplasmic reticulum lumen&#39;
+      propagation_review:
+        root_cause: PROPAGATION_BAD
+        failure_modes:
+          - COMPARTMENT_OR_COMPLEX_MISMATCH
+        source_entities:
+          - source_id: PANTHER:PTN002321897
+            source_status: SUPPORTS_SOURCE_BUT_NOT_TARGET
+            comment: &gt;-
+              GO_Central IBA propagated across the broad HSP70 tree, which contains
+              cytosolic/nuclear members; HSP-3 is a signal-peptide-bearing, KDEL-retained
+              ER-lumenal BiP, so the cytosolic localization does not transfer to it.
+  - term:
+      id: GO:0005788
+      label: endoplasmic reticulum lumen
+    evidence_type: IBA
+    original_reference_id: GO_REF:0000033
+    qualifier: is_active_in
+    review:
+      summary: &gt;-
+        The ER lumen is the primary functional location of HSP-3, consistent with its
+        signal peptide, KDEL retention motif, and direct experimental localization.
+      action: ACCEPT
+      reason: &gt;-
+        Core localization of HSP-3/BiP. UniProt records ER lumen localization and the
+        FIC-1 study directly reports HSP-3 retention in the ER lumen.
+      supported_by:
+        - reference_id: UniProt:P27420
+          supporting_text: &#39;SUBCELLULAR LOCATION: Endoplasmic reticulum lumen&#39;
+        - reference_id: PMID:27138431
+          supporting_text: HSP-1 is predominantly cytosolic, whereas HSP-3 is retained
+            within the ER lumen.
+  - term:
+      id: GO:0016887
+      label: ATP hydrolysis activity
+    evidence_type: IBA
+    original_reference_id: GO_REF:0000033
+    qualifier: enables
+    review:
+      summary: &gt;-
+        HSP-3/BiP is an ATPase; ATP hydrolysis drives the allosteric chaperone cycle of
+        substrate binding and release. This is a conserved core molecular function of the
+        HSP70 family.
+      action: ACCEPT
+      reason: &gt;-
+        ATP hydrolysis is essential to the HSP70/BiP chaperone cycle. UniProt annotates
+        this activity (ISS to yeast KAR2), and it is a defining feature of the family.
+      supported_by:
+        - reference_id: UniProt:P27420
+          supporting_text: GO:0016887; F:ATP hydrolysis activity; ISS:WormBase
+        - reference_id: UniProt:P27420
+          supporting_text: Belongs to the heat shock protein 70 family
+  - term:
+      id: GO:0044183
+      label: protein folding chaperone
+    evidence_type: IBA
+    original_reference_id: GO_REF:0000033
+    qualifier: enables
+    review:
+      summary: &gt;-
+        HSP-3 is an ER-resident molecular chaperone that assists folding and assembly of
+        client proteins in the ER lumen, the core molecular function of BiP orthologs.
+      action: ACCEPT
+      reason: &gt;-
+        This is the core molecular function of HSP-3. UniProt describes a role in
+        facilitating assembly of multimeric protein complexes in the ER, and the FIC-1
+        study frames HSP-3 and HSP-4 as cross-compensating ER-resident chaperones.
+      supported_by:
+        - reference_id: UniProt:P27420
+          supporting_text: Probably plays a role in facilitating the assembly of
+        - reference_id: PMID:27138431
+          supporting_text: elegans encodes two Grp78/BiP homologues, hsp-3 and hsp-4,
+            assumed to cross-compensate for each other in their roles as ER-residing
+            protein chaperones
+        - reference_id: file:worm/hsp-3/hsp-3-deep-research-falcon.md
+          supporting_text: primarily responsible for de novo protein folding and the
+            refolding of misfolded proteins within the ER lumen
+  - term:
+      id: GO:0005634
+      label: nucleus
+    evidence_type: IBA
+    original_reference_id: GO_REF:0000033
+    qualifier: is_active_in
+    review:
+      summary: &gt;-
+        IBA annotation propagated from nuclear/cytosolic HSP70 family members. HSP-3 is an
+        ER-lumenal BiP and is not a nuclear protein.
+      action: MARK_AS_OVER_ANNOTATED
+      reason: &gt;-
+        Over-propagation from the broad HSP70 tree. HSP-3 has a signal peptide and a KDEL
+        ER-retention motif and is directly reported to reside in the ER lumen; nuclear
+        localization does not represent its function.
+      supported_by:
+        - reference_id: PMID:27138431
+          supporting_text: HSP-1 is predominantly cytosolic, whereas HSP-3 is retained
+            within the ER lumen.
+        - reference_id: UniProt:P27420
+          supporting_text: &#39;SUBCELLULAR LOCATION: Endoplasmic reticulum lumen&#39;
+      propagation_review:
+        root_cause: PROPAGATION_BAD
+        failure_modes:
+          - COMPARTMENT_OR_COMPLEX_MISMATCH
+        source_entities:
+          - source_id: PANTHER:PTN001834223
+            source_status: SUPPORTS_SOURCE_BUT_NOT_TARGET
+            comment: &gt;-
+              Nuclear localization is contributed by nuclear/cytosolic HSP70 members of the
+              family tree; it does not transfer to the ER-lumenal BiP HSP-3.
+  - term:
+      id: GO:0031072
+      label: heat shock protein binding
+    evidence_type: IBA
+    original_reference_id: GO_REF:0000033
+    qualifier: enables
+    review:
+      summary: &gt;-
+        HSP70/BiP chaperones cooperate with co-chaperones (J-domain/Hsp40 proteins and
+        nucleotide-exchange factors) that regulate the ATPase cycle and substrate
+        handling; this is captured by heat shock protein binding.
+      action: ACCEPT
+      reason: &gt;-
+        A defensible family-level function that is more informative than generic protein
+        binding: it reflects the co-chaperone interactions central to the HSP70 mechanism.
+        Retained as a supporting (non-defining) molecular function.
+      supported_by:
+        - reference_id: UniProt:P27420
+          supporting_text: Belongs to the heat shock protein 70 family
+  - term:
+      id: GO:0036503
+      label: ERAD pathway
+    evidence_type: IBA
+    original_reference_id: GO_REF:0000033
+    qualifier: involved_in
+    review:
+      summary: &gt;-
+        BiP orthologs recognize and retain misfolded ER proteins destined for
+        ER-associated degradation. This is a genuine BiP-family role, but there is no
+        hsp-3-specific experimental evidence in C. elegans and it is peripheral to the
+        constitutive folding role.
+      action: KEEP_AS_NON_CORE
+      reason: &gt;-
+        Plausible by orthology (BiP participates in ERAD substrate recognition) but not the
+        primary, directly demonstrated function of HSP-3; retained as a non-core role
+        pending worm-specific evidence.
+      supported_by:
+        - reference_id: UniProt:P27420
+          supporting_text: Belongs to the heat shock protein 70 family
+  - term:
+      id: GO:0016020
+      label: membrane
+    evidence_type: IBA
+    original_reference_id: GO_REF:0000033
+    qualifier: is_active_in
+    review:
+      summary: &gt;-
+        HSP-3 is a soluble ER-lumen protein, not a membrane-embedded protein. It may
+        transiently associate with membrane-bound clients or the translocon, but is not an
+        integral membrane protein.
+      action: MARK_AS_OVER_ANNOTATED
+      reason: &gt;-
+        Overly broad and imprecise for a soluble ER-lumenal BiP with a KDEL retention
+        motif. The specific location endoplasmic reticulum lumen (GO:0005788) is more
+        appropriate.
+      proposed_replacement_terms:
+        - id: GO:0005788
+          label: endoplasmic reticulum lumen
+      supported_by:
+        - reference_id: UniProt:P27420
+          supporting_text: &#39;SUBCELLULAR LOCATION: Endoplasmic reticulum lumen&#39;
+      propagation_review:
+        root_cause: TERM_SCOPING_PROBLEM
+        failure_modes:
+          - GRANULARITY_MISMATCH
+          - COMPARTMENT_OR_COMPLEX_MISMATCH
+        source_entities:
+          - source_id: PANTHER:PTN001834223
+            source_status: SUPPORTS_SOURCE_BUT_NOT_TARGET
+            comment: &gt;-
+              The generic membrane term reflects membrane-associated HSP70 family members;
+              HSP-3 is a soluble ER-lumen protein, so ER lumen (GO:0005788) is the correct
+              scoped location.
+  - term:
+      id: GO:0042026
+      label: protein refolding
+    evidence_type: IBA
+    original_reference_id: GO_REF:0000033
+    qualifier: involved_in
+    review:
+      summary: &gt;-
+        HSP70/BiP chaperones iteratively bind and release substrates through the
+        ATP-driven cycle to promote (re)folding of unfolded or misfolded ER clients.
+      action: ACCEPT
+      reason: &gt;-
+        Refolding/folding of ER clients is a core activity of HSP-3/BiP, driven by its
+        ATPase cycle. Consistent with UniProt and the family-level chaperone role.
+      supported_by:
+        - reference_id: UniProt:P27420
+          supporting_text: Probably plays a role in facilitating the assembly of
+        - reference_id: UniProt:P27420
+          supporting_text: Belongs to the heat shock protein 70 family
+  - term:
+      id: GO:0034663
+      label: endoplasmic reticulum chaperone complex
+    evidence_type: IBA
+    original_reference_id: GO_REF:0000033
+    qualifier: part_of
+    review:
+      summary: &gt;-
+        HSP-3 functions within the ER chaperone machinery, cooperating with co-chaperones
+        and other ER quality-control factors, and it physically associates with the UPR
+        stress sensors in the ER membrane.
+      action: ACCEPT
+      reason: &gt;-
+        HSP-3/BiP is a component of the ER chaperone complex. This is supported both by
+        phylogenetic inference and by the direct demonstration that HSP-3 forms a complex
+        with IRE-1, ATF-6 and PEK-1.
+      supported_by:
+        - reference_id: PMID:27138431
+          supporting_text: form a complex with IRE-1, ATF-6 and PEK-1, to preclude
+            activation of UPR-related signaling events
+  - term:
+      id: GO:0030968
+      label: endoplasmic reticulum unfolded protein response
+    evidence_type: IBA
+    original_reference_id: GO_REF:0000033
+    qualifier: involved_in
+    review:
+      summary: &gt;-
+        HSP-3/BiP is both a UPR effector and a target. It binds the UPR sensors to keep
+        them inactive under basal conditions, and its transcription is induced by ER
+        stress in an ire-1/xbp-1-dependent manner.
+      action: ACCEPT
+      reason: &gt;-
+        Involvement in the ER UPR is a core BiP function. HSP-3 directly participates in
+        the sensor-repressive complex and is a modestly xbp-1-dependent UPR target gene.
+      supported_by:
+        - reference_id: PMID:27138431
+          supporting_text: form a complex with IRE-1, ATF-6 and PEK-1, to preclude
+            activation of UPR-related signaling events
+        - reference_id: PMID:12186849
+          supporting_text: in C. elegans, the ire-1 and xbp-1 pathway has retained its
+            essential role in upregulating expression of many UPR target genes that are
+            similarly upregulated by the homologous pathway in yeast
+  - term:
+      id: GO:0005524
+      label: ATP binding
+    evidence_type: IEA
+    original_reference_id: GO_REF:0000002
+    qualifier: enables
+    review:
+      summary: &gt;-
+        HSP-3 binds ATP through its nucleotide-binding domain; ATP binding and its
+        allosteric coupling to the substrate-binding domain drive the chaperone cycle.
+      action: ACCEPT
+      reason: &gt;-
+        Core molecular function of HSP-3/BiP, supported by the conserved HSP70
+        nucleotide-binding domain and UniProt keyword annotation.
+      supported_by:
+        - reference_id: UniProt:P27420
+          supporting_text: GO:0005524; F:ATP binding; IEA:UniProtKB-KW
+  - term:
+      id: GO:0005788
+      label: endoplasmic reticulum lumen
+    evidence_type: IEA
+    original_reference_id: GO_REF:0000044
+    qualifier: located_in
+    review:
+      summary: &gt;-
+        IEA localization from UniProt subcellular-location mapping, duplicating the IBA
+        call from a different source. ER lumen is the established location of HSP-3.
+      action: ACCEPT
+      reason: &gt;-
+        Correct and well-supported localization; multiple independent evidence sources for
+        the ER lumen are appropriate.
+      supported_by:
+        - reference_id: UniProt:P27420
+          supporting_text: &#39;SUBCELLULAR LOCATION: Endoplasmic reticulum lumen&#39;
+  - term:
+      id: GO:0016887
+      label: ATP hydrolysis activity
+    evidence_type: IEA
+    original_reference_id: GO_REF:0000002
+    qualifier: enables
+    review:
+      summary: &gt;-
+        IEA annotation from InterPro-to-GO mapping, duplicating the IBA ATP hydrolysis
+        call. HSP-3 is an ATPase.
+      action: ACCEPT
+      reason: &gt;-
+        ATP hydrolysis is a core function of HSP-3/BiP; multiple evidence sources are
+        appropriate.
+      supported_by:
+        - reference_id: UniProt:P27420
+          supporting_text: GO:0016887; F:ATP hydrolysis activity; ISS:WormBase
+  - term:
+      id: GO:0030968
+      label: endoplasmic reticulum unfolded protein response
+    evidence_type: IEA
+    original_reference_id: GO_REF:0000117
+    qualifier: involved_in
+    review:
+      summary: &gt;-
+        IEA annotation from ARBA machine-learning models, duplicating the UPR involvement
+        supported by direct and expression evidence.
+      action: ACCEPT
+      reason: &gt;-
+        HSP-3 involvement in the ER UPR is well-supported by direct interaction with the
+        UPR sensors and by its xbp-1-dependent induction.
+      supported_by:
+        - reference_id: PMID:27138431
+          supporting_text: form a complex with IRE-1, ATF-6 and PEK-1, to preclude
+            activation of UPR-related signaling events
+  - term:
+      id: GO:0036498
+      label: IRE1-mediated unfolded protein response
+    evidence_type: IEP
+    original_reference_id: PMID:11779465
+    qualifier: involved_in
+    review:
+      summary: &gt;-
+        IEP annotation based on expression pattern. Shen et al. (2001) established the
+        ire-1/xbp-1 UPR pathway in C. elegans, which controls UPR target-gene transcription
+        including the BiP genes.
+      action: ACCEPT
+      reason: &gt;-
+        hsp-3 is induced by ER stress in an ire-1/xbp-1-dependent manner (see the Urano
+        microarray, cosmid C15H9.6). The IEP call from the foundational UPR paper is
+        defensible; the full text (read by the WormBase curator) is not cached, so the
+        specific hsp-3 expression evidence is deferred to the curator.
+      supported_by:
+        - reference_id: PMID:11779465
+          supporting_text: C. elegans requires ire-1-mediated splicing of xbp-1 mRNA for
+            UPR gene transcription and survival upon ER stress
+  - term:
+      id: GO:0036498
+      label: IRE1-mediated unfolded protein response
+    evidence_type: HEP
+    original_reference_id: PMID:12186849
+    qualifier: involved_in
+    review:
+      summary: &gt;-
+        HEP annotation from the genome-wide ER-stress microarray. hsp-3 (cosmid C15H9.6)
+        is among the tunicamycin-induced genes whose induction is attenuated in xbp-1
+        mutants, placing it downstream of the ire-1/xbp-1 (IRE1-mediated) UPR branch.
+      action: ACCEPT
+      reason: &gt;-
+        Directly supported: C15H9.6 (= hsp-3) appears in Table I of xbp-1-dependent,
+        tunicamycin-induced genes (N2 log2 1.32, reduced to 0.68 in xbp-1), a modest but
+        genuine IRE1/xbp-1-dependent induction.
+      supported_by:
+        - reference_id: PMID:12186849
+          supporting_text: in C. elegans, the ire-1 and xbp-1 pathway has retained its
+            essential role in upregulating expression of many UPR target genes that are
+            similarly upregulated by the homologous pathway in yeast
+  - term:
+      id: GO:0030968
+      label: endoplasmic reticulum unfolded protein response
+    evidence_type: IEP
+    original_reference_id: PMID:11779465
+    qualifier: involved_in
+    review:
+      summary: &gt;-
+        IEP annotation from the foundational C. elegans UPR study, based on the ER-stress
+        expression program controlled by ire-1/xbp-1.
+      action: ACCEPT
+      reason: &gt;-
+        hsp-3 is an ER-stress-responsive gene within the ire-1/xbp-1-controlled UPR program
+        (see Urano microarray). Deferred to the WormBase curator for the specific full-text
+        expression evidence.
+      supported_by:
+        - reference_id: PMID:11779465
+          supporting_text: C. elegans requires ire-1-mediated splicing of xbp-1 mRNA for
+            UPR gene transcription and survival upon ER stress
+  - term:
+      id: GO:0030968
+      label: endoplasmic reticulum unfolded protein response
+    evidence_type: HEP
+    original_reference_id: PMID:12186849
+    qualifier: involved_in
+    review:
+      summary: &gt;-
+        HEP annotation from the ER-stress microarray. hsp-3 (C15H9.6) is a tunicamycin-
+        induced, xbp-1-dependent gene, marking it as part of the ER UPR transcriptional
+        program.
+      action: ACCEPT
+      reason: &gt;-
+        Supported by Table I of Urano et al., where C15H9.6 (= hsp-3) is induced by ER
+        stress and attenuated in xbp-1 mutants. Consistent with BiP being a canonical UPR
+        target.
+      supported_by:
+        - reference_id: PMID:12186849
+          supporting_text: in C. elegans, the ire-1 and xbp-1 pathway has retained its
+            essential role in upregulating expression of many UPR target genes that are
+            similarly upregulated by the homologous pathway in yeast
+  - term:
+      id: GO:0034663
+      label: endoplasmic reticulum chaperone complex
+    evidence_type: ISS
+    original_reference_id: PMID:11779465
+    qualifier: part_of
+    review:
+      summary: &gt;-
+        ISS annotation (by similarity to human BiP, UniProtKB:P11021) placing HSP-3 in the
+        ER chaperone complex. Corroborated by its physical association with the ER UPR
+        sensors.
+      action: ACCEPT
+      reason: &gt;-
+        HSP-3 is orthologous to mammalian BiP, a component of the ER chaperone machinery,
+        and directly forms a complex with IRE-1/ATF-6/PEK-1 in the ER.
+      supported_by:
+        - reference_id: PMID:27138431
+          supporting_text: form a complex with IRE-1, ATF-6 and PEK-1, to preclude
+            activation of UPR-related signaling events
+        - reference_id: UniProt:P27420
+          supporting_text: Belongs to the heat shock protein 70 family
+  - term:
+      id: GO:0016887
+      label: ATP hydrolysis activity
+    evidence_type: ISS
+    original_reference_id: PMID:2225768
+    qualifier: enables
+    review:
+      summary: &gt;-
+        ISS annotation (by similarity to yeast KAR2/BiP, UniProtKB:P16474) for the HSP70
+        ATPase activity. HSP-3 is an ER-resident HSP70 with conserved ATPase machinery.
+      action: ACCEPT
+      reason: &gt;-
+        ATP hydrolysis is a conserved core function of ER HSP70/BiP proteins. The ISS to
+        yeast KAR2 is appropriate given the strong sequence conservation of the HSP70
+        nucleotide-binding domain.
+      supported_by:
+        - reference_id: UniProt:P27420
+          supporting_text: GO:0016887; F:ATP hydrolysis activity; ISS:WormBase
+        - reference_id: UniProt:P27420
+          supporting_text: Belongs to the heat shock protein 70 family
+  - term:
+      id: GO:0006457
+      label: protein folding
+    evidence_type: NAS
+    review:
+      summary: &gt;-
+        Added to align core_functions with existing_annotations. Protein folding is the
+        biological process served by the HSP-3 chaperone/ATPase activities in the ER lumen.
+      action: NEW
+      reason: &gt;-
+        Core process term not present among the GOA existing annotations; HSP-3/BiP is an
+        ATP-dependent chaperone whose primary role is folding of ER client proteins.
+      supported_by:
+        - reference_id: UniProt:P27420
+          supporting_text: Probably plays a role in facilitating the assembly of
+core_functions:
+  - description: &gt;-
+      HSP-3 is an ER-lumen-resident HSP70/BiP molecular chaperone that assists folding,
+      refolding and assembly of nascent secretory and membrane client proteins in the ER
+      lumen, using ATP-dependent cycles of substrate binding and release. It also
+      participates in the ER unfolded protein response, both as a sensor-repressing
+      chaperone and as a stress-inducible effector.
+    molecular_function:
+      id: GO:0044183
+      label: protein folding chaperone
+    directly_involved_in:
+      - id: GO:0006457
+        label: protein folding
+      - id: GO:0030968
+        label: endoplasmic reticulum unfolded protein response
+    locations:
+      - id: GO:0005788
+        label: endoplasmic reticulum lumen
+    supported_by:
+      - reference_id: UniProt:P27420
+        supporting_text: Probably plays a role in facilitating the assembly of
+      - reference_id: PMID:27138431
+        supporting_text: HSP-1 is predominantly cytosolic, whereas HSP-3 is retained
+          within the ER lumen.
+  - description: &gt;-
+      ATP hydrolysis drives the HSP-3 chaperone cycle. Allosteric coupling between the
+      nucleotide-binding and substrate-binding domains converts ATP turnover into
+      regulated binding and release of client polypeptides.
+    molecular_function:
+      id: GO:0016887
+      label: ATP hydrolysis activity
+    directly_involved_in:
+      - id: GO:0006457
+        label: protein folding
+    locations:
+      - id: GO:0005788
+        label: endoplasmic reticulum lumen
+    supported_by:
+      - reference_id: UniProt:P27420
+        supporting_text: GO:0016887; F:ATP hydrolysis activity; ISS:WormBase
+  - description: &gt;-
+      HSP-3 binds ATP through its conserved HSP70 nucleotide-binding domain; nucleotide
+      state allosterically controls substrate-binding affinity during the chaperone cycle.
+    molecular_function:
+      id: GO:0005524
+      label: ATP binding
+    locations:
+      - id: GO:0005788
+        label: endoplasmic reticulum lumen
+    supported_by:
+      - reference_id: UniProt:P27420
+        supporting_text: GO:0005524; F:ATP binding; IEA:UniProtKB-KW
+proposed_new_terms: []
+knowledge_gaps:
+  - gap_statement: &gt;-
+      The molecular basis of the division of labor between the two C. elegans BiP paralogs
+      HSP-3 and HSP-4 is undetermined: which client proteins specifically require HSP-3
+      (versus HSP-4), and which tissue programs and signaling interfaces each paralog
+      serves, are not established.
+    boundary: &gt;-
+      Both are ER-lumen HSP70/BiP orthologs with canonical nucleotide- and substrate-
+      binding domains that share &gt;70% sequence similarity, and recent paralog-resolved
+      work indicates they are functionally diversified rather than strictly interchangeable
+      (HSP-3 canonical folding; HSP-4 specialized for stress/ER-phagy signaling). What is
+      undetermined is the paralog-specific clientele and mechanism.
+    gap_kind:
+      - BIOLOGY
+    dark_aspect: RESIDUAL_SUBGAP
+    status: NARROWING
+    significance: &gt;-
+      Distinguishing HSP-3- from HSP-4-dependent clients is required to interpret loss-of-
+      function phenotypes, to model human BiP (single-gene) biology in the two-paralog worm
+      system, and to know which paralog controls a given secretory or stress phenotype.
+    resolution: &gt;-
+      Paralog-resolved interactome/client proteomics (e.g. proximity labeling of tagged
+      endogenous HSP-3 vs HSP-4) under basal and ER-stress conditions, with reciprocal
+      rescue and paralog-swap experiments.
+    provenance:
+      - reference_id: PMID:27138431
+        supporting_text: elegans encodes two Grp78/BiP homologues, hsp-3 and hsp-4,
+          assumed to cross-compensate for each other in their roles as ER-residing protein
+          chaperones
+  - gap_statement: &gt;-
+      The functional consequence of HSP-3 AMPylation by FIC-1 is unknown: whether, where,
+      and under what conditions this modification alters HSP-3 ATPase or chaperone activity
+      in vivo has not been determined.
+    boundary: &gt;-
+      HSP-3 is a confirmed in vivo AMPylation substrate of the sole C. elegans Fic protein
+      FIC-1 (identified by mass spectrometry), and AMPylation is a reversible
+      post-translational modification, but its regulatory effect on HSP-3 activity is not
+      characterized.
+    gap_kind:
+      - BIOLOGY
+    dark_aspect: RESIDUAL_SUBGAP
+    status: OPEN
+    significance: &gt;-
+      AMPylation of BiP-family chaperones is a candidate mechanism for tuning ER chaperone
+      capacity during stress and recovery; knowing its effect on HSP-3 would clarify how
+      chaperone activity is post-translationally regulated in the worm ER.
+    resolution: &gt;-
+      Measure the ATPase/chaperone activity of AMPylated versus unmodified HSP-3 and
+      phenotype non-AMPylatable HSP-3 knock-in animals under ER stress and pathogen
+      challenge.
+    provenance:
+      - reference_id: PMID:27138431
+        supporting_text: results in diverse changes of their activities remains to be
+          studied.
+      - reference_id: PMID:27138431
+        supporting_text: two classes of proteins over-represented amongst the AMPylated
+          fraction of proteins
+suggested_questions:
+  - question: &gt;-
+      Which secretory/membrane client proteins specifically depend on HSP-3 (rather than
+      HSP-4) for folding in the C. elegans ER, and in which tissues?
+    experts: []
+  - question: &gt;-
+      Does FIC-1-mediated AMPylation inhibit or otherwise tune HSP-3 chaperone activity in
+      vivo, and is it dynamically regulated during ER-stress recovery?
+    experts: []
+  - question: &gt;-
+      Is the BiP-mediated repression of the IRE-1/ATF-6/PEK-1 sensors exerted specifically
+      by HSP-3, by HSP-4, or does it require both paralogs?
+    experts: []
+suggested_experiments:
+  - description: &gt;-
+      Proximity labeling (TurboID/BioID) of endogenously tagged HSP-3 and HSP-4 under basal
+      and tunicamycin/pathogen-induced ER stress, to define paralog-specific client and
+      interactor repertoires.
+    experiment_type: proteomics
+    hypothesis: HSP-3 and HSP-4 have overlapping but distinct client and interactor sets.
+  - description: &gt;-
+      Generate non-AMPylatable HSP-3 knock-in alleles (mutating the FIC-1 target residue)
+      and assay ER-stress tolerance, innate-immune resistance to P. aeruginosa, and
+      chaperone-dependent folding reporters.
+    experiment_type: genetics / phenotyping
+    hypothesis: AMPylation of HSP-3 modulates its chaperone activity and stress tolerance.
+  - description: &gt;-
+      Paralog-specific depletion (hsp-3 vs hsp-4) combined with a UPR reporter and sensor
+      activation assays to test which paralog restrains IRE-1/ATF-6/PEK-1 under basal
+      conditions.
+    experiment_type: genetics / reporter assay
+    hypothesis: HSP-3 and HSP-4 differ in their contribution to UPR-sensor repression.
+tags:
+  - caeel-proteostasis
+  - caeel-upr-stress
+</code></pre>
+            </div>
+        </details>
+    </div>
+
+    <!-- Pathway Visualization Link -->
+
+
+    <style>
+        /* Markdown Section Styles */
+        .markdown-section {
+            margin-bottom: 1rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .markdown-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .markdown-section summary h3 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.1rem;
+        }
+
+        .markdown-section summary:hover h3 {
+            color: #007bff;
+        }
+
+        .markdown-section[open] {
+            background-color: #fff;
+        }
+
+        .markdown-content {
+            margin-top: 1rem;
+            padding: 1rem;
+            border-top: 1px solid #dee2e6;
+        }
+
+        /* Markdown content styling */
+        .markdown-content h1 { font-size: 1.5rem; margin-top: 1.5rem; }
+        .markdown-content h2 { font-size: 1.3rem; margin-top: 1.3rem; }
+        .markdown-content h3 { font-size: 1.1rem; margin-top: 1.1rem; }
+        .markdown-content h4 { font-size: 1rem; margin-top: 1rem; }
+
+        .markdown-content pre {
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .markdown-content code {
+            background-color: #f8f9fa;
+            padding: 0.2rem 0.4rem;
+            border-radius: 3px;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+        }
+
+        .markdown-content pre code {
+            background: none;
+            padding: 0;
+        }
+
+        .markdown-content table {
+            border-collapse: collapse;
+            width: 100%;
+            margin: 1rem 0;
+        }
+
+        .markdown-content table th,
+        .markdown-content table td {
+            border: 1px solid #dee2e6;
+            padding: 0.5rem;
+            text-align: left;
+        }
+
+        .markdown-content table th {
+            background-color: #f8f9fa;
+            font-weight: bold;
+        }
+
+        .markdown-content blockquote {
+            border-left: 4px solid #007bff;
+            padding-left: 1rem;
+            margin-left: 0;
+            color: #666;
+        }
+
+        /* YAML Preview Styles */
+        .yaml-preview {
+            margin-top: 2rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .yaml-preview summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .yaml-preview summary h2 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.3rem;
+        }
+
+        .yaml-preview summary:hover h2 {
+            color: #007bff;
+        }
+
+        .yaml-preview[open] {
+            background-color: #fff;
+        }
+
+        .yaml-content {
+            margin-top: 1rem;
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .yaml-content pre {
+            margin: 0;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+            line-height: 1.4;
+        }
+
+        .yaml-content code {
+            color: #333;
+            background: none;
+            padding: 0;
+        }
+
+        /* Pathway Link Styles */
+        .pathway-link {
+            margin: 1rem 0;
+        }
+
+        .btn-link {
+            display: inline-block;
+            padding: 0.5rem 1rem;
+            background-color: #007bff;
+            color: white !important;
+            text-decoration: none;
+            border-radius: 4px;
+            font-weight: 500;
+            transition: background-color 0.2s;
+        }
+
+        .btn-link:hover {
+            background-color: #0056b3;
+            text-decoration: none;
+        }
+
+        /* Voting buttons */
+        .vote-buttons {
+            display: inline-block;
+            margin-left: 0.5rem;
+        }
+
+        .vote-btn {
+            background: none;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 2px 6px;
+            margin: 0 2px;
+            cursor: pointer;
+            font-size: 0.9rem;
+            transition: all 0.2s;
+            opacity: 0.6;
+        }
+
+        .vote-btn:hover {
+            opacity: 1;
+            transform: scale(1.1);
+        }
+
+        .vote-btn.voted {
+            opacity: 1;
+            border-color: #28a745;
+            background-color: #d4edda;
+        }
+
+        .vote-btn.voted-down {
+            border-color: #dc3545;
+            background-color: #f8d7da;
+        }
+
+        .vote-btn-small {
+            font-size: 0.7rem;
+            padding: 1px 4px;
+            margin: 0 1px;
+        }
+    </style>
+
+    <script>
+        // Add collapsible functionality
+        document.querySelectorAll('.collapsible').forEach(element => {
+            element.addEventListener('click', function() {
+                this.classList.toggle('collapsed');
+            });
+        });
+
+        // Voting functionality
+        const VOTE_URL = 'https://script.google.com/macros/s/AKfycbwPKH7d3seuPNBtB0ugVjqGeTiByyOGD5vkqB_Ck6K8eOcPQYbJqBOuz6GFgXHKBNWK/exec';
+
+        // Get or create session ID
+        let sessionId = localStorage.getItem('review_session_id');
+        if (!sessionId) {
+            sessionId = 's' + Date.now() + '_' + Math.random().toString(36).substr(2, 9);
+            localStorage.setItem('review_session_id', sessionId);
+        }
+
+        // Show previous votes on page load
+        document.addEventListener('DOMContentLoaded', function() {
+            document.querySelectorAll('.vote-buttons').forEach(container => {
+                const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+                const previousVote = localStorage.getItem(key);
+                if (previousVote) {
+                    const btn = container.querySelector(`[data-v="${previousVote}"]`);
+                    if (btn) btn.classList.add(previousVote === 'up' ? 'voted' : 'voted-down');
+                }
+            });
+        });
+
+        // Handle vote clicks - Simple image beacon approach
+        document.addEventListener('click', function(e) {
+            if (!e.target.classList.contains('vote-btn')) return;
+
+            // Prevent the click from bubbling to parent elements (like summary)
+            e.preventDefault();
+            e.stopPropagation();
+
+            const btn = e.target;
+            const container = btn.closest('.vote-buttons');
+            if (!container) return;
+
+            const voteType = btn.dataset.v;
+
+            // Check if already voted (locally)
+            const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+            const previousVote = localStorage.getItem(key);
+
+            if (previousVote === voteType) {
+                // Same vote - do nothing
+                btn.style.animation = 'shake 0.5s';
+                setTimeout(() => btn.style.animation = '', 500);
+                return;
+            }
+
+            // Build URL
+            const params = new URLSearchParams({
+                gene_id: container.dataset.g,
+                annotation_id: container.dataset.a,
+                ref_id: container.dataset.r || '',
+                action: container.dataset.act,
+                vote: voteType,
+                session_id: sessionId,
+                ua: navigator.userAgent.substring(0, 100)
+            });
+
+            // Clear previous vote styling
+            container.querySelectorAll('.vote-btn').forEach(b => {
+                b.classList.remove('voted', 'voted-down');
+            });
+
+            // Apply new vote styling immediately (optimistic UI)
+            btn.classList.add(voteType === 'up' ? 'voted' : 'voted-down');
+
+            // Store locally
+            localStorage.setItem(key, voteType);
+
+            // Send vote using fetch with no-cors mode (fire and forget)
+            const fullUrl = VOTE_URL + '?' + params;
+            console.log('Sending vote to:', fullUrl);
+
+            // Use fetch in no-cors mode - we won't get a response but the request will be sent
+            fetch(fullUrl, {
+                mode: 'no-cors',
+                method: 'GET'
+            }).then(() => {
+                console.log('Vote request sent (no response due to no-cors mode)');
+            }).catch(err => {
+                console.warn('Vote may not have been recorded, but saved locally:', err);
+
+                // Fallback: try image beacon as well
+                const img = new Image();
+                img.src = fullUrl;
+            });
+        });
+
+        // Optional: Add shake animation for feedback
+        const style = document.createElement('style');
+        style.textContent = `
+            @keyframes shake {
+                0%, 100% { transform: translateX(0); }
+                25% { transform: translateX(-5px); }
+                75% { transform: translateX(5px); }
+            }
+        `;
+        document.head.appendChild(style);
+    </script>
+</body>
+</html>

--- a/pages/projects/CAEEL_UPR_STRESS.html
+++ b/pages/projects/CAEEL_UPR_STRESS.html
@@ -393,7 +393,7 @@
 - <strong><a href="../../genes/worm/ire-1/ire-1-ai-review.html">ire-1</a></strong> - IRE1 kinase/RNase (sensor)<br />
 - <strong><a href="../../genes/worm/xbp-1/xbp-1-ai-review.html">xbp-1</a></strong> - XBP1 transcription factor (spliced by <a href="../../genes/worm/ire-1/ire-1-ai-review.html">IRE-1</a>)<br />
 - <strong><a href="../../genes/worm/hsp-4/hsp-4-ai-review.html">hsp-4</a></strong> - BiP/GRP78 (HSP70 chaperone, readout gene)<br />
-- <strong>hsp-3</strong> - BiP family</p>
+- <strong><a href="../../genes/worm/hsp-3/hsp-3-ai-review.html">hsp-3</a></strong> - BiP family</p>
 <h3 id="2-upr-er-pek-1perk-branch">2. UPR-ER: <a href="../../genes/worm/pek-1/pek-1-ai-review.html">PEK-1</a>/PERK Branch</h3>
 <p>Translation attenuation:<br />
 - <strong><a href="../../genes/worm/pek-1/pek-1-ai-review.html">pek-1</a></strong> - PERK kinase (sensor)<br />


### PR DESCRIPTION
## Summary

Automated regeneration of static assets after gene review or template changes.

## Generated Assets

| Asset | Count/Status |
|-------|--------------|
| Gene review YAML files | 2858 |
| Gene review HTML pages | 2858 |
| Project pages | 1095 |
| Module pages | 87 |
| Browser app (data.js) | Updated |
| Validation report | Updated |

## Trigger

This PR was triggered by changes to:
- genes/**/*.yaml - gene review data files
- src/ai_gene_review/schema/** - LinkML schema files
- src/ai_gene_review/templates/** - Jinja2 templates
- src/ai_gene_review/render.py - rendering code
- src/ai_gene_review/render_modules.py - module rendering code
- src/ai_gene_review/export/** - export code
- src/ai_gene_review/browser/** - browser app assets
- src/ai_gene_review/tools/minify_linkml_browser_data.py - browser data compaction
- projects/*.md - project definitions
- modules/**/*.yaml - module definitions
- project.justfile - just recipes used by CI
- .github/workflows/generate-pages.yaml - workflow definition

## Review

- [ ] Spot-check a few gene review HTML pages render correctly
- [ ] Spot-check module tree browser pages render correctly
- [ ] Verify browser app loads and filters work
- [ ] Check validation report for new issues
