### PR TITLE
Regenerate pages and browser app

### DIFF
--- a/genes/worm/cct-1/cct-1-ai-review.html
+++ b/genes/worm/cct-1/cct-1-ai-review.html
@@ -1,0 +1,3182 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>cct-1 - AI Gene Review</title>
+    <style>
+        :root {
+            --color-accept: #22c55e;
+            --color-remove: #ef4444;
+            --color-modify: #f97316;
+            --color-keep-non-core: #3b82f6;
+            --color-undecided: #6b7280;
+            --color-new: #8b5cf6;
+            --color-mark-over: #eab308;
+            --bg-light: #f9fafb;
+            --border-color: #e5e7eb;
+            --text-muted: #6b7280;
+            --text-primary: #111827;
+        }
+
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+            line-height: 1.6;
+            color: var(--text-primary);
+            background-color: #ffffff;
+            padding: 2rem;
+            max-width: 1400px;
+            margin: 0 auto;
+        }
+
+        .header {
+            border-bottom: 2px solid var(--border-color);
+            padding-bottom: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        h1 {
+            font-size: 2.5rem;
+            font-weight: 700;
+            margin-bottom: 0.5rem;
+            color: #1f2937;
+        }
+
+        .gene-info {
+            display: flex;
+            gap: 2rem;
+            flex-wrap: wrap;
+            margin-top: 1rem;
+        }
+
+        .info-item {
+            display: flex;
+            gap: 0.5rem;
+        }
+
+        .info-label {
+            font-weight: 600;
+            color: var(--text-muted);
+        }
+
+        .aliases {
+            display: flex;
+            gap: 0.5rem;
+            flex-wrap: wrap;
+        }
+
+        .badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.875rem;
+            font-weight: 500;
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+        }
+
+        .status-badge {
+            padding: 0.375rem 0.875rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .status-initialized {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fde68a;
+        }
+
+        .status-in-progress {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+        }
+
+        .status-draft {
+            background-color: #fce7f3;
+            color: #831843;
+            border: 1px solid #fbcfe8;
+        }
+
+        .status-complete {
+            background-color: #d1fae5;
+            color: #065f46;
+            border: 1px solid #a7f3d0;
+        }
+
+        .description-card {
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        .description-card h2 {
+            font-size: 1.25rem;
+            margin-bottom: 1rem;
+            color: #374151;
+        }
+
+        .section {
+            margin-bottom: 2.5rem;
+        }
+
+        .section-title {
+            font-size: 1.5rem;
+            font-weight: 600;
+            margin-bottom: 1.5rem;
+            color: #1f2937;
+            border-bottom: 1px solid var(--border-color);
+            padding-bottom: 0.5rem;
+        }
+
+        .annotations-table {
+            width: 100%;
+            border-collapse: collapse;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            overflow: hidden;
+        }
+
+        .annotations-table thead {
+            background-color: var(--bg-light);
+        }
+
+        .annotations-table th {
+            text-align: left;
+            padding: 1rem;
+            font-weight: 600;
+            border-bottom: 2px solid var(--border-color);
+            font-size: 0.875rem;
+            text-transform: uppercase;
+            letter-spacing: 0.05em;
+            color: var(--text-muted);
+        }
+
+        .annotations-table td {
+            padding: 1rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .annotations-table tbody tr:hover {
+            background-color: #f9fafb;
+        }
+
+        .action-badge {
+            display: inline-block;
+            padding: 0.375rem 0.75rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .action-accept {
+            background-color: var(--color-accept);
+            color: white;
+        }
+
+        .action-remove {
+            background-color: var(--color-remove);
+            color: white;
+        }
+
+        .action-modify {
+            background-color: var(--color-modify);
+            color: white;
+        }
+
+        .action-keep_as_non_core {
+            background-color: var(--color-keep-non-core);
+            color: white;
+        }
+
+        .action-undecided {
+            background-color: var(--color-undecided);
+            color: white;
+        }
+
+        .action-new {
+            background-color: var(--color-new);
+            color: white;
+        }
+
+        .action-mark_as_over_annotated {
+            background-color: var(--color-mark-over);
+            color: white;
+        }
+
+        .term-info {
+            display: flex;
+            flex-direction: column;
+            gap: 0.25rem;
+        }
+
+        .term-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .term-label {
+            font-weight: 500;
+        }
+
+        .evidence-code {
+            font-family: monospace;
+            background-color: var(--bg-light);
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .not-badge {
+            display: inline-block;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-weight: 600;
+            margin-left: 0.25rem;
+        }
+
+        .isoform-badge {
+            display: inline-block;
+            background-color: #eff6ff;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            margin-top: 0.25rem;
+        }
+
+        .core-function-card {
+            background-color: white;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 1rem;
+        }
+
+        .core-function-card h3 {
+            font-size: 1.125rem;
+            margin-bottom: 1rem;
+            color: #1f2937;
+        }
+
+        .core-function-statement {
+            margin-bottom: 1rem;
+            padding: 0.75rem;
+            background-color: var(--bg-light);
+            border-left: 4px solid var(--color-accept);
+            border-radius: 0.25rem;
+        }
+
+        .function-annotations {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin-top: 1rem;
+        }
+
+        .reference-item {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+        }
+
+        .reference-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: start;
+            margin-bottom: 0.75rem;
+        }
+
+        .reference-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #2563eb;
+        }
+
+        .supported-by {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f3f4f6;
+            border-left: 3px solid #3b82f6;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .supported-by-title {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .support-item {
+            margin-bottom: 0.5rem;
+        }
+
+        .support-ref {
+            font-weight: 500;
+            color: #2563eb;
+        }
+
+        .support-text {
+            color: #6b7280;
+            font-style: italic;
+            margin-left: 1rem;
+        }
+
+        .propagation-review {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f8fafc;
+            border-left: 3px solid #64748b;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .propagation-title {
+            font-weight: 600;
+            color: #334155;
+            margin-bottom: 0.25rem;
+        }
+
+        .propagation-row {
+            margin-top: 0.25rem;
+        }
+
+        .propagation-source {
+            margin-top: 0.5rem;
+            padding-top: 0.5rem;
+            border-top: 1px solid #e5e7eb;
+        }
+
+        .propagation-source-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #1d4ed8;
+        }
+
+        .propagation-comment {
+            color: #4b5563;
+            margin-left: 1rem;
+        }
+
+        a.term-link {
+            color: #2563eb;
+            text-decoration: none;
+        }
+
+        a.term-link:hover {
+            text-decoration: underline;
+        }
+
+        .core-function-terms {
+            margin-top: 1rem;
+        }
+
+        .function-term-group {
+            margin-bottom: 1rem;
+        }
+
+        .function-term-label {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .reference-title {
+            font-weight: 500;
+            margin-bottom: 0.5rem;
+        }
+
+        .findings-list {
+            margin-top: 1rem;
+            padding-left: 1.5rem;
+        }
+
+        .finding-item {
+            margin-bottom: 0.75rem;
+        }
+
+        .finding-statement {
+            font-weight: 500;
+            margin-bottom: 0.25rem;
+        }
+
+        .finding-text {
+            color: var(--text-muted);
+            font-size: 0.95rem;
+            font-style: italic;
+        }
+
+        .proposed-term {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #fef3c7;
+        }
+
+        .question-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #dbeafe;
+        }
+
+        .experiment-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #f3e8ff;
+        }
+
+        .prediction-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: white;
+        }
+
+        .prediction-card .prediction-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+        }
+
+        .prediction-source {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+        }
+
+        .assessment-badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.8rem;
+            font-weight: 600;
+            text-transform: uppercase;
+        }
+
+        .assessment-cor { background-color: #dcfce7; color: #166534; }
+        .assessment-cnn { background-color: #dbeafe; color: #1e40af; }
+        .assessment-lsp { background-color: #fef9c3; color: #854d0e; }
+        .assessment-unc { background-color: #f3f4f6; color: #374151; }
+        .assessment-pli { background-color: #fee2e2; color: #991b1b; }
+        .assessment-npi { background-color: #fecaca; color: #7f1d1d; }
+        .assessment-rep { background-color: #fde68a; color: #92400e; }
+
+        .confidence-score {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+            margin-left: 0.5rem;
+        }
+
+        .error-type-badge {
+            font-size: 0.75rem;
+            padding: 0.125rem 0.5rem;
+            border-radius: 0.25rem;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+        }
+
+        .isoforms-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fill, minmax(400px, 1fr));
+            gap: 1rem;
+        }
+
+        .isoform-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            background-color: white;
+            transition: box-shadow 0.2s;
+        }
+
+        .isoform-card:hover {
+            box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+        }
+
+        .functional-isoform-type {
+            display: inline-block;
+            padding: 0.2rem 0.5rem;
+            border-radius: 0.25rem;
+            font-size: 0.7rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.03em;
+        }
+
+        .type-SPLICE_VARIANT, .type-SPLICE_CLASS {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #93c5fd;
+        }
+
+        .type-CLEAVAGE_PRODUCT {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fcd34d;
+        }
+
+        .type-MODIFICATION_STATE {
+            background-color: #f3e8ff;
+            color: #6b21a8;
+            border: 1px solid #c4b5fd;
+        }
+
+        .type-CONFORMATIONAL_STATE {
+            background-color: #dcfce7;
+            color: #166534;
+            border: 1px solid #86efac;
+        }
+
+        .functional-isoform-mappings {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+            font-size: 0.85rem;
+        }
+
+        .functional-isoform-mappings .mapping-type {
+            font-weight: 600;
+            color: var(--text-muted);
+            font-size: 0.75rem;
+        }
+
+        .functional-isoform-go {
+            margin-top: 0.5rem;
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.25rem;
+        }
+
+        .go-chip {
+            display: inline-block;
+            padding: 0.15rem 0.4rem;
+            background-color: #ecfdf5;
+            color: #047857;
+            border: 1px solid #a7f3d0;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-family: monospace;
+        }
+
+        .isoform-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+            padding-bottom: 0.5rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .isoform-name {
+            font-weight: 600;
+            font-size: 1.1rem;
+            color: #1f2937;
+        }
+
+        .isoform-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .isoform-sequence-note {
+            font-size: 0.875rem;
+            color: var(--text-muted);
+            margin-bottom: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+        }
+
+        .isoform-description {
+            font-size: 0.95rem;
+            line-height: 1.5;
+        }
+
+        .collapsible {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .collapsible:after {
+            content: ' ▼';
+            font-size: 0.75rem;
+        }
+
+        .collapsible.collapsed:after {
+            content: ' ►';
+        }
+
+        .collapse-content {
+            transition: max-height 0.3s ease;
+            overflow: hidden;
+        }
+
+        .collapsed + .collapse-content {
+            max-height: 0;
+        }
+
+        .no-data {
+            color: var(--text-muted);
+            font-style: italic;
+            padding: 1rem;
+            text-align: center;
+            background-color: var(--bg-light);
+            border-radius: 0.5rem;
+        }
+
+        /* Styling for markdown section summaries with voting */
+        .markdown-section summary {
+            padding: 0.75rem;
+            background: var(--bg-light);
+            border-radius: 0.5rem;
+            margin-bottom: 0.5rem;
+        }
+
+        .markdown-section summary:hover {
+            background: #e5e7eb;
+        }
+
+        .markdown-section summary .vote-buttons {
+            margin-left: auto;
+        }
+
+        .deep-research-section {
+            margin-bottom: 1rem;
+            border: 1px solid #c7d2fe;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8faff;
+        }
+
+        .deep-research-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .deep-research-section summary h3 {
+            margin: 0;
+            color: #3730a3;
+            font-size: 1.1rem;
+        }
+
+        .report-meta {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin: 0.75rem 0 1rem;
+            align-items: center;
+        }
+
+        .report-badge {
+            display: inline-flex;
+            align-items: center;
+            border: 1px solid #c7d2fe;
+            border-radius: 999px;
+            background: #eef2ff;
+            color: #4338ca;
+            font-size: 0.78rem;
+            font-weight: 600;
+            padding: 0.2rem 0.6rem;
+        }
+
+        .report-meta-text {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+        }
+
+        .artifact-list {
+            display: grid;
+            gap: 0.75rem;
+            margin: 0.75rem 0 1rem;
+        }
+
+        .artifact-link {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+            margin-top: 0.5rem;
+            word-break: break-word;
+        }
+
+        @media print {
+            body {
+                padding: 1rem;
+            }
+
+            .collapsible:after {
+                display: none;
+            }
+
+            .collapsed + .collapse-content {
+                max-height: none !important;
+            }
+        }
+
+        @media (max-width: 768px) {
+            body {
+                padding: 1rem;
+            }
+
+            h1 {
+                font-size: 2rem;
+            }
+
+            .annotations-table {
+                font-size: 0.875rem;
+            }
+
+            .annotations-table th,
+            .annotations-table td {
+                padding: 0.5rem;
+            }
+        }
+    </style>
+</head>
+<body>
+    <div class="header">
+        <h1>cct-1</h1>
+        <div class="gene-info">
+
+            <div class="info-item">
+
+                <span class="info-label">UniProt ID:</span>
+                <span>
+                    <a href="https://www.uniprot.org/uniprotkb/P41988" target="_blank" class="term-link">
+                        P41988
+                    </a>
+                </span>
+
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Organism:</span>
+                <span>Caenorhabditis elegans</span>
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Review Status:</span>
+                <span class="status-badge status-complete">
+                    COMPLETE
+                </span>
+            </div>
+
+
+        </div>
+        <div style="margin-top: 1rem; text-align: center;">
+            <a id="feedback-form-link"
+               href="#"
+               target="_blank"
+               style="display: inline-block; padding: 10px 20px; background-color: #4CAF50; color: white; text-decoration: none; border-radius: 5px; font-weight: 600;">
+                📝 Provide Detailed Feedback
+            </a>
+            <script>
+                // Construct the form URL with proper encoding
+                // Extract organism code from the current page path (e.g., /genes/ARATH/APO1/ -> ARATH)
+                const pathParts = window.location.pathname.split('/');
+                const genesIndex = pathParts.indexOf('genes');
+                let organism = '';
+                if (genesIndex !== -1 && pathParts[genesIndex + 1]) {
+                    organism = pathParts[genesIndex + 1].toUpperCase();
+                }
+                const geneSymbol = "cct-1";
+                const speciesGene = organism + ' ' + geneSymbol;
+                const formBaseUrl = 'https://docs.google.com/forms/d/e/1FAIpQLSdTot9L6GVkkZYgLQT0E8ZdAJv8RiN5ZgOVkgWNcKSbYvxxzQ/viewform';
+                const entryId = '1226477767'; // Correct entry ID for Species/Gene field
+                const formUrl = formBaseUrl + '?entry.' + entryId + '=' + encodeURIComponent(speciesGene);
+                const feedbackLink = document.getElementById('feedback-form-link');
+                feedbackLink.href = formUrl;
+                // Add tooltip showing the pre-filled value
+                feedbackLink.title = 'Opens form with pre-filled: ' + speciesGene;
+            </script>
+        </div>
+    </div>
+
+
+    <div class="description-card">
+        <div style="display: flex; justify-content: space-between; align-items: center;">
+            <h2>Gene Description</h2>
+            <span class="vote-buttons" data-g="P41988" data-a="DESCRIPTION: cct-1 encodes the alpha (TCP-1-alpha / CCT-alpha) ..." data-r="" data-act="DESCRIPTION">
+                <button class="vote-btn" data-v="up" title="Agree with this description">👍</button>
+                <button class="vote-btn" data-v="down" title="Disagree with this description">👎</button>
+            </span>
+        </div>
+        <p>cct-1 encodes the alpha (TCP-1-alpha / CCT-alpha) subunit of the eukaryotic cytosolic chaperonin CCT (chaperonin-containing TCP-1), also known as TRiC. CCT/TRiC is an ATP-dependent, hetero-oligomeric double-ring chaperonin whose two stacked rings are each built from eight distinct but paralogous subunits (CCT1-CCT8 / alpha-theta); cct-1 is the alpha paralog. The assembled ~900 kDa complex, not any individual subunit, is the folding machine: it uses cycles of ATP binding and hydrolysis by its subunits to fold a subset of cytosolic proteins, most notably the obligate cytoskeletal substrates actin and tubulin, as well as WD40 beta-propeller proteins. The alpha subunit contributes an equatorial nucleotide-binding module and an apical substrate-binding surface and, unlike the low-ATPase subunits, retains a canonical ATP-binding/ATPase site. In C. elegans, cct-1 is a single-copy gene on chromosome II expressed constitutively throughout development, most prominently in neuronal and muscle tissues; the chaperonin acts in the cytoplasm and, together with the other seven CCT subunits, is essential for embryogenesis and for the in vivo biogenesis of actin and tubulin that underlies microtubule organization and microvillus formation.</p>
+    </div>
+
+
+
+
+
+    <div class="section">
+        <h2 class="section-title">Proposed New Ontology Terms</h2>
+
+        <div class="proposed-term">
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+                <h3>chaperonin substrate-binding subunit activity</h3>
+                <span class="vote-buttons" data-g="P41988" data-a="chaperonin substrate-binding subunit activity" data-r="" data-act="NEW">
+                    <button class="vote-btn" data-v="up" title="Agree this term should be created">👍</button>
+                    <button class="vote-btn" data-v="down" title="Disagree with creating this term">👎</button>
+                </span>
+            </div>
+
+
+            <p><strong>Definition:</strong> A molecular function of a single subunit of a group II chaperonin (CCT/TRiC) that presents an apical-domain substrate-binding surface and contributes subunit-specific contacts to the ATP-dependent folding of client proteins by the assembled chaperonin, without itself folding a substrate independently of the complex.</p>
+
+
+
+            <p><strong>Justification:</strong> Individual CCT subunits have no adequate GO molecular-function term and can only be annotated with the complex-level foldase activity or a generic catalytic term, obscuring subunit-specific substrate selectivity.</p>
+
+
+
+            <p><strong>Parent term:</strong>
+                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0003674" target="_blank" class="term-link">
+                    molecular_function
+                </a>
+            </p>
+
+
+
+
+
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Existing Annotations Review</h2>
+        <table class="annotations-table">
+            <thead>
+                <tr>
+                    <th>GO Term</th>
+                    <th>Evidence</th>
+                    <th>Action</th>
+                    <th>Reason</th>
+                </tr>
+            </thead>
+            <tbody>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006457" target="_blank" class="term-link">
+                                    GO:0006457
+                                </a>
+                            </span>
+                            <span class="term-label">protein folding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P41988" data-a="GO:0006457" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> cct-1 is the alpha subunit of the cytosolic chaperonin CCT/TRiC, which catalyzes ATP-dependent folding of actin, tubulin, and other cytosolic substrates. Protein folding is the core biological process for this subunit.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> The phylogenetic (IBA) inference is consistent with the conserved chaperonin family assignment (PANTHER PTHR11353; InterPro alpha-subunit signature IPR012715) and with direct evidence that the C. elegans CCT complex is required for actin and tubulin biogenesis in vivo. Protein folding is the correct core process annotation.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/16762366" target="_blank" class="term-link">
+                                        PMID:16762366
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">The eukaryotic cytosolic chaperonin CCT is an essential ATP-dependent protein folding machine whose action is required for folding the cytoskeletal proteins actin and tubulin</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/25143409" target="_blank" class="term-link">
+                                        PMID:25143409
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">CCT depletion causes a reduction in the tubulin levels and disorganization of the microtubule network</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005832" target="_blank" class="term-link">
+                                    GO:0005832
+                                </a>
+                            </span>
+                            <span class="term-label">chaperonin-containing T-complex</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P41988" data-a="GO:0005832" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> cct-1 is an integral subunit of the chaperonin-containing T-complex (CCT/TRiC), built from eight paralogous subunits per ring.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Complex membership is the best-supported annotation for this gene. The phylogenetic inference agrees with direct biochemical purification of the C. elegans CCT complex, in which CCT-1 was identified as a subunit by antibody Western blot, and with yeast genetics showing the ring is built from eight distinct Cct subunits.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/9434769" target="_blank" class="term-link">
+                                        PMID:9434769
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">The chaperonin containing TCP-1 (CCT) from the free-living nematode Caenorhabditis elegans was purified and shown to contain at least seven subunit species ranging from 52-65 kDa</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/15704212" target="_blank" class="term-link">
+                                        PMID:15704212
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">stoichiometric array of eight different subunits, which are denoted Cct1p-Cct8p</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005524" target="_blank" class="term-link">
+                                    GO:0005524
+                                </a>
+                            </span>
+                            <span class="term-label">ATP binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000002
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P41988" data-a="GO:0005524" data-r="GO_REF:0000002" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Each CCT subunit binds ATP/ADP through the conserved equatorial nucleotide-binding site of the group II chaperonin fold; nucleotide binding drives the folding cycle.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> ATP binding is directly supported for the C. elegans protein: purified CCT-1/TCP-1 was shown to be a subunit of a high-molecular-mass complex that binds ATP. This is fully consistent with the InterPro chaperonin domains and the ATP-dependent mechanism of the complex. The alpha subunit retains a canonical nucleotide-binding site.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/7758963" target="_blank" class="term-link">
+                                        PMID:7758963
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Ce TCP-1 is a 57-kDa protein subunit of a high-molecular-mass complex capable of binding ATP</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/16762366" target="_blank" class="term-link">
+                                        PMID:16762366
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">The eukaryotic cytosolic chaperonin CCT is an essential ATP-dependent protein folding machine</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005737" target="_blank" class="term-link">
+                                    GO:0005737
+                                </a>
+                            </span>
+                            <span class="term-label">cytoplasm</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000044
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P41988" data-a="GO:0005737" data-r="GO_REF:0000044" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> CCT/TRiC is a cytosolic chaperonin; cct-1 acts in the cytoplasm on cytosolic substrates.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Cytoplasmic localization is consistent with the known biology of the cytosolic chaperonin and with the UniProt subcellular location. The more specific term cytosol (GO:0005829) would be preferable, but the broader cytoplasm annotation is not incorrect and is retained.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/16762366" target="_blank" class="term-link">
+                                        PMID:16762366
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">The eukaryotic cytosolic chaperonin CCT is an essential ATP-dependent protein folding machine</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006457" target="_blank" class="term-link">
+                                    GO:0006457
+                                </a>
+                            </span>
+                            <span class="term-label">protein folding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000002
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P41988" data-a="GO:0006457" data-r="GO_REF:0000002" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> InterPro domain-based annotation of protein folding, duplicating the IBA protein-folding annotation.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Consistent electronic (InterPro) support for the core protein-folding process, in agreement with the IBA annotation and the conserved chaperonin mechanism.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/16762366" target="_blank" class="term-link">
+                                        PMID:16762366
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Yeast CCT catalyses the folding of yeast ACT1p and human beta-actin with nearly identical rate constants and yields.</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016887" target="_blank" class="term-link">
+                                    GO:0016887
+                                </a>
+                            </span>
+                            <span class="term-label">ATP hydrolysis activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000002
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P41988" data-a="GO:0016887" data-r="GO_REF:0000002" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> The CCT subunits are ATPases; ATP hydrolysis around the ring powers the substrate-folding cycle of the chaperonin.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> ATP hydrolysis is a conserved catalytic activity of the CCT/TRiC family, supported by the InterPro chaperonin domains and by the demonstration that the worm CCT-1 complex binds ATP. The alpha subunit retains a functional nucleotide-binding/ATPase site, so the term is appropriate.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/16762366" target="_blank" class="term-link">
+                                        PMID:16762366
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">The eukaryotic cytosolic chaperonin CCT is an essential ATP-dependent protein folding machine</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/7758963" target="_blank" class="term-link">
+                                        PMID:7758963
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Ce TCP-1 is a 57-kDa protein subunit of a high-molecular-mass complex capable of binding ATP</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0140662" target="_blank" class="term-link">
+                                    GO:0140662
+                                </a>
+                            </span>
+                            <span class="term-label">ATP-dependent protein folding chaperone</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000002
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P41988" data-a="GO:0140662" data-r="GO_REF:0000002" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> ATP-dependent protein folding chaperone is the most informative molecular-function term for CCT/TRiC; cct-1 contributes to this activity as a subunit of the complex.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> This term precisely captures the activity of the CCT chaperonin. Strictly it is a complex-level activity to which the alpha subunit contributes rather than one it enables in isolation, but it is the best available molecular-function descriptor for this gene.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/16762366" target="_blank" class="term-link">
+                                        PMID:16762366
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">The eukaryotic cytosolic chaperonin CCT is an essential ATP-dependent protein folding machine whose action is required for folding the cytoskeletal proteins actin and tubulin</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005634" target="_blank" class="term-link">
+                                    GO:0005634
+                                </a>
+                            </span>
+                            <span class="term-label">nucleus</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/9434769" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:9434769
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Subunit characterization of the Caenorhabditis elegans chape...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-undecided">
+                            UNDECIDED
+                        </span>
+                        <span class="vote-buttons" data-g="P41988" data-a="GO:0005634" data-r="PMID:9434769" data-act="UNDECIDED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> A nucleus located_in annotation attributed to the 1997 C. elegans CCT-1 paper. CCT/TRiC is canonically a cytoplasmic chaperonin, and the primary evidence for a nuclear location of CCT-1 cannot be verified from the available record.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> The cited paper is abstract-only in the cache (full text not accessible). Its abstract describes only a transcriptional promoter-reporter for cct-1 expression (tissue-level, neuronal and muscle), not protein immunolocalization; in C. elegans such reporters commonly carry a nuclear localization signal, which produces nuclear signal by construct design rather than reflecting endogenous protein location. CCT is a cytosolic chaperonin (UniProt subcellular location: cytoplasm). Because I cannot read the full text to establish the basis for a nucleus located_in call, and per curation guidance for annotations whose supporting publication is inaccessible, this is left UNDECIDED rather than removed; nuclear localization is at most a minor, non-core location for this cytosolic chaperonin subunit.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/9434769" target="_blank" class="term-link">
+                                        PMID:9434769
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Expression of a reporter gene under the control of the C. elegans cct-1 promoter is found to be mainly restricted to neuronal and muscle tissues</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/16762366" target="_blank" class="term-link">
+                                        PMID:16762366
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">The eukaryotic cytosolic chaperonin CCT is an essential ATP-dependent protein folding machine</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005832" target="_blank" class="term-link">
+                                    GO:0005832
+                                </a>
+                            </span>
+                            <span class="term-label">chaperonin-containing T-complex</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/9434769" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:9434769
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Subunit characterization of the Caenorhabditis elegans chape...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="P41988" data-a="GO:0005832" data-r="PMID:9434769" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Direct experimental (IDA) demonstration that CCT-1 is a subunit of the purified C. elegans chaperonin-containing T-complex.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> This is the strongest annotation for the gene: the worm CCT complex was purified and CCT-1 identified as a subunit by anti-CCT-1 Western blot, with a subunit composition closely matching bovine CCT. Complex membership is experimentally established in the correct organism.
+                        </div>
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/9434769" target="_blank" class="term-link">
+                                        PMID:9434769
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">The chaperonin containing TCP-1 (CCT) from the free-living nematode Caenorhabditis elegans was purified and shown to contain at least seven subunit species ranging from 52-65 kDa</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/7758963" target="_blank" class="term-link">
+                                        PMID:7758963
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Ce TCP-1 is a 57-kDa protein subunit of a high-molecular-mass complex capable of binding ATP</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+            </tbody>
+        </table>
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Core Functions</h2>
+
+        <div class="core-function-card">
+
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+                <h3>cct-1 is the alpha subunit of the cytosolic chaperonin CCT/TRiC. As part of the hetero-oligomeric double-ring complex it binds nucleotide through its equatorial domain and presents an apical substrate-binding surface, contributing to the ATP-dependent folding of actin, tubulin, and other cytosolic clients. The foldase activity is a property of the assembled complex, to which the alpha subunit contributes; unlike the low-ATPase subunits, alpha retains a canonical nucleotide-binding/ATPase site.</h3>
+                <span class="vote-buttons" data-g="P41988" data-a="FUNCTION: cct-1 is the alpha subunit of the cytosolic chaper..." data-r="" data-act="CORE_FUNCTION">
+                    <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
+                    <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
+                </span>
+            </div>
+
+
+            <div class="core-function-terms">
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Molecular Function:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005524" target="_blank" class="term-link">
+                            ATP binding
+                        </a>
+                    </span>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Directly Involved In:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006457" target="_blank" class="term-link">
+                                protein folding
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Cellular Locations:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005737" target="_blank" class="term-link">
+                                cytoplasm
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">In Complex:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005832" target="_blank" class="term-link">
+                            chaperonin-containing T-complex
+                        </a>
+                    </span>
+                </div>
+
+
+
+            </div>
+
+
+            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
+                <strong>Supporting Evidence:</strong>
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/7758963" target="_blank" class="term-link">
+                                PMID:7758963
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">Ce TCP-1 is a 57-kDa protein subunit of a high-molecular-mass complex capable of binding ATP</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/16762366" target="_blank" class="term-link">
+                                PMID:16762366
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">The eukaryotic cytosolic chaperonin CCT is an essential ATP-dependent protein folding machine whose action is required for folding the cytoskeletal proteins actin and tubulin</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/25143409" target="_blank" class="term-link">
+                                PMID:25143409
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">is essential for proper formation of microvilli in intestinal cells</div>
+
+                    </li>
+
+                </ul>
+            </div>
+
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title collapsible">References</h2>
+        <div class="collapse-content">
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000002.md" target="_blank" class="term-link">
+                            GO_REF:0000002
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Gene Ontology annotation through association of InterPro records with GO terms</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000033.md" target="_blank" class="term-link">
+                            GO_REF:0000033
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Annotation inferences using phylogenetic trees</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000044.md" target="_blank" class="term-link">
+                            GO_REF:0000044
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location vocabulary mapping, accompanied by conservative changes to GO terms applied by UniProt</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/9434769" target="_blank" class="term-link">
+                            PMID:9434769
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Subunit characterization of the Caenorhabditis elegans chaperonin containing TCP-1 and expression pattern of the gene encoding CCT-1.</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">The C. elegans CCT complex was purified and shown to contain CCT-1 among at least seven subunit species, with a composition like bovine CCT.</div>
+
+                        <div class="finding-text">"The chaperonin containing TCP-1 (CCT) from the free-living nematode Caenorhabditis elegans was purified and shown to contain at least seven subunit species ranging from 52-65 kDa"</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <div class="finding-statement">A cct-1 promoter reporter is expressed mainly in neuronal and muscle tissues, consistent with a role in actin and tubulin folding.</div>
+
+                        <div class="finding-text">"Expression of a reporter gene under the control of the C. elegans cct-1 promoter is found to be mainly restricted to neuronal and muscle tissues"</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/7758963" target="_blank" class="term-link">
+                            PMID:7758963
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Molecular analysis of Caenorhabditis elegans tcp-1, a gene encoding a chaperonin protein.</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">The C. elegans TCP-1/CCT-1 protein is a 57-kDa subunit of a high-molecular-mass ATP-binding complex; tcp-1 is single-copy on chromosome II and constitutively expressed.</div>
+
+                        <div class="finding-text">"Ce TCP-1 is a 57-kDa protein subunit of a high-molecular-mass complex capable of binding ATP"</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/7576182" target="_blank" class="term-link">
+                            PMID:7576182
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Characterization of four new tcp-1-related cct genes from the nematode Caenorhabditis elegans.</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">cct-1 (tcp-1) belongs to a C. elegans CCT multigene family whose members are expressed in all life stages.</div>
+
+                        <div class="finding-text">"The five C. elegans cct genes are expressed in all life stages"</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/16762366" target="_blank" class="term-link">
+                            PMID:16762366
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Quantitative actin folding reactions using yeast CCT purified via an internal tag in the CCT3/gamma subunit.</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">CCT/TRiC is an ATP-dependent folding machine for actin and tubulin.</div>
+
+                        <div class="finding-text">"The eukaryotic cytosolic chaperonin CCT is an essential ATP-dependent protein folding machine whose action is required for folding the cytoskeletal proteins actin and tubulin"</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <div class="finding-statement">Purified yeast CCT catalyzes actin folding.</div>
+
+                        <div class="finding-text">"Yeast CCT catalyses the folding of yeast ACT1p and human beta-actin with nearly identical rate constants and yields."</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/15704212" target="_blank" class="term-link">
+                            PMID:15704212
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Physiological effects of unassembled chaperonin Cct subunits in the yeast Saccharomyces cerevisiae.</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">CCT is built from eight distinct subunits Cct1p-Cct8p per ring that are functionally non-equivalent.</div>
+
+                        <div class="finding-text">"stoichiometric array of eight different subunits, which are denoted Cct1p-Cct8p"</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/25143409" target="_blank" class="term-link">
+                            PMID:25143409
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Caenorhabditis elegans chaperonin CCT/TRiC is required for actin and tubulin biogenesis and microvillus formation in intestinal epithelial cells.</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">C. elegans CCT is required in vivo for microvillus formation in intestinal cells.</div>
+
+                        <div class="finding-text">"is essential for proper formation of microvilli in intestinal cells"</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <div class="finding-statement">CCT depletion reduces tubulin levels and disorganizes the microtubule network.</div>
+
+                        <div class="finding-text">"CCT depletion causes a reduction in the tubulin levels and disorganization of the microtubule network"</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <div class="finding-statement">CCT acts specifically on actin and tubulin among the filamentous cytoskeletons.</div>
+
+                        <div class="finding-text">"suggesting substrate specificity of CCT in the folding of filamentous cytoskeletons in vivo"</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+        </div>
+    </div>
+
+
+
+
+    <div class="section">
+        <h2 class="section-title">Suggested Questions for Experts</h2>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> Which native C. elegans clients depend specifically on the alpha (cct-1) subunit contacts, as opposed to the CCT/TRiC complex as a whole?</p>
+
+                </div>
+                <span class="vote-buttons" data-g="P41988" data-a="Q: Which native C. elegans clients depend specificall..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> Does CCT-1 have any genuine nuclear pool or function in C. elegans, or is the nucleus annotation an artifact of an NLS-tagged transcriptional reporter?</p>
+
+                </div>
+                <span class="vote-buttons" data-g="P41988" data-a="Q: Does CCT-1 have any genuine nuclear pool or functi..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Suggested Experiments</h2>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> Perform affinity purification/mass spectrometry of tagged cct-1 (or the assembled CCT/TRiC) from C. elegans to identify native clients and interactors.</p>
+
+
+                    <p style="margin-top: 0.5rem;"><em>Hypothesis: cct-1 engages a defined set of native C. elegans clients dominated by actin and tubulin but including additional cytosolic proteins.</em></p>
+
+
+                </div>
+                <span class="vote-buttons" data-g="P41988" data-a="EXPERIMENT: Perform affinity purification/mass spectrometry of..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> Determine the endogenous subcellular localization of CCT-1 by immunostaining or a tagged knock-in, comparing against an NLS-free transcriptional reporter, to test whether a genuine nuclear pool exists.</p>
+
+
+                    <p style="margin-top: 0.5rem;"><em>Hypothesis: Endogenous CCT-1 is predominantly cytoplasmic, and the nucleus annotation reflects reporter design rather than protein localization.</em></p>
+
+
+                </div>
+                <span class="vote-buttons" data-g="P41988" data-a="EXPERIMENT: Determine the endogenous subcellular localization ..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Knowledge Gaps</h2>
+        <p style="color: #555; font-size: 0.92rem; margin-top: -0.3rem;">
+            What is <em>not</em> known — curated, literature-grounded statements of the open
+            unknowns (the inverse of core functions).
+        </p>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> There is no GO molecular-function term that expresses &#34;substrate-binding subunit of the CCT chaperonin&#34;. The alpha (CCT-1) subunit&#39;s own activity can therefore only be annotated as the complex-level foldase (GO:0140662) or as generic ATP binding/hydrolysis, leaving cct-1 molecular-function-dark at the subunit level, and its native C. elegans client repertoire (beyond actin and tubulin) is undefined.</p>
+            <p style="margin-top: 0.4rem;">
+                <span class="badge">OPEN</span>
+                <span class="badge">ONTOLOGY</span><span class="badge">BIOLOGY</span>
+                <span class="badge">MF_DARK</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> It is firmly established that cct-1 is the alpha subunit of the eight-membered CCT/TRiC ring, that the assembled complex folds actin, tubulin, WD40 proteins and other cytosolic clients, that the worm CCT-1 protein is part of a high-molecular-mass ATP-binding complex, and that the eight subunits are functionally non-equivalent. What is missing is a term (and worm-specific data) that captures the alpha subunit&#39;s specific substrate-binding contribution.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Significance:</strong> CCT subunits are individually essential and non-redundant, so subunit-specific substrate engagement underlies the complex&#39;s client selectivity. Because no ontology term names a chaperonin substrate-binding subunit activity, the alpha subunit&#39;s characterized structural/regulatory role cannot be curated, and its native worm-specific clients remain unmapped.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>What would resolve it:</strong> Affinity-proteomics of the C. elegans CCT/TRiC to define native clients that depend on the alpha subunit, plus crosslinking or cryo-EM mapping of alpha apical-domain contacts, would define the subunit contribution; a new GO molecular-function term for a chaperonin substrate-binding subunit activity would let the knowledge be expressed.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Provenance (the field's own admissions):</strong></p>
+            <ul style="margin-top: 0.2rem;">
+
+                <li><em>"These results provide evidence for functional differences among Cct subunits and for physiological properties of unassembled subunits"</em> — PMID:15704212</li>
+
+                <li><em>"Ce TCP-1 is a 57-kDa protein subunit of a high-molecular-mass complex capable of binding ATP"</em> — PMID:7758963</li>
+
+            </ul>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Proposed term (ontology gap):</strong></p>
+            <ul style="margin-top: 0.2rem;">
+
+                <li><strong>chaperonin substrate-binding subunit activity</strong> — Individual CCT subunits such as cct-1/alpha have no adequate GO molecular-function term: they can currently be annotated only with the complex-level foldase activity (GO:0140662) or a generic catalytic term, neither of which captures the subunit-specific substrate-binding contribution that distinguishes the eight paralogous subunits.</li>
+
+            </ul>
+
+        </div>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> Whether CCT-1 has any genuine, function-relevant nuclear localization in C. elegans is unresolved. A nucleus located_in annotation exists (from the 1997 CCT-1 paper) but its experimental basis cannot be verified, and the chaperonin is canonically cytoplasmic.</p>
+            <p style="margin-top: 0.4rem;">
+                <span class="badge">OPEN</span>
+                <span class="badge">BIOLOGY</span><span class="badge">CURATION</span>
+                <span class="badge">RESIDUAL_SUBGAP</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> UniProt records the subcellular location of CCT-1 as cytoplasm, consistent with CCT being a cytosolic chaperonin. The cited primary paper&#39;s abstract describes only a transcriptional promoter-reporter (tissue-level expression), not protein immunolocalization, so it does not by itself establish an endogenous nuclear pool.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Significance:</strong> Some CCT/TRiC subunits have reported moonlighting roles outside the assembled chaperonin; distinguishing a genuine nuclear function of CCT-1 from a reporter-construct artifact would clarify whether the annotation should stand.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>What would resolve it:</strong> Endogenous immunolocalization or a tagged CCT-1 knock-in in C. elegans, with and without an NLS-free transcriptional reporter as control, to test for a genuine nuclear pool and any nuclear function.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Provenance (the field's own admissions):</strong></p>
+            <ul style="margin-top: 0.2rem;">
+
+                <li><em>"Expression of a reporter gene under the control of the C. elegans cct-1 promoter is found to be mainly restricted to neuronal and muscle tissues"</em> — PMID:9434769</li>
+
+                <li><em>"The eukaryotic cytosolic chaperonin CCT is an essential ATP-dependent protein folding machine"</em> — PMID:16762366</li>
+
+            </ul>
+
+
+        </div>
+
+    </div>
+
+
+
+
+    <!-- Computational Predictions Section -->
+
+
+    <!-- Deep Research Sections -->
+
+
+    <!-- Additional Documentation Sections -->
+
+    <div class="section">
+        <h2 class="section-title">📚 Additional Documentation</h2>
+
+        <details class="markdown-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; cursor: pointer;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Notes</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(cct-1-notes.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="P41988" data-a="DOC: Notes" data-r="" data-act="DOCUMENTATION" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This documentation is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This documentation needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+                <h1 id="cct-1-c-elegans-research-notes">cct-1 (C. elegans) research notes</h1>
+<p>UniProt: P41988 (TCPA_CAEEL). Gene: cct-1 (synonym tcp-1; ORF T05C12.7);<br />
+WormBase WBGene00000377. Chromosome II. 549 aa, ~58.8 kDa.</p>
+<h2 id="identity-summary">Identity / summary</h2>
+<p>cct-1 encodes the <strong>alpha (TCP-1-alpha / CCT-alpha) subunit</strong> of the eukaryotic<br />
+cytosolic chaperonin CCT (chaperonin-containing TCP-1), also called TRiC. CCT/TRiC<br />
+is an ATP-dependent, hetero-oligomeric double-ring chaperonin; each ring is built<br />
+from eight distinct but paralogous subunits (CCT1-CCT8 / alpha-theta). cct-1 is the<br />
+alpha paralog. The assembled complex — not any single subunit — is the folding<br />
+machine; it folds actin, tubulin, and a subset of other cytosolic proteins.</p>
+<ul>
+<li>UniProt FUNCTION: "Molecular chaperone; assists the folding of proteins upon ATP<br />
+  hydrolysis. Known to play a role, in vitro, in the folding of actin and tubulin."</li>
+<li>UniProt SUBUNIT: "Heterooligomeric complex of about 850 to 900 kDa that forms two<br />
+  stacked rings, 12 to 16 nm in diameter."</li>
+<li>UniProt SUBCELLULAR LOCATION: Cytoplasm.</li>
+<li>UniProt family: TCP-1 chaperonin family. PANTHER PTHR11353 (CHAPERONIN);<br />
+  InterPro IPR012715 (Chap_CCT_alpha, alpha-subunit-specific).</li>
+<li>Note: UniProt cross-references also list GO:0051082 unfolded protein binding<br />
+  (IBA), which is NOT in the QuickGO GOA export used to seed the review; not added<br />
+  as an existing annotation.</li>
+</ul>
+<h2 id="known-well-supported">KNOWN (well supported)</h2>
+<ol>
+<li><strong>cct-1 is the alpha subunit of a large ATP-binding chaperonin complex in<br />
+   C. elegans (experimental, worm-specific).</strong><br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/7758963" title="Ce TCP-1 is a 57-kDa protein subunit of a high-molecular-mass    complex capable of binding ATP">PMID:7758963</a> — direct biochemical evidence (sucrose gradient</li>
+<li>
+<p>ATP-agarose) that the C. elegans TCP-1/CCT-1 protein is a subunit of a large<br />
+   ATP-binding complex. Also: single-copy gene on chromosome II, transcript<br />
+   constant through development <a href="https://pubmed.ncbi.nlm.nih.gov/7758963" title="the overall level of the tcp-1    transcript is approximately constant throughout the development of the    nematode">PMID:7758963</a>, and unlike Hsp60 it is not heat-inducible ("tcp-1 is not upregulated<br />
+   at elevated temperatures, but instead appears to be down-regulated").</p>
+</li>
+<li>
+<p><strong>The C. elegans CCT complex contains CCT-1 as a subunit (experimental IDA).</strong><br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/9434769" title="The chaperonin containing TCP-1 (CCT) from the free-living    nematode Caenorhabditis elegans was purified and shown to contain at least seven    subunit species ranging from 52-65 kDa">PMID:9434769</a> with Western blots using anti-CCT-1 and<br />
+   anti-CCT-5 antibodies; the worm CCT subunit composition closely matches bovine<br />
+   CCT. This paper is the basis for the WormBase IDA annotations<br />
+   (GO:0005832 chaperonin-containing T-complex; GO:0005634 nucleus).</p>
+</li>
+<li>
+<p><strong>CCT/TRiC is an ATP-dependent foldase for actin and tubulin (conserved<br />
+   mechanism).</strong><br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/16762366" title="The eukaryotic cytosolic chaperonin CCT is an essential    ATP-dependent protein folding machine whose action is required for folding the    cytoskeletal proteins actin and tubulin, and a small number of other substrates,    including members of the WD40-propellor repeat-containing protein family">PMID:16762366</a>;<br />
+   purified yeast CCT catalyses actin folding <a href="https://pubmed.ncbi.nlm.nih.gov/16762366" title="Yeast CCT catalyses    the folding of yeast ACT1p and human beta-actin with nearly identical rate    constants and yields">PMID:16762366</a>.</p>
+</li>
+<li>
+<p><strong>The eight subunits are non-equivalent and form a stoichiometric ring.</strong><br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/15704212" title="Eukaryotic chaperonins, the Cct complexes, are assembled into    two rings, each of which is composed of a stoichiometric array of eight different    subunits, which are denoted Cct1p-Cct8p">PMID:15704212</a> and "These results provide evidence for<br />
+   functional differences among Cct subunits and for physiological properties of<br />
+   unassembled subunits."</p>
+</li>
+<li>
+<p><strong>In C. elegans the CCT subunits (cct-1..cct-8) are ubiquitously expressed,<br />
+   essential for embryogenesis, and required in vivo for actin/tubulin biogenesis.</strong><br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/25143409" title="The C. elegans genome contains eight genes encoding the    individual CCT subunits (cct-1 to cct-8)...These genes are ubiquitously expressed    during all developmental stages and are essential for embryogenesis">PMID:25143409</a>;<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/25143409" title="In C. elegans, CCT is important for tubulin folding and    microtubule growth in the early embryo">PMID:25143409</a>; loss of CCT causes actin/tubulin<br />
+   biogenesis failure and <a href="https://pubmed.ncbi.nlm.nih.gov/25143409" title="essential for proper formation of    microvilli in intestinal cells">PMID:25143409</a>. IFB-2 intermediate filament is unaffected —<br />
+   substrate specificity for actin/tubulin.</p>
+</li>
+<li>
+<p><strong>Subcellular localization: predominantly cytoplasmic.</strong><br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/25143409" title="Immunostaining using an anti-CCT-5 antibody showed that CCT    existed diffusely in the cytoplasm but less in the nucleus">PMID:25143409</a>. Consistent with<br />
+   UniProt SUBCELLULAR LOCATION: Cytoplasm.</p>
+</li>
+<li>
+<p><strong>cct-1 promoter drives expression in neuronal and muscle tissues</strong> (transcriptional<br />
+   reporter), consistent with actin/tubulin-rich tissues <a href="https://pubmed.ncbi.nlm.nih.gov/9434769" title="Expression    of a reporter gene under the control of the C. elegans cct-1 promoter is found to    be mainly restricted to neuronal and muscle tissues, an observation which is    consistent with the participation of CCT in actin and tubulin folding">PMID:9434769</a>.</p>
+</li>
+</ol>
+<h2 id="not-known-uncertain">NOT known / uncertain</h2>
+<ul>
+<li>
+<p><strong>Nucleus localization (GO:0005634, IDA, PMID:9434769):</strong> The 1997 paper's<br />
+  abstract (full text not accessible; <code>full_text_available: false</code>) describes only a<br />
+<em>transcriptional</em> promoter-reporter for expression (tissue level: neuron/muscle),<br />
+  not protein subcellular immunolocalization. C. elegans transcriptional reporters<br />
+  commonly carry an NLS, giving nuclear signal by design. Independent immunostaining<br />
+  of the assembled worm CCT complex shows it is predominantly cytoplasmic ("less in<br />
+  the nucleus", PMID:25143409). I cannot verify from the cached abstract what<br />
+  evidence underlies a nucleus located_in call for CCT-1. Per repo guidance<br />
+  (cannot access the relevant publication's full text), this annotation is marked<br />
+  UNDECIDED rather than removed; it is at most a minor / non-core localization.</p>
+</li>
+<li>
+<p><strong>Subunit-specific (alpha) native client repertoire</strong> in C. elegans is undefined;<br />
+  there is no GO molecular-function term expressing "substrate-binding CCT subunit",<br />
+  so the alpha subunit's own MF can only be annotated as the complex-level foldase<br />
+  (GO:0140662) or generic ATP binding/hydrolysis (ontology-level gap; shared across<br />
+  the CCT family, cf. cct-8 review).</p>
+</li>
+</ul>
+<h2 id="annotation-plan-9-goa-annotations">Annotation plan (9 GOA annotations)</h2>
+<ol>
+<li>GO:0006457 protein folding (IBA) — ACCEPT (core BP)</li>
+<li>GO:0005832 chaperonin-containing T-complex (IBA, part_of) — ACCEPT (core CC)</li>
+<li>GO:0005524 ATP binding (IEA InterPro) — ACCEPT (worm-specific support PMID:7758963)</li>
+<li>GO:0005737 cytoplasm (IEA SubCell) — ACCEPT (cytosol GO:0005829 would be more precise)</li>
+<li>GO:0006457 protein folding (IEA InterPro) — ACCEPT (duplicate electronic of core BP)</li>
+<li>GO:0016887 ATP hydrolysis activity (IEA InterPro) — ACCEPT (alpha is a genuine ATPase subunit)</li>
+<li>GO:0140662 ATP-dependent protein folding chaperone (IEA InterPro) — ACCEPT (best MF term; complex-level)</li>
+<li>GO:0005634 nucleus (IDA PMID:9434769, located_in) — UNDECIDED (see above)</li>
+<li>GO:0005832 chaperonin-containing T-complex (IDA PMID:9434769, part_of) — ACCEPT (worm IDA)</li>
+</ol>
+<h2 id="deep-research-provenance">Deep research provenance</h2>
+<p>Automated deep research was unavailable for this gene: the falcon provider<br />
+(<code>just deep-research-falcon worm cct-1 --fallback perplexity-lite</code>) hung/timed out on<br />
+repeated attempts and produced no output, so there is intentionally no<br />
+<code>cct-1-deep-research-falcon.md</code> file (a fabricated one must never be created). This<br />
+review is instead grounded in the UniProt record (P41988 / TCPA_CAEEL), the QuickGO GOA<br />
+export, and the cached primary literature listed above (PMID:7758963, PMID:9434769,<br />
+PMID:7576182 — C. elegans-specific; PMID:16762366, PMID:15704212 — yeast mechanism;<br />
+PMID:25143409 — C. elegans in vivo). Every <code>supporting_text</code> in the review is a verbatim<br />
+substring of one of these cached publications.</p>
+<h2 id="modeling-subunit-vs-complex">Modeling (subunit vs complex)</h2>
+<p>Following the cct-8 review pattern: core_functions models the subunit as<br />
+molecular_function = ATP binding (GO:0005524, the concrete per-subunit MF),<br />
+contributes_to_molecular_function = ATP-dependent protein folding chaperone<br />
+(GO:0140662, the complex-level activity), directly_involved_in = protein folding<br />
+(GO:0006457), in_complex = chaperonin-containing T-complex (GO:0005832),<br />
+locations = cytoplasm (GO:0005737). Unlike theta (a low-ATPase subunit), alpha<br />
+retains a canonical nucleotide-binding/ATPase site.</p>
+            </div>
+        </details>
+
+    </div>
+
+
+    <!-- YAML Preview Section -->
+    <div class="section">
+        <details class="yaml-preview">
+            <summary>
+                <h2 style="display: inline;">📄 View Raw YAML</h2>
+            </summary>
+            <div class="yaml-content">
+                <pre><code>id: P41988
+gene_symbol: cct-1
+product_type: PROTEIN
+status: COMPLETE
+taxon:
+  id: NCBITaxon:6239
+  label: Caenorhabditis elegans
+description: &gt;-
+  cct-1 encodes the alpha (TCP-1-alpha / CCT-alpha) subunit of the eukaryotic
+  cytosolic chaperonin CCT (chaperonin-containing TCP-1), also known as TRiC.
+  CCT/TRiC is an ATP-dependent, hetero-oligomeric double-ring chaperonin whose two
+  stacked rings are each built from eight distinct but paralogous subunits
+  (CCT1-CCT8 / alpha-theta); cct-1 is the alpha paralog. The assembled ~900 kDa
+  complex, not any individual subunit, is the folding machine: it uses cycles of
+  ATP binding and hydrolysis by its subunits to fold a subset of cytosolic
+  proteins, most notably the obligate cytoskeletal substrates actin and tubulin,
+  as well as WD40 beta-propeller proteins. The alpha subunit contributes an
+  equatorial nucleotide-binding module and an apical substrate-binding surface and,
+  unlike the low-ATPase subunits, retains a canonical ATP-binding/ATPase site. In
+  C. elegans, cct-1 is a single-copy gene on chromosome II expressed constitutively
+  throughout development, most prominently in neuronal and muscle tissues; the
+  chaperonin acts in the cytoplasm and, together with the other seven CCT subunits,
+  is essential for embryogenesis and for the in vivo biogenesis of actin and
+  tubulin that underlies microtubule organization and microvillus formation.
+existing_annotations:
+  - term:
+      id: GO:0006457
+      label: protein folding
+    evidence_type: IBA
+    original_reference_id: GO_REF:0000033
+    qualifier: involved_in
+    review:
+      summary: &gt;-
+        cct-1 is the alpha subunit of the cytosolic chaperonin CCT/TRiC, which
+        catalyzes ATP-dependent folding of actin, tubulin, and other cytosolic
+        substrates. Protein folding is the core biological process for this subunit.
+      action: ACCEPT
+      reason: &gt;-
+        The phylogenetic (IBA) inference is consistent with the conserved
+        chaperonin family assignment (PANTHER PTHR11353; InterPro alpha-subunit
+        signature IPR012715) and with direct evidence that the C. elegans CCT
+        complex is required for actin and tubulin biogenesis in vivo. Protein
+        folding is the correct core process annotation.
+      supported_by:
+        - reference_id: PMID:16762366
+          supporting_text: &gt;-
+            The eukaryotic cytosolic chaperonin CCT is an essential ATP-dependent
+            protein folding machine whose action is required for folding the
+            cytoskeletal proteins actin and tubulin
+        - reference_id: PMID:25143409
+          supporting_text: &gt;-
+            CCT depletion causes a reduction in the tubulin levels and disorganization
+            of the microtubule network
+  - term:
+      id: GO:0005832
+      label: chaperonin-containing T-complex
+    evidence_type: IBA
+    original_reference_id: GO_REF:0000033
+    qualifier: part_of
+    review:
+      summary: &gt;-
+        cct-1 is an integral subunit of the chaperonin-containing T-complex
+        (CCT/TRiC), built from eight paralogous subunits per ring.
+      action: ACCEPT
+      reason: &gt;-
+        Complex membership is the best-supported annotation for this gene. The
+        phylogenetic inference agrees with direct biochemical purification of the
+        C. elegans CCT complex, in which CCT-1 was identified as a subunit by
+        antibody Western blot, and with yeast genetics showing the ring is built
+        from eight distinct Cct subunits.
+      supported_by:
+        - reference_id: PMID:9434769
+          supporting_text: &gt;-
+            The chaperonin containing TCP-1 (CCT) from the free-living nematode
+            Caenorhabditis elegans was purified and shown to contain at least seven
+            subunit species ranging from 52-65 kDa
+        - reference_id: PMID:15704212
+          supporting_text: &gt;-
+            stoichiometric array of eight different subunits, which are denoted
+            Cct1p-Cct8p
+  - term:
+      id: GO:0005524
+      label: ATP binding
+    evidence_type: IEA
+    original_reference_id: GO_REF:0000002
+    qualifier: enables
+    review:
+      summary: &gt;-
+        Each CCT subunit binds ATP/ADP through the conserved equatorial
+        nucleotide-binding site of the group II chaperonin fold; nucleotide binding
+        drives the folding cycle.
+      action: ACCEPT
+      reason: &gt;-
+        ATP binding is directly supported for the C. elegans protein: purified
+        CCT-1/TCP-1 was shown to be a subunit of a high-molecular-mass complex that
+        binds ATP. This is fully consistent with the InterPro chaperonin domains and
+        the ATP-dependent mechanism of the complex. The alpha subunit retains a
+        canonical nucleotide-binding site.
+      supported_by:
+        - reference_id: PMID:7758963
+          supporting_text: &gt;-
+            Ce TCP-1 is a 57-kDa protein subunit of a high-molecular-mass complex
+            capable of binding ATP
+        - reference_id: PMID:16762366
+          supporting_text: &gt;-
+            The eukaryotic cytosolic chaperonin CCT is an essential ATP-dependent
+            protein folding machine
+  - term:
+      id: GO:0005737
+      label: cytoplasm
+    evidence_type: IEA
+    original_reference_id: GO_REF:0000044
+    qualifier: located_in
+    review:
+      summary: &gt;-
+        CCT/TRiC is a cytosolic chaperonin; cct-1 acts in the cytoplasm on cytosolic
+        substrates.
+      action: ACCEPT
+      reason: &gt;-
+        Cytoplasmic localization is consistent with the known biology of the
+        cytosolic chaperonin and with the UniProt subcellular location. The more
+        specific term cytosol (GO:0005829) would be preferable, but the broader
+        cytoplasm annotation is not incorrect and is retained.
+      supported_by:
+        - reference_id: PMID:16762366
+          supporting_text: &gt;-
+            The eukaryotic cytosolic chaperonin CCT is an essential ATP-dependent
+            protein folding machine
+  - term:
+      id: GO:0006457
+      label: protein folding
+    evidence_type: IEA
+    original_reference_id: GO_REF:0000002
+    qualifier: involved_in
+    review:
+      summary: &gt;-
+        InterPro domain-based annotation of protein folding, duplicating the IBA
+        protein-folding annotation.
+      action: ACCEPT
+      reason: &gt;-
+        Consistent electronic (InterPro) support for the core protein-folding
+        process, in agreement with the IBA annotation and the conserved chaperonin
+        mechanism.
+      supported_by:
+        - reference_id: PMID:16762366
+          supporting_text: &gt;-
+            Yeast CCT catalyses the folding of yeast ACT1p and human beta-actin with
+            nearly identical rate constants and yields.
+  - term:
+      id: GO:0016887
+      label: ATP hydrolysis activity
+    evidence_type: IEA
+    original_reference_id: GO_REF:0000002
+    qualifier: enables
+    review:
+      summary: &gt;-
+        The CCT subunits are ATPases; ATP hydrolysis around the ring powers the
+        substrate-folding cycle of the chaperonin.
+      action: ACCEPT
+      reason: &gt;-
+        ATP hydrolysis is a conserved catalytic activity of the CCT/TRiC family,
+        supported by the InterPro chaperonin domains and by the demonstration that
+        the worm CCT-1 complex binds ATP. The alpha subunit retains a functional
+        nucleotide-binding/ATPase site, so the term is appropriate.
+      supported_by:
+        - reference_id: PMID:16762366
+          supporting_text: &gt;-
+            The eukaryotic cytosolic chaperonin CCT is an essential ATP-dependent
+            protein folding machine
+        - reference_id: PMID:7758963
+          supporting_text: &gt;-
+            Ce TCP-1 is a 57-kDa protein subunit of a high-molecular-mass complex
+            capable of binding ATP
+  - term:
+      id: GO:0140662
+      label: ATP-dependent protein folding chaperone
+    evidence_type: IEA
+    original_reference_id: GO_REF:0000002
+    qualifier: enables
+    review:
+      summary: &gt;-
+        ATP-dependent protein folding chaperone is the most informative
+        molecular-function term for CCT/TRiC; cct-1 contributes to this activity as
+        a subunit of the complex.
+      action: ACCEPT
+      reason: &gt;-
+        This term precisely captures the activity of the CCT chaperonin. Strictly it
+        is a complex-level activity to which the alpha subunit contributes rather
+        than one it enables in isolation, but it is the best available
+        molecular-function descriptor for this gene.
+      supported_by:
+        - reference_id: PMID:16762366
+          supporting_text: &gt;-
+            The eukaryotic cytosolic chaperonin CCT is an essential ATP-dependent
+            protein folding machine whose action is required for folding the
+            cytoskeletal proteins actin and tubulin
+  - term:
+      id: GO:0005634
+      label: nucleus
+    evidence_type: IDA
+    original_reference_id: PMID:9434769
+    qualifier: located_in
+    review:
+      summary: &gt;-
+        A nucleus located_in annotation attributed to the 1997 C. elegans CCT-1
+        paper. CCT/TRiC is canonically a cytoplasmic chaperonin, and the primary
+        evidence for a nuclear location of CCT-1 cannot be verified from the
+        available record.
+      action: UNDECIDED
+      reason: &gt;-
+        The cited paper is abstract-only in the cache (full text not accessible). Its
+        abstract describes only a transcriptional promoter-reporter for cct-1
+        expression (tissue-level, neuronal and muscle), not protein immunolocalization;
+        in C. elegans such reporters commonly carry a nuclear localization signal,
+        which produces nuclear signal by construct design rather than reflecting
+        endogenous protein location. CCT is a cytosolic chaperonin (UniProt
+        subcellular location: cytoplasm). Because I cannot read the full text to
+        establish the basis for a nucleus located_in call, and per curation guidance
+        for annotations whose supporting publication is inaccessible, this is left
+        UNDECIDED rather than removed; nuclear localization is at most a minor,
+        non-core location for this cytosolic chaperonin subunit.
+      supported_by:
+        - reference_id: PMID:9434769
+          supporting_text: &gt;-
+            Expression of a reporter gene under the control of the C. elegans cct-1
+            promoter is found to be mainly restricted to neuronal and muscle tissues
+        - reference_id: PMID:16762366
+          supporting_text: &gt;-
+            The eukaryotic cytosolic chaperonin CCT is an essential ATP-dependent
+            protein folding machine
+  - term:
+      id: GO:0005832
+      label: chaperonin-containing T-complex
+    evidence_type: IDA
+    original_reference_id: PMID:9434769
+    qualifier: part_of
+    review:
+      summary: &gt;-
+        Direct experimental (IDA) demonstration that CCT-1 is a subunit of the
+        purified C. elegans chaperonin-containing T-complex.
+      action: ACCEPT
+      reason: &gt;-
+        This is the strongest annotation for the gene: the worm CCT complex was
+        purified and CCT-1 identified as a subunit by anti-CCT-1 Western blot, with a
+        subunit composition closely matching bovine CCT. Complex membership is
+        experimentally established in the correct organism.
+      supported_by:
+        - reference_id: PMID:9434769
+          supporting_text: &gt;-
+            The chaperonin containing TCP-1 (CCT) from the free-living nematode
+            Caenorhabditis elegans was purified and shown to contain at least seven
+            subunit species ranging from 52-65 kDa
+        - reference_id: PMID:7758963
+          supporting_text: &gt;-
+            Ce TCP-1 is a 57-kDa protein subunit of a high-molecular-mass complex
+            capable of binding ATP
+core_functions:
+  - description: &gt;-
+      cct-1 is the alpha subunit of the cytosolic chaperonin CCT/TRiC. As part of the
+      hetero-oligomeric double-ring complex it binds nucleotide through its equatorial
+      domain and presents an apical substrate-binding surface, contributing to the
+      ATP-dependent folding of actin, tubulin, and other cytosolic clients. The
+      foldase activity is a property of the assembled complex, to which the alpha
+      subunit contributes; unlike the low-ATPase subunits, alpha retains a canonical
+      nucleotide-binding/ATPase site.
+    molecular_function:
+      id: GO:0005524
+      label: ATP binding
+    contributes_to_molecular_function:
+      id: GO:0140662
+      label: ATP-dependent protein folding chaperone
+    directly_involved_in:
+      - id: GO:0006457
+        label: protein folding
+    locations:
+      - id: GO:0005737
+        label: cytoplasm
+    in_complex:
+      id: GO:0005832
+      label: chaperonin-containing T-complex
+    supported_by:
+      - reference_id: PMID:7758963
+        supporting_text: &gt;-
+          Ce TCP-1 is a 57-kDa protein subunit of a high-molecular-mass complex
+          capable of binding ATP
+      - reference_id: PMID:16762366
+        supporting_text: &gt;-
+          The eukaryotic cytosolic chaperonin CCT is an essential ATP-dependent
+          protein folding machine whose action is required for folding the
+          cytoskeletal proteins actin and tubulin
+      - reference_id: PMID:25143409
+        supporting_text: &gt;-
+          is essential for proper formation of microvilli in intestinal cells
+knowledge_gaps:
+  - gap_statement: &gt;-
+      There is no GO molecular-function term that expresses &#34;substrate-binding subunit
+      of the CCT chaperonin&#34;. The alpha (CCT-1) subunit&#39;s own activity can therefore
+      only be annotated as the complex-level foldase (GO:0140662) or as generic ATP
+      binding/hydrolysis, leaving cct-1 molecular-function-dark at the subunit level,
+      and its native C. elegans client repertoire (beyond actin and tubulin) is
+      undefined.
+    boundary: &gt;-
+      It is firmly established that cct-1 is the alpha subunit of the eight-membered
+      CCT/TRiC ring, that the assembled complex folds actin, tubulin, WD40 proteins
+      and other cytosolic clients, that the worm CCT-1 protein is part of a
+      high-molecular-mass ATP-binding complex, and that the eight subunits are
+      functionally non-equivalent. What is missing is a term (and worm-specific data)
+      that captures the alpha subunit&#39;s specific substrate-binding contribution.
+    gap_kind:
+      - ONTOLOGY
+      - BIOLOGY
+    dark_aspect: MF_DARK
+    status: OPEN
+    significance: &gt;-
+      CCT subunits are individually essential and non-redundant, so subunit-specific
+      substrate engagement underlies the complex&#39;s client selectivity. Because no
+      ontology term names a chaperonin substrate-binding subunit activity, the alpha
+      subunit&#39;s characterized structural/regulatory role cannot be curated, and its
+      native worm-specific clients remain unmapped.
+    resolution: &gt;-
+      Affinity-proteomics of the C. elegans CCT/TRiC to define native clients that
+      depend on the alpha subunit, plus crosslinking or cryo-EM mapping of alpha
+      apical-domain contacts, would define the subunit contribution; a new GO
+      molecular-function term for a chaperonin substrate-binding subunit activity
+      would let the knowledge be expressed.
+    provenance:
+      - reference_id: PMID:15704212
+        supporting_text: &gt;-
+          These results provide evidence for functional differences among Cct subunits
+          and for physiological properties of unassembled subunits
+      - reference_id: PMID:7758963
+        supporting_text: &gt;-
+          Ce TCP-1 is a 57-kDa protein subunit of a high-molecular-mass complex
+          capable of binding ATP
+    proposed_terms:
+      - proposed_name: chaperonin substrate-binding subunit activity
+        proposed_definition: &gt;-
+          A molecular function of a single subunit of a group II chaperonin
+          (CCT/TRiC) that presents an apical-domain substrate-binding surface and
+          contributes subunit-specific contacts to the ATP-dependent folding of
+          client proteins by the assembled chaperonin, without itself folding a
+          substrate independently of the complex.
+        justification: &gt;-
+          Individual CCT subunits such as cct-1/alpha have no adequate GO
+          molecular-function term: they can currently be annotated only with the
+          complex-level foldase activity (GO:0140662) or a generic catalytic term,
+          neither of which captures the subunit-specific substrate-binding
+          contribution that distinguishes the eight paralogous subunits.
+        proposed_parent:
+          id: GO:0003674
+          label: molecular_function
+  - gap_statement: &gt;-
+      Whether CCT-1 has any genuine, function-relevant nuclear localization in
+      C. elegans is unresolved. A nucleus located_in annotation exists (from the 1997
+      CCT-1 paper) but its experimental basis cannot be verified, and the chaperonin
+      is canonically cytoplasmic.
+    boundary: &gt;-
+      UniProt records the subcellular location of CCT-1 as cytoplasm, consistent with
+      CCT being a cytosolic chaperonin. The cited primary paper&#39;s abstract describes
+      only a transcriptional promoter-reporter (tissue-level expression), not protein
+      immunolocalization, so it does not by itself establish an endogenous nuclear
+      pool.
+    gap_kind:
+      - BIOLOGY
+      - CURATION
+    dark_aspect: RESIDUAL_SUBGAP
+    status: OPEN
+    significance: &gt;-
+      Some CCT/TRiC subunits have reported moonlighting roles outside the assembled
+      chaperonin; distinguishing a genuine nuclear function of CCT-1 from a
+      reporter-construct artifact would clarify whether the annotation should stand.
+    resolution: &gt;-
+      Endogenous immunolocalization or a tagged CCT-1 knock-in in C. elegans, with and
+      without an NLS-free transcriptional reporter as control, to test for a genuine
+      nuclear pool and any nuclear function.
+    provenance:
+      - reference_id: PMID:9434769
+        supporting_text: &gt;-
+          Expression of a reporter gene under the control of the C. elegans cct-1
+          promoter is found to be mainly restricted to neuronal and muscle tissues
+      - reference_id: PMID:16762366
+        supporting_text: &gt;-
+          The eukaryotic cytosolic chaperonin CCT is an essential ATP-dependent
+          protein folding machine
+proposed_new_terms:
+  - proposed_name: chaperonin substrate-binding subunit activity
+    proposed_definition: &gt;-
+      A molecular function of a single subunit of a group II chaperonin (CCT/TRiC)
+      that presents an apical-domain substrate-binding surface and contributes
+      subunit-specific contacts to the ATP-dependent folding of client proteins by the
+      assembled chaperonin, without itself folding a substrate independently of the
+      complex.
+    justification: &gt;-
+      Individual CCT subunits have no adequate GO molecular-function term and can only
+      be annotated with the complex-level foldase activity or a generic catalytic
+      term, obscuring subunit-specific substrate selectivity.
+    proposed_parent:
+      id: GO:0003674
+      label: molecular_function
+suggested_questions:
+  - question: &gt;-
+      Which native C. elegans clients depend specifically on the alpha (cct-1) subunit
+      contacts, as opposed to the CCT/TRiC complex as a whole?
+  - question: &gt;-
+      Does CCT-1 have any genuine nuclear pool or function in C. elegans, or is the
+      nucleus annotation an artifact of an NLS-tagged transcriptional reporter?
+suggested_experiments:
+  - description: &gt;-
+      Perform affinity purification/mass spectrometry of tagged cct-1 (or the assembled
+      CCT/TRiC) from C. elegans to identify native clients and interactors.
+    hypothesis: &gt;-
+      cct-1 engages a defined set of native C. elegans clients dominated by actin and
+      tubulin but including additional cytosolic proteins.
+  - description: &gt;-
+      Determine the endogenous subcellular localization of CCT-1 by immunostaining or a
+      tagged knock-in, comparing against an NLS-free transcriptional reporter, to test
+      whether a genuine nuclear pool exists.
+    hypothesis: &gt;-
+      Endogenous CCT-1 is predominantly cytoplasmic, and the nucleus annotation
+      reflects reporter design rather than protein localization.
+references:
+  - id: GO_REF:0000002
+    title: Gene Ontology annotation through association of InterPro records with GO terms
+    findings: []
+  - id: GO_REF:0000033
+    title: Annotation inferences using phylogenetic trees
+    findings: []
+  - id: GO_REF:0000044
+    title: &gt;-
+      Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location
+      vocabulary mapping, accompanied by conservative changes to GO terms applied by
+      UniProt
+    findings: []
+  - id: PMID:9434769
+    title: &gt;-
+      Subunit characterization of the Caenorhabditis elegans chaperonin containing
+      TCP-1 and expression pattern of the gene encoding CCT-1.
+    findings:
+      - statement: &gt;-
+          The C. elegans CCT complex was purified and shown to contain CCT-1 among at
+          least seven subunit species, with a composition like bovine CCT.
+        supporting_text: &gt;-
+          The chaperonin containing TCP-1 (CCT) from the free-living nematode
+          Caenorhabditis elegans was purified and shown to contain at least seven
+          subunit species ranging from 52-65 kDa
+      - statement: &gt;-
+          A cct-1 promoter reporter is expressed mainly in neuronal and muscle
+          tissues, consistent with a role in actin and tubulin folding.
+        supporting_text: &gt;-
+          Expression of a reporter gene under the control of the C. elegans cct-1
+          promoter is found to be mainly restricted to neuronal and muscle tissues
+    reference_review:
+      relevance: HIGH
+      correctness: VERIFIED
+      review_notes: &gt;-
+        PubMed-verified C. elegans-specific primary paper; basis for the WormBase IDA
+        complex-membership annotation. Abstract-only in cache, so the nucleus IDA it
+        also underlies cannot be independently verified (see the nucleus annotation
+        review).
+  - id: PMID:7758963
+    title: Molecular analysis of Caenorhabditis elegans tcp-1, a gene encoding a chaperonin protein.
+    findings:
+      - statement: &gt;-
+          The C. elegans TCP-1/CCT-1 protein is a 57-kDa subunit of a
+          high-molecular-mass ATP-binding complex; tcp-1 is single-copy on chromosome
+          II and constitutively expressed.
+        supporting_text: &gt;-
+          Ce TCP-1 is a 57-kDa protein subunit of a high-molecular-mass complex
+          capable of binding ATP
+    reference_review:
+      relevance: HIGH
+      correctness: VERIFIED
+      review_notes: &gt;-
+        PubMed-verified. Direct biochemical evidence in C. elegans that CCT-1 is a
+        subunit of a large ATP-binding complex; anchors the ATP binding and
+        complex-membership annotations.
+  - id: PMID:7576182
+    title: Characterization of four new tcp-1-related cct genes from the nematode Caenorhabditis elegans.
+    findings:
+      - statement: &gt;-
+          cct-1 (tcp-1) belongs to a C. elegans CCT multigene family whose members are
+          expressed in all life stages.
+        supporting_text: &gt;-
+          The five C. elegans cct genes are expressed in all life stages
+    reference_review:
+      relevance: MEDIUM
+      correctness: VERIFIED
+      review_notes: &gt;-
+        PubMed-verified. Establishes the C. elegans cct gene family and constitutive
+        expression; background/context for cct-1.
+  - id: PMID:16762366
+    title: &gt;-
+      Quantitative actin folding reactions using yeast CCT purified via an internal tag
+      in the CCT3/gamma subunit.
+    findings:
+      - statement: CCT/TRiC is an ATP-dependent folding machine for actin and tubulin.
+        supporting_text: &gt;-
+          The eukaryotic cytosolic chaperonin CCT is an essential ATP-dependent protein
+          folding machine whose action is required for folding the cytoskeletal proteins
+          actin and tubulin
+      - statement: Purified yeast CCT catalyzes actin folding.
+        supporting_text: &gt;-
+          Yeast CCT catalyses the folding of yeast ACT1p and human beta-actin with
+          nearly identical rate constants and yields.
+    reference_review:
+      relevance: HIGH
+      correctness: VERIFIED
+      review_notes: &gt;-
+        PubMed-verified. A yeast-based study establishing the conserved ATP-dependent
+        foldase mechanism and actin/tubulin/WD40 substrate scope of CCT/TRiC that
+        applies to the C. elegans alpha subunit. Used for mechanism, not a
+        worm-specific claim.
+  - id: PMID:15704212
+    title: Physiological effects of unassembled chaperonin Cct subunits in the yeast Saccharomyces cerevisiae.
+    findings:
+      - statement: CCT is built from eight distinct subunits Cct1p-Cct8p per ring that are functionally non-equivalent.
+        supporting_text: &gt;-
+          stoichiometric array of eight different subunits, which are denoted
+          Cct1p-Cct8p
+    reference_review:
+      relevance: MEDIUM
+      correctness: VERIFIED
+      review_notes: &gt;-
+        PubMed-verified. Yeast genetics showing the eight Cct subunits are distinct and
+        non-redundant; supports the subunit-level knowledge gap framing.
+  - id: PMID:25143409
+    title: &gt;-
+      Caenorhabditis elegans chaperonin CCT/TRiC is required for actin and tubulin
+      biogenesis and microvillus formation in intestinal epithelial cells.
+    findings:
+      - statement: &gt;-
+          C. elegans CCT is required in vivo for microvillus formation in intestinal
+          cells.
+        supporting_text: &gt;-
+          is essential for proper formation of microvilli in intestinal cells
+      - statement: CCT depletion reduces tubulin levels and disorganizes the microtubule network.
+        supporting_text: &gt;-
+          CCT depletion causes a reduction in the tubulin levels and disorganization of
+          the microtubule network
+      - statement: CCT acts specifically on actin and tubulin among the filamentous cytoskeletons.
+        supporting_text: &gt;-
+          suggesting substrate specificity of CCT in the folding of filamentous
+          cytoskeletons in vivo
+    reference_review:
+      relevance: HIGH
+      correctness: VERIFIED
+      review_notes: &gt;-
+        PubMed-verified C. elegans primary paper. Direct in vivo evidence for CCT
+        function in actin/tubulin biogenesis; strongly informs the protein-folding
+        annotations. (Validator sees abstract only; quotes drawn from the abstract.)
+</code></pre>
+            </div>
+        </details>
+    </div>
+
+    <!-- Pathway Visualization Link -->
+
+
+    <style>
+        /* Markdown Section Styles */
+        .markdown-section {
+            margin-bottom: 1rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .markdown-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .markdown-section summary h3 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.1rem;
+        }
+
+        .markdown-section summary:hover h3 {
+            color: #007bff;
+        }
+
+        .markdown-section[open] {
+            background-color: #fff;
+        }
+
+        .markdown-content {
+            margin-top: 1rem;
+            padding: 1rem;
+            border-top: 1px solid #dee2e6;
+        }
+
+        /* Markdown content styling */
+        .markdown-content h1 { font-size: 1.5rem; margin-top: 1.5rem; }
+        .markdown-content h2 { font-size: 1.3rem; margin-top: 1.3rem; }
+        .markdown-content h3 { font-size: 1.1rem; margin-top: 1.1rem; }
+        .markdown-content h4 { font-size: 1rem; margin-top: 1rem; }
+
+        .markdown-content pre {
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .markdown-content code {
+            background-color: #f8f9fa;
+            padding: 0.2rem 0.4rem;
+            border-radius: 3px;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+        }
+
+        .markdown-content pre code {
+            background: none;
+            padding: 0;
+        }
+
+        .markdown-content table {
+            border-collapse: collapse;
+            width: 100%;
+            margin: 1rem 0;
+        }
+
+        .markdown-content table th,
+        .markdown-content table td {
+            border: 1px solid #dee2e6;
+            padding: 0.5rem;
+            text-align: left;
+        }
+
+        .markdown-content table th {
+            background-color: #f8f9fa;
+            font-weight: bold;
+        }
+
+        .markdown-content blockquote {
+            border-left: 4px solid #007bff;
+            padding-left: 1rem;
+            margin-left: 0;
+            color: #666;
+        }
+
+        /* YAML Preview Styles */
+        .yaml-preview {
+            margin-top: 2rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .yaml-preview summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .yaml-preview summary h2 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.3rem;
+        }
+
+        .yaml-preview summary:hover h2 {
+            color: #007bff;
+        }
+
+        .yaml-preview[open] {
+            background-color: #fff;
+        }
+
+        .yaml-content {
+            margin-top: 1rem;
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .yaml-content pre {
+            margin: 0;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+            line-height: 1.4;
+        }
+
+        .yaml-content code {
+            color: #333;
+            background: none;
+            padding: 0;
+        }
+
+        /* Pathway Link Styles */
+        .pathway-link {
+            margin: 1rem 0;
+        }
+
+        .btn-link {
+            display: inline-block;
+            padding: 0.5rem 1rem;
+            background-color: #007bff;
+            color: white !important;
+            text-decoration: none;
+            border-radius: 4px;
+            font-weight: 500;
+            transition: background-color 0.2s;
+        }
+
+        .btn-link:hover {
+            background-color: #0056b3;
+            text-decoration: none;
+        }
+
+        /* Voting buttons */
+        .vote-buttons {
+            display: inline-block;
+            margin-left: 0.5rem;
+        }
+
+        .vote-btn {
+            background: none;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 2px 6px;
+            margin: 0 2px;
+            cursor: pointer;
+            font-size: 0.9rem;
+            transition: all 0.2s;
+            opacity: 0.6;
+        }
+
+        .vote-btn:hover {
+            opacity: 1;
+            transform: scale(1.1);
+        }
+
+        .vote-btn.voted {
+            opacity: 1;
+            border-color: #28a745;
+            background-color: #d4edda;
+        }
+
+        .vote-btn.voted-down {
+            border-color: #dc3545;
+            background-color: #f8d7da;
+        }
+
+        .vote-btn-small {
+            font-size: 0.7rem;
+            padding: 1px 4px;
+            margin: 0 1px;
+        }
+    </style>
+
+    <script>
+        // Add collapsible functionality
+        document.querySelectorAll('.collapsible').forEach(element => {
+            element.addEventListener('click', function() {
+                this.classList.toggle('collapsed');
+            });
+        });
+
+        // Voting functionality
+        const VOTE_URL = 'https://script.google.com/macros/s/AKfycbwPKH7d3seuPNBtB0ugVjqGeTiByyOGD5vkqB_Ck6K8eOcPQYbJqBOuz6GFgXHKBNWK/exec';
+
+        // Get or create session ID
+        let sessionId = localStorage.getItem('review_session_id');
+        if (!sessionId) {
+            sessionId = 's' + Date.now() + '_' + Math.random().toString(36).substr(2, 9);
+            localStorage.setItem('review_session_id', sessionId);
+        }
+
+        // Show previous votes on page load
+        document.addEventListener('DOMContentLoaded', function() {
+            document.querySelectorAll('.vote-buttons').forEach(container => {
+                const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+                const previousVote = localStorage.getItem(key);
+                if (previousVote) {
+                    const btn = container.querySelector(`[data-v="${previousVote}"]`);
+                    if (btn) btn.classList.add(previousVote === 'up' ? 'voted' : 'voted-down');
+                }
+            });
+        });
+
+        // Handle vote clicks - Simple image beacon approach
+        document.addEventListener('click', function(e) {
+            if (!e.target.classList.contains('vote-btn')) return;
+
+            // Prevent the click from bubbling to parent elements (like summary)
+            e.preventDefault();
+            e.stopPropagation();
+
+            const btn = e.target;
+            const container = btn.closest('.vote-buttons');
+            if (!container) return;
+
+            const voteType = btn.dataset.v;
+
+            // Check if already voted (locally)
+            const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+            const previousVote = localStorage.getItem(key);
+
+            if (previousVote === voteType) {
+                // Same vote - do nothing
+                btn.style.animation = 'shake 0.5s';
+                setTimeout(() => btn.style.animation = '', 500);
+                return;
+            }
+
+            // Build URL
+            const params = new URLSearchParams({
+                gene_id: container.dataset.g,
+                annotation_id: container.dataset.a,
+                ref_id: container.dataset.r || '',
+                action: container.dataset.act,
+                vote: voteType,
+                session_id: sessionId,
+                ua: navigator.userAgent.substring(0, 100)
+            });
+
+            // Clear previous vote styling
+            container.querySelectorAll('.vote-btn').forEach(b => {
+                b.classList.remove('voted', 'voted-down');
+            });
+
+            // Apply new vote styling immediately (optimistic UI)
+            btn.classList.add(voteType === 'up' ? 'voted' : 'voted-down');
+
+            // Store locally
+            localStorage.setItem(key, voteType);
+
+            // Send vote using fetch with no-cors mode (fire and forget)
+            const fullUrl = VOTE_URL + '?' + params;
+            console.log('Sending vote to:', fullUrl);
+
+            // Use fetch in no-cors mode - we won't get a response but the request will be sent
+            fetch(fullUrl, {
+                mode: 'no-cors',
+                method: 'GET'
+            }).then(() => {
+                console.log('Vote request sent (no response due to no-cors mode)');
+            }).catch(err => {
+                console.warn('Vote may not have been recorded, but saved locally:', err);
+
+                // Fallback: try image beacon as well
+                const img = new Image();
+                img.src = fullUrl;
+            });
+        });
+
+        // Optional: Add shake animation for feedback
+        const style = document.createElement('style');
+        style.textContent = `
+            @keyframes shake {
+                0%, 100% { transform: translateX(0); }
+                25% { transform: translateX(-5px); }
+                75% { transform: translateX(5px); }
+            }
+        `;
+        document.head.appendChild(style);
+    </script>
+</body>
+</html>

--- a/pages/projects/CAEEL_PROTEOSTASIS.html
+++ b/pages/projects/CAEEL_PROTEOSTASIS.html
@@ -388,7 +388,7 @@
 - <strong><a href="../../genes/worm/daf-21/daf-21-ai-review.html">daf-21</a></strong> - HSP90 ortholog</p>
 <h3 id="2-chaperonins">2. Chaperonins</h3>
 <p>Protein folding chambers:<br />
-- <strong>cct-1 through <a href="../../genes/worm/cct-8/cct-8-ai-review.html">cct-8</a></strong> - TRiC/CCT complex subunits<br />
+- <strong><a href="../../genes/worm/cct-1/cct-1-ai-review.html">cct-1</a> through <a href="../../genes/worm/cct-8/cct-8-ai-review.html">cct-8</a></strong> - TRiC/CCT complex subunits<br />
 - <strong><a href="../../genes/worm/hsp-60/hsp-60-ai-review.html">hsp-60</a></strong> - Mitochondrial chaperonin</p>
 <h3 id="3-hsp70-co-chaperones">3. HSP70 Co-chaperones</h3>
 <ul>


### PR DESCRIPTION
## Summary

Automated regeneration of static assets after gene review or template changes.

## Generated Assets

| Asset | Count/Status |
|-------|--------------|
| Gene review YAML files | 2863 |
| Gene review HTML pages | 2863 |
| Project pages | 1098 |
| Module pages | 87 |
| Browser app (data.js) | Updated |
| Validation report | Updated |

## Trigger

This PR was triggered by changes to:
- genes/**/*.yaml - gene review data files
- src/ai_gene_review/schema/** - LinkML schema files
- src/ai_gene_review/templates/** - Jinja2 templates
- src/ai_gene_review/render.py - rendering code
- src/ai_gene_review/render_modules.py - module rendering code
- src/ai_gene_review/export/** - export code
- src/ai_gene_review/browser/** - browser app assets
- src/ai_gene_review/tools/minify_linkml_browser_data.py - browser data compaction
- projects/*.md - project definitions
- modules/**/*.yaml - module definitions
- project.justfile - just recipes used by CI
- .github/workflows/generate-pages.yaml - workflow definition

## Review

- [ ] Spot-check a few gene review HTML pages render correctly
- [ ] Spot-check module tree browser pages render correctly
- [ ] Verify browser app loads and filters work
- [ ] Check validation report for new issues
