### PR TITLE
Regenerate pages and browser app

### DIFF
--- a/genes/worm/phb-2/phb-2-ai-review.html
+++ b/genes/worm/phb-2/phb-2-ai-review.html
@@ -1,0 +1,5920 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>phb-2 - AI Gene Review</title>
+    <style>
+        :root {
+            --color-accept: #22c55e;
+            --color-remove: #ef4444;
+            --color-modify: #f97316;
+            --color-keep-non-core: #3b82f6;
+            --color-undecided: #6b7280;
+            --color-new: #8b5cf6;
+            --color-mark-over: #eab308;
+            --bg-light: #f9fafb;
+            --border-color: #e5e7eb;
+            --text-muted: #6b7280;
+            --text-primary: #111827;
+        }
+
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+            line-height: 1.6;
+            color: var(--text-primary);
+            background-color: #ffffff;
+            padding: 2rem;
+            max-width: 1400px;
+            margin: 0 auto;
+        }
+
+        .header {
+            border-bottom: 2px solid var(--border-color);
+            padding-bottom: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        h1 {
+            font-size: 2.5rem;
+            font-weight: 700;
+            margin-bottom: 0.5rem;
+            color: #1f2937;
+        }
+
+        .gene-info {
+            display: flex;
+            gap: 2rem;
+            flex-wrap: wrap;
+            margin-top: 1rem;
+        }
+
+        .info-item {
+            display: flex;
+            gap: 0.5rem;
+        }
+
+        .info-label {
+            font-weight: 600;
+            color: var(--text-muted);
+        }
+
+        .aliases {
+            display: flex;
+            gap: 0.5rem;
+            flex-wrap: wrap;
+        }
+
+        .badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.875rem;
+            font-weight: 500;
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+        }
+
+        .status-badge {
+            padding: 0.375rem 0.875rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .status-initialized {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fde68a;
+        }
+
+        .status-in-progress {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+        }
+
+        .status-draft {
+            background-color: #fce7f3;
+            color: #831843;
+            border: 1px solid #fbcfe8;
+        }
+
+        .status-complete {
+            background-color: #d1fae5;
+            color: #065f46;
+            border: 1px solid #a7f3d0;
+        }
+
+        .description-card {
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        .description-card h2 {
+            font-size: 1.25rem;
+            margin-bottom: 1rem;
+            color: #374151;
+        }
+
+        .section {
+            margin-bottom: 2.5rem;
+        }
+
+        .section-title {
+            font-size: 1.5rem;
+            font-weight: 600;
+            margin-bottom: 1.5rem;
+            color: #1f2937;
+            border-bottom: 1px solid var(--border-color);
+            padding-bottom: 0.5rem;
+        }
+
+        .annotations-table {
+            width: 100%;
+            border-collapse: collapse;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            overflow: hidden;
+        }
+
+        .annotations-table thead {
+            background-color: var(--bg-light);
+        }
+
+        .annotations-table th {
+            text-align: left;
+            padding: 1rem;
+            font-weight: 600;
+            border-bottom: 2px solid var(--border-color);
+            font-size: 0.875rem;
+            text-transform: uppercase;
+            letter-spacing: 0.05em;
+            color: var(--text-muted);
+        }
+
+        .annotations-table td {
+            padding: 1rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .annotations-table tbody tr:hover {
+            background-color: #f9fafb;
+        }
+
+        .action-badge {
+            display: inline-block;
+            padding: 0.375rem 0.75rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .action-accept {
+            background-color: var(--color-accept);
+            color: white;
+        }
+
+        .action-remove {
+            background-color: var(--color-remove);
+            color: white;
+        }
+
+        .action-modify {
+            background-color: var(--color-modify);
+            color: white;
+        }
+
+        .action-keep_as_non_core {
+            background-color: var(--color-keep-non-core);
+            color: white;
+        }
+
+        .action-undecided {
+            background-color: var(--color-undecided);
+            color: white;
+        }
+
+        .action-new {
+            background-color: var(--color-new);
+            color: white;
+        }
+
+        .action-mark_as_over_annotated {
+            background-color: var(--color-mark-over);
+            color: white;
+        }
+
+        .term-info {
+            display: flex;
+            flex-direction: column;
+            gap: 0.25rem;
+        }
+
+        .term-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .term-label {
+            font-weight: 500;
+        }
+
+        .evidence-code {
+            font-family: monospace;
+            background-color: var(--bg-light);
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .not-badge {
+            display: inline-block;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-weight: 600;
+            margin-left: 0.25rem;
+        }
+
+        .isoform-badge {
+            display: inline-block;
+            background-color: #eff6ff;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            margin-top: 0.25rem;
+        }
+
+        .core-function-card {
+            background-color: white;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 1rem;
+        }
+
+        .core-function-card h3 {
+            font-size: 1.125rem;
+            margin-bottom: 1rem;
+            color: #1f2937;
+        }
+
+        .core-function-statement {
+            margin-bottom: 1rem;
+            padding: 0.75rem;
+            background-color: var(--bg-light);
+            border-left: 4px solid var(--color-accept);
+            border-radius: 0.25rem;
+        }
+
+        .function-annotations {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin-top: 1rem;
+        }
+
+        .reference-item {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+        }
+
+        .reference-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: start;
+            margin-bottom: 0.75rem;
+        }
+
+        .reference-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #2563eb;
+        }
+
+        .supported-by {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f3f4f6;
+            border-left: 3px solid #3b82f6;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .supported-by-title {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .support-item {
+            margin-bottom: 0.5rem;
+        }
+
+        .support-ref {
+            font-weight: 500;
+            color: #2563eb;
+        }
+
+        .support-text {
+            color: #6b7280;
+            font-style: italic;
+            margin-left: 1rem;
+        }
+
+        .propagation-review {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f8fafc;
+            border-left: 3px solid #64748b;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .propagation-title {
+            font-weight: 600;
+            color: #334155;
+            margin-bottom: 0.25rem;
+        }
+
+        .propagation-row {
+            margin-top: 0.25rem;
+        }
+
+        .propagation-source {
+            margin-top: 0.5rem;
+            padding-top: 0.5rem;
+            border-top: 1px solid #e5e7eb;
+        }
+
+        .propagation-source-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #1d4ed8;
+        }
+
+        .propagation-comment {
+            color: #4b5563;
+            margin-left: 1rem;
+        }
+
+        a.term-link {
+            color: #2563eb;
+            text-decoration: none;
+        }
+
+        a.term-link:hover {
+            text-decoration: underline;
+        }
+
+        .core-function-terms {
+            margin-top: 1rem;
+        }
+
+        .function-term-group {
+            margin-bottom: 1rem;
+        }
+
+        .function-term-label {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .reference-title {
+            font-weight: 500;
+            margin-bottom: 0.5rem;
+        }
+
+        .findings-list {
+            margin-top: 1rem;
+            padding-left: 1.5rem;
+        }
+
+        .finding-item {
+            margin-bottom: 0.75rem;
+        }
+
+        .finding-statement {
+            font-weight: 500;
+            margin-bottom: 0.25rem;
+        }
+
+        .finding-text {
+            color: var(--text-muted);
+            font-size: 0.95rem;
+            font-style: italic;
+        }
+
+        .proposed-term {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #fef3c7;
+        }
+
+        .question-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #dbeafe;
+        }
+
+        .experiment-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #f3e8ff;
+        }
+
+        .prediction-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: white;
+        }
+
+        .prediction-card .prediction-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+        }
+
+        .prediction-source {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+        }
+
+        .assessment-badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.8rem;
+            font-weight: 600;
+            text-transform: uppercase;
+        }
+
+        .assessment-cor { background-color: #dcfce7; color: #166534; }
+        .assessment-cnn { background-color: #dbeafe; color: #1e40af; }
+        .assessment-lsp { background-color: #fef9c3; color: #854d0e; }
+        .assessment-unc { background-color: #f3f4f6; color: #374151; }
+        .assessment-pli { background-color: #fee2e2; color: #991b1b; }
+        .assessment-npi { background-color: #fecaca; color: #7f1d1d; }
+        .assessment-rep { background-color: #fde68a; color: #92400e; }
+
+        .confidence-score {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+            margin-left: 0.5rem;
+        }
+
+        .error-type-badge {
+            font-size: 0.75rem;
+            padding: 0.125rem 0.5rem;
+            border-radius: 0.25rem;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+        }
+
+        .isoforms-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fill, minmax(400px, 1fr));
+            gap: 1rem;
+        }
+
+        .isoform-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            background-color: white;
+            transition: box-shadow 0.2s;
+        }
+
+        .isoform-card:hover {
+            box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+        }
+
+        .functional-isoform-type {
+            display: inline-block;
+            padding: 0.2rem 0.5rem;
+            border-radius: 0.25rem;
+            font-size: 0.7rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.03em;
+        }
+
+        .type-SPLICE_VARIANT, .type-SPLICE_CLASS {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #93c5fd;
+        }
+
+        .type-CLEAVAGE_PRODUCT {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fcd34d;
+        }
+
+        .type-MODIFICATION_STATE {
+            background-color: #f3e8ff;
+            color: #6b21a8;
+            border: 1px solid #c4b5fd;
+        }
+
+        .type-CONFORMATIONAL_STATE {
+            background-color: #dcfce7;
+            color: #166534;
+            border: 1px solid #86efac;
+        }
+
+        .functional-isoform-mappings {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+            font-size: 0.85rem;
+        }
+
+        .functional-isoform-mappings .mapping-type {
+            font-weight: 600;
+            color: var(--text-muted);
+            font-size: 0.75rem;
+        }
+
+        .functional-isoform-go {
+            margin-top: 0.5rem;
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.25rem;
+        }
+
+        .go-chip {
+            display: inline-block;
+            padding: 0.15rem 0.4rem;
+            background-color: #ecfdf5;
+            color: #047857;
+            border: 1px solid #a7f3d0;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-family: monospace;
+        }
+
+        .isoform-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+            padding-bottom: 0.5rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .isoform-name {
+            font-weight: 600;
+            font-size: 1.1rem;
+            color: #1f2937;
+        }
+
+        .isoform-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .isoform-sequence-note {
+            font-size: 0.875rem;
+            color: var(--text-muted);
+            margin-bottom: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+        }
+
+        .isoform-description {
+            font-size: 0.95rem;
+            line-height: 1.5;
+        }
+
+        .collapsible {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .collapsible:after {
+            content: ' ▼';
+            font-size: 0.75rem;
+        }
+
+        .collapsible.collapsed:after {
+            content: ' ►';
+        }
+
+        .collapse-content {
+            transition: max-height 0.3s ease;
+            overflow: hidden;
+        }
+
+        .collapsed + .collapse-content {
+            max-height: 0;
+        }
+
+        .no-data {
+            color: var(--text-muted);
+            font-style: italic;
+            padding: 1rem;
+            text-align: center;
+            background-color: var(--bg-light);
+            border-radius: 0.5rem;
+        }
+
+        /* Styling for markdown section summaries with voting */
+        .markdown-section summary {
+            padding: 0.75rem;
+            background: var(--bg-light);
+            border-radius: 0.5rem;
+            margin-bottom: 0.5rem;
+        }
+
+        .markdown-section summary:hover {
+            background: #e5e7eb;
+        }
+
+        .markdown-section summary .vote-buttons {
+            margin-left: auto;
+        }
+
+        .deep-research-section {
+            margin-bottom: 1rem;
+            border: 1px solid #c7d2fe;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8faff;
+        }
+
+        .deep-research-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .deep-research-section summary h3 {
+            margin: 0;
+            color: #3730a3;
+            font-size: 1.1rem;
+        }
+
+        .report-meta {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin: 0.75rem 0 1rem;
+            align-items: center;
+        }
+
+        .report-badge {
+            display: inline-flex;
+            align-items: center;
+            border: 1px solid #c7d2fe;
+            border-radius: 999px;
+            background: #eef2ff;
+            color: #4338ca;
+            font-size: 0.78rem;
+            font-weight: 600;
+            padding: 0.2rem 0.6rem;
+        }
+
+        .report-meta-text {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+        }
+
+        .artifact-list {
+            display: grid;
+            gap: 0.75rem;
+            margin: 0.75rem 0 1rem;
+        }
+
+        .artifact-link {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+            margin-top: 0.5rem;
+            word-break: break-word;
+        }
+
+        @media print {
+            body {
+                padding: 1rem;
+            }
+
+            .collapsible:after {
+                display: none;
+            }
+
+            .collapsed + .collapse-content {
+                max-height: none !important;
+            }
+        }
+
+        @media (max-width: 768px) {
+            body {
+                padding: 1rem;
+            }
+
+            h1 {
+                font-size: 2rem;
+            }
+
+            .annotations-table {
+                font-size: 0.875rem;
+            }
+
+            .annotations-table th,
+            .annotations-table td {
+                padding: 0.5rem;
+            }
+        }
+    </style>
+</head>
+<body>
+    <div class="header">
+        <h1>phb-2</h1>
+        <div class="gene-info">
+
+            <div class="info-item">
+
+                <span class="info-label">UniProt ID:</span>
+                <span>
+                    <a href="https://www.uniprot.org/uniprotkb/P50093" target="_blank" class="term-link">
+                        P50093
+                    </a>
+                </span>
+
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Organism:</span>
+                <span>Caenorhabditis elegans</span>
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Review Status:</span>
+                <span class="status-badge status-complete">
+                    COMPLETE
+                </span>
+            </div>
+
+
+        </div>
+        <div style="margin-top: 1rem; text-align: center;">
+            <a id="feedback-form-link"
+               href="#"
+               target="_blank"
+               style="display: inline-block; padding: 10px 20px; background-color: #4CAF50; color: white; text-decoration: none; border-radius: 5px; font-weight: 600;">
+                📝 Provide Detailed Feedback
+            </a>
+            <script>
+                // Construct the form URL with proper encoding
+                // Extract organism code from the current page path (e.g., /genes/ARATH/APO1/ -> ARATH)
+                const pathParts = window.location.pathname.split('/');
+                const genesIndex = pathParts.indexOf('genes');
+                let organism = '';
+                if (genesIndex !== -1 && pathParts[genesIndex + 1]) {
+                    organism = pathParts[genesIndex + 1].toUpperCase();
+                }
+                const geneSymbol = "phb-2";
+                const speciesGene = organism + ' ' + geneSymbol;
+                const formBaseUrl = 'https://docs.google.com/forms/d/e/1FAIpQLSdTot9L6GVkkZYgLQT0E8ZdAJv8RiN5ZgOVkgWNcKSbYvxxzQ/viewform';
+                const entryId = '1226477767'; // Correct entry ID for Species/Gene field
+                const formUrl = formBaseUrl + '?entry.' + entryId + '=' + encodeURIComponent(speciesGene);
+                const feedbackLink = document.getElementById('feedback-form-link');
+                feedbackLink.href = formUrl;
+                // Add tooltip showing the pre-filled value
+                feedbackLink.title = 'Opens form with pre-filled: ' + speciesGene;
+            </script>
+        </div>
+    </div>
+
+
+    <div class="description-card">
+        <div style="display: flex; justify-content: space-between; align-items: center;">
+            <h2>Gene Description</h2>
+            <span class="vote-buttons" data-g="P50093" data-a="DESCRIPTION: phb-2 encodes prohibitin-2, one of the two subunit..." data-r="" data-act="DESCRIPTION">
+                <button class="vote-btn" data-v="up" title="Agree with this description">👍</button>
+                <button class="vote-btn" data-v="down" title="Disagree with this description">👎</button>
+            </span>
+        </div>
+        <p>phb-2 encodes prohibitin-2, one of the two subunits (with phb-1) of the mitochondrial prohibitin (PHB) complex, a ring-shaped, high-molecular-weight assembly embedded in the inner mitochondrial membrane. PHB-1 and PHB-2 are mutually dependent: they bind each other to form heterodimers that oligomerize into the ring, and loss of either subunit destabilizes the entire complex. PHB-2 is a single-pass type II inner-membrane protein of the SPFH/Band-7 (stomatin/prohibitin) superfamily, with most of the protein, including its Band-7/PHB domain and C-terminal coiled coil, exposed on the intermembrane-space side. The complex is proposed to act as a membrane-bound chaperone/holdase that holds and stabilizes newly synthesized mitochondrial-encoded respiratory-chain proteins and/or as a scaffold that organizes inner-membrane proteins and lipids (cardiolipin/phosphatidylethanolamine) within a defined microdomain. Distinct from phb-1, PHB-2 additionally serves as an inner-membrane mitophagy receptor: upon mitochondrial depolarization and proteasome-dependent rupture of the outer membrane, PHB-2 directly binds the autophagosomal ATG8/LC3 protein through an LC3-interacting region (LIR), linking damaged mitochondria to the autophagy machinery. In C. elegans the PHB complex is essential: depletion blocks embryonic development, disrupts somatic and germline differentiation of the gonad, and alters mitochondrial biogenesis in body-wall muscle; the mitophagy receptor activity of phb-2 is specifically required for the clearance of paternal (sperm-derived) mitochondria after fertilization, ensuring maternal mitochondrial inheritance. Beyond these roles the prohibitin complex is a context-dependent modulator of ageing that couples mitochondrial metabolism and fat utilization to insulin/IGF (daf-2) and dietary-restriction signalling.</p>
+    </div>
+
+
+
+
+
+
+
+    <div class="section">
+        <h2 class="section-title">Existing Annotations Review</h2>
+        <table class="annotations-table">
+            <thead>
+                <tr>
+                    <th>GO Term</th>
+                    <th>Evidence</th>
+                    <th>Action</th>
+                    <th>Reason</th>
+                </tr>
+            </thead>
+            <tbody>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005739" target="_blank" class="term-link">
+                                    GO:0005739
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrion</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P50093" data-a="GO:0005739" data-r="GO_REF:0000033" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Correct but general mitochondrial localization inferred phylogenetically. The specific inner-membrane and prohibitin-complex localizations are experimentally supported and separately annotated, so this broad term is retained as non-core.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> phb-2 is a bona fide mitochondrial protein, so the term is not wrong, but GO:0005743 (mitochondrial inner membrane) and GO:0035632 (mitochondrial prohibitin complex) are the informative, experimentally supported localizations for this subunit.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0007005" target="_blank" class="term-link">
+                                    GO:0007005
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrion organization</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P50093" data-a="GO:0007005" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Phylogenetic inference that phb-2 acts in mitochondrion organization, corroborated by experimental (IMP) and author-statement (NAS) annotations for the same term. A core process for this gene.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Consistent with the experimentally demonstrated requirement of the PHB complex for normal mitochondrial biogenesis/organization.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/12794069" target="_blank" class="term-link">
+                                        PMID:12794069
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">a deficiency in PHB proteins results in altered mitochondrial biogenesis in body wall muscle cells</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0002082" target="_blank" class="term-link">
+                                    GO:0002082
+                                </a>
+                            </span>
+                            <span class="term-label">regulation of oxidative phosphorylation</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000117
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P50093" data-a="GO:0002082" data-r="GO_REF:0000117" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Electronic (ARBA) annotation that mirrors the experimental WB IMP annotation to the same term. Biologically defensible given the conserved role of prohibitins in stabilizing respiratory-chain subunits, but it is a downstream consequence of complex loss rather than a dedicated phb-2 activity.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Redundant electronic echo of the experimental IMP annotation (PMID:12794069); effect on oxidative phosphorylation is an indirect consequence of losing an essential inner-membrane complex, so it is non-core.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005739" target="_blank" class="term-link">
+                                    GO:0005739
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrion</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000117
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P50093" data-a="GO:0005739" data-r="GO_REF:0000117" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Electronic (ARBA) mitochondrial localization, redundant with the more specific and experimentally supported inner-membrane/complex annotations.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct but general; the informative localizations GO:0005743 and GO:0035632 are experimentally established and separately annotated.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005743" target="_blank" class="term-link">
+                                    GO:0005743
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrial inner membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000044
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P50093" data-a="GO:0005743" data-r="GO_REF:0000044" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Electronic subcellular-location mapping to the mitochondrial inner membrane, independently confirmed by experimental IDA/EXP evidence. This is the correct, core localization of the PHB complex.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> The inner-membrane localization is experimentally established and matches the UniProt SUBCELLULAR LOCATION for phb-2.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/12794069" target="_blank" class="term-link">
+                                        PMID:12794069
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">prohibitins in C. elegans form a high molecular weight complex in the mitochondrial inner membrane similar to that of yeast and humans</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006979" target="_blank" class="term-link">
+                                    GO:0006979
+                                </a>
+                            </span>
+                            <span class="term-label">response to oxidative stress</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000117
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P50093" data-a="GO:0006979" data-r="GO_REF:0000117" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Electronic (ARBA) annotation mirroring the WB IMP annotation. Altered oxidative-stress sensitivity is a plausible but indirect consequence of impaired mitochondrial function in prohibitin-depleted animals.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Redundant with the experimental IMP annotation (PMID:12794069); pleiotropic downstream phenotype of an essential mitochondrial gene, not a core function.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0007283" target="_blank" class="term-link">
+                                    GO:0007283
+                                </a>
+                            </span>
+                            <span class="term-label">spermatogenesis</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000117
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P50093" data-a="GO:0007283" data-r="GO_REF:0000117" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Electronic (ARBA) annotation mirroring the WB IMP germline phenotype.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Redundant with the experimental IMP annotation (PMID:12794069); germline/ spermatogenesis defects are a pleiotropic consequence of depleting an essential mitochondrial complex, not a dedicated phb-2 function.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0008406" target="_blank" class="term-link">
+                                    GO:0008406
+                                </a>
+                            </span>
+                            <span class="term-label">gonad development</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000117
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P50093" data-a="GO:0008406" data-r="GO_REF:0000117" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Electronic (ARBA) annotation mirroring the WB IMP gonad phenotype.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Redundant with the experimental IMP annotation (PMID:12794069); pleiotropic developmental consequence of losing the essential PHB complex.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0009792" target="_blank" class="term-link">
+                                    GO:0009792
+                                </a>
+                            </span>
+                            <span class="term-label">embryo development ending in birth or egg hatching</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000117
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P50093" data-a="GO:0009792" data-r="GO_REF:0000117" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Electronic (ARBA) annotation mirroring the WB IMP embryonic-lethality phenotype.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Redundant with the experimental IMP annotation (PMID:12794069); embryonic arrest reflects the essentiality of the complex rather than a dedicated embryogenesis function of phb-2.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016020" target="_blank" class="term-link">
+                                    GO:0016020
+                                </a>
+                            </span>
+                            <span class="term-label">membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000002
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="P50093" data-a="GO:0016020" data-r="GO_REF:0000002" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Generic InterPro-to-GO membrane localization. Uninformative given that the specific mitochondrial inner-membrane localization is experimentally established.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> GO:0016020 (membrane) is an over-general parent; the informative and correct localization GO:0005743 (mitochondrial inner membrane) is already annotated.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0030421" target="_blank" class="term-link">
+                                    GO:0030421
+                                </a>
+                            </span>
+                            <span class="term-label">defecation</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000117
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P50093" data-a="GO:0030421" data-r="GO_REF:0000117" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Electronic (ARBA) annotation mirroring the WB IMP behavioural phenotype.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Redundant with the experimental IMP annotation (PMID:12794069); altered defecation is a pleiotropic behavioural consequence of mitochondrial dysfunction, not a core molecular role.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0040018" target="_blank" class="term-link">
+                                    GO:0040018
+                                </a>
+                            </span>
+                            <span class="term-label">positive regulation of multicellular organism growth</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000117
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P50093" data-a="GO:0040018" data-r="GO_REF:0000117" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Electronic (ARBA) annotation mirroring the WB IMP body-size/growth phenotype.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Redundant with the experimental IMP annotation (PMID:12794069); reduced growth on prohibitin depletion is a systemic consequence of impaired mitochondrial function, not a dedicated function.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0043051" target="_blank" class="term-link">
+                                    GO:0043051
+                                </a>
+                            </span>
+                            <span class="term-label">regulation of nematode pharyngeal pumping</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000117
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P50093" data-a="GO:0043051" data-r="GO_REF:0000117" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Electronic (ARBA) annotation mirroring the WB IMP behavioural phenotype.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Redundant with the experimental IMP annotation (PMID:12794069); pharyngeal pumping change is a pleiotropic behavioural consequence, not a core function.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0048477" target="_blank" class="term-link">
+                                    GO:0048477
+                                </a>
+                            </span>
+                            <span class="term-label">oogenesis</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000117
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P50093" data-a="GO:0048477" data-r="GO_REF:0000117" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Electronic (ARBA) annotation mirroring the WB IMP germline phenotype.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Redundant with the experimental IMP annotation (PMID:12794069); oogenesis defects are a pleiotropic consequence of losing the essential PHB complex.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005743" target="_blank" class="term-link">
+                                    GO:0005743
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrial inner membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/26092086" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:26092086
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Analysis of the effect of the mitochondrial prohibitin compl...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P50093" data-a="GO:0005743" data-r="PMID:26092086" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Direct experimental evidence (ComplexPortal curation) that the PHB complex, of which phb-2 is a subunit, resides in the mitochondrial inner membrane. Core localization.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Established inner-membrane localization; the heterodimer assembles into a ring embedded in the inner mitochondrial membrane.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/26092086" target="_blank" class="term-link">
+                                        PMID:26092086
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">which bind to each other to form a heterodimer that is assembled into a ring-like macromolecular structure at the inner mitochondrial membrane</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0007005" target="_blank" class="term-link">
+                                    GO:0007005
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrion organization</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">NAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/26092086" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:26092086
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Analysis of the effect of the mitochondrial prohibitin compl...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P50093" data-a="GO:0007005" data-r="PMID:26092086" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Author-stated involvement of the PHB complex in mitochondrion organization, consistent with the experimental IMP annotation. Core process.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Prohibitin depletion perturbs mitochondrial biogenesis/organization; a well-supported core role.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/12794069" target="_blank" class="term-link">
+                                        PMID:12794069
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">a deficiency in PHB proteins results in altered mitochondrial biogenesis in body wall muscle cells</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0035632" target="_blank" class="term-link">
+                                    GO:0035632
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrial prohibitin complex</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/26092086" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:26092086
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Analysis of the effect of the mitochondrial prohibitin compl...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P50093" data-a="GO:0035632" data-r="PMID:26092086" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Direct evidence that phb-2 is part of the mitochondrial prohibitin complex. This complex membership is the defining, primary core annotation for phb-2.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> phb-1 and phb-2 form the obligate ring complex; membership is experimentally established and the two subunits are interdependent for its formation.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/26092086" target="_blank" class="term-link">
+                                        PMID:26092086
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">These two subunits are interdependent for the formation of the complex, leading the absence of one of them to the absence of the whole complex</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0050821" target="_blank" class="term-link">
+                                    GO:0050821
+                                </a>
+                            </span>
+                            <span class="term-label">protein stabilization</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">NAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/26092086" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:26092086
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Analysis of the effect of the mitochondrial prohibitin compl...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P50093" data-a="GO:0050821" data-r="PMID:26092086" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Author-stated role of the PHB complex as a membrane-bound chaperone that holds and stabilizes newly synthesized mitochondrial-encoded proteins. This is the closest capture of the complex&#39;s candidate molecular role, though it is a proposed (largely yeast/human-derived) function rather than one biochemically demonstrated in worm.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Represents the proposed complex-level chaperone/holdase activity; retained as a candidate core function, with the caveat that the true molecular mechanism remains debated (see knowledge_gaps).
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/26092086" target="_blank" class="term-link">
+                                        PMID:26092086
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">a membrane-bound chaperone, which holds and stabilizes newly synthesised mitochondrial-encoded proteins</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005743" target="_blank" class="term-link">
+                                    GO:0005743
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrial inner membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">EXP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/12794069" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:12794069
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    The mitochondrial prohibitin complex is essential for embryo...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P50093" data-a="GO:0005743" data-r="PMID:12794069" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Direct experimental evidence that phb-2 localizes to the mitochondrial inner membrane as part of the high-molecular-weight PHB complex. Core localization.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Experimentally established inner-membrane localization in C. elegans, matching the UniProt SUBCELLULAR LOCATION.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/12794069" target="_blank" class="term-link">
+                                        PMID:12794069
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">prohibitins in C. elegans form a high molecular weight complex in the mitochondrial inner membrane similar to that of yeast and humans</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0042803" target="_blank" class="term-link">
+                                    GO:0042803
+                                </a>
+                            </span>
+                            <span class="term-label">protein homodimerization activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">ISS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000024
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="P50093" data-a="GO:0042803" data-r="GO_REF:0000024" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Electronic ISS transfer from human PHB2 (UniProtKB:Q99623) of a &#34;homodimerization&#34; molecular function. This does not capture the biology of the worm protein: prohibitin-2 forms an obligate HETERODIMER with prohibitin-1 that oligomerizes into the ring, and the two subunits are interdependent.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> The informative molecular role of phb-2 is as a structural constituent of the heterodimeric prohibitin ring (captured in core_functions via GO:0005198 and GO:0035632), not homodimerization; the ISS &#34;homodimerization activity&#34; transfer is uninformative/over-annotated for this obligate heterodimer.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/26092086" target="_blank" class="term-link">
+                                        PMID:26092086
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">These two subunits are interdependent for the formation of the complex, leading the absence of one of them to the absence of the whole complex</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0000423" target="_blank" class="term-link">
+                                    GO:0000423
+                                </a>
+                            </span>
+                            <span class="term-label">mitophagy</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/28017329" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:28017329
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Prohibitin 2 Is an Inner Mitochondrial Membrane Mitophagy Re...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P50093" data-a="GO:0000423" data-r="PMID:28017329" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Direct experimental evidence that phb-2 is required for mitophagy: paternal RNAi knockdown of phb-2 blocks the autophagic clearance of sperm-derived mitochondria after fertilization in C. elegans. This receptor role, mediated by direct binding of PHB2 to the autophagosomal ATG8/LC3 protein via a LIR motif, is a phb-2-specific core function that distinguishes it from phb-1 (which binds LC3 only indirectly through the heterodimer).
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Experimentally demonstrated in worm (paternal-mitochondria clearance assay) and mechanistically established for the conserved ortholog; a defining phb-2-specific core function.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/28017329" target="_blank" class="term-link">
+                                        PMID:28017329
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Thus, sperm-derived phb-2 is essential for the proper degradation of paternal mitochondria</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/28017329" target="_blank" class="term-link">
+                                        PMID:28017329
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">we identify the inner mitochondrial membrane protein, prohibitin 2 (PHB2), as a crucial mitophagy receptor involved in targeting mitochondria for autophagic degradation</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005886" target="_blank" class="term-link">
+                                    GO:0005886
+                                </a>
+                            </span>
+                            <span class="term-label">plasma membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">ISS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000024
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="P50093" data-a="GO:0005886" data-r="GO_REF:0000024" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Electronic ISS transfer from human PHB2 (UniProtKB:Q99623) of a plasma-membrane localization. Mammalian prohibitin-2 has documented moonlighting cell-surface/ plasma-membrane pools, but there is no evidence for such localization of the worm protein, which is a single-pass type II inner mitochondrial membrane protein.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Unsupported ISS transfer of a mammalian moonlighting localization not established in C. elegans; the worm protein is an inner-mitochondrial-membrane protein and this term is misleading here.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/20089839" target="_blank" class="term-link">
+                                        PMID:20089839
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">C. elegans prohibitin-2 (PHB-2), a protein localized to the inner mitochondrial membrane</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0009986" target="_blank" class="term-link">
+                                    GO:0009986
+                                </a>
+                            </span>
+                            <span class="term-label">cell surface</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">ISS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000024
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="P50093" data-a="GO:0009986" data-r="GO_REF:0000024" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Electronic ISS transfer from human PHB2 (UniProtKB:Q99623) of a cell-surface localization. As for the plasma-membrane term, this reflects a mammalian moonlighting pool and is not supported for the worm inner-membrane protein.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Unsupported ISS transfer of a mammalian moonlighting localization not established in C. elegans; misleading for an inner-mitochondrial-membrane protein.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/20089839" target="_blank" class="term-link">
+                                        PMID:20089839
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">C. elegans prohibitin-2 (PHB-2), a protein localized to the inner mitochondrial membrane</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005739" target="_blank" class="term-link">
+                                    GO:0005739
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrion</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">HDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/20188671" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:20188671
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    The matrix peptide exporter HAF-1 signals a mitochondrial UP...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P50093" data-a="GO:0005739" data-r="PMID:20188671" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> High-throughput (mitochondrial proteome) detection of phb-2 in mitochondria. Correct but general; the specific inner-membrane/complex localizations are experimentally supported and separately annotated.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct organelle localization from a proteome-scale dataset; superseded in informativeness by the IDA/EXP inner-membrane and prohibitin-complex annotations.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005739" target="_blank" class="term-link">
+                                    GO:0005739
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrion</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">ISS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/20089839" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:20089839
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Mitochondrial dysfunction confers resistance to multiple dru...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P50093" data-a="GO:0005739" data-r="PMID:20089839" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Sequence-similarity mitochondrial localization associated with the paper that identified a drug-resistance-conferring phb-2 missense allele and describes PHB-2 as an inner-mitochondrial-membrane protein. Correct but general.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Correct organelle localization; less informative than the experimentally supported inner-membrane/complex terms.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/20089839" target="_blank" class="term-link">
+                                        PMID:20089839
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">C. elegans prohibitin-2 (PHB-2), a protein localized to the inner mitochondrial membrane</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0035632" target="_blank" class="term-link">
+                                    GO:0035632
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrial prohibitin complex</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/19812672" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:19812672
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Prohibitin couples diapause signalling to mitochondrial meta...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P50093" data-a="GO:0035632" data-r="PMID:19812672" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Physical-interaction evidence (with phb-1, WB:WBGene00004014) that phb-2 is part of the mitochondrial prohibitin complex. Direct support for the obligate phb-1/phb-2 partnership.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Confirms the direct phb-1/phb-2 interaction that constitutes the ring complex; a defining core annotation.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/19812672" target="_blank" class="term-link">
+                                        PMID:19812672
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">form a ring-like, high-molecular-mass complex at the inner membrane of mitochondria</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0002082" target="_blank" class="term-link">
+                                    GO:0002082
+                                </a>
+                            </span>
+                            <span class="term-label">regulation of oxidative phosphorylation</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IMP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/12794069" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:12794069
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    The mitochondrial prohibitin complex is essential for embryo...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P50093" data-a="GO:0002082" data-r="PMID:12794069" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Experimental (RNAi) evidence linking prohibitin depletion to altered oxidative phosphorylation, consistent with the conserved role of the complex in stabilizing respiratory-chain subunits. An indirect, non-core consequence of losing the essential complex.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Full-text-based experimental annotation (retained, not removed); effect on oxidative phosphorylation reflects downstream respiratory-chain destabilization rather than a dedicated regulatory activity of phb-2.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006979" target="_blank" class="term-link">
+                                    GO:0006979
+                                </a>
+                            </span>
+                            <span class="term-label">response to oxidative stress</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IMP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/12794069" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:12794069
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    The mitochondrial prohibitin complex is essential for embryo...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P50093" data-a="GO:0006979" data-r="PMID:12794069" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Experimental (RNAi) evidence of altered oxidative-stress response upon prohibitin depletion. Pleiotropic consequence of mitochondrial dysfunction.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Retained as an experimental annotation; oxidative-stress phenotype is an indirect consequence of impaired mitochondrial function, not a core role.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0007005" target="_blank" class="term-link">
+                                    GO:0007005
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrion organization</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IMP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/12794069" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:12794069
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    The mitochondrial prohibitin complex is essential for embryo...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P50093" data-a="GO:0007005" data-r="PMID:12794069" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Experimental (RNAi) evidence that prohibitin depletion alters mitochondrial biogenesis/organization in body-wall muscle. Core process for phb-2.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Directly supported by the observed mitochondrial-biogenesis defect; a core function of the complex.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/12794069" target="_blank" class="term-link">
+                                        PMID:12794069
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">a deficiency in PHB proteins results in altered mitochondrial biogenesis in body wall muscle cells</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0007283" target="_blank" class="term-link">
+                                    GO:0007283
+                                </a>
+                            </span>
+                            <span class="term-label">spermatogenesis</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IMP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/12794069" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:12794069
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    The mitochondrial prohibitin complex is essential for embryo...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P50093" data-a="GO:0007283" data-r="PMID:12794069" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Experimental (RNAi) germline phenotype. Pleiotropic developmental consequence of depleting the essential PHB complex.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Retained as an experimental annotation; germline/spermatogenesis defects follow from loss of an essential mitochondrial complex during germline differentiation rather than a dedicated spermatogenesis function.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/12794069" target="_blank" class="term-link">
+                                        PMID:12794069
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">PHB proteins are essential during embryonic development and are required for somatic and germline differentiation in the larval gonad</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0008406" target="_blank" class="term-link">
+                                    GO:0008406
+                                </a>
+                            </span>
+                            <span class="term-label">gonad development</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IMP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/12794069" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:12794069
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    The mitochondrial prohibitin complex is essential for embryo...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P50093" data-a="GO:0008406" data-r="PMID:12794069" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Experimental (RNAi) evidence of somatic and germline gonad differentiation defects. Pleiotropic developmental consequence.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Retained as an experimental annotation; gonad-development defect reflects the essentiality of the complex in dividing/differentiating tissue, not a dedicated gonadogenesis function.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/12794069" target="_blank" class="term-link">
+                                        PMID:12794069
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">PHB proteins are essential during embryonic development and are required for somatic and germline differentiation in the larval gonad</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0009792" target="_blank" class="term-link">
+                                    GO:0009792
+                                </a>
+                            </span>
+                            <span class="term-label">embryo development ending in birth or egg hatching</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IMP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/12794069" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:12794069
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    The mitochondrial prohibitin complex is essential for embryo...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P50093" data-a="GO:0009792" data-r="PMID:12794069" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Experimental (RNAi) embryonic-lethality phenotype. Reflects essentiality of the PHB complex.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Retained as an experimental annotation; embryonic arrest is a consequence of the complex being essential rather than a dedicated embryogenesis function of phb-2.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/12794069" target="_blank" class="term-link">
+                                        PMID:12794069
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">PHB proteins are essential during embryonic development and are required for somatic and germline differentiation in the larval gonad</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0030421" target="_blank" class="term-link">
+                                    GO:0030421
+                                </a>
+                            </span>
+                            <span class="term-label">defecation</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IMP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/12794069" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:12794069
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    The mitochondrial prohibitin complex is essential for embryo...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P50093" data-a="GO:0030421" data-r="PMID:12794069" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Experimental (RNAi) behavioural phenotype scored by WormBase curators from the full text. Pleiotropic consequence of mitochondrial dysfunction.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Retained as an experimental annotation (curators read the full text); altered defecation is a pleiotropic behavioural readout, not a core molecular role.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0031966" target="_blank" class="term-link">
+                                    GO:0031966
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrial membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/12794069" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:12794069
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    The mitochondrial prohibitin complex is essential for embryo...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P50093" data-a="GO:0031966" data-r="PMID:12794069" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Direct experimental evidence of mitochondrial-membrane localization. Correct but less specific than the separately annotated mitochondrial inner membrane, so retained as non-core.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> The localization is correct; GO:0005743 (mitochondrial inner membrane) is the more precise term and is also annotated, so this broader term is retained but non-core.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/12794069" target="_blank" class="term-link">
+                                        PMID:12794069
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">prohibitins in C. elegans form a high molecular weight complex in the mitochondrial inner membrane similar to that of yeast and humans</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0040018" target="_blank" class="term-link">
+                                    GO:0040018
+                                </a>
+                            </span>
+                            <span class="term-label">positive regulation of multicellular organism growth</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IMP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/12794069" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:12794069
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    The mitochondrial prohibitin complex is essential for embryo...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P50093" data-a="GO:0040018" data-r="PMID:12794069" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Experimental (RNAi) body-size/growth phenotype. Systemic consequence of impaired mitochondrial function.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Retained as an experimental annotation; reduced growth on depletion is a systemic consequence of mitochondrial dysfunction rather than a dedicated growth-promoting activity.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0043051" target="_blank" class="term-link">
+                                    GO:0043051
+                                </a>
+                            </span>
+                            <span class="term-label">regulation of nematode pharyngeal pumping</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IMP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/12794069" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:12794069
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    The mitochondrial prohibitin complex is essential for embryo...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P50093" data-a="GO:0043051" data-r="PMID:12794069" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Experimental (RNAi) behavioural phenotype. Pleiotropic consequence of mitochondrial dysfunction.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Retained as an experimental annotation; pharyngeal-pumping change is a pleiotropic behavioural readout, not a core molecular role.
+                        </div>
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0048477" target="_blank" class="term-link">
+                                    GO:0048477
+                                </a>
+                            </span>
+                            <span class="term-label">oogenesis</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IMP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/12794069" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:12794069
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    The mitochondrial prohibitin complex is essential for embryo...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="P50093" data-a="GO:0048477" data-r="PMID:12794069" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Experimental (RNAi) germline phenotype. Pleiotropic developmental consequence of depleting the essential PHB complex.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Retained as an experimental annotation; oogenesis defects follow from loss of an essential mitochondrial complex during germline differentiation.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/12794069" target="_blank" class="term-link">
+                                        PMID:12794069
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">PHB proteins are essential during embryonic development and are required for somatic and germline differentiation in the larval gonad</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+            </tbody>
+        </table>
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Core Functions</h2>
+
+        <div class="core-function-card">
+
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+                <h3>phb-2 is a structural constituent of the mitochondrial prohibitin ring complex. It has no known independent catalytic activity; instead its function is to be an obligate subunit that, together with phb-1, assembles into the ring-shaped, high-molecular-weight PHB complex embedded in the mitochondrial inner membrane. The two subunits are interdependent, so phb-2 is required for the existence of the complex itself.</h3>
+                <span class="vote-buttons" data-g="P50093" data-a="FUNCTION: phb-2 is a structural constituent of the mitochond..." data-r="" data-act="CORE_FUNCTION">
+                    <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
+                    <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
+                </span>
+            </div>
+
+
+            <div class="core-function-terms">
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Molecular Function:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005198" target="_blank" class="term-link">
+                            structural molecule activity
+                        </a>
+                    </span>
+                </div>
+
+
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Cellular Locations:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005743" target="_blank" class="term-link">
+                                mitochondrial inner membrane
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">In Complex:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0035632" target="_blank" class="term-link">
+                            mitochondrial prohibitin complex
+                        </a>
+                    </span>
+                </div>
+
+
+
+            </div>
+
+
+            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
+                <strong>Supporting Evidence:</strong>
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/26092086" target="_blank" class="term-link">
+                                PMID:26092086
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">which bind to each other to form a heterodimer that is assembled into a ring-like macromolecular structure at the inner mitochondrial membrane</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/26092086" target="_blank" class="term-link">
+                                PMID:26092086
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">These two subunits are interdependent for the formation of the complex, leading the absence of one of them to the absence of the whole complex</div>
+
+                    </li>
+
+                </ul>
+            </div>
+
+        </div>
+
+        <div class="core-function-card">
+
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+                <h3>Distinct from phb-1, phb-2 acts as an inner-membrane mitophagy receptor. Upon mitochondrial depolarization and proteasome-dependent rupture of the outer membrane, the intermembrane-space-exposed phb-2 directly binds the autophagosomal ATG8/LC3 protein through an LC3-interacting region, bringing the inner mitochondrial membrane and the autophagosome membrane together to target damaged/unwanted mitochondria for autophagic degradation. In C. elegans this receptor activity is required for the clearance of paternal (sperm-derived) mitochondria after fertilization. (The direct LC3-LIR biochemistry was established for the conserved ortholog; the worm requirement is demonstrated genetically via paternal phb-2 RNAi.)</h3>
+                <span class="vote-buttons" data-g="P50093" data-a="FUNCTION: Distinct from phb-1, phb-2 acts as an inner-membra..." data-r="" data-act="CORE_FUNCTION">
+                    <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
+                    <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
+                </span>
+            </div>
+
+
+            <div class="core-function-terms">
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Molecular Function:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0140580" target="_blank" class="term-link">
+                            mitochondrion autophagosome adaptor activity
+                        </a>
+                    </span>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Directly Involved In:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0000423" target="_blank" class="term-link">
+                                mitophagy
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Cellular Locations:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005743" target="_blank" class="term-link">
+                                mitochondrial inner membrane
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">In Complex:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0035632" target="_blank" class="term-link">
+                            mitochondrial prohibitin complex
+                        </a>
+                    </span>
+                </div>
+
+
+
+            </div>
+
+
+            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
+                <strong>Supporting Evidence:</strong>
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/28017329" target="_blank" class="term-link">
+                                PMID:28017329
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">PHB2 binds the autophagosomal membrane-associated protein LC3 through an LC3-interaction region (LIR) domain upon mitochondrial depolarization and proteasome-dependent outer membrane rupture</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/28017329" target="_blank" class="term-link">
+                                PMID:28017329
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">Thus, sperm-derived phb-2 is essential for the proper degradation of paternal mitochondria</div>
+
+                    </li>
+
+                </ul>
+            </div>
+
+        </div>
+
+        <div class="core-function-card">
+
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+                <h3>As part of the mitochondrial prohibitin complex, phb-2 contributes to organization of the mitochondrial inner membrane and to stabilization of newly synthesized mitochondrial-encoded proteins (a proposed membrane-bound chaperone/holdase and lipid/protein scaffold role), and thereby to mitochondrial biogenesis and function. Through this activity the complex acts as a context-dependent modulator of mitochondrial metabolism, fat utilization, and adult lifespan.</h3>
+                <span class="vote-buttons" data-g="P50093" data-a="FUNCTION: As part of the mitochondrial prohibitin complex, p..." data-r="" data-act="CORE_FUNCTION">
+                    <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
+                    <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
+                </span>
+            </div>
+
+
+            <div class="core-function-terms">
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Directly Involved In:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0007005" target="_blank" class="term-link">
+                                mitochondrion organization
+                            </a>
+                        </span>
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0050821" target="_blank" class="term-link">
+                                protein stabilization
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Cellular Locations:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005743" target="_blank" class="term-link">
+                                mitochondrial inner membrane
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">In Complex:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0035632" target="_blank" class="term-link">
+                            mitochondrial prohibitin complex
+                        </a>
+                    </span>
+                </div>
+
+
+
+            </div>
+
+
+            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
+                <strong>Supporting Evidence:</strong>
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/12794069" target="_blank" class="term-link">
+                                PMID:12794069
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">a deficiency in PHB proteins results in altered mitochondrial biogenesis in body wall muscle cells</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/26092086" target="_blank" class="term-link">
+                                PMID:26092086
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">a membrane-bound chaperone, which holds and stabilizes newly synthesised mitochondrial-encoded proteins</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/19812672" target="_blank" class="term-link">
+                                PMID:19812672
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">the mitochondrial prohibitin complex promotes longevity by modulating mitochondrial function and fat metabolism</div>
+
+                    </li>
+
+                </ul>
+            </div>
+
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title collapsible">References</h2>
+        <div class="collapse-content">
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000002.md" target="_blank" class="term-link">
+                            GO_REF:0000002
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Gene Ontology annotation through association of InterPro records with GO terms</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000024.md" target="_blank" class="term-link">
+                            GO_REF:0000024
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Manual transfer of experimentally-verified manual GO annotation data to orthologs by curator judgment of sequence similarity</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000033.md" target="_blank" class="term-link">
+                            GO_REF:0000033
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Annotation inferences using phylogenetic trees</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000044.md" target="_blank" class="term-link">
+                            GO_REF:0000044
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location vocabulary mapping, accompanied by conservative changes to GO terms applied by UniProt</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000117.md" target="_blank" class="term-link">
+                            GO_REF:0000117
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Electronic Gene Ontology annotations created by ARBA machine learning models</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/12794069" target="_blank" class="term-link">
+                            PMID:12794069
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">The mitochondrial prohibitin complex is essential for embryonic viability and germline function in Caenorhabditis elegans.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/19812672" target="_blank" class="term-link">
+                            PMID:19812672
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Prohibitin couples diapause signalling to mitochondrial metabolism during ageing in C. elegans.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/20089839" target="_blank" class="term-link">
+                            PMID:20089839
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Mitochondrial dysfunction confers resistance to multiple drugs in Caenorhabditis elegans.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/20188671" target="_blank" class="term-link">
+                            PMID:20188671
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">The matrix peptide exporter HAF-1 signals a mitochondrial UPR by activating the transcription factor ZC376.7 in C. elegans.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/26092086" target="_blank" class="term-link">
+                            PMID:26092086
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Analysis of the effect of the mitochondrial prohibitin complex, a context-dependent modulator of longevity, on the C. elegans metabolome.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/28017329" target="_blank" class="term-link">
+                            PMID:28017329
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Prohibitin 2 Is an Inner Mitochondrial Membrane Mitophagy Receptor.</div>
+
+
+            </div>
+
+        </div>
+    </div>
+
+
+
+
+    <div class="section">
+        <h2 class="section-title">Suggested Questions for Experts</h2>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> Is the worm PHB complex primarily a chaperone/holdase for nascent mitochondrial-encoded proteins, a membrane/lipid scaffold, or a regulator of inner-membrane proteostasis?</p>
+
+                </div>
+                <span class="vote-buttons" data-g="P50093" data-a="Q: Is the worm PHB complex primarily a chaperone/hold..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> Does C. elegans phb-2 use a defined LGG-1/LGG-2 (LC3) LIR motif in vivo, and what exposes the inner-membrane receptor during paternal-mitochondria clearance?</p>
+
+                </div>
+                <span class="vote-buttons" data-g="P50093" data-a="Q: Does C. elegans phb-2 use a defined LGG-1/LGG-2 (L..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> Which prohibitin-dependent metabolic step determines whether depletion shortens or extends lifespan in a given genetic/nutritional context?</p>
+
+                </div>
+                <span class="vote-buttons" data-g="P50093" data-a="Q: Which prohibitin-dependent metabolic step determin..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Suggested Experiments</h2>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> Reconstitute or affinity-purify the worm PHB ring and test in vitro holdase/ chaperone activity against candidate mitochondrial-encoded substrates versus a scaffold/lipid-organizing readout, to discriminate the proposed molecular roles.</p>
+
+
+
+                    <p style="margin-top: 0.5rem;">Type: biochemical reconstitution</p>
+
+                </div>
+                <span class="vote-buttons" data-g="P50093" data-a="EXPERIMENT: Reconstitute or affinity-purify the worm PHB ring ..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> Map and mutate the worm phb-2 LC3/LGG-family LIR with separation-of-function alleles, and live-image outer-membrane rupture and phb-2 exposure during paternal-mitochondria clearance, to define the in-vivo receptor mechanism.</p>
+
+
+
+                    <p style="margin-top: 0.5rem;">Type: structure-function / live imaging</p>
+
+                </div>
+                <span class="vote-buttons" data-g="P50093" data-a="EXPERIMENT: Map and mutate the worm phb-2 LC3/LGG-family LIR w..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> Carry out epistasis and targeted metabolic-flux analysis of phb-2 depletion across wild-type, daf-2, and dietary-restricted backgrounds to localize the node responsible for the opposite longevity outcomes.</p>
+
+
+
+                    <p style="margin-top: 0.5rem;">Type: genetic epistasis / metabolomics</p>
+
+                </div>
+                <span class="vote-buttons" data-g="P50093" data-a="EXPERIMENT: Carry out epistasis and targeted metabolic-flux an..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Knowledge Gaps</h2>
+        <p style="color: #555; font-size: 0.92rem; margin-top: -0.3rem;">
+            What is <em>not</em> known — curated, literature-grounded statements of the open
+            unknowns (the inverse of core functions).
+        </p>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> The molecular mechanism of the mitochondrial prohibitin complex is unresolved. It is not established whether the complex acts primarily as a membrane-bound chaperone/holdase for newly synthesized mitochondrial-encoded proteins, as a scaffold that organizes inner-membrane proteins within a defined (cardiolipin/phospholipid) microdomain, or as a regulator of inner-membrane proteostasis (e.g. of the m-AAA protease); nor is the direct molecular activity of phb-2 as a ring subunit expressible as a specific GO molecular function.</p>
+            <p style="margin-top: 0.4rem;">
+                <span class="badge">OPEN</span>
+                <span class="badge">BIOLOGY</span><span class="badge">ONTOLOGY</span>
+                <span class="badge">MF_DARK</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> It is firmly established that phb-1 and phb-2 bind each other and assemble into a ring-like, high-molecular-weight complex in the mitochondrial inner membrane, that the two subunits are interdependent (loss of one abolishes the complex), and that depletion is embryonic-lethal, disrupts gonad/germline differentiation, and alters mitochondrial biogenesis. What is NOT established is the biochemical mechanism by which the complex produces these effects.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Significance:</strong> Prohibitins are ubiquitous and essential across eukaryotes; resolving whether the complex is fundamentally a chaperone, a membrane scaffold, or a lipid/proteostasis organizer would explain a large body of pleiotropic phenotypes and the conserved link between mitochondrial membrane organization and ageing. The absence of a GO molecular-function term for a structural ring subunit is why the gene reads as MF-dark despite rich process/localization annotation.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>What would resolve it:</strong> In vitro reconstitution / structural work on the worm (or conserved) PHB ring to test holdase vs scaffold activity; lipidomic and proximity-labeling mapping of the inner-membrane microdomain the complex organizes; separation-of-function alleles that uncouple candidate activities. In parallel, an ontology term for the structural/scaffolding molecular activity of a prohibitin-type ring subunit.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Provenance (the field's own admissions):</strong></p>
+            <ul style="margin-top: 0.2rem;">
+
+                <li><em>"the true function of the mitochondrial prohibitin complex remains elusive"</em> — PMID:26092086</li>
+
+                <li><em>"as scaffold proteins that recruit membrane proteins to a specific lipid environment"</em> — PMID:26092086</li>
+
+            </ul>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Proposed term (ontology gap):</strong></p>
+            <ul style="margin-top: 0.2rem;">
+
+                <li><strong>prohibitin complex structural constituent activity</strong> — phb-1/phb-2 and their orthologs have no adequate GO molecular-function term for their role as structural ring subunits and inner-membrane scaffolds. They are currently annotatable only at the complex/process level or with the generic &#39;structural molecule activity&#39;, leaving the gene MF-dark despite a well-defined cellular role.</li>
+
+            </ul>
+
+        </div>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> How phb-2&#39;s mitophagy-receptor activity is molecularly integrated with, and separated from, its obligate structural role in the same protein is not resolved in C. elegans. It is unknown whether the worm phb-2 uses a defined LC3/LGG-family LIR motif in vivo (as shown for the mammalian ortholog), how outer-membrane rupture exposes the inner-membrane receptor to the cytosol in the physiological setting of paternal-mitochondria clearance, and which autophagy pathway (Parkin-independent) acts with phb-2 in the worm.</p>
+            <p style="margin-top: 0.4rem;">
+                <span class="badge">OPEN</span>
+                <span class="badge">BIOLOGY</span>
+                <span class="badge">RESIDUAL_SUBGAP</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> It is established that phb-2 is required for autophagic clearance of paternal mitochondria in worm (paternal phb-2 RNAi phenocopies atg-7 loss), that the mammalian ortholog binds LC3-II directly through a LIR while PHB1 binds only indirectly, and that a LIR point mutation abolishes mitophagy without disturbing the other prohibitin-dependent mitochondrial functions (i.e. the receptor and structural activities are separable in mammalian cells). What is NOT established is the in-vivo worm mechanism, its LGG-1/LGG-2 partner usage, and how the two activities of a single obligate subunit are coordinated.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Significance:</strong> PHB2 is the founding inner-mitochondrial-membrane mitophagy receptor, and paternal-mitochondria elimination in C. elegans is a premier in-vivo model of developmental mitophagy and uniparental mtDNA inheritance. Dissecting how one obligate structural subunit doubles as a receptor would clarify a conserved, Parkin-independent branch of mitophagy relevant to neurodegeneration and ageing.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>What would resolve it:</strong> Map and mutate the worm phb-2 LIR (LGG-1/LGG-2 binding) with separation-of- function alleles; live-imaging of OMM rupture and phb-2 exposure during paternal mitophagy; epistasis with the worm autophagy machinery to place phb-2 in the Parkin-independent receptor pathway.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Provenance (the field's own admissions):</strong></p>
+            <ul style="margin-top: 0.2rem;">
+
+                <li><em>"PHB2 interacts directly with LC3-II, whereas PHB1 interacts indirectly with LC3-II as a result of being part of a heterodimeric complex with PHB2"</em> — PMID:28017329</li>
+
+                <li><em>"the PHB2 LIR mutation does not affect previously described mitochondrial processes controlled by prohibitins, but does abrogate the ability of PHB2 to mediate mitophagy"</em> — PMID:28017329</li>
+
+            </ul>
+
+
+        </div>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> The mechanistic basis by which the SAME reduction of the prohibitin complex produces OPPOSITE ageing outcomes is unknown - prohibitin deficiency shortens the lifespan of otherwise wild-type animals yet extends the lifespan of diapause (daf-2), dietary-restricted, and respiration/fat-metabolism-compromised animals. The metabolic node at which the complex converts genetic/nutritional context into opposite longevity responses is undefined.</p>
+            <p style="margin-top: 0.4rem;">
+                <span class="badge">OPEN</span>
+                <span class="badge">BIOLOGY</span>
+                <span class="badge">RESIDUAL_SUBGAP</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> The context-dependence itself is well documented (life-shortening in wild type vs life-extending in daf-2/dietary-restricted/mitochondrial mutants), and depletion is known to change ATP levels, fat content, mitochondrial proliferation, and the whole-animal metabolome. The upstream signalling (insulin/IGF) and downstream metabolic readouts are mapped, but the causal molecular link through the complex is not.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Significance:</strong> This paradox is a clean, conserved example of how mitochondrial membrane organization gates lifespan in a metabolic-state-dependent manner; resolving it would connect prohibitin biology to insulin/IGF and dietary-restriction ageing pathways mechanistically.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>What would resolve it:</strong> Epistasis and metabolic-flux analysis across the opposing backgrounds; identify the prohibitin-dependent metabolic step whose perturbation flips the longevity sign; test candidate mediators (fat mobilization, respiratory-chain assembly).</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Provenance (the field's own admissions):</strong></p>
+            <ul style="margin-top: 0.2rem;">
+
+                <li><em>"prohibitin deficiency shortens the lifespan of otherwise wild-type animals"</em> — PMID:19812672</li>
+
+                <li><em>"knockdown of prohibitin promotes longevity in diapause mutants or under conditions of dietary restriction"</em> — PMID:19812672</li>
+
+            </ul>
+
+
+        </div>
+
+    </div>
+
+
+
+
+    <!-- Computational Predictions Section -->
+
+
+    <!-- Deep Research Sections -->
+
+    <div class="section">
+        <h2 class="section-title">Deep Research</h2>
+
+        <details class="deep-research-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; gap: 1rem;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Falcon</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(phb-2-deep-research-falcon.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="P50093" data-a="DEEP_RESEARCH: Falcon" data-r="" data-act="DEEP_RESEARCH" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This deep research is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This deep research needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+
+                <div class="report-meta">
+
+                    <span class="report-meta-text">Comprehensive Research Report: *C. elegans* PHB-2 (Prohibitin-2)</span>
+
+
+                    <span class="report-badge">Falcon</span>
+
+
+                    <span class="report-badge">Edison Scientific Literature</span>
+
+
+                    <span class="report-badge">31 citations</span>
+
+
+                    <span class="report-badge">1 artifacts</span>
+
+
+                    <span class="report-meta-text">2026-07-04T12:32:37.991537</span>
+
+
+
+                </div>
+
+
+                <div class="artifact-list">
+
+
+
+                    <div class="artifact-link">
+                        <a href="phb-2-deep-research-falcon_artifacts/artifact-00.md" class="term-link">Edison artifact artifact-00</a>
+                        <span>(text/markdown)</span>
+                    </div>
+
+
+                </div>
+
+                <p>The research report should be a detailed narrative explaining the function, biological processes, and localization of the gene product. Citations should be given for all claims.</p>
+<p>You should prioritize authoritative reviews and primary scientific literature when conducting research. You can supplement<br />
+this with annotations you find in gene/protein databases, but these can be outdated or inaccurate.</p>
+<p>We are specifically interested in the primary function of the gene - for enzymes, what reaction is catalyzed, and what is the substrate specificity? For transporters, what is the substrate? For structural proteins or adapters, what is the broader structural role? For signaling molecules, what is the role in the pathway.</p>
+<p>We are interested in where in or outside the cell the gene product carries out its function.</p>
+<p>We are also interested in the signaling or biochemical pathways in which the gene functions. We are less interested in broad pleiotropic effects, except where these elucidate the precise role.</p>
+<p>Include evidence where possible. We are interested in both experimental evidence as well as inference from structure, evolution, or bioinformatic analysis. Precise studies should be prioritized over high-throughput, where available.</p>
+<h1 id="comprehensive-research-report-c-elegans-phb-2-prohibitin-2">Comprehensive Research Report: <em>C. elegans</em> PHB-2 (Prohibitin-2)</h1>
+<h2 id="gene-identity-and-overview">Gene Identity and Overview</h2>
+<p>The gene <em>phb-2</em> (ORF name T24H7.1) in <em>Caenorhabditis elegans</em> encodes Mitochondrial Prohibitin Complex Protein 2 (Prohibitin-2), a highly conserved inner mitochondrial membrane (IMM) scaffold protein (UniProt: P50093). PHB-2 belongs to the prohibitin family and contains a characteristic Band 7/SPFH domain (IPR001107) and a prohibitin domain (IPR000163). Together with its obligate partner PHB-1, PHB-2 assembles into a large, multimeric prohibitin (PHB) complex that is essential for mitochondrial homeostasis, development, and organismal longevity. PHB-2 is not an enzyme; rather, it functions as a structural scaffold and membrane organizer with an additional, experimentally validated role as a mitophagy receptor.</p>
+<h2 id="1-protein-structure-and-the-prohibitin-complex">1. Protein Structure and the Prohibitin Complex</h2>
+<h3 id="domain-architecture">Domain Architecture</h3>
+<p>PHB-2 is a 34 kDa protein containing an N-terminal transmembrane domain that anchors it to the IMM, a conserved PHB/Band 7 domain (common to scaffold proteins such as stomatin and flotillin), and a C-terminal coiled-coil domain that mediates heterodimeric interaction with PHB-1 (hernandorodriguez2018mitochondrialqualitycontrol pages 8-10, artalsanz2009prohibitinandmitochondrial pages 1-2). The N-terminal transmembrane helix (predicted at approximately positions 37–59 based on yeast orthologue data) positions a short segment in the mitochondrial matrix, while the bulk of the protein, including the PHB domain and coiled-coil region, projects into the intermembrane space (artalsanz2009prohibitinandmitochondrial pages 1-2).</p>
+<h3 id="ringbell-shaped-complex">Ring/Bell-Shaped Complex</h3>
+<p>PHB-1 and PHB-2 are mutually dependent: depletion of either subunit leads to loss of the entire complex (artalsanz2009prohibitinandmitochondrial pages 1-2). Historically, biochemical studies indicated that approximately 12–16 PHB-1/PHB-2 heterodimers assemble into a ring-like macromolecular structure of ~1 MDa with a diameter of 20–25 nm at the IMM (artalsanz2009prohibitinandmitochondrial pages 1-2). A landmark 2025 study by Lange et al. using cryo-electron tomography (cryo-ET) and subtomogram averaging determined the <em>in situ</em> architecture of the human prohibitin complex at 16.3 Å resolution, revealing a <strong>bell-shaped structure composed of 11 alternating PHB1 and PHB2 molecules</strong> (either 6:5 or 5:6 stoichiometry), with a diameter of ~190 Å and height of ~84 Å (lange2025insituarchitecture pages 1-2, lange2025insituarchitecture pages 4-7). The bell's top is stabilized by coiled-coil domains with alternating charged residues providing strong electrostatic interactions (lange2025insituarchitecture pages 4-7). Quantitative analysis revealed approximately 43 prohibitin complexes per crista, collectively covering 1–3% of the cristae membrane area (lange2025insituarchitecture pages 1-2, lange2025insituarchitecture pages 7-8). Given the extreme conservation of prohibitins, this architecture is expected to be conserved in <em>C. elegans</em>.</p>
+<h2 id="2-subcellular-localization">2. Subcellular Localization</h2>
+<p>PHB-2 is primarily localized to the <strong>mitochondrial inner membrane</strong>, where it resides within cristae membranes as part of the PHB complex (lange2025insituarchitecture pages 3-4, hernandorodriguez2018mitochondrialqualitycontrol pages 8-10). The complex projects from the IMM into the intermembrane space, forming a scaffold at the cristae. In physiological contexts involving outer mitochondrial membrane rupture (e.g., during paternal mitochondria degradation after fertilization), PHB-2 becomes exposed to the cytoplasm, enabling its secondary function as a mitophagy receptor (wei2017prohibitin2is pages 13-14, wei2017prohibitin2is pages 1-3).</p>
+<h2 id="3-primary-molecular-functions">3. Primary Molecular Functions</h2>
+<h3 id="31-membrane-scaffold-and-organizer">3.1 Membrane Scaffold and Organizer</h3>
+<p>The primary function of PHB-2, acting within the PHB complex, is as an <strong>inner mitochondrial membrane scaffold that organizes membrane lipids and proteins</strong>. The complex acts as a membrane organizer affecting the distribution of mitochondrial membrane lipids, particularly cardiolipin and phosphatidylethanolamine (lourenco2021themitochondrialprohibitin pages 3-5, hernandorodriguez2018mitochondrialqualitycontrol pages 8-10). It stabilizes newly synthesized mitochondrial-encoded electron transport chain (ETC) subunits through proposed holdase-unfoldase chaperone activity, protecting hydrophobic membrane proteins until they can be properly assembled with their nuclear-encoded partners (hernandorodriguez2018mitochondrialqualitycontrol pages 8-10, artalsanz2009prohibitinandmitochondrial pages 3-4). The PHB complex also interacts functionally with the m-AAA protease, which degrades unassembled or damaged membrane proteins; PHB appears to shield substrates from premature proteolysis (artalsanz2009prohibitinandmitochondrial pages 2-3, hernandorodriguez2018mitochondrialqualitycontrol pages 8-10).</p>
+<h3 id="32-cristae-morphogenesis">3.2 Cristae Morphogenesis</h3>
+<p>PHB-2 is essential for maintaining mitochondrial cristae architecture. The complex stabilizes OPA1 (a GTPase critical for mitochondrial inner membrane fusion and cristae remodeling), thereby regulating cristae junction integrity and keeping cristae membranes in close proximity (wei2017prohibitin2is pages 12-13, artalsanz2009prohibitinandmitochondrial pages 3-4). PHB-2 increases apoptosis resistance by stabilizing OPA1, which controls mitochondrial cristae remodeling and fusion (qi2023essentialproteinphb2 pages 5-6). Loss of PHB in <em>C. elegans</em> causes severe mitochondrial fragmentation (hernandorodriguez2018mitochondrialqualitycontrol pages 8-10).</p>
+<h3 id="33-mitochondrial-nucleoid-organization">3.3 Mitochondrial Nucleoid Organization</h3>
+<p>The PHB complex participates in organizing mitochondrial nucleoids—the structures that package and maintain mitochondrial DNA (hernandorodriguez2018mitochondrialqualitycontrol pages 8-10).</p>
+<h3 id="34-mitophagy-receptor">3.4 Mitophagy Receptor</h3>
+<p>A seminal 2017 study by Wei et al. in <em>Cell</em> identified PHB2 as the <strong>first inner mitochondrial membrane mitophagy receptor</strong> (wei2017prohibitin2is pages 1-3, wei2017prohibitin2is pages 13-14). PHB-2 contains an LC3-interacting region (LIR) domain through which it directly binds LC3-II (and its <em>C. elegans</em> orthologues LGG-1 and LGG-2) to recruit autophagic machinery for selective mitochondrial degradation (wei2017prohibitin2is pages 13-14, wei2017prohibitin2is pages 12-13). This interaction becomes possible when the outer mitochondrial membrane is ruptured (via proteasome-dependent degradation), exposing the IMM-resident PHB-2 to cytoplasmic autophagy components (wei2017prohibitin2is pages 1-3). In <em>C. elegans</em>, this function is critically important for the <strong>elimination of paternal mitochondria after fertilization</strong>, thereby ensuring maternal mitochondrial inheritance. RNAi knockdown of <em>phb-2</em> in males results in delayed paternal mitochondrial clearance and persistence of paternal mtDNA in embryos and subsequent generations (wei2017prohibitin2is pages 13-14, lahiri2017phb2prohibitin2an pages 2-2, choubey2021molecularmechanismsand pages 19-20). Notably, PHB-2-mediated paternal mitophagy in <em>C. elegans</em> appears to be Parkin-independent, distinguishing it from the canonical PINK1-Parkin pathway (wei2017prohibitin2is pages 1-3). In mammalian cells, PHB2 also promotes PINK1-PRKN/Parkin-dependent mitophagy through the PARL-PGAM5-PINK1 axis, where PHB2 negatively regulates the protease PARL to stabilize PINK1 on the outer mitochondrial membrane (qi2023essentialproteinphb2 pages 5-6, choubey2021molecularmechanismsand pages 19-20).</p>
+<h2 id="4-biological-processes-and-signaling-pathways">4. Biological Processes and Signaling Pathways</h2>
+<h3 id="41-development-and-reproduction">4.1 Development and Reproduction</h3>
+<p>Prohibitins are required for embryonic development in <em>C. elegans</em>. Postembryonic depletion of PHB by RNAi causes severe germline defects, indicating an essential role in cell proliferation (hernandorodriguez2018mitochondrialqualitycontrol pages 8-10, artalsanz2009prohibitinandmitochondrial pages 2-3).</p>
+<h3 id="42-mitochondrial-unfolded-protein-response-uprmt">4.2 Mitochondrial Unfolded Protein Response (UPR^mt)</h3>
+<p>PHB depletion strongly induces the UPR^mt in <em>C. elegans</em>, a retrograde stress signaling pathway from mitochondria to nucleus that activates transcriptional programs to restore mitochondrial proteostasis (hernandorodriguez2018mitochondrialqualitycontrol pages 1-3, fernandezabascal<em>2023twoconservedtranscription pages 1-4). The UPR^mt induction upon PHB depletion is mediated fully by the transcription factor ATFS-1 and partially by DVE-1 (fernandezabascal</em>2023twoconservedtranscription pages 11-13, fernandezabascal<em>2023twoconservedtranscription pages 4-7). Recent genome-wide screening identified two additional conserved transcription factors, ZNF-622 and TLF-1, as specific regulators of the PHB-mediated mitochondrial stress response, along with the histone deubiquitinase USP-48 as a strong differential modulator (fernandezabascal</em>2023twoconservedtranscription pages 4-7, fernandezabascal<em>2023twoconservedtranscription pages 7-9). Importantly, the strength of UPR^mt induction differs depending on the metabolic/genetic context: it is robust in wild-type animals upon PHB depletion but attenuated in </em>daf-2<em> insulin receptor mutants (fernandezabascal</em>2023twoconservedtranscription pages 11-13, fernandezabascal*2023twoconservedtranscription pages 1-4).</p>
+<h3 id="43-aging-and-lifespan-regulation">4.3 Aging and Lifespan Regulation</h3>
+<p>The PHB complex is a <strong>context-dependent modulator of longevity</strong> in <em>C. elegans</em>, exhibiting a remarkable and paradoxical effect on lifespan (lourenco2021themitochondrialprohibitin pages 1-2, hernandorodriguez2018mitochondrialqualitycontrol pages 1-3):</p>
+<ul>
+<li><strong>In wild-type animals</strong>, PHB-1 or PHB-2 depletion <strong>shortens lifespan</strong>, consistent with impaired mitochondrial function (belser2021roleofprohibitins pages 2-3, hernandorodriguez2018mitochondrialqualitycontrol pages 10-12).</li>
+<li><strong>In metabolically compromised mutants</strong>, PHB depletion <strong>dramatically extends lifespan</strong> — up to 150% longer in <em>daf-2</em> (insulin/IGF-1 receptor) mutants, and similarly in ETC mutants, dietary restriction mutants, and fat metabolism mutants (belser2021roleofprohibitins pages 2-3, hernandorodriguez2018mitochondrialqualitycontrol pages 1-3).</li>
+</ul>
+<p>This differential effect involves the insulin/IGF-1 signaling (IIS) pathway. In <em>daf-2</em> mutants, PHB depletion extends lifespan while attenuating the UPR^mt, and this lifespan extension requires a functional UPR^mt response and ATFS-1 (fernandezabascal<em>2023twoconservedtranscription pages 11-13, fernandezabascal</em>2023twoconservedtranscription pages 4-7). The transcription factors ZNF-622 and TLF-1 show much greater lifespan impact in <em>daf-2</em> backgrounds (38–58% reduction) than in wild-type (4–16% reduction), confirming the insulin signaling-dependent nature of PHB-mediated longevity (fernandezabascal*2023twoconservedtranscription pages 7-9).</p>
+<p>PHB depletion also extends lifespan in TORC2/SGK-1 mutants through autophagy and UPR^mt activation. In <em>sgk-1</em> mutants, PHB depletion suppresses impaired mitochondrial homeostasis, lipogenesis, and yolk formation defects, and the lifespan extension requires both UPR^mt and autophagy but not mitophagy (fernandezabascal*2023twoconservedtranscription pages 18-21, lourenco2021themitochondrialprohibitin pages 7-8).</p>
+<h3 id="44-lipid-and-metabolic-regulation">4.4 Lipid and Metabolic Regulation</h3>
+<p>PHB-2 and the PHB complex profoundly influence lipid metabolism and the <em>C. elegans</em> metabolome (lourenco2021themitochondrialprohibitin pages 1-2, lourenco2021themitochondrialprohibitin pages 3-5):</p>
+<ul>
+<li><strong>Lipid composition</strong>: PHB depletion significantly alters the lipidome, increasing glycerolipid and triacylglyceride (TAG) pools, with preferential effects on longer-chain, less unsaturated TAG species. Sphingomyelin and ceramide pools decrease, as do phosphatidylcholine and phosphatidylethanolamine levels (lourenco2021themitochondrialprohibitin pages 2-3, lourenco2021themitochondrialprohibitin pages 3-5).</li>
+<li><strong>Fat storage</strong>: PHB depletion increases lipid droplet intestinal coverage and accommodates excess TAGs in larger intestinal lipid droplets; these can be mobilized during aging through ATGL-1 regulation (lourenco2021themitochondrialprohibitin pages 7-8).</li>
+<li><strong>Mitochondrial membrane lipids</strong>: The complex affects mitochondrial cardiolipin and phosphatidylethanolamine distribution, which are critical for respiratory chain function and membrane integrity (lourenco2021themitochondrialprohibitin pages 3-5).</li>
+<li><strong>Broader metabolism</strong>: PHB depletion alters amino acid levels (branched-chain amino acids, alanine), TCA cycle intermediates (reduced succinate), increases trehalose accumulation (a stress protectant), and shifts metabolism toward the glyoxylate cycle in <em>daf-2</em> backgrounds (lourenco2021themitochondrialprohibitin pages 5-7).</li>
+</ul>
+<p>These metabolic effects are insulin signaling-dependent, with differential impacts between wild-type and <em>daf-2</em> mutant animals. The biochemical data collectively support the model that <strong>PHB modulates longevity through moderation of fat utilization and energy production via the mitochondrial respiratory chain</strong> (lourenco2021themitochondrialprohibitin pages 1-2).</p>
+<h3 id="45-interaction-with-oxphos-and-respiratory-chain">4.5 Interaction with OXPHOS and Respiratory Chain</h3>
+<p>PHB-2 interacts with the sphingosine-1-phosphate (S1P) pathway, supporting proper assembly of respiratory complex IV and cytochrome c oxidase activity (lourenco2021themitochondrialprohibitin pages 12-13). PHB depletion leads to impaired respiratory supercomplex formation and activation of mitochondrial flashes, indicative of compromised bioenergetics (lourenco2021themitochondrialprohibitin pages 12-13).</p>
+<h2 id="5-summary-of-key-functions">5. Summary of Key Functions</h2>
+<p>The following table summarizes the experimentally supported and inferred functions of <em>C. elegans</em> PHB-2:</p>
+<table>
+<thead>
+<tr>
+<th>Function/Role</th>
+<th>Mechanism</th>
+<th>Key Pathway Partners</th>
+<th>Evidence Type</th>
+<th>Key References</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>Mitochondrial inner membrane scaffold</td>
+<td>PHB-2 forms a large hetero-oligomeric prohibitin complex with PHB-1 in the inner mitochondrial membrane; acts as a membrane organizer/scaffold influencing lipid distribution and membrane microdomain organization</td>
+<td>PHB-1, inner membrane lipids, cardiolipin/phospholipid environment</td>
+<td>Biochemical/structural inference, genetics, review synthesis; recent in situ cryo-ET in mammals supports conserved architecture</td>
+<td>(hernandorodriguez2018mitochondrialqualitycontrol pages 8-10, artalsanz2009prohibitinandmitochondrial pages 1-2, lange2025insituarchitecture pages 1-2)</td>
+</tr>
+<tr>
+<td>Mitophagy receptor</td>
+<td>PHB-2 contains an LC3-interacting region (LIR) and, upon outer membrane rupture, binds LGG-1/LGG-2 (LC3 orthologs) to target paternal mitochondria for autophagic clearance after fertilization</td>
+<td>LGG-1, LGG-2, autophagy machinery, paternal mitochondria</td>
+<td>Primary experimental evidence in C. elegans and mammalian cells; mechanistic cell biology</td>
+<td>(wei2017prohibitin2is pages 13-14, wei2017prohibitin2is pages 1-3, lahiri2017phb2prohibitin2an pages 2-2, wei2017prohibitin2is pages 12-13, bliek2017cellbiologyof pages 21-22)</td>
+</tr>
+<tr>
+<td>OXPHOS complex stabilization</td>
+<td>Proposed holdase/unfoldase-like chaperone activity stabilizes newly synthesized or unassembled ETC subunits and protects membrane proteins from degradation; functionally linked to m-AAA protease-dependent quality control</td>
+<td>Electron transport chain subunits, m-AAA protease, mitochondrial translation/protein import machinery</td>
+<td>Genetic and biochemical inference; comparative mitochondrial biology reviews</td>
+<td>(hernandorodriguez2018mitochondrialqualitycontrol pages 8-10, artalsanz2009prohibitinandmitochondrial pages 3-4, hernandorodriguez2018mitochondrialqualitycontrol pages 10-12, artalsanz2009prohibitinandmitochondrial pages 2-3)</td>
+</tr>
+<tr>
+<td>Cristae morphogenesis</td>
+<td>Supports cristae architecture by stabilizing OPA1 and maintaining cristae junctions/inner membrane organization; loss of PHB perturbs mitochondrial morphology</td>
+<td>OPA1, cristae-shaping machinery, fusion-related factors</td>
+<td>Cell biological and genetic evidence; conserved mechanism from broader PHB literature</td>
+<td>(wei2017prohibitin2is pages 12-13, hernandorodriguez2018mitochondrialqualitycontrol pages 8-10, artalsanz2009prohibitinandmitochondrial pages 3-4, hernandorodriguez2018mitochondrialqualitycontrol pages 10-12)</td>
+</tr>
+<tr>
+<td>UPRmt regulation</td>
+<td>PHB depletion strongly induces the mitochondrial unfolded protein response; signaling requires ATFS-1 and is partly mediated by DVE-1, with output varying by metabolic/genetic context</td>
+<td>ATFS-1, DVE-1, UPRmt transcriptional network</td>
+<td>Genetic interaction studies, stress-response assays, recent screening work</td>
+<td>(hernandorodriguez2018mitochondrialqualitycontrol pages 1-3, hernandorodriguez2018mitochondrialqualitycontrol pages 10-12, fernandezabascal<em>2023twoconservedtranscription pages 11-13, fernandezabascal</em>2023twoconservedtranscription pages 4-7)</td>
+</tr>
+<tr>
+<td>Lifespan modulation</td>
+<td>Context-dependent longevity regulator: PHB depletion shortens wild-type lifespan but extends lifespan in metabolically compromised backgrounds such as daf-2, sgk-1, and rict-1 mutants</td>
+<td>DAF-2/insulin-IGF signaling, SGK-1, TORC2/RICT-1, autophagy, UPRmt</td>
+<td>Lifespan genetics, epistasis, metabolic phenotyping</td>
+<td>(belser2021roleofprohibitins pages 2-3, fernandezabascal<em>2023twoconservedtranscription pages 18-21, fernandezabascal</em>2023twoconservedtranscription pages 7-9, lourenco2021themitochondrialprohibitin pages 7-8)</td>
+</tr>
+<tr>
+<td>Lipid metabolism</td>
+<td>Alters mitochondrial and organismal lipid homeostasis, including TAG pools, cardiolipin/glycerophospholipid balance, fatty-acid composition, lipid droplet storage, and yolk accumulation</td>
+<td>TAG/lipid droplets, cardiolipin, phosphatidylcholine, phosphatidylethanolamine, IIS-linked metabolic programs</td>
+<td>Lipidomics/metabolomics, physiological phenotyping, genetic interaction studies</td>
+<td>(lourenco2021themitochondrialprohibitin pages 3-5, lourenco2021themitochondrialprohibitin pages 2-3, lourenco2021themitochondrialprohibitin pages 7-8, lourenco2021themitochondrialprohibitin pages 5-7, lourenco2021themitochondrialprohibitin pages 10-11, lourenco2021themitochondrialprohibitin pages 1-2)</td>
+</tr>
+</tbody>
+</table>
+<p><em>Table: This table summarizes the main experimentally supported and inferred functions of C. elegans PHB-2, emphasizing its mitochondrial scaffold role, mitophagy receptor function, and links to stress responses, metabolism, and aging. It is useful as a compact reference for the gene’s core biological annotation.</em></p>
+<h2 id="6-conclusions">6. Conclusions</h2>
+<p><em>C. elegans</em> PHB-2 is a multifunctional inner mitochondrial membrane protein whose primary role is as a <strong>structural scaffold within the prohibitin complex</strong>, organizing membrane lipids and stabilizing respiratory chain components and cristae architecture. Its secondary, experimentally well-validated function as a <strong>mitophagy receptor</strong> — binding LGG-1/LC3 via its LIR domain upon outer membrane rupture — is essential for paternal mitochondrial elimination and maternal mitochondrial DNA inheritance. Beyond these molecular activities, PHB-2 operates at the nexus of mitochondrial stress signaling (UPR^mt), insulin/IGF-1 signaling, mTORC2/SGK-1 pathways, and lipid metabolism to modulate organismal aging in a context-dependent manner. The recent determination of the bell-shaped 11-subunit <em>in situ</em> architecture of the homologous human prohibitin complex by cryo-ET (lange2025insituarchitecture pages 1-2, lange2025insituarchitecture pages 4-7) provides a structural foundation for understanding how this conserved scaffold contributes to the spatial organization and functional integrity of the mitochondrial inner membrane.</p>
+<p>References</p>
+<ol>
+<li>
+<p>(hernandorodriguez2018mitochondrialqualitycontrol pages 8-10): Blanca Hernando-Rodríguez and Marta Artal-Sanz. Mitochondrial quality control mechanisms and the phb (prohibitin) complex. Cells, Nov 2018. URL: https://doi.org/10.3390/cells7120238, doi:10.3390/cells7120238. This article has 93 citations.</p>
+</li>
+<li>
+<p>(artalsanz2009prohibitinandmitochondrial pages 1-2): Marta Artal-Sanz and Nektarios Tavernarakis. Prohibitin and mitochondrial biology. Trends in Endocrinology &amp; Metabolism, 20:394-401, Oct 2009. URL: https://doi.org/10.1016/j.tem.2009.04.004, doi:10.1016/j.tem.2009.04.004. This article has 363 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(lange2025insituarchitecture pages 1-2): Felix Lange, Michael Ratz, Jan-Niklas Dohrke, Maxence Le Vasseur, Dirk Wenzel, Peter Ilgen, Dietmar Riedel, and Stefan Jakobs. In situ architecture of the human prohibitin complex. Nature Cell Biology, 27:633-640, Mar 2025. URL: https://doi.org/10.1038/s41556-025-01620-1, doi:10.1038/s41556-025-01620-1. This article has 39 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(lange2025insituarchitecture pages 4-7): Felix Lange, Michael Ratz, Jan-Niklas Dohrke, Maxence Le Vasseur, Dirk Wenzel, Peter Ilgen, Dietmar Riedel, and Stefan Jakobs. In situ architecture of the human prohibitin complex. Nature Cell Biology, 27:633-640, Mar 2025. URL: https://doi.org/10.1038/s41556-025-01620-1, doi:10.1038/s41556-025-01620-1. This article has 39 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(lange2025insituarchitecture pages 7-8): Felix Lange, Michael Ratz, Jan-Niklas Dohrke, Maxence Le Vasseur, Dirk Wenzel, Peter Ilgen, Dietmar Riedel, and Stefan Jakobs. In situ architecture of the human prohibitin complex. Nature Cell Biology, 27:633-640, Mar 2025. URL: https://doi.org/10.1038/s41556-025-01620-1, doi:10.1038/s41556-025-01620-1. This article has 39 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(lange2025insituarchitecture pages 3-4): Felix Lange, Michael Ratz, Jan-Niklas Dohrke, Maxence Le Vasseur, Dirk Wenzel, Peter Ilgen, Dietmar Riedel, and Stefan Jakobs. In situ architecture of the human prohibitin complex. Nature Cell Biology, 27:633-640, Mar 2025. URL: https://doi.org/10.1038/s41556-025-01620-1, doi:10.1038/s41556-025-01620-1. This article has 39 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(wei2017prohibitin2is pages 13-14): Yongjie Wei, Wei-Chung Chiang, Rhea Sumpter, Prashant Mishra, and Beth Levine. Prohibitin 2 is an inner mitochondrial membrane mitophagy receptor. Cell, 168:224-238.e10, Jan 2017. URL: https://doi.org/10.1016/j.cell.2016.11.042, doi:10.1016/j.cell.2016.11.042. This article has 932 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(wei2017prohibitin2is pages 1-3): Yongjie Wei, Wei-Chung Chiang, Rhea Sumpter, Prashant Mishra, and Beth Levine. Prohibitin 2 is an inner mitochondrial membrane mitophagy receptor. Cell, 168:224-238.e10, Jan 2017. URL: https://doi.org/10.1016/j.cell.2016.11.042, doi:10.1016/j.cell.2016.11.042. This article has 932 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(lourenco2021themitochondrialprohibitin pages 3-5): Artur B. Lourenço and Marta Artal-Sanz. The mitochondrial prohibitin (phb) complex in c. elegans metabolism and ageing regulation. Metabolites, 11:636, Sep 2021. URL: https://doi.org/10.3390/metabo11090636, doi:10.3390/metabo11090636. This article has 16 citations.</p>
+</li>
+<li>
+<p>(artalsanz2009prohibitinandmitochondrial pages 3-4): Marta Artal-Sanz and Nektarios Tavernarakis. Prohibitin and mitochondrial biology. Trends in Endocrinology &amp; Metabolism, 20:394-401, Oct 2009. URL: https://doi.org/10.1016/j.tem.2009.04.004, doi:10.1016/j.tem.2009.04.004. This article has 363 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(artalsanz2009prohibitinandmitochondrial pages 2-3): Marta Artal-Sanz and Nektarios Tavernarakis. Prohibitin and mitochondrial biology. Trends in Endocrinology &amp; Metabolism, 20:394-401, Oct 2009. URL: https://doi.org/10.1016/j.tem.2009.04.004, doi:10.1016/j.tem.2009.04.004. This article has 363 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(wei2017prohibitin2is pages 12-13): Yongjie Wei, Wei-Chung Chiang, Rhea Sumpter, Prashant Mishra, and Beth Levine. Prohibitin 2 is an inner mitochondrial membrane mitophagy receptor. Cell, 168:224-238.e10, Jan 2017. URL: https://doi.org/10.1016/j.cell.2016.11.042, doi:10.1016/j.cell.2016.11.042. This article has 932 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(qi2023essentialproteinphb2 pages 5-6): Amanda Qi, Lillie Lamont, Evelyn Liu, Sarina D. Murray, Xiangbing Meng, and Shujie Yang. Essential protein phb2 and its regulatory mechanisms in cancer. Cells, 12:1211, Apr 2023. URL: https://doi.org/10.3390/cells12081211, doi:10.3390/cells12081211. This article has 34 citations.</p>
+</li>
+<li>
+<p>(lahiri2017phb2prohibitin2an pages 2-2): Vikramjit Lahiri and Daniel J Klionsky. Phb2/prohibitin 2: an inner membrane mitophagy receptor. Cell Research, 27:311-312, Feb 2017. URL: https://doi.org/10.1038/cr.2017.23, doi:10.1038/cr.2017.23. This article has 62 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(choubey2021molecularmechanismsand pages 19-20): Vinay Choubey, Akbar Zeb, and Allen Kaasik. Molecular mechanisms and regulation of mammalian mitophagy. Cells, 11:38, Dec 2021. URL: https://doi.org/10.3390/cells11010038, doi:10.3390/cells11010038. This article has 140 citations.</p>
+</li>
+<li>
+<p>(hernandorodriguez2018mitochondrialqualitycontrol pages 1-3): Blanca Hernando-Rodríguez and Marta Artal-Sanz. Mitochondrial quality control mechanisms and the phb (prohibitin) complex. Cells, Nov 2018. URL: https://doi.org/10.3390/cells7120238, doi:10.3390/cells7120238. This article has 93 citations.</p>
+</li>
+<li>
+<p>(fernandezabascal<em>2023twoconservedtranscription pages 1-4): Jesús Fernandez-Abascal</em>, Blanca Hernando-Rodríguez*, María Jesús Rodríguez-Palero, Aitor Jarit-Cabanillas, Manuel D. Martínez-Bueno, Mercedes M. Pérez-Jiménez, Enrique J. Clavijo-Bernal, Aitana Cambón, Ildefonso Cases, and Marta Artal-Sanz. Two conserved transcription factors and a histone deubiquitinase regulate the mitochondrial unfolded protein response and longevity interacting with insulin signalling. Unknown journal, Oct 2025. URL: https://doi.org/10.21203/rs.3.rs-3337719/v1, doi:10.21203/rs.3.rs-3337719/v1.</p>
+</li>
+<li>
+<p>(fernandezabascal<em>2023twoconservedtranscription pages 11-13): Jesús Fernandez-Abascal</em>, Blanca Hernando-Rodríguez*, María Jesús Rodríguez-Palero, Aitor Jarit-Cabanillas, Manuel D. Martínez-Bueno, Mercedes M. Pérez-Jiménez, Enrique J. Clavijo-Bernal, Aitana Cambón, Ildefonso Cases, and Marta Artal-Sanz. Two conserved transcription factors and a histone deubiquitinase regulate the mitochondrial unfolded protein response and longevity interacting with insulin signalling. Unknown journal, Oct 2025. URL: https://doi.org/10.21203/rs.3.rs-3337719/v1, doi:10.21203/rs.3.rs-3337719/v1.</p>
+</li>
+<li>
+<p>(fernandezabascal<em>2023twoconservedtranscription pages 4-7): Jesús Fernandez-Abascal</em>, Blanca Hernando-Rodríguez*, María Jesús Rodríguez-Palero, Aitor Jarit-Cabanillas, Manuel D. Martínez-Bueno, Mercedes M. Pérez-Jiménez, Enrique J. Clavijo-Bernal, Aitana Cambón, Ildefonso Cases, and Marta Artal-Sanz. Two conserved transcription factors and a histone deubiquitinase regulate the mitochondrial unfolded protein response and longevity interacting with insulin signalling. Unknown journal, Oct 2025. URL: https://doi.org/10.21203/rs.3.rs-3337719/v1, doi:10.21203/rs.3.rs-3337719/v1.</p>
+</li>
+<li>
+<p>(fernandezabascal<em>2023twoconservedtranscription pages 7-9): Jesús Fernandez-Abascal</em>, Blanca Hernando-Rodríguez*, María Jesús Rodríguez-Palero, Aitor Jarit-Cabanillas, Manuel D. Martínez-Bueno, Mercedes M. Pérez-Jiménez, Enrique J. Clavijo-Bernal, Aitana Cambón, Ildefonso Cases, and Marta Artal-Sanz. Two conserved transcription factors and a histone deubiquitinase regulate the mitochondrial unfolded protein response and longevity interacting with insulin signalling. Unknown journal, Oct 2025. URL: https://doi.org/10.21203/rs.3.rs-3337719/v1, doi:10.21203/rs.3.rs-3337719/v1.</p>
+</li>
+<li>
+<p>(lourenco2021themitochondrialprohibitin pages 1-2): Artur B. Lourenço and Marta Artal-Sanz. The mitochondrial prohibitin (phb) complex in c. elegans metabolism and ageing regulation. Metabolites, 11:636, Sep 2021. URL: https://doi.org/10.3390/metabo11090636, doi:10.3390/metabo11090636. This article has 16 citations.</p>
+</li>
+<li>
+<p>(belser2021roleofprohibitins pages 2-3): Misa Belser and David W. Walker. Role of prohibitins in aging and therapeutic potential against age-related diseases. Frontiers in Genetics, Oct 2021. URL: https://doi.org/10.3389/fgene.2021.714228, doi:10.3389/fgene.2021.714228. This article has 27 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(hernandorodriguez2018mitochondrialqualitycontrol pages 10-12): Blanca Hernando-Rodríguez and Marta Artal-Sanz. Mitochondrial quality control mechanisms and the phb (prohibitin) complex. Cells, Nov 2018. URL: https://doi.org/10.3390/cells7120238, doi:10.3390/cells7120238. This article has 93 citations.</p>
+</li>
+<li>
+<p>(fernandezabascal<em>2023twoconservedtranscription pages 18-21): Jesús Fernandez-Abascal</em>, Blanca Hernando-Rodríguez*, María Jesús Rodríguez-Palero, Aitor Jarit-Cabanillas, Manuel D. Martínez-Bueno, Mercedes M. Pérez-Jiménez, Enrique J. Clavijo-Bernal, Aitana Cambón, Ildefonso Cases, and Marta Artal-Sanz. Two conserved transcription factors and a histone deubiquitinase regulate the mitochondrial unfolded protein response and longevity interacting with insulin signalling. Unknown journal, Oct 2025. URL: https://doi.org/10.21203/rs.3.rs-3337719/v1, doi:10.21203/rs.3.rs-3337719/v1.</p>
+</li>
+<li>
+<p>(lourenco2021themitochondrialprohibitin pages 7-8): Artur B. Lourenço and Marta Artal-Sanz. The mitochondrial prohibitin (phb) complex in c. elegans metabolism and ageing regulation. Metabolites, 11:636, Sep 2021. URL: https://doi.org/10.3390/metabo11090636, doi:10.3390/metabo11090636. This article has 16 citations.</p>
+</li>
+<li>
+<p>(lourenco2021themitochondrialprohibitin pages 2-3): Artur B. Lourenço and Marta Artal-Sanz. The mitochondrial prohibitin (phb) complex in c. elegans metabolism and ageing regulation. Metabolites, 11:636, Sep 2021. URL: https://doi.org/10.3390/metabo11090636, doi:10.3390/metabo11090636. This article has 16 citations.</p>
+</li>
+<li>
+<p>(lourenco2021themitochondrialprohibitin pages 5-7): Artur B. Lourenço and Marta Artal-Sanz. The mitochondrial prohibitin (phb) complex in c. elegans metabolism and ageing regulation. Metabolites, 11:636, Sep 2021. URL: https://doi.org/10.3390/metabo11090636, doi:10.3390/metabo11090636. This article has 16 citations.</p>
+</li>
+<li>
+<p>(lourenco2021themitochondrialprohibitin pages 12-13): Artur B. Lourenço and Marta Artal-Sanz. The mitochondrial prohibitin (phb) complex in c. elegans metabolism and ageing regulation. Metabolites, 11:636, Sep 2021. URL: https://doi.org/10.3390/metabo11090636, doi:10.3390/metabo11090636. This article has 16 citations.</p>
+</li>
+<li>
+<p>(bliek2017cellbiologyof pages 21-22): Alexander M van der Bliek, Margaret M Sedensky, and Phil G Morgan. Cell biology of the mitochondrion. Genetics, 207:843-871, Oct 2017. URL: https://doi.org/10.1534/genetics.117.300262, doi:10.1534/genetics.117.300262. This article has 517 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(lourenco2021themitochondrialprohibitin pages 10-11): Artur B. Lourenço and Marta Artal-Sanz. The mitochondrial prohibitin (phb) complex in c. elegans metabolism and ageing regulation. Metabolites, 11:636, Sep 2021. URL: https://doi.org/10.3390/metabo11090636, doi:10.3390/metabo11090636. This article has 16 citations.</p>
+</li>
+</ol>
+<h2 id="artifacts">Artifacts</h2>
+<ul>
+<li><a href="phb-2-deep-research-falcon_artifacts/artifact-00.md">Edison artifact artifact-00</a></li>
+</ul>
+<h2 id="citations">Citations</h2>
+<ol>
+<li>artalsanz2009prohibitinandmitochondrial pages 1-2</li>
+<li>lange2025insituarchitecture pages 4-7</li>
+<li>hernandorodriguez2018mitochondrialqualitycontrol pages 8-10</li>
+<li>lourenco2021themitochondrialprohibitin pages 7-8</li>
+<li>lourenco2021themitochondrialprohibitin pages 3-5</li>
+<li>lourenco2021themitochondrialprohibitin pages 5-7</li>
+<li>lourenco2021themitochondrialprohibitin pages 1-2</li>
+<li>lourenco2021themitochondrialprohibitin pages 12-13</li>
+<li>lange2025insituarchitecture pages 1-2</li>
+<li>lange2025insituarchitecture pages 7-8</li>
+<li>lange2025insituarchitecture pages 3-4</li>
+<li>artalsanz2009prohibitinandmitochondrial pages 3-4</li>
+<li>artalsanz2009prohibitinandmitochondrial pages 2-3</li>
+<li>choubey2021molecularmechanismsand pages 19-20</li>
+<li>hernandorodriguez2018mitochondrialqualitycontrol pages 1-3</li>
+<li>belser2021roleofprohibitins pages 2-3</li>
+<li>hernandorodriguez2018mitochondrialqualitycontrol pages 10-12</li>
+<li>lourenco2021themitochondrialprohibitin pages 2-3</li>
+<li>bliek2017cellbiologyof pages 21-22</li>
+<li>lourenco2021themitochondrialprohibitin pages 10-11</li>
+<li>https://doi.org/10.3390/cells7120238,</li>
+<li>https://doi.org/10.1016/j.tem.2009.04.004,</li>
+<li>https://doi.org/10.1038/s41556-025-01620-1,</li>
+<li>https://doi.org/10.1016/j.cell.2016.11.042,</li>
+<li>https://doi.org/10.3390/metabo11090636,</li>
+<li>https://doi.org/10.3390/cells12081211,</li>
+<li>https://doi.org/10.1038/cr.2017.23,</li>
+<li>https://doi.org/10.3390/cells11010038,</li>
+<li>https://doi.org/10.21203/rs.3.rs-3337719/v1,</li>
+<li>https://doi.org/10.3389/fgene.2021.714228,</li>
+<li>https://doi.org/10.1534/genetics.117.300262,</li>
+</ol>
+            </div>
+        </details>
+
+    </div>
+
+
+    <!-- Additional Documentation Sections -->
+
+    <div class="section">
+        <h2 class="section-title">📚 Additional Documentation</h2>
+
+        <details class="markdown-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; cursor: pointer;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Notes</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(phb-2-notes.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="P50093" data-a="DOC: Notes" data-r="" data-act="DOCUMENTATION" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This documentation is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This documentation needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+                <h1 id="phb-2-caenorhabditis-elegans-curation-notes">phb-2 (Caenorhabditis elegans) — curation notes</h1>
+<p>UniProt: P50093 (PHB2_CAEEL) · WormBase: WBGene00004015 · ORF: T24H7.1<br />
+Gene: phb-2 (prohibitin-2). Obligate partner of phb-1 in the mitochondrial prohibitin (PHB) ring complex.<br />
+294 aa; SPFH/Band-7 (stomatin/prohibitin) superfamily; PANTHER PTHR23222 (PROHIBITIN), subfamily PTHR23222:SF1 (PROHIBITIN-2).</p>
+<h2 id="protein-architecture-from-uniprot-p50093">Protein architecture (from UniProt P50093)</h2>
+<ul>
+<li>TRANSMEM 20-42: "Helical; Signal-anchor for type II membrane protein" (single-pass type II membrane protein; N-in/C-out topology places most of the protein on the intermembrane-space side).</li>
+<li>COILED 212-237.</li>
+<li>Keywords: Coiled coil, Membrane, Mitochondrion, Mitochondrion inner membrane, Signal-anchor, Transmembrane, Transmembrane helix.</li>
+<li>SUBCELLULAR LOCATION (UniProt): "Mitochondrion inner membrane; Single-pass type II membrane protein; Intermembrane side" [ECO:0000269|PMID:12794069].</li>
+<li>SUBUNIT (UniProt): "High molecular weight complex that consist of phb-1 and phb-2." <a href="https://pubmed.ncbi.nlm.nih.gov/12794069">PMID:12794069</a>.</li>
+<li>ComplexPortal CPX-4114 "Prohibitin complex".</li>
+</ul>
+<h2 id="known-experimentally-established">KNOWN (experimentally established)</h2>
+<h3 id="the-phb-complex-obligate-phb-1phb-2-heterodimeric-ring-in-the-inner-mitochondrial-membrane">The PHB complex: obligate phb-1/phb-2 heterodimeric ring in the inner mitochondrial membrane</h3>
+<ul>
+<li><a href="https://pubmed.ncbi.nlm.nih.gov/12794069" title="prohibitins in C. elegans form a high molecular weight complex in the mitochondrial inner membrane similar to that of yeast and humans">PMID:12794069</a> — direct demonstration in worm (BN-PAGE etc.).</li>
+<li><a href="https://pubmed.ncbi.nlm.nih.gov/12794069" title="Prohibitins in eukaryotes consist of two subunits (PHB1 and PHB2) that together form a high molecular weight complex in the mitochondrial inner membrane">PMID:12794069</a>.</li>
+<li><a href="https://pubmed.ncbi.nlm.nih.gov/26092086" title="which bind to each other to form a heterodimer that is assembled into a ring-like macromolecular structure at the inner mitochondrial membrane">PMID:26092086</a>.</li>
+<li><a href="https://pubmed.ncbi.nlm.nih.gov/26092086" title="These two subunits are interdependent for the formation of the complex, leading the absence of one of them to the absence of the whole complex">PMID:26092086</a> — the two subunits are mutually dependent; loss of one abolishes the whole complex. Same obligate-partner logic as phb-1.</li>
+<li><a href="https://pubmed.ncbi.nlm.nih.gov/19812672" title="form a ring-like, high-molecular-mass complex at the inner membrane of mitochondria">PMID:19812672</a>.</li>
+<li>Physical interaction with phb-1 curated as IPI (GO:0035632 mitochondrial prohibitin complex, with WB:WBGene00004014 = phb-1) from PMID:19812672.</li>
+<li>Mammalian ortholog corroboration: <a href="https://pubmed.ncbi.nlm.nih.gov/28017329" title="an evolutionarily conserved ~34 kDa protein that forms a large heterodimeric IMM complex with prohibitin 1 (PHB1)">PMID:28017329</a> and <a href="https://pubmed.ncbi.nlm.nih.gov/28017329" title="PHB2 are PHB1 are only stable when bound to each other in a heterodimeric state">PMID:28017329</a>.</li>
+</ul>
+<h3 id="essential-developmental-role-rnai-worm">Essential developmental role (RNAi, worm)</h3>
+<ul>
+<li><a href="https://pubmed.ncbi.nlm.nih.gov/12794069" title="PHB proteins are essential during embryonic development and are required for somatic and germline differentiation in the larval gonad">PMID:12794069</a> — source of the WormBase IMP annotations: embryo development ending in birth/egg hatching (GO:0009792), gonad development (GO:0008406), spermatogenesis (GO:0007283), oogenesis (GO:0048477).</li>
+<li><a href="https://pubmed.ncbi.nlm.nih.gov/12794069" title="a deficiency in PHB proteins results in altered mitochondrial biogenesis in body wall muscle cells">PMID:12794069</a> — source of mitochondrion organization (GO:0007005) IMP.</li>
+<li>Additional WormBase IMP behavioural/growth phenotypes scored from full text (not in abstract): defecation (GO:0030421), regulation of nematode pharyngeal pumping (GO:0043051), positive regulation of multicellular organism growth (GO:0040018), regulation of oxidative phosphorylation (GO:0002082), response to oxidative stress (GO:0006979). These are pleiotropic downstream consequences of depleting an essential mitochondrial complex, not dedicated molecular functions.</li>
+</ul>
+<h3 id="context-dependent-modulator-of-ageing-metabolism">Context-dependent modulator of ageing / metabolism</h3>
+<ul>
+<li><a href="https://pubmed.ncbi.nlm.nih.gov/19812672" title="the mitochondrial prohibitin complex promotes longevity by modulating mitochondrial function and fat metabolism in the nematode Caenorhabditis elegans">PMID:19812672</a>.</li>
+<li><a href="https://pubmed.ncbi.nlm.nih.gov/19812672" title="prohibitin deficiency shortens the lifespan of otherwise wild-type animals">PMID:19812672</a> but <a href="https://pubmed.ncbi.nlm.nih.gov/19812672" title="knockdown of prohibitin promotes longevity in diapause mutants or under conditions of dietary restriction">PMID:19812672</a> and <a href="https://pubmed.ncbi.nlm.nih.gov/19812672" title="prohibitin deficiency extends the lifespan of animals with compromised mitochondrial function or fat metabolism">PMID:19812672</a>.</li>
+<li><a href="https://pubmed.ncbi.nlm.nih.gov/19812672" title="Depletion of prohibitin influences ATP levels, animal fat content and mitochondrial proliferation in a genetic-background- and age-specific manner">PMID:19812672</a>.</li>
+<li>Metabolome study frames the complex as a "context-dependent modulator of longevity" (PMID:26092086, title).</li>
+</ul>
+<h3 id="phb-2-specific-role-inner-membrane-mitophagy-receptor-distinguishes-phb-2-from-phb-1">phb-2-SPECIFIC role: inner-membrane mitophagy receptor (distinguishes phb-2 from phb-1)</h3>
+<p>This is the key functional distinction from phb-1.<br />
+- <a href="https://pubmed.ncbi.nlm.nih.gov/28017329" title="we identify the inner mitochondrial membrane protein, prohibitin 2 (PHB2), as a crucial mitophagy receptor involved in targeting mitochondria for autophagic degradation">PMID:28017329</a>.<br />
+- <a href="https://pubmed.ncbi.nlm.nih.gov/28017329" title="PHB2 binds the autophagosomal membrane-associated protein LC3 through an LC3-interaction region (LIR) domain upon mitochondrial depolarization and proteasome-dependent outer membrane rupture">PMID:28017329</a>.<br />
+- Direct/indirect binding asymmetry: <a href="https://pubmed.ncbi.nlm.nih.gov/28017329" title="PHB2 interacts directly with LC3-II, whereas PHB1 interacts indirectly with LC3-II as a result of being part of a heterodimeric complex with PHB2">PMID:28017329</a>. LIR mapped to aa 121-124 (YQRL) in human PHB2; this is a PHB2-specific determinant, since the equivalent PHB1 residue does not bind LC3.<br />
+- Worm in-vivo requirement (IDA, GO:0000423 mitophagy, PMID:28017329): <a href="https://pubmed.ncbi.nlm.nih.gov/28017329" title="paternal inactivation of phb-2 impaired sperm-derived mitochondrial degradation in a manner similar to maternal inactivation of atg-7, a core autophagy gene previously reported to be essential for paternal mitochondrial elimination">PMID:28017329</a> and <a href="https://pubmed.ncbi.nlm.nih.gov/28017329" title="Thus, sperm-derived phb-2 is essential for the proper degradation of paternal mitochondria">PMID:28017329</a>.<br />
+- Framed as conserved: <a href="https://pubmed.ncbi.nlm.nih.gov/28017329" title="PHB2 is required for Parkin-induced mitophagy in mammalian cells and for the clearance of paternal mitochondria after embryonic fertilization in C. elegans">PMID:28017329</a>.<br />
+- NOTE on granularity: the LC3-LIR direct-binding biochemistry was done on the human ortholog; the worm evidence is genetic (paternal phb-2 RNAi blocks sperm-mitochondria clearance). The molecular-function term GO:0140580 (mitochondrion autophagosome adaptor activity) captures this receptor/adaptor role and is a reasonable core MF for phb-2, with the caveat that the direct LC3 binding is inferred from the conserved mammalian ortholog.</p>
+<h3 id="drug-resistance-mitochondrial-localization-secondary">Drug resistance / mitochondrial localization (secondary)</h3>
+<ul>
+<li>PMID:20089839: missense mutations in phb-2 (ad2154, ad2155dm) confer resistance to multiple drugs (hemiasterlin etc.) via a ROS-sensitive mechanism. Localization statement: <a href="https://pubmed.ncbi.nlm.nih.gov/20089839" title="C. elegans prohibitin-2 (PHB-2), a protein localized to the inner mitochondrial membrane">PMID:20089839</a>. GOA uses this paper as an ISS mitochondrion localization reference.</li>
+<li>PMID:20188671 (HAF-1 mitochondrial UPR paper): the abstract does not mention phb-2; the GOA GO:0005739 mitochondrion HDA annotation is a high-throughput mitochondrial-proteome detection (phb-2 present in isolated mitochondria). Localization is correct but this is a proteome-scale dataset, not a phb-2-focused study.</li>
+</ul>
+<h2 id="not-known-knowledge-gaps">NOT known / knowledge gaps</h2>
+<ol>
+<li><strong>Molecular mechanism of the PHB ring is unresolved</strong> (shared with phb-1). Chaperone/holdase vs membrane/lipid scaffold vs proteostasis regulator (m-AAA protease). <a href="https://pubmed.ncbi.nlm.nih.gov/26092086" title="the true function of the mitochondrial prohibitin complex remains elusive">PMID:26092086</a>; proposed roles: <a href="https://pubmed.ncbi.nlm.nih.gov/26092086" title="a membrane-bound chaperone, which holds and stabilizes newly synthesised mitochondrial-encoded proteins">PMID:26092086</a> and <a href="https://pubmed.ncbi.nlm.nih.gov/26092086" title="as scaffold proteins that recruit membrane proteins to a specific lipid environment">PMID:26092086</a>. Ontology gap: no GO MF term for "structural subunit of the prohibitin ring". Documented in phb-1 review too.</li>
+<li><strong>How mitophagy-receptor activity is integrated with the structural/scaffold role of the same protein.</strong> PHB2 is simultaneously an obligate structural ring subunit AND the LC3-binding mitophagy receptor. In mammals the LIR mutation abrogates mitophagy without disturbing the other mitochondrial (cristae/OPA1/proliferation) functions (<a href="https://pubmed.ncbi.nlm.nih.gov/28017329" title="the PHB2 LIR mutation does not affect previously described mitochondrial processes controlled by prohibitins, but does abrogate the ability of PHB2 to mediate mitophagy">PMID:28017329</a>) — i.e. separable activities — but whether the worm phb-2 LIR is used the same way in vivo, and how OMM rupture exposes the IMM receptor, remain to be dissected in worm.</li>
+<li><strong>Context-dependent longevity paradox</strong> (shared with phb-1): the same complex reduction shortens WT lifespan yet extends it in daf-2/DR/mito-mutant backgrounds; the metabolic node is undefined.</li>
+</ol>
+<h2 id="go-annotation-review-plan-37-goa-annotations">GO annotation review plan (37 GOA annotations)</h2>
+<ul>
+<li>Complex membership GO:0035632 (IDA/IPI) → ACCEPT (core; defining annotation).</li>
+<li>Inner membrane GO:0005743 (IDA/EXP/IEA) → ACCEPT (core localization).</li>
+<li>Mitochondrion GO:0005739 (IBA/IEA/HDA/ISS) → KEEP_AS_NON_CORE (correct but less specific).</li>
+<li>Mitochondrial membrane GO:0031966 (IDA) → KEEP_AS_NON_CORE (less specific than inner membrane).</li>
+<li>Membrane GO:0016020 (IEA InterPro) → MARK_AS_OVER_ANNOTATED (over-general).</li>
+<li>Mitochondrion organization GO:0007005 (IBA/NAS/IMP) → ACCEPT (core process).</li>
+<li>Protein stabilization GO:0050821 (NAS) → ACCEPT non-core / candidate complex-level activity (proposed chaperone role).</li>
+<li>Mitophagy GO:0000423 (IDA, PMID:28017329) → ACCEPT (core, phb-2-specific).</li>
+<li>protein homodimerization activity GO:0042803 (ISS from human Q99623) → review: PHB proteins form phb-1/phb-2 HETERO-dimers; the human ISS "homodimerization" is questionable for the obligate heterodimer. MARK_AS_OVER_ANNOTATED / MODIFY toward the structural/complex role. Avoid uninformative dimerization MF.</li>
+<li>plasma membrane GO:0005886 / cell surface GO:0009986 (ISS from human Q99623) → these transfer human PHB2 cell-surface/plasma-membrane annotations. No worm evidence; the worm protein is an IMM protein. MARK_AS_OVER_ANNOTATED (ISS transfer of a mammalian moonlighting localization not established in worm).</li>
+<li>Pleiotropic developmental/behavioural IMP + ARBA IEA (embryo dev, gonad dev, spermatogenesis, oogenesis, defecation, pharyngeal pumping, growth, oxphos regulation, oxidative-stress response) → KEEP_AS_NON_CORE (experimental annotations retained; downstream consequences of losing an essential complex), matching phb-1 treatment.</li>
+</ul>
+<h2 id="consistency-with-phb-1-pr-1684-branch-originclaudeworm-phb-1-review">Consistency with phb-1 (PR #1684, branch origin/claude/worm-phb-1-review)</h2>
+<p>phb-1 modeled with core_functions: structural molecule activity (GO:0005198) + in_complex GO:0035632 + location GO:0005743; second core fn mitochondrion organization + protein stabilization. Same knowledge_gaps (mechanism unresolved; longevity paradox). phb-2 mirrors this but ADDS the distinctive mitophagy-receptor core function (GO:0140580 / GO:0000423), which phb-1 lacks (phb-1 binds LC3 only indirectly).</p>
+            </div>
+        </details>
+
+    </div>
+
+
+    <!-- YAML Preview Section -->
+    <div class="section">
+        <details class="yaml-preview">
+            <summary>
+                <h2 style="display: inline;">📄 View Raw YAML</h2>
+            </summary>
+            <div class="yaml-content">
+                <pre><code>id: P50093
+gene_symbol: phb-2
+product_type: PROTEIN
+status: COMPLETE
+taxon:
+  id: NCBITaxon:6239
+  label: Caenorhabditis elegans
+description: &gt;-
+  phb-2 encodes prohibitin-2, one of the two subunits (with phb-1) of the
+  mitochondrial prohibitin (PHB) complex, a ring-shaped, high-molecular-weight
+  assembly embedded in the inner mitochondrial membrane. PHB-1 and PHB-2 are
+  mutually dependent: they bind each other to form heterodimers that oligomerize
+  into the ring, and loss of either subunit destabilizes the entire complex.
+  PHB-2 is a single-pass type II inner-membrane protein of the SPFH/Band-7
+  (stomatin/prohibitin) superfamily, with most of the protein, including its
+  Band-7/PHB domain and C-terminal coiled coil, exposed on the intermembrane-space
+  side. The complex is proposed to act as a membrane-bound chaperone/holdase that
+  holds and stabilizes newly synthesized mitochondrial-encoded respiratory-chain
+  proteins and/or as a scaffold that organizes inner-membrane proteins and lipids
+  (cardiolipin/phosphatidylethanolamine) within a defined microdomain. Distinct
+  from phb-1, PHB-2 additionally serves as an inner-membrane mitophagy receptor:
+  upon mitochondrial depolarization and proteasome-dependent rupture of the outer
+  membrane, PHB-2 directly binds the autophagosomal ATG8/LC3 protein through an
+  LC3-interacting region (LIR), linking damaged mitochondria to the autophagy
+  machinery. In C. elegans the PHB complex is essential: depletion blocks
+  embryonic development, disrupts somatic and germline differentiation of the
+  gonad, and alters mitochondrial biogenesis in body-wall muscle; the mitophagy
+  receptor activity of phb-2 is specifically required for the clearance of
+  paternal (sperm-derived) mitochondria after fertilization, ensuring maternal
+  mitochondrial inheritance. Beyond these roles the prohibitin complex is a
+  context-dependent modulator of ageing that couples mitochondrial metabolism and
+  fat utilization to insulin/IGF (daf-2) and dietary-restriction signalling.
+existing_annotations:
+- term:
+    id: GO:0005739
+    label: mitochondrion
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: is_active_in
+  review:
+    summary: &gt;-
+      Correct but general mitochondrial localization inferred phylogenetically.
+      The specific inner-membrane and prohibitin-complex localizations are
+      experimentally supported and separately annotated, so this broad term is
+      retained as non-core.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      phb-2 is a bona fide mitochondrial protein, so the term is not wrong, but
+      GO:0005743 (mitochondrial inner membrane) and GO:0035632 (mitochondrial
+      prohibitin complex) are the informative, experimentally supported
+      localizations for this subunit.
+- term:
+    id: GO:0007005
+    label: mitochondrion organization
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Phylogenetic inference that phb-2 acts in mitochondrion organization,
+      corroborated by experimental (IMP) and author-statement (NAS) annotations
+      for the same term. A core process for this gene.
+    action: ACCEPT
+    reason: &gt;-
+      Consistent with the experimentally demonstrated requirement of the PHB
+      complex for normal mitochondrial biogenesis/organization.
+    supported_by:
+    - reference_id: PMID:12794069
+      supporting_text: &gt;-
+        a deficiency in PHB proteins results in altered mitochondrial biogenesis
+        in body wall muscle cells
+      reference_section_type: ABSTRACT
+- term:
+    id: GO:0002082
+    label: regulation of oxidative phosphorylation
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000117
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Electronic (ARBA) annotation that mirrors the experimental WB IMP annotation
+      to the same term. Biologically defensible given the conserved role of
+      prohibitins in stabilizing respiratory-chain subunits, but it is a downstream
+      consequence of complex loss rather than a dedicated phb-2 activity.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      Redundant electronic echo of the experimental IMP annotation (PMID:12794069);
+      effect on oxidative phosphorylation is an indirect consequence of losing an
+      essential inner-membrane complex, so it is non-core.
+- term:
+    id: GO:0005739
+    label: mitochondrion
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000117
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      Electronic (ARBA) mitochondrial localization, redundant with the more
+      specific and experimentally supported inner-membrane/complex annotations.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      Correct but general; the informative localizations GO:0005743 and GO:0035632
+      are experimentally established and separately annotated.
+- term:
+    id: GO:0005743
+    label: mitochondrial inner membrane
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000044
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      Electronic subcellular-location mapping to the mitochondrial inner membrane,
+      independently confirmed by experimental IDA/EXP evidence. This is the correct,
+      core localization of the PHB complex.
+    action: ACCEPT
+    reason: &gt;-
+      The inner-membrane localization is experimentally established and matches the
+      UniProt SUBCELLULAR LOCATION for phb-2.
+    supported_by:
+    - reference_id: PMID:12794069
+      supporting_text: &gt;-
+        prohibitins in C. elegans form a high molecular weight complex in the
+        mitochondrial inner membrane similar to that of yeast and humans
+      reference_section_type: ABSTRACT
+- term:
+    id: GO:0006979
+    label: response to oxidative stress
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000117
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Electronic (ARBA) annotation mirroring the WB IMP annotation. Altered
+      oxidative-stress sensitivity is a plausible but indirect consequence of
+      impaired mitochondrial function in prohibitin-depleted animals.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      Redundant with the experimental IMP annotation (PMID:12794069); pleiotropic
+      downstream phenotype of an essential mitochondrial gene, not a core function.
+- term:
+    id: GO:0007283
+    label: spermatogenesis
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000117
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Electronic (ARBA) annotation mirroring the WB IMP germline phenotype.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      Redundant with the experimental IMP annotation (PMID:12794069); germline/
+      spermatogenesis defects are a pleiotropic consequence of depleting an
+      essential mitochondrial complex, not a dedicated phb-2 function.
+- term:
+    id: GO:0008406
+    label: gonad development
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000117
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Electronic (ARBA) annotation mirroring the WB IMP gonad phenotype.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      Redundant with the experimental IMP annotation (PMID:12794069); pleiotropic
+      developmental consequence of losing the essential PHB complex.
+- term:
+    id: GO:0009792
+    label: embryo development ending in birth or egg hatching
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000117
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Electronic (ARBA) annotation mirroring the WB IMP embryonic-lethality
+      phenotype.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      Redundant with the experimental IMP annotation (PMID:12794069); embryonic
+      arrest reflects the essentiality of the complex rather than a dedicated
+      embryogenesis function of phb-2.
+- term:
+    id: GO:0016020
+    label: membrane
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000002
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      Generic InterPro-to-GO membrane localization. Uninformative given that the
+      specific mitochondrial inner-membrane localization is experimentally
+      established.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: &gt;-
+      GO:0016020 (membrane) is an over-general parent; the informative and correct
+      localization GO:0005743 (mitochondrial inner membrane) is already annotated.
+- term:
+    id: GO:0030421
+    label: defecation
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000117
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Electronic (ARBA) annotation mirroring the WB IMP behavioural phenotype.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      Redundant with the experimental IMP annotation (PMID:12794069); altered
+      defecation is a pleiotropic behavioural consequence of mitochondrial
+      dysfunction, not a core molecular role.
+- term:
+    id: GO:0040018
+    label: positive regulation of multicellular organism growth
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000117
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Electronic (ARBA) annotation mirroring the WB IMP body-size/growth
+      phenotype.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      Redundant with the experimental IMP annotation (PMID:12794069); reduced
+      growth on prohibitin depletion is a systemic consequence of impaired
+      mitochondrial function, not a dedicated function.
+- term:
+    id: GO:0043051
+    label: regulation of nematode pharyngeal pumping
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000117
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Electronic (ARBA) annotation mirroring the WB IMP behavioural phenotype.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      Redundant with the experimental IMP annotation (PMID:12794069); pharyngeal
+      pumping change is a pleiotropic behavioural consequence, not a core function.
+- term:
+    id: GO:0048477
+    label: oogenesis
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000117
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Electronic (ARBA) annotation mirroring the WB IMP germline phenotype.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      Redundant with the experimental IMP annotation (PMID:12794069); oogenesis
+      defects are a pleiotropic consequence of losing the essential PHB complex.
+- term:
+    id: GO:0005743
+    label: mitochondrial inner membrane
+  evidence_type: IDA
+  original_reference_id: PMID:26092086
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      Direct experimental evidence (ComplexPortal curation) that the PHB complex,
+      of which phb-2 is a subunit, resides in the mitochondrial inner membrane.
+      Core localization.
+    action: ACCEPT
+    reason: &gt;-
+      Established inner-membrane localization; the heterodimer assembles into a
+      ring embedded in the inner mitochondrial membrane.
+    supported_by:
+    - reference_id: PMID:26092086
+      supporting_text: &gt;-
+        which bind to each other to form a heterodimer that is assembled into a
+        ring-like macromolecular structure at the inner mitochondrial membrane
+      reference_section_type: INTRODUCTION
+- term:
+    id: GO:0007005
+    label: mitochondrion organization
+  evidence_type: NAS
+  original_reference_id: PMID:26092086
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Author-stated involvement of the PHB complex in mitochondrion organization,
+      consistent with the experimental IMP annotation. Core process.
+    action: ACCEPT
+    reason: &gt;-
+      Prohibitin depletion perturbs mitochondrial biogenesis/organization; a
+      well-supported core role.
+    supported_by:
+    - reference_id: PMID:12794069
+      supporting_text: &gt;-
+        a deficiency in PHB proteins results in altered mitochondrial biogenesis
+        in body wall muscle cells
+      reference_section_type: ABSTRACT
+- term:
+    id: GO:0035632
+    label: mitochondrial prohibitin complex
+  evidence_type: IDA
+  original_reference_id: PMID:26092086
+  qualifier: part_of
+  review:
+    summary: &gt;-
+      Direct evidence that phb-2 is part of the mitochondrial prohibitin complex.
+      This complex membership is the defining, primary core annotation for phb-2.
+    action: ACCEPT
+    reason: &gt;-
+      phb-1 and phb-2 form the obligate ring complex; membership is experimentally
+      established and the two subunits are interdependent for its formation.
+    supported_by:
+    - reference_id: PMID:26092086
+      supporting_text: &gt;-
+        These two subunits are interdependent for the formation of the complex,
+        leading the absence of one of them to the absence of the whole complex
+      reference_section_type: INTRODUCTION
+- term:
+    id: GO:0050821
+    label: protein stabilization
+  evidence_type: NAS
+  original_reference_id: PMID:26092086
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Author-stated role of the PHB complex as a membrane-bound chaperone that
+      holds and stabilizes newly synthesized mitochondrial-encoded proteins. This
+      is the closest capture of the complex&#39;s candidate molecular role, though it
+      is a proposed (largely yeast/human-derived) function rather than one
+      biochemically demonstrated in worm.
+    action: ACCEPT
+    reason: &gt;-
+      Represents the proposed complex-level chaperone/holdase activity; retained
+      as a candidate core function, with the caveat that the true molecular
+      mechanism remains debated (see knowledge_gaps).
+    supported_by:
+    - reference_id: PMID:26092086
+      supporting_text: &gt;-
+        a membrane-bound chaperone, which holds and stabilizes newly synthesised
+        mitochondrial-encoded proteins
+      reference_section_type: INTRODUCTION
+- term:
+    id: GO:0005743
+    label: mitochondrial inner membrane
+  evidence_type: EXP
+  original_reference_id: PMID:12794069
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      Direct experimental evidence that phb-2 localizes to the mitochondrial inner
+      membrane as part of the high-molecular-weight PHB complex. Core localization.
+    action: ACCEPT
+    reason: &gt;-
+      Experimentally established inner-membrane localization in C. elegans,
+      matching the UniProt SUBCELLULAR LOCATION.
+    supported_by:
+    - reference_id: PMID:12794069
+      supporting_text: &gt;-
+        prohibitins in C. elegans form a high molecular weight complex in the
+        mitochondrial inner membrane similar to that of yeast and humans
+      reference_section_type: ABSTRACT
+- term:
+    id: GO:0042803
+    label: protein homodimerization activity
+  evidence_type: ISS
+  original_reference_id: GO_REF:0000024
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Electronic ISS transfer from human PHB2 (UniProtKB:Q99623) of a
+      &#34;homodimerization&#34; molecular function. This does not capture the biology of
+      the worm protein: prohibitin-2 forms an obligate HETERODIMER with prohibitin-1
+      that oligomerizes into the ring, and the two subunits are interdependent.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: &gt;-
+      The informative molecular role of phb-2 is as a structural constituent of the
+      heterodimeric prohibitin ring (captured in core_functions via GO:0005198 and
+      GO:0035632), not homodimerization; the ISS &#34;homodimerization activity&#34;
+      transfer is uninformative/over-annotated for this obligate heterodimer.
+    supported_by:
+    - reference_id: PMID:26092086
+      supporting_text: &gt;-
+        These two subunits are interdependent for the formation of the complex,
+        leading the absence of one of them to the absence of the whole complex
+      reference_section_type: INTRODUCTION
+- term:
+    id: GO:0000423
+    label: mitophagy
+  evidence_type: IDA
+  original_reference_id: PMID:28017329
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Direct experimental evidence that phb-2 is required for mitophagy: paternal
+      RNAi knockdown of phb-2 blocks the autophagic clearance of sperm-derived
+      mitochondria after fertilization in C. elegans. This receptor role, mediated
+      by direct binding of PHB2 to the autophagosomal ATG8/LC3 protein via a LIR
+      motif, is a phb-2-specific core function that distinguishes it from phb-1
+      (which binds LC3 only indirectly through the heterodimer).
+    action: ACCEPT
+    reason: &gt;-
+      Experimentally demonstrated in worm (paternal-mitochondria clearance assay)
+      and mechanistically established for the conserved ortholog; a defining
+      phb-2-specific core function.
+    supported_by:
+    - reference_id: PMID:28017329
+      supporting_text: &gt;-
+        Thus, sperm-derived phb-2 is essential for the proper degradation of
+        paternal mitochondria
+      reference_section_type: RESULTS
+    - reference_id: PMID:28017329
+      supporting_text: &gt;-
+        we identify the inner mitochondrial membrane protein, prohibitin 2 (PHB2),
+        as a crucial mitophagy receptor involved in targeting mitochondria for
+        autophagic degradation
+      reference_section_type: ABSTRACT
+- term:
+    id: GO:0005886
+    label: plasma membrane
+  evidence_type: ISS
+  original_reference_id: GO_REF:0000024
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      Electronic ISS transfer from human PHB2 (UniProtKB:Q99623) of a plasma-membrane
+      localization. Mammalian prohibitin-2 has documented moonlighting cell-surface/
+      plasma-membrane pools, but there is no evidence for such localization of the
+      worm protein, which is a single-pass type II inner mitochondrial membrane
+      protein.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: &gt;-
+      Unsupported ISS transfer of a mammalian moonlighting localization not
+      established in C. elegans; the worm protein is an inner-mitochondrial-membrane
+      protein and this term is misleading here.
+    supported_by:
+    - reference_id: PMID:20089839
+      supporting_text: &gt;-
+        C. elegans prohibitin-2 (PHB-2), a protein localized to the inner
+        mitochondrial membrane
+      reference_section_type: INTRODUCTION
+- term:
+    id: GO:0009986
+    label: cell surface
+  evidence_type: ISS
+  original_reference_id: GO_REF:0000024
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      Electronic ISS transfer from human PHB2 (UniProtKB:Q99623) of a cell-surface
+      localization. As for the plasma-membrane term, this reflects a mammalian
+      moonlighting pool and is not supported for the worm inner-membrane protein.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: &gt;-
+      Unsupported ISS transfer of a mammalian moonlighting localization not
+      established in C. elegans; misleading for an inner-mitochondrial-membrane
+      protein.
+    supported_by:
+    - reference_id: PMID:20089839
+      supporting_text: &gt;-
+        C. elegans prohibitin-2 (PHB-2), a protein localized to the inner
+        mitochondrial membrane
+      reference_section_type: INTRODUCTION
+- term:
+    id: GO:0005739
+    label: mitochondrion
+  evidence_type: HDA
+  original_reference_id: PMID:20188671
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      High-throughput (mitochondrial proteome) detection of phb-2 in mitochondria.
+      Correct but general; the specific inner-membrane/complex localizations are
+      experimentally supported and separately annotated.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      Correct organelle localization from a proteome-scale dataset; superseded in
+      informativeness by the IDA/EXP inner-membrane and prohibitin-complex
+      annotations.
+- term:
+    id: GO:0005739
+    label: mitochondrion
+  evidence_type: ISS
+  original_reference_id: PMID:20089839
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      Sequence-similarity mitochondrial localization associated with the paper that
+      identified a drug-resistance-conferring phb-2 missense allele and describes
+      PHB-2 as an inner-mitochondrial-membrane protein. Correct but general.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      Correct organelle localization; less informative than the experimentally
+      supported inner-membrane/complex terms.
+    supported_by:
+    - reference_id: PMID:20089839
+      supporting_text: &gt;-
+        C. elegans prohibitin-2 (PHB-2), a protein localized to the inner
+        mitochondrial membrane
+      reference_section_type: INTRODUCTION
+- term:
+    id: GO:0035632
+    label: mitochondrial prohibitin complex
+  evidence_type: IPI
+  original_reference_id: PMID:19812672
+  qualifier: part_of
+  review:
+    summary: &gt;-
+      Physical-interaction evidence (with phb-1, WB:WBGene00004014) that phb-2 is
+      part of the mitochondrial prohibitin complex. Direct support for the obligate
+      phb-1/phb-2 partnership.
+    action: ACCEPT
+    reason: &gt;-
+      Confirms the direct phb-1/phb-2 interaction that constitutes the ring
+      complex; a defining core annotation.
+    supported_by:
+    - reference_id: PMID:19812672
+      supporting_text: &gt;-
+        form a ring-like, high-molecular-mass complex at the inner membrane of
+        mitochondria
+      reference_section_type: ABSTRACT
+- term:
+    id: GO:0002082
+    label: regulation of oxidative phosphorylation
+  evidence_type: IMP
+  original_reference_id: PMID:12794069
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Experimental (RNAi) evidence linking prohibitin depletion to altered
+      oxidative phosphorylation, consistent with the conserved role of the complex
+      in stabilizing respiratory-chain subunits. An indirect, non-core consequence
+      of losing the essential complex.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      Full-text-based experimental annotation (retained, not removed); effect on
+      oxidative phosphorylation reflects downstream respiratory-chain destabilization
+      rather than a dedicated regulatory activity of phb-2.
+- term:
+    id: GO:0006979
+    label: response to oxidative stress
+  evidence_type: IMP
+  original_reference_id: PMID:12794069
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Experimental (RNAi) evidence of altered oxidative-stress response upon
+      prohibitin depletion. Pleiotropic consequence of mitochondrial dysfunction.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      Retained as an experimental annotation; oxidative-stress phenotype is an
+      indirect consequence of impaired mitochondrial function, not a core role.
+- term:
+    id: GO:0007005
+    label: mitochondrion organization
+  evidence_type: IMP
+  original_reference_id: PMID:12794069
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Experimental (RNAi) evidence that prohibitin depletion alters mitochondrial
+      biogenesis/organization in body-wall muscle. Core process for phb-2.
+    action: ACCEPT
+    reason: &gt;-
+      Directly supported by the observed mitochondrial-biogenesis defect; a core
+      function of the complex.
+    supported_by:
+    - reference_id: PMID:12794069
+      supporting_text: &gt;-
+        a deficiency in PHB proteins results in altered mitochondrial biogenesis
+        in body wall muscle cells
+      reference_section_type: ABSTRACT
+- term:
+    id: GO:0007283
+    label: spermatogenesis
+  evidence_type: IMP
+  original_reference_id: PMID:12794069
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Experimental (RNAi) germline phenotype. Pleiotropic developmental
+      consequence of depleting the essential PHB complex.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      Retained as an experimental annotation; germline/spermatogenesis defects
+      follow from loss of an essential mitochondrial complex during germline
+      differentiation rather than a dedicated spermatogenesis function.
+    supported_by:
+    - reference_id: PMID:12794069
+      supporting_text: &gt;-
+        PHB proteins are essential during embryonic development and are required
+        for somatic and germline differentiation in the larval gonad
+      reference_section_type: ABSTRACT
+- term:
+    id: GO:0008406
+    label: gonad development
+  evidence_type: IMP
+  original_reference_id: PMID:12794069
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Experimental (RNAi) evidence of somatic and germline gonad differentiation
+      defects. Pleiotropic developmental consequence.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      Retained as an experimental annotation; gonad-development defect reflects the
+      essentiality of the complex in dividing/differentiating tissue, not a
+      dedicated gonadogenesis function.
+    supported_by:
+    - reference_id: PMID:12794069
+      supporting_text: &gt;-
+        PHB proteins are essential during embryonic development and are required
+        for somatic and germline differentiation in the larval gonad
+      reference_section_type: ABSTRACT
+- term:
+    id: GO:0009792
+    label: embryo development ending in birth or egg hatching
+  evidence_type: IMP
+  original_reference_id: PMID:12794069
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Experimental (RNAi) embryonic-lethality phenotype. Reflects essentiality of
+      the PHB complex.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      Retained as an experimental annotation; embryonic arrest is a consequence of
+      the complex being essential rather than a dedicated embryogenesis function
+      of phb-2.
+    supported_by:
+    - reference_id: PMID:12794069
+      supporting_text: &gt;-
+        PHB proteins are essential during embryonic development and are required
+        for somatic and germline differentiation in the larval gonad
+      reference_section_type: ABSTRACT
+- term:
+    id: GO:0030421
+    label: defecation
+  evidence_type: IMP
+  original_reference_id: PMID:12794069
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Experimental (RNAi) behavioural phenotype scored by WormBase curators from
+      the full text. Pleiotropic consequence of mitochondrial dysfunction.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      Retained as an experimental annotation (curators read the full text); altered
+      defecation is a pleiotropic behavioural readout, not a core molecular role.
+- term:
+    id: GO:0031966
+    label: mitochondrial membrane
+  evidence_type: IDA
+  original_reference_id: PMID:12794069
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      Direct experimental evidence of mitochondrial-membrane localization. Correct
+      but less specific than the separately annotated mitochondrial inner membrane,
+      so retained as non-core.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      The localization is correct; GO:0005743 (mitochondrial inner membrane) is the
+      more precise term and is also annotated, so this broader term is retained but
+      non-core.
+    supported_by:
+    - reference_id: PMID:12794069
+      supporting_text: &gt;-
+        prohibitins in C. elegans form a high molecular weight complex in the
+        mitochondrial inner membrane similar to that of yeast and humans
+      reference_section_type: ABSTRACT
+- term:
+    id: GO:0040018
+    label: positive regulation of multicellular organism growth
+  evidence_type: IMP
+  original_reference_id: PMID:12794069
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Experimental (RNAi) body-size/growth phenotype. Systemic consequence of
+      impaired mitochondrial function.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      Retained as an experimental annotation; reduced growth on depletion is a
+      systemic consequence of mitochondrial dysfunction rather than a dedicated
+      growth-promoting activity.
+- term:
+    id: GO:0043051
+    label: regulation of nematode pharyngeal pumping
+  evidence_type: IMP
+  original_reference_id: PMID:12794069
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Experimental (RNAi) behavioural phenotype. Pleiotropic consequence of
+      mitochondrial dysfunction.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      Retained as an experimental annotation; pharyngeal-pumping change is a
+      pleiotropic behavioural readout, not a core molecular role.
+- term:
+    id: GO:0048477
+    label: oogenesis
+  evidence_type: IMP
+  original_reference_id: PMID:12794069
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Experimental (RNAi) germline phenotype. Pleiotropic developmental
+      consequence of depleting the essential PHB complex.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      Retained as an experimental annotation; oogenesis defects follow from loss of
+      an essential mitochondrial complex during germline differentiation.
+    supported_by:
+    - reference_id: PMID:12794069
+      supporting_text: &gt;-
+        PHB proteins are essential during embryonic development and are required
+        for somatic and germline differentiation in the larval gonad
+      reference_section_type: ABSTRACT
+core_functions:
+- description: &gt;-
+    phb-2 is a structural constituent of the mitochondrial prohibitin ring
+    complex. It has no known independent catalytic activity; instead its function
+    is to be an obligate subunit that, together with phb-1, assembles into the
+    ring-shaped, high-molecular-weight PHB complex embedded in the mitochondrial
+    inner membrane. The two subunits are interdependent, so phb-2 is required for
+    the existence of the complex itself.
+  molecular_function:
+    id: GO:0005198
+    label: structural molecule activity
+  locations:
+  - id: GO:0005743
+    label: mitochondrial inner membrane
+  in_complex:
+    id: GO:0035632
+    label: mitochondrial prohibitin complex
+  supported_by:
+  - reference_id: PMID:26092086
+    supporting_text: &gt;-
+      which bind to each other to form a heterodimer that is assembled into a
+      ring-like macromolecular structure at the inner mitochondrial membrane
+    reference_section_type: INTRODUCTION
+  - reference_id: PMID:26092086
+    supporting_text: &gt;-
+      These two subunits are interdependent for the formation of the complex,
+      leading the absence of one of them to the absence of the whole complex
+    reference_section_type: INTRODUCTION
+- description: &gt;-
+    Distinct from phb-1, phb-2 acts as an inner-membrane mitophagy receptor. Upon
+    mitochondrial depolarization and proteasome-dependent rupture of the outer
+    membrane, the intermembrane-space-exposed phb-2 directly binds the
+    autophagosomal ATG8/LC3 protein through an LC3-interacting region, bringing the
+    inner mitochondrial membrane and the autophagosome membrane together to target
+    damaged/unwanted mitochondria for autophagic degradation. In C. elegans this
+    receptor activity is required for the clearance of paternal (sperm-derived)
+    mitochondria after fertilization. (The direct LC3-LIR biochemistry was
+    established for the conserved ortholog; the worm requirement is demonstrated
+    genetically via paternal phb-2 RNAi.)
+  molecular_function:
+    id: GO:0140580
+    label: mitochondrion autophagosome adaptor activity
+  directly_involved_in:
+  - id: GO:0000423
+    label: mitophagy
+  locations:
+  - id: GO:0005743
+    label: mitochondrial inner membrane
+  in_complex:
+    id: GO:0035632
+    label: mitochondrial prohibitin complex
+  supported_by:
+  - reference_id: PMID:28017329
+    supporting_text: &gt;-
+      PHB2 binds the autophagosomal membrane-associated protein LC3 through an
+      LC3-interaction region (LIR) domain upon mitochondrial depolarization and
+      proteasome-dependent outer membrane rupture
+    reference_section_type: ABSTRACT
+  - reference_id: PMID:28017329
+    supporting_text: &gt;-
+      Thus, sperm-derived phb-2 is essential for the proper degradation of
+      paternal mitochondria
+    reference_section_type: RESULTS
+- description: &gt;-
+    As part of the mitochondrial prohibitin complex, phb-2 contributes to
+    organization of the mitochondrial inner membrane and to stabilization of newly
+    synthesized mitochondrial-encoded proteins (a proposed membrane-bound
+    chaperone/holdase and lipid/protein scaffold role), and thereby to
+    mitochondrial biogenesis and function. Through this activity the complex acts
+    as a context-dependent modulator of mitochondrial metabolism, fat utilization,
+    and adult lifespan.
+  directly_involved_in:
+  - id: GO:0007005
+    label: mitochondrion organization
+  - id: GO:0050821
+    label: protein stabilization
+  locations:
+  - id: GO:0005743
+    label: mitochondrial inner membrane
+  in_complex:
+    id: GO:0035632
+    label: mitochondrial prohibitin complex
+  supported_by:
+  - reference_id: PMID:12794069
+    supporting_text: &gt;-
+      a deficiency in PHB proteins results in altered mitochondrial biogenesis in
+      body wall muscle cells
+    reference_section_type: ABSTRACT
+  - reference_id: PMID:26092086
+    supporting_text: &gt;-
+      a membrane-bound chaperone, which holds and stabilizes newly synthesised
+      mitochondrial-encoded proteins
+    reference_section_type: INTRODUCTION
+  - reference_id: PMID:19812672
+    supporting_text: &gt;-
+      the mitochondrial prohibitin complex promotes longevity by modulating
+      mitochondrial function and fat metabolism
+    reference_section_type: ABSTRACT
+knowledge_gaps:
+- gap_statement: &gt;-
+    The molecular mechanism of the mitochondrial prohibitin complex is unresolved.
+    It is not established whether the complex acts primarily as a membrane-bound
+    chaperone/holdase for newly synthesized mitochondrial-encoded proteins, as a
+    scaffold that organizes inner-membrane proteins within a defined
+    (cardiolipin/phospholipid) microdomain, or as a regulator of inner-membrane
+    proteostasis (e.g. of the m-AAA protease); nor is the direct molecular activity
+    of phb-2 as a ring subunit expressible as a specific GO molecular function.
+  boundary: &gt;-
+    It is firmly established that phb-1 and phb-2 bind each other and assemble into
+    a ring-like, high-molecular-weight complex in the mitochondrial inner membrane,
+    that the two subunits are interdependent (loss of one abolishes the complex),
+    and that depletion is embryonic-lethal, disrupts gonad/germline differentiation,
+    and alters mitochondrial biogenesis. What is NOT established is the biochemical
+    mechanism by which the complex produces these effects.
+  gap_kind:
+  - BIOLOGY
+  - ONTOLOGY
+  dark_aspect: MF_DARK
+  status: OPEN
+  significance: &gt;-
+    Prohibitins are ubiquitous and essential across eukaryotes; resolving whether
+    the complex is fundamentally a chaperone, a membrane scaffold, or a
+    lipid/proteostasis organizer would explain a large body of pleiotropic
+    phenotypes and the conserved link between mitochondrial membrane organization
+    and ageing. The absence of a GO molecular-function term for a structural ring
+    subunit is why the gene reads as MF-dark despite rich process/localization
+    annotation.
+  resolution: &gt;-
+    In vitro reconstitution / structural work on the worm (or conserved) PHB ring
+    to test holdase vs scaffold activity; lipidomic and proximity-labeling mapping
+    of the inner-membrane microdomain the complex organizes; separation-of-function
+    alleles that uncouple candidate activities. In parallel, an ontology term for
+    the structural/scaffolding molecular activity of a prohibitin-type ring subunit.
+  provenance:
+  - reference_id: PMID:26092086
+    supporting_text: &gt;-
+      the true function of the mitochondrial prohibitin complex remains elusive
+    reference_section_type: ABSTRACT
+  - reference_id: PMID:26092086
+    supporting_text: &gt;-
+      as scaffold proteins that recruit membrane proteins to a specific lipid
+      environment
+    reference_section_type: INTRODUCTION
+  proposed_terms:
+  - proposed_name: prohibitin complex structural constituent activity
+    proposed_definition: &gt;-
+      A structural molecule activity of a prohibitin-family (SPFH/Band-7) protein by
+      which it acts as an obligate subunit of the ring-shaped mitochondrial
+      prohibitin complex, contributing to the assembly and integrity of a
+      membrane-bound scaffold/holdase in the inner mitochondrial membrane, without
+      itself catalyzing a known biochemical reaction.
+    justification: &gt;-
+      phb-1/phb-2 and their orthologs have no adequate GO molecular-function term
+      for their role as structural ring subunits and inner-membrane scaffolds. They
+      are currently annotatable only at the complex/process level or with the
+      generic &#39;structural molecule activity&#39;, leaving the gene MF-dark despite a
+      well-defined cellular role.
+    proposed_parent:
+      id: GO:0005198
+      label: structural molecule activity
+- gap_statement: &gt;-
+    How phb-2&#39;s mitophagy-receptor activity is molecularly integrated with, and
+    separated from, its obligate structural role in the same protein is not
+    resolved in C. elegans. It is unknown whether the worm phb-2 uses a defined
+    LC3/LGG-family LIR motif in vivo (as shown for the mammalian ortholog), how
+    outer-membrane rupture exposes the inner-membrane receptor to the cytosol in
+    the physiological setting of paternal-mitochondria clearance, and which
+    autophagy pathway (Parkin-independent) acts with phb-2 in the worm.
+  boundary: &gt;-
+    It is established that phb-2 is required for autophagic clearance of paternal
+    mitochondria in worm (paternal phb-2 RNAi phenocopies atg-7 loss), that the
+    mammalian ortholog binds LC3-II directly through a LIR while PHB1 binds only
+    indirectly, and that a LIR point mutation abolishes mitophagy without disturbing
+    the other prohibitin-dependent mitochondrial functions (i.e. the receptor and
+    structural activities are separable in mammalian cells). What is NOT established
+    is the in-vivo worm mechanism, its LGG-1/LGG-2 partner usage, and how the two
+    activities of a single obligate subunit are coordinated.
+  gap_kind:
+  - BIOLOGY
+  dark_aspect: RESIDUAL_SUBGAP
+  status: OPEN
+  significance: &gt;-
+    PHB2 is the founding inner-mitochondrial-membrane mitophagy receptor, and
+    paternal-mitochondria elimination in C. elegans is a premier in-vivo model of
+    developmental mitophagy and uniparental mtDNA inheritance. Dissecting how one
+    obligate structural subunit doubles as a receptor would clarify a conserved,
+    Parkin-independent branch of mitophagy relevant to neurodegeneration and ageing.
+  resolution: &gt;-
+    Map and mutate the worm phb-2 LIR (LGG-1/LGG-2 binding) with separation-of-
+    function alleles; live-imaging of OMM rupture and phb-2 exposure during paternal
+    mitophagy; epistasis with the worm autophagy machinery to place phb-2 in the
+    Parkin-independent receptor pathway.
+  provenance:
+  - reference_id: PMID:28017329
+    supporting_text: &gt;-
+      PHB2 interacts directly with LC3-II, whereas PHB1 interacts indirectly with
+      LC3-II as a result of being part of a heterodimeric complex with PHB2
+    reference_section_type: RESULTS
+  - reference_id: PMID:28017329
+    supporting_text: &gt;-
+      the PHB2 LIR mutation does not affect previously described mitochondrial
+      processes controlled by prohibitins, but does abrogate the ability of PHB2 to
+      mediate mitophagy
+    reference_section_type: RESULTS
+- gap_statement: &gt;-
+    The mechanistic basis by which the SAME reduction of the prohibitin complex
+    produces OPPOSITE ageing outcomes is unknown - prohibitin deficiency shortens
+    the lifespan of otherwise wild-type animals yet extends the lifespan of
+    diapause (daf-2), dietary-restricted, and respiration/fat-metabolism-compromised
+    animals. The metabolic node at which the complex converts genetic/nutritional
+    context into opposite longevity responses is undefined.
+  boundary: &gt;-
+    The context-dependence itself is well documented (life-shortening in wild type
+    vs life-extending in daf-2/dietary-restricted/mitochondrial mutants), and
+    depletion is known to change ATP levels, fat content, mitochondrial
+    proliferation, and the whole-animal metabolome. The upstream signalling
+    (insulin/IGF) and downstream metabolic readouts are mapped, but the causal
+    molecular link through the complex is not.
+  gap_kind:
+  - BIOLOGY
+  dark_aspect: RESIDUAL_SUBGAP
+  status: OPEN
+  significance: &gt;-
+    This paradox is a clean, conserved example of how mitochondrial membrane
+    organization gates lifespan in a metabolic-state-dependent manner; resolving it
+    would connect prohibitin biology to insulin/IGF and dietary-restriction ageing
+    pathways mechanistically.
+  resolution: &gt;-
+    Epistasis and metabolic-flux analysis across the opposing backgrounds; identify
+    the prohibitin-dependent metabolic step whose perturbation flips the longevity
+    sign; test candidate mediators (fat mobilization, respiratory-chain assembly).
+  provenance:
+  - reference_id: PMID:19812672
+    supporting_text: &gt;-
+      prohibitin deficiency shortens the lifespan of otherwise wild-type animals
+    reference_section_type: ABSTRACT
+  - reference_id: PMID:19812672
+    supporting_text: &gt;-
+      knockdown of prohibitin promotes longevity in diapause mutants or under
+      conditions of dietary restriction
+    reference_section_type: ABSTRACT
+suggested_questions:
+- question: &gt;-
+    Is the worm PHB complex primarily a chaperone/holdase for nascent
+    mitochondrial-encoded proteins, a membrane/lipid scaffold, or a regulator of
+    inner-membrane proteostasis?
+- question: &gt;-
+    Does C. elegans phb-2 use a defined LGG-1/LGG-2 (LC3) LIR motif in vivo, and
+    what exposes the inner-membrane receptor during paternal-mitochondria
+    clearance?
+- question: &gt;-
+    Which prohibitin-dependent metabolic step determines whether depletion shortens
+    or extends lifespan in a given genetic/nutritional context?
+suggested_experiments:
+- description: &gt;-
+    Reconstitute or affinity-purify the worm PHB ring and test in vitro holdase/
+    chaperone activity against candidate mitochondrial-encoded substrates versus a
+    scaffold/lipid-organizing readout, to discriminate the proposed molecular roles.
+  experiment_type: biochemical reconstitution
+- description: &gt;-
+    Map and mutate the worm phb-2 LC3/LGG-family LIR with separation-of-function
+    alleles, and live-image outer-membrane rupture and phb-2 exposure during
+    paternal-mitochondria clearance, to define the in-vivo receptor mechanism.
+  experiment_type: structure-function / live imaging
+- description: &gt;-
+    Carry out epistasis and targeted metabolic-flux analysis of phb-2 depletion
+    across wild-type, daf-2, and dietary-restricted backgrounds to localize the node
+    responsible for the opposite longevity outcomes.
+  experiment_type: genetic epistasis / metabolomics
+references:
+- id: GO_REF:0000002
+  title: Gene Ontology annotation through association of InterPro records with GO
+    terms
+  findings: []
+- id: GO_REF:0000024
+  title: Manual transfer of experimentally-verified manual GO annotation data to orthologs
+    by curator judgment of sequence similarity
+  findings: []
+- id: GO_REF:0000033
+  title: Annotation inferences using phylogenetic trees
+  findings: []
+- id: GO_REF:0000044
+  title: Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location
+    vocabulary mapping, accompanied by conservative changes to GO terms applied by
+    UniProt
+  findings: []
+- id: GO_REF:0000117
+  title: Electronic Gene Ontology annotations created by ARBA machine learning models
+  findings: []
+- id: PMID:12794069
+  title: The mitochondrial prohibitin complex is essential for embryonic viability
+    and germline function in Caenorhabditis elegans.
+  findings: []
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      PubMed-verified primary paper (Artal-Sanz et al. 2003, J Biol Chem). Source of
+      the WormBase experimental (IMP/IDA/EXP) annotations. The abstract directly
+      supports inner-membrane high-molecular-weight complex formation, embryonic
+      essentiality, germline/somatic gonad differentiation defects, and altered
+      mitochondrial biogenesis; the more specific behavioural terms (defecation,
+      pharyngeal pumping) derive from the full text read by curators. Cache is
+      abstract-only.
+- id: PMID:19812672
+  title: Prohibitin couples diapause signalling to mitochondrial metabolism during
+    ageing in C. elegans.
+  findings: []
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      PubMed-verified primary paper (Artal-Sanz &amp; Tavernarakis 2009, Nature). Source
+      of the physical-interaction (IPI, with phb-1) complex annotation and of the
+      context-dependent longevity role. Abstract supports the ring-like inner-membrane
+      complex and the opposite lifespan outcomes in wild-type vs diapause/dietary-
+      restricted animals.
+- id: PMID:20089839
+  title: Mitochondrial dysfunction confers resistance to multiple drugs in Caenorhabditis
+    elegans.
+  findings: []
+  reference_review:
+    relevance: MEDIUM
+    correctness: VERIFIED
+    review_notes: &gt;-
+      PubMed-verified primary paper (Zubovych et al. 2010, Mol Biol Cell) with full
+      text in cache. Identifies drug-resistance-conferring phb-2 missense alleles and
+      explicitly describes PHB-2 as an inner-mitochondrial-membrane protein; used by
+      GOA as an ISS mitochondrion localization reference. Relevant to localization and
+      a ROS-linked stress phenotype, not to the core molecular function.
+- id: PMID:20188671
+  title: The matrix peptide exporter HAF-1 signals a mitochondrial UPR by activating
+    the transcription factor ZC376.7 in C. elegans.
+  findings: []
+  reference_review:
+    relevance: LOW
+    correctness: VERIFIED
+    review_notes: &gt;-
+      PubMed-verified paper (Haynes et al. 2010, Mol Cell); its abstract concerns
+      HAF-1/ClpP UPRmt signalling and does not mention phb-2. The associated GOA
+      annotation is a high-throughput (HDA) mitochondrial-proteome localization; phb-2
+      was detected in isolated mitochondria. Correct organelle localization, but a
+      proteome-scale dataset rather than a phb-2-focused study.
+- id: PMID:26092086
+  title: Analysis of the effect of the mitochondrial prohibitin complex, a context-dependent
+    modulator of longevity, on the C. elegans metabolome.
+  findings: []
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      PubMed-verified primary paper with full text in cache (Lourenço et al. 2015, BBA
+      Bioenergetics). Source of the ComplexPortal IDA/NAS annotations and the richest
+      verbatim source for complex architecture (heterodimeric ring, subunit
+      interdependence), the proposed chaperone/scaffold molecular roles, and the
+      explicit statement that the true function of the complex remains elusive.
+- id: PMID:28017329
+  title: Prohibitin 2 Is an Inner Mitochondrial Membrane Mitophagy Receptor.
+  findings: []
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      PubMed-verified primary paper with full text in cache (Wei et al. 2017, Cell).
+      Establishes the phb-2-specific inner-membrane mitophagy-receptor function: PHB2
+      binds LC3-II directly via a LIR (PHB1 only indirectly), the LIR is required for
+      mitophagy but not other prohibitin functions, and paternal phb-2 RNAi blocks
+      clearance of sperm-derived mitochondria in C. elegans (source of the IDA
+      mitophagy annotation).
+</code></pre>
+            </div>
+        </details>
+    </div>
+
+    <!-- Pathway Visualization Link -->
+
+
+    <style>
+        /* Markdown Section Styles */
+        .markdown-section {
+            margin-bottom: 1rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .markdown-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .markdown-section summary h3 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.1rem;
+        }
+
+        .markdown-section summary:hover h3 {
+            color: #007bff;
+        }
+
+        .markdown-section[open] {
+            background-color: #fff;
+        }
+
+        .markdown-content {
+            margin-top: 1rem;
+            padding: 1rem;
+            border-top: 1px solid #dee2e6;
+        }
+
+        /* Markdown content styling */
+        .markdown-content h1 { font-size: 1.5rem; margin-top: 1.5rem; }
+        .markdown-content h2 { font-size: 1.3rem; margin-top: 1.3rem; }
+        .markdown-content h3 { font-size: 1.1rem; margin-top: 1.1rem; }
+        .markdown-content h4 { font-size: 1rem; margin-top: 1rem; }
+
+        .markdown-content pre {
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .markdown-content code {
+            background-color: #f8f9fa;
+            padding: 0.2rem 0.4rem;
+            border-radius: 3px;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+        }
+
+        .markdown-content pre code {
+            background: none;
+            padding: 0;
+        }
+
+        .markdown-content table {
+            border-collapse: collapse;
+            width: 100%;
+            margin: 1rem 0;
+        }
+
+        .markdown-content table th,
+        .markdown-content table td {
+            border: 1px solid #dee2e6;
+            padding: 0.5rem;
+            text-align: left;
+        }
+
+        .markdown-content table th {
+            background-color: #f8f9fa;
+            font-weight: bold;
+        }
+
+        .markdown-content blockquote {
+            border-left: 4px solid #007bff;
+            padding-left: 1rem;
+            margin-left: 0;
+            color: #666;
+        }
+
+        /* YAML Preview Styles */
+        .yaml-preview {
+            margin-top: 2rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .yaml-preview summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .yaml-preview summary h2 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.3rem;
+        }
+
+        .yaml-preview summary:hover h2 {
+            color: #007bff;
+        }
+
+        .yaml-preview[open] {
+            background-color: #fff;
+        }
+
+        .yaml-content {
+            margin-top: 1rem;
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .yaml-content pre {
+            margin: 0;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+            line-height: 1.4;
+        }
+
+        .yaml-content code {
+            color: #333;
+            background: none;
+            padding: 0;
+        }
+
+        /* Pathway Link Styles */
+        .pathway-link {
+            margin: 1rem 0;
+        }
+
+        .btn-link {
+            display: inline-block;
+            padding: 0.5rem 1rem;
+            background-color: #007bff;
+            color: white !important;
+            text-decoration: none;
+            border-radius: 4px;
+            font-weight: 500;
+            transition: background-color 0.2s;
+        }
+
+        .btn-link:hover {
+            background-color: #0056b3;
+            text-decoration: none;
+        }
+
+        /* Voting buttons */
+        .vote-buttons {
+            display: inline-block;
+            margin-left: 0.5rem;
+        }
+
+        .vote-btn {
+            background: none;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 2px 6px;
+            margin: 0 2px;
+            cursor: pointer;
+            font-size: 0.9rem;
+            transition: all 0.2s;
+            opacity: 0.6;
+        }
+
+        .vote-btn:hover {
+            opacity: 1;
+            transform: scale(1.1);
+        }
+
+        .vote-btn.voted {
+            opacity: 1;
+            border-color: #28a745;
+            background-color: #d4edda;
+        }
+
+        .vote-btn.voted-down {
+            border-color: #dc3545;
+            background-color: #f8d7da;
+        }
+
+        .vote-btn-small {
+            font-size: 0.7rem;
+            padding: 1px 4px;
+            margin: 0 1px;
+        }
+    </style>
+
+    <script>
+        // Add collapsible functionality
+        document.querySelectorAll('.collapsible').forEach(element => {
+            element.addEventListener('click', function() {
+                this.classList.toggle('collapsed');
+            });
+        });
+
+        // Voting functionality
+        const VOTE_URL = 'https://script.google.com/macros/s/AKfycbwPKH7d3seuPNBtB0ugVjqGeTiByyOGD5vkqB_Ck6K8eOcPQYbJqBOuz6GFgXHKBNWK/exec';
+
+        // Get or create session ID
+        let sessionId = localStorage.getItem('review_session_id');
+        if (!sessionId) {
+            sessionId = 's' + Date.now() + '_' + Math.random().toString(36).substr(2, 9);
+            localStorage.setItem('review_session_id', sessionId);
+        }
+
+        // Show previous votes on page load
+        document.addEventListener('DOMContentLoaded', function() {
+            document.querySelectorAll('.vote-buttons').forEach(container => {
+                const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+                const previousVote = localStorage.getItem(key);
+                if (previousVote) {
+                    const btn = container.querySelector(`[data-v="${previousVote}"]`);
+                    if (btn) btn.classList.add(previousVote === 'up' ? 'voted' : 'voted-down');
+                }
+            });
+        });
+
+        // Handle vote clicks - Simple image beacon approach
+        document.addEventListener('click', function(e) {
+            if (!e.target.classList.contains('vote-btn')) return;
+
+            // Prevent the click from bubbling to parent elements (like summary)
+            e.preventDefault();
+            e.stopPropagation();
+
+            const btn = e.target;
+            const container = btn.closest('.vote-buttons');
+            if (!container) return;
+
+            const voteType = btn.dataset.v;
+
+            // Check if already voted (locally)
+            const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+            const previousVote = localStorage.getItem(key);
+
+            if (previousVote === voteType) {
+                // Same vote - do nothing
+                btn.style.animation = 'shake 0.5s';
+                setTimeout(() => btn.style.animation = '', 500);
+                return;
+            }
+
+            // Build URL
+            const params = new URLSearchParams({
+                gene_id: container.dataset.g,
+                annotation_id: container.dataset.a,
+                ref_id: container.dataset.r || '',
+                action: container.dataset.act,
+                vote: voteType,
+                session_id: sessionId,
+                ua: navigator.userAgent.substring(0, 100)
+            });
+
+            // Clear previous vote styling
+            container.querySelectorAll('.vote-btn').forEach(b => {
+                b.classList.remove('voted', 'voted-down');
+            });
+
+            // Apply new vote styling immediately (optimistic UI)
+            btn.classList.add(voteType === 'up' ? 'voted' : 'voted-down');
+
+            // Store locally
+            localStorage.setItem(key, voteType);
+
+            // Send vote using fetch with no-cors mode (fire and forget)
+            const fullUrl = VOTE_URL + '?' + params;
+            console.log('Sending vote to:', fullUrl);
+
+            // Use fetch in no-cors mode - we won't get a response but the request will be sent
+            fetch(fullUrl, {
+                mode: 'no-cors',
+                method: 'GET'
+            }).then(() => {
+                console.log('Vote request sent (no response due to no-cors mode)');
+            }).catch(err => {
+                console.warn('Vote may not have been recorded, but saved locally:', err);
+
+                // Fallback: try image beacon as well
+                const img = new Image();
+                img.src = fullUrl;
+            });
+        });
+
+        // Optional: Add shake animation for feedback
+        const style = document.createElement('style');
+        style.textContent = `
+            @keyframes shake {
+                0%, 100% { transform: translateX(0); }
+                25% { transform: translateX(-5px); }
+                75% { transform: translateX(5px); }
+            }
+        `;
+        document.head.appendChild(style);
+    </script>
+</body>
+</html>

--- a/pages/projects/all-projects.html
+++ b/pages/projects/all-projects.html
@@ -1532,7 +1532,7 @@
                 <td><span class="tag t-PIPELINE">PIPELINE</span></td>
                 <td><span class="muted">&mdash;</span></td>
                 <td><span class="muted">&mdash;</span></td>
-                <td>1</td>
+                <td>2</td>
             </tr>
 
             <tr


### PR DESCRIPTION
## Summary

Automated regeneration of static assets after gene review or template changes.

## Generated Assets

| Asset | Count/Status |
|-------|--------------|
| Gene review YAML files | 2862 |
| Gene review HTML pages | 2862 |
| Project pages | 1098 |
| Module pages | 87 |
| Browser app (data.js) | Updated |
| Validation report | Updated |

## Trigger

This PR was triggered by changes to:
- genes/**/*.yaml - gene review data files
- src/ai_gene_review/schema/** - LinkML schema files
- src/ai_gene_review/templates/** - Jinja2 templates
- src/ai_gene_review/render.py - rendering code
- src/ai_gene_review/render_modules.py - module rendering code
- src/ai_gene_review/export/** - export code
- src/ai_gene_review/browser/** - browser app assets
- src/ai_gene_review/tools/minify_linkml_browser_data.py - browser data compaction
- projects/*.md - project definitions
- modules/**/*.yaml - module definitions
- project.justfile - just recipes used by CI
- .github/workflows/generate-pages.yaml - workflow definition

## Review

- [ ] Spot-check a few gene review HTML pages render correctly
- [ ] Spot-check module tree browser pages render correctly
- [ ] Verify browser app loads and filters work
- [ ] Check validation report for new issues
