### PR TITLE
Regenerate pages and browser app

### DIFF
--- a/pages/projects/KW_1110_TRAF_KW2GO.html
+++ b/pages/projects/KW_1110_TRAF_KW2GO.html
@@ -1,0 +1,484 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>KW-1110 (Inhibition of host TRAFs by virus) — KW2GO remapping - AI Gene Review Projects</title>
+    <style>
+        :root {
+            --color-accept: #22c55e;
+            --color-remove: #ef4444;
+            --color-modify: #f97316;
+            --color-primary: #3498db;
+            --bg-light: #f9fafb;
+            --border-color: #e5e7eb;
+            --text-muted: #6b7280;
+            --text-primary: #111827;
+        }
+
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+            line-height: 1.6;
+            color: var(--text-primary);
+            background-color: #ffffff;
+            padding: 2rem;
+            max-width: 1200px;
+            margin: 0 auto;
+        }
+
+        .breadcrumb {
+            margin-bottom: 1.5rem;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .breadcrumb a {
+            color: var(--color-primary);
+            text-decoration: none;
+        }
+
+        .breadcrumb a:hover {
+            text-decoration: underline;
+        }
+
+        .header {
+            border-bottom: 2px solid var(--border-color);
+            padding-bottom: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        h1 {
+            font-size: 2.5rem;
+            font-weight: 700;
+            margin-bottom: 0.5rem;
+            color: #1f2937;
+        }
+
+        h2 {
+            font-size: 1.75rem;
+            font-weight: 600;
+            margin-top: 2rem;
+            margin-bottom: 1rem;
+            color: #1f2937;
+            border-bottom: 1px solid var(--border-color);
+            padding-bottom: 0.5rem;
+        }
+
+        h3 {
+            font-size: 1.25rem;
+            font-weight: 600;
+            margin-top: 1.5rem;
+            margin-bottom: 0.75rem;
+            color: #374151;
+        }
+
+        h4 {
+            font-size: 1rem;
+            font-weight: 600;
+            margin-top: 1.25rem;
+            margin-bottom: 0.5rem;
+            color: #4b5563;
+        }
+
+        p {
+            margin-bottom: 1rem;
+        }
+
+        a {
+            color: var(--color-primary);
+            text-decoration: none;
+        }
+
+        a:hover {
+            text-decoration: underline;
+        }
+
+        /* Gene symbol links */
+        .content a[href*="/genes/"] {
+            background-color: #dbeafe;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-weight: 500;
+        }
+
+        .content a[href*="/genes/"]:hover {
+            background-color: #bfdbfe;
+        }
+
+        ul, ol {
+            margin-bottom: 1rem;
+            padding-left: 2rem;
+        }
+
+        li {
+            margin-bottom: 0.25rem;
+        }
+
+        code {
+            background: #f4f4f4;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-family: 'SFMono-Regular', Consolas, 'Liberation Mono', Menlo, monospace;
+            font-size: 0.875em;
+        }
+
+        pre {
+            background: #1f2937;
+            color: #f9fafb;
+            padding: 1rem;
+            border-radius: 0.5rem;
+            overflow-x: auto;
+            margin-bottom: 1rem;
+        }
+
+        pre code {
+            background: none;
+            padding: 0;
+            color: inherit;
+        }
+
+        blockquote {
+            border-left: 4px solid var(--color-primary);
+            margin-left: 0;
+            padding-left: 1.5rem;
+            color: #4b5563;
+            font-style: italic;
+            margin-bottom: 1rem;
+        }
+
+        table {
+            width: 100%;
+            border-collapse: collapse;
+            margin: 1.5rem 0;
+        }
+
+        th, td {
+            border: 1px solid var(--border-color);
+            padding: 0.75rem;
+            text-align: left;
+        }
+
+        th {
+            background-color: var(--bg-light);
+            font-weight: 600;
+            color: var(--text-muted);
+            text-transform: uppercase;
+            font-size: 0.75rem;
+            letter-spacing: 0.05em;
+        }
+
+        tr:nth-child(even) {
+            background-color: #f9fafb;
+        }
+
+        tr:hover {
+            background-color: #f3f4f6;
+        }
+
+        /* Mermaid diagrams */
+        .mermaid {
+            text-align: center;
+            margin: 2rem 0;
+            background: white;
+            padding: 1.5rem;
+            border-radius: 0.5rem;
+            border: 1px solid var(--border-color);
+        }
+
+        .mermaid svg {
+            max-width: 100%;
+            height: auto;
+        }
+
+        /* Warnings section */
+        .warnings {
+            background-color: #fef3c7;
+            border: 1px solid #fde68a;
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 2rem;
+        }
+
+        .warnings h3 {
+            color: #92400e;
+            margin-top: 0;
+            margin-bottom: 0.5rem;
+            font-size: 1rem;
+        }
+
+        .warnings ul {
+            margin-bottom: 0;
+            color: #78350f;
+        }
+
+        /* Task lists (checkboxes) */
+        li input[type="checkbox"] {
+            margin-right: 0.5rem;
+        }
+
+        /* Status badges */
+        .badge {
+            display: inline-block;
+            padding: 0.25rem 0.625rem;
+            border-radius: 9999px;
+            font-size: 0.75rem;
+            font-weight: 600;
+            text-transform: uppercase;
+        }
+
+        .badge-success {
+            background-color: #d1fae5;
+            color: #065f46;
+        }
+
+        .badge-warning {
+            background-color: #fef3c7;
+            color: #92400e;
+        }
+
+        .badge-info {
+            background-color: #dbeafe;
+            color: #1e40af;
+        }
+
+        /* Project meta: maturity + tag badges */
+        .project-meta { margin-bottom: 0.5rem; }
+        .project-meta .badge { margin: 0 0.25rem 0.25rem 0; }
+        .gene-list {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.375rem;
+            margin-bottom: 1rem;
+        }
+        .gene-list a,
+        .gene-list span {
+            background-color: #dbeafe;
+            border-radius: 0.25rem;
+            color: #1e40af;
+            display: inline-block;
+            font-weight: 500;
+            padding: 0.125rem 0.375rem;
+        }
+        .gene-list a:hover {
+            background-color: #bfdbfe;
+            text-decoration: none;
+        }
+        .m-SCOPING     { background: #fef3c7; color: #92400e; }
+        .m-IN_PROGRESS { background: #dbeafe; color: #1e40af; }
+        .m-MATURE      { background: #dcfce7; color: #166534; }
+        .m-COMPLETE    { background: #d1fae5; color: #065f46; }
+        .m-ARCHIVED    { background: #f3f4f6; color: #6b7280; }
+        .badge.tag { text-transform: none; }
+        .t-FLAGSHIP       { background: #fae8ff; color: #86198f; }
+        .t-BIOLOGY_DOMAIN { background: #e0f2fe; color: #075985; }
+        .t-PIPELINE       { background: #ede9fe; color: #5b21b6; }
+        .t-OBSOLETION     { background: #fee2e2; color: #991b1b; }
+
+        /* Manual reviews */
+        .manual-reviews {
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem 1.25rem;
+            margin-bottom: 2rem;
+        }
+        .manual-reviews h3 { margin-top: 0; margin-bottom: 0.75rem; font-size: 1rem; }
+        .manual-reviews .review { padding: 0.5rem 0; }
+        .manual-reviews .review + .review { border-top: 1px dashed var(--border-color); }
+        .manual-reviews .review-head { margin-bottom: 0.25rem; }
+        .manual-reviews .review-head .badge { margin-right: 0.5rem; }
+        .manual-reviews .review-head .who { font-weight: 600; }
+        .manual-reviews .review-head .when { color: var(--text-muted); font-size: 0.85rem; margin-left: 0.5rem; }
+        .manual-reviews .review-notes { margin: 0.25rem 0; }
+        .manual-reviews .review-todos { margin: 0.25rem 0 0.5rem; }
+        .badge.r-READY             { background: #dcfce7; color: #166534; }
+        .badge.r-CHANGES_REQUESTED { background: #fee2e2; color: #991b1b; }
+
+        /* Content wrapper */
+        .content {
+            margin-bottom: 2rem;
+        }
+
+        /* Footer */
+        footer {
+            margin-top: 3rem;
+            padding-top: 1.5rem;
+            border-top: 1px solid var(--border-color);
+            color: var(--text-muted);
+            font-size: 0.875rem;
+            text-align: center;
+        }
+
+        footer small {
+            display: block;
+        }
+    </style>
+    <!-- Mermaid.js for diagram rendering -->
+    <script src="https://cdn.jsdelivr.net/npm/mermaid@10/dist/mermaid.min.js"></script>
+    <script>
+        mermaid.initialize({
+            startOnLoad: true,
+            theme: 'default',
+            themeVariables: {
+                primaryColor: '#3498db',
+                primaryTextColor: '#fff',
+                primaryBorderColor: '#2c3e50',
+                lineColor: '#333',
+                secondaryColor: '#ecf0f1',
+                tertiaryColor: '#f39c12'
+            },
+            flowchart: {
+                htmlLabels: true,
+                curve: 'basis'
+            }
+        });
+    </script>
+</head>
+<body>
+    <nav class="breadcrumb">
+        <a href="../index.html">Home</a> &raquo;
+        <a href="index.html">Projects</a> &raquo;
+        KW-1110 (Inhibition of host TRAFs by virus) — KW2GO remapping
+    </nav>
+
+    <header class="header">
+        <h1>KW-1110 (Inhibition of host TRAFs by virus) — KW2GO remapping</h1>
+
+        <p class="project-meta">
+            <span class="badge m-SCOPING">SCOPING</span>
+            <span class="badge tag t-KW2GO">KW2GO</span><span class="badge tag t-OBSOLETION">OBSOLETION</span>
+        </p>
+
+
+
+    </header>
+
+
+
+
+
+    <div class="content">
+        <h1 id="kw-1110-inhibition-of-host-trafs-by-virus-kw2go-remapping">KW-1110 (Inhibition of host TRAFs by virus) — KW2GO remapping</h1>
+<h2 id="overview">Overview</h2>
+<p>Tracks a UniProt keyword-to-GO (KW2GO) mapping change proposed upstream: the<br />
+mapping from <strong>UniProt keyword KW-1110 "Inhibition of host TRAFs by virus"</strong> to<br />
+its current GO term is being moved to a more informative target that fits the<br />
+keyword's biology.</p>
+<ul>
+<li><strong>Keyword:</strong> <a href="https://www.uniprot.org/keywords/KW-1110">KW-1110 "Inhibition of host TRAFs by virus"</a></li>
+<li><strong>Parent keyword:</strong> <a href="https://www.uniprot.org/keywords/KW-1113">KW-1113 "Inhibition of host RLR pathway by virus"</a></li>
+</ul>
+<h3 id="current-mapping-to-be-removed">Current mapping (to be removed)</h3>
+<table>
+<thead>
+<tr>
+<th>GO ID</th>
+<th>Label</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><a href="http://amigo.geneontology.org/amigo/term/GO:0039527">GO:0039527</a></td>
+<td>symbiont-mediated suppression of host TRAF-mediated signal transduction</td>
+</tr>
+</tbody>
+</table>
+<ul>
+<li>OLS lookup confirms this label. <a href="http://amigo.geneontology.org/amigo/term/GO:0039527">GO:0039527</a> is itself queued for obsoletion via<br />
+<a href="https://github.com/geneontology/go-ontology/issues/29238">geneontology/go-ontology#29238</a><br />
+  because "TRAF-mediated signal transduction" is not a real pathway on the<br />
+  ontology's process branch (TRAFs act in many downstream pathways: TLR,<br />
+  TNF/TNFR, cGAS-STING, RLR, etc.).</li>
+</ul>
+<h3 id="proposed-replacement-mapping-to-be-added">Proposed replacement mapping (to be added)</h3>
+<table>
+<thead>
+<tr>
+<th>GO ID</th>
+<th>Label</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><a href="http://amigo.geneontology.org/amigo/term/GO:0140476">GO:0140476</a></td>
+<td>symbiont-mediated suppression of host cytoplasmic pattern recognition receptor signaling pathway via inhibition of TRAF activity</td>
+</tr>
+</tbody>
+</table>
+<ul>
+<li><strong>The <a href="http://amigo.geneontology.org/amigo/term/GO:0140476">GO:0140476</a> term ID does not yet resolve in OLS</strong> (verified 2026-07-04).<br />
+  Per the annotation tracker discussion, this term still needs to be created in<br />
+  the ontology before the KW-1110 mapping can be repointed at it. The<br />
+  annotation tracker ticket is waiting on confirmation before deleting the<br />
+  existing mapping and adding the new one (the deletion is reversible if the<br />
+  new term is delayed).</li>
+</ul>
+<h3 id="nature-of-the-change">Nature of the change</h3>
+<p>Lateral / more-specific move within the same "symbiont-mediated suppression of<br />
+host signaling" branch. The proposed target explicitly ties TRAF-inhibition to<br />
+the <strong>cytoplasmic pattern recognition receptor (PRR) signaling pathway</strong> family<br />
+(RIG-I / MDA5 / LGP2 → MAVS → <a href="../../genes/human/TBK1/TBK1-ai-review.html">TBK1</a> / IRF3 / NF-κB), which matches the parent<br />
+keyword KW-1113 "Inhibition of host RLR pathway by virus". Reviewers on the<br />
+upstream thread note that TRAF is used by TLRs, TNFR, and cGAS-STING as well,<br />
+so this new target is a better fit for the specifically viral / RLR context<br />
+that KW-1110 sits under, but it does <em>not</em> cover TRAF interference by bacteria<br />
+or by viral proteins that act via TLR or TNFR routes — those need their own<br />
+child terms if the ontology decides to model them (see the upstream comments<br />
+by @genegodbold and @pgaudet for candidate templates).</p>
+<h2 id="upstream-tickets">Upstream tickets</h2>
+<ul>
+<li>Annotation tracker: <a href="https://github.com/geneontology/go-annotation/issues/6470">geneontology/go-annotation#6470</a> (open)</li>
+<li>Ontology / obsoletion ticket: <a href="https://github.com/geneontology/go-ontology/issues/29238">geneontology/go-ontology#29238</a> (closed)</li>
+<li>Prior TRAF-branch discussion (signal-transduction cleanup): geneontology/go-ontology#26498 (referenced by #29238)</li>
+</ul>
+<h2 id="impact-on-this-repo">Impact on this repo</h2>
+<p><strong>No gene reviews currently touch either identifier.</strong></p>
+<p>Searches performed on 2026-07-04:</p>
+<ul>
+<li><code>grep -rl "0039527" genes</code> — no gene review files match (only a false-positive<br />
+  substring hit inside an Ensembl ID in a cached UniProt record).</li>
+<li><code>grep -rl "0140476" genes</code> — no matches (as expected: term not yet created).</li>
+<li><code>grep -rl "KW-1110" genes</code> — no matches.</li>
+</ul>
+<p>So this repo has no reviews that will need to be rewritten when the mapping<br />
+lands. The purpose of this project page is therefore purely to <strong>remember to<br />
+re-check once the ontology change and mapping change ship</strong>, not to queue<br />
+existing rework.</p>
+<h2 id="follow-up">Follow-up</h2>
+<ol>
+<li>Watch <a href="https://github.com/geneontology/go-ontology/issues/29238">go-ontology#29238</a><br />
+   and <a href="https://github.com/geneontology/go-annotation/issues/6470">go-annotation#6470</a><br />
+   for term creation and mapping deployment.</li>
+<li>Once <a href="http://amigo.geneontology.org/amigo/term/GO:0140476">GO:0140476</a> (or whatever ID the new term receives) is created and the<br />
+   KW-1110 mapping is repointed, re-run the two greps above to catch any newly<br />
+   added reviews for viral effector genes carrying KW-1110 (e.g. EBV BPLF1,<br />
+   FMDV Lb(pro), HSV-1 ICP0, SARS-CoV-2 M, and the bacterial TRAF-interfering<br />
+   effectors listed in the go-ontology thread).</li>
+<li>If any of those viral / bacterial effector genes enter this repo later,<br />
+   their <code>existing_annotations</code> review should MODIFY away from <a href="http://amigo.geneontology.org/amigo/term/GO:0039527">GO:0039527</a> and<br />
+   toward the new PRR-signaling target when the annotation actually carries<br />
+   evidence for a cytoplasmic-PRR context; TLR or TNFR contexts should go to<br />
+   the appropriate sibling term instead (see @pgaudet's per-effector<br />
+   assignments in <a href="https://github.com/geneontology/go-ontology/issues/29238">go-ontology#29238</a>).</li>
+</ol>
+<h2 id="status">Status</h2>
+<ul>
+<li><strong>Created:</strong> 2026-07-04</li>
+<li><strong>Blocker:</strong> <a href="http://amigo.geneontology.org/amigo/term/GO:0140476">GO:0140476</a> not yet minted; KW2GO deployment blocked on that.</li>
+<li><strong>Action needed here:</strong> none until upstream ships. This page is a watch-list<br />
+  entry so the mapping change is not silently missed when it lands.</li>
+</ul>
+    </div>
+
+    <footer>
+        <small>Generated from KW_1110_TRAF_KW2GO.md</small>
+        <small>AI Gene Review Project</small>
+    </footer>
+</body>
+</html>

--- a/pages/projects/all-projects.html
+++ b/pages/projects/all-projects.html
@@ -83,7 +83,7 @@
         <p class="subtitle">Complete, automatically generated index of every project page in <code>projects/</code></p>
     </div>
 
-    <p class="meta-note"><span id="visible-count">133</span> of 133 projects.
+    <p class="meta-note"><span id="visible-count">134</span> of 134 projects.
     Derived from each project's YAML frontmatter; the <a href="index.html">curated index</a> is the hand-organized entry point.
     Filters combine (AND across groups, OR within a group).</p>
 
@@ -1084,6 +1084,22 @@
                 <td><span class="tag t-PIPELINE">PIPELINE</span><span class="tag t-FLAGSHIP">FLAGSHIP</span></td>
                 <td><span class="sp">human</span><span class="sp">mouse</span><span class="sp">rat</span><span class="sp">DROME</span></td>
                 <td><span title="POMC, App, APP, AGRN, WT1, BCL2L1, Ang2, Ghr, Myc, Akt1, Casp3, VEGFA, FAS, CASP9, FN1, TPM1, FGFR2, PKM">18</span></td>
+                <td><span class="muted">&mdash;</span></td>
+            </tr>
+
+            <tr
+                data-title="kw-1110 (inhibition of host trafs by virus) — kw2go remapping"
+                data-slug="kw_1110_traf_kw2go"
+                data-maturity="SCOPING"
+                data-review=""
+                data-tags="KW2GO OBSOLETION"
+                data-species="">
+                <td><a href="KW_1110_TRAF_KW2GO.html">KW-1110 (Inhibition of host TRAFs by virus) — KW2GO remapping</a><br><code class="muted">KW_1110_TRAF_KW2GO</code></td>
+                <td><span class="badge m-SCOPING">SCOPING</span></td>
+                <td><span class="muted">&mdash;</span></td>
+                <td><span class="tag t-KW2GO">KW2GO</span><span class="tag t-OBSOLETION">OBSOLETION</span></td>
+                <td><span class="muted">&mdash;</span></td>
+                <td><span class="muted">&mdash;</span></td>
                 <td><span class="muted">&mdash;</span></td>
             </tr>
 


### PR DESCRIPTION
## Summary

Automated regeneration of static assets after gene review or template changes.

## Generated Assets

| Asset | Count/Status |
|-------|--------------|
| Gene review YAML files | 2860 |
| Gene review HTML pages | 2860 |
| Project pages | 1096 |
| Module pages | 87 |
| Browser app (data.js) | Updated |
| Validation report | Updated |

## Trigger

This PR was triggered by changes to:
- genes/**/*.yaml - gene review data files
- src/ai_gene_review/schema/** - LinkML schema files
- src/ai_gene_review/templates/** - Jinja2 templates
- src/ai_gene_review/render.py - rendering code
- src/ai_gene_review/render_modules.py - module rendering code
- src/ai_gene_review/export/** - export code
- src/ai_gene_review/browser/** - browser app assets
- src/ai_gene_review/tools/minify_linkml_browser_data.py - browser data compaction
- projects/*.md - project definitions
- modules/**/*.yaml - module definitions
- project.justfile - just recipes used by CI
- .github/workflows/generate-pages.yaml - workflow definition

## Review

- [ ] Spot-check a few gene review HTML pages render correctly
- [ ] Spot-check module tree browser pages render correctly
- [ ] Verify browser app loads and filters work
- [ ] Check validation report for new issues
