### PR TITLE
Regenerate pages and browser app

### DIFF
--- a/genes/worm/dyf-5/dyf-5-ai-review.html
+++ b/genes/worm/dyf-5/dyf-5-ai-review.html
@@ -1,0 +1,5027 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>dyf-5 - AI Gene Review</title>
+    <style>
+        :root {
+            --color-accept: #22c55e;
+            --color-remove: #ef4444;
+            --color-modify: #f97316;
+            --color-keep-non-core: #3b82f6;
+            --color-undecided: #6b7280;
+            --color-new: #8b5cf6;
+            --color-mark-over: #eab308;
+            --bg-light: #f9fafb;
+            --border-color: #e5e7eb;
+            --text-muted: #6b7280;
+            --text-primary: #111827;
+        }
+
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+            line-height: 1.6;
+            color: var(--text-primary);
+            background-color: #ffffff;
+            padding: 2rem;
+            max-width: 1400px;
+            margin: 0 auto;
+        }
+
+        .header {
+            border-bottom: 2px solid var(--border-color);
+            padding-bottom: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        h1 {
+            font-size: 2.5rem;
+            font-weight: 700;
+            margin-bottom: 0.5rem;
+            color: #1f2937;
+        }
+
+        .gene-info {
+            display: flex;
+            gap: 2rem;
+            flex-wrap: wrap;
+            margin-top: 1rem;
+        }
+
+        .info-item {
+            display: flex;
+            gap: 0.5rem;
+        }
+
+        .info-label {
+            font-weight: 600;
+            color: var(--text-muted);
+        }
+
+        .aliases {
+            display: flex;
+            gap: 0.5rem;
+            flex-wrap: wrap;
+        }
+
+        .badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.875rem;
+            font-weight: 500;
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+        }
+
+        .status-badge {
+            padding: 0.375rem 0.875rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .status-initialized {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fde68a;
+        }
+
+        .status-in-progress {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+        }
+
+        .status-draft {
+            background-color: #fce7f3;
+            color: #831843;
+            border: 1px solid #fbcfe8;
+        }
+
+        .status-complete {
+            background-color: #d1fae5;
+            color: #065f46;
+            border: 1px solid #a7f3d0;
+        }
+
+        .description-card {
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        .description-card h2 {
+            font-size: 1.25rem;
+            margin-bottom: 1rem;
+            color: #374151;
+        }
+
+        .section {
+            margin-bottom: 2.5rem;
+        }
+
+        .section-title {
+            font-size: 1.5rem;
+            font-weight: 600;
+            margin-bottom: 1.5rem;
+            color: #1f2937;
+            border-bottom: 1px solid var(--border-color);
+            padding-bottom: 0.5rem;
+        }
+
+        .annotations-table {
+            width: 100%;
+            border-collapse: collapse;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            overflow: hidden;
+        }
+
+        .annotations-table thead {
+            background-color: var(--bg-light);
+        }
+
+        .annotations-table th {
+            text-align: left;
+            padding: 1rem;
+            font-weight: 600;
+            border-bottom: 2px solid var(--border-color);
+            font-size: 0.875rem;
+            text-transform: uppercase;
+            letter-spacing: 0.05em;
+            color: var(--text-muted);
+        }
+
+        .annotations-table td {
+            padding: 1rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .annotations-table tbody tr:hover {
+            background-color: #f9fafb;
+        }
+
+        .action-badge {
+            display: inline-block;
+            padding: 0.375rem 0.75rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .action-accept {
+            background-color: var(--color-accept);
+            color: white;
+        }
+
+        .action-remove {
+            background-color: var(--color-remove);
+            color: white;
+        }
+
+        .action-modify {
+            background-color: var(--color-modify);
+            color: white;
+        }
+
+        .action-keep_as_non_core {
+            background-color: var(--color-keep-non-core);
+            color: white;
+        }
+
+        .action-undecided {
+            background-color: var(--color-undecided);
+            color: white;
+        }
+
+        .action-new {
+            background-color: var(--color-new);
+            color: white;
+        }
+
+        .action-mark_as_over_annotated {
+            background-color: var(--color-mark-over);
+            color: white;
+        }
+
+        .term-info {
+            display: flex;
+            flex-direction: column;
+            gap: 0.25rem;
+        }
+
+        .term-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .term-label {
+            font-weight: 500;
+        }
+
+        .evidence-code {
+            font-family: monospace;
+            background-color: var(--bg-light);
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .not-badge {
+            display: inline-block;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-weight: 600;
+            margin-left: 0.25rem;
+        }
+
+        .isoform-badge {
+            display: inline-block;
+            background-color: #eff6ff;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            margin-top: 0.25rem;
+        }
+
+        .core-function-card {
+            background-color: white;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 1rem;
+        }
+
+        .core-function-card h3 {
+            font-size: 1.125rem;
+            margin-bottom: 1rem;
+            color: #1f2937;
+        }
+
+        .core-function-statement {
+            margin-bottom: 1rem;
+            padding: 0.75rem;
+            background-color: var(--bg-light);
+            border-left: 4px solid var(--color-accept);
+            border-radius: 0.25rem;
+        }
+
+        .function-annotations {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin-top: 1rem;
+        }
+
+        .reference-item {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+        }
+
+        .reference-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: start;
+            margin-bottom: 0.75rem;
+        }
+
+        .reference-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #2563eb;
+        }
+
+        .supported-by {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f3f4f6;
+            border-left: 3px solid #3b82f6;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .supported-by-title {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .support-item {
+            margin-bottom: 0.5rem;
+        }
+
+        .support-ref {
+            font-weight: 500;
+            color: #2563eb;
+        }
+
+        .support-text {
+            color: #6b7280;
+            font-style: italic;
+            margin-left: 1rem;
+        }
+
+        .propagation-review {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f8fafc;
+            border-left: 3px solid #64748b;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .propagation-title {
+            font-weight: 600;
+            color: #334155;
+            margin-bottom: 0.25rem;
+        }
+
+        .propagation-row {
+            margin-top: 0.25rem;
+        }
+
+        .propagation-source {
+            margin-top: 0.5rem;
+            padding-top: 0.5rem;
+            border-top: 1px solid #e5e7eb;
+        }
+
+        .propagation-source-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #1d4ed8;
+        }
+
+        .propagation-comment {
+            color: #4b5563;
+            margin-left: 1rem;
+        }
+
+        a.term-link {
+            color: #2563eb;
+            text-decoration: none;
+        }
+
+        a.term-link:hover {
+            text-decoration: underline;
+        }
+
+        .core-function-terms {
+            margin-top: 1rem;
+        }
+
+        .function-term-group {
+            margin-bottom: 1rem;
+        }
+
+        .function-term-label {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .reference-title {
+            font-weight: 500;
+            margin-bottom: 0.5rem;
+        }
+
+        .findings-list {
+            margin-top: 1rem;
+            padding-left: 1.5rem;
+        }
+
+        .finding-item {
+            margin-bottom: 0.75rem;
+        }
+
+        .finding-statement {
+            font-weight: 500;
+            margin-bottom: 0.25rem;
+        }
+
+        .finding-text {
+            color: var(--text-muted);
+            font-size: 0.95rem;
+            font-style: italic;
+        }
+
+        .proposed-term {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #fef3c7;
+        }
+
+        .question-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #dbeafe;
+        }
+
+        .experiment-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #f3e8ff;
+        }
+
+        .prediction-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: white;
+        }
+
+        .prediction-card .prediction-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+        }
+
+        .prediction-source {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+        }
+
+        .assessment-badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.8rem;
+            font-weight: 600;
+            text-transform: uppercase;
+        }
+
+        .assessment-cor { background-color: #dcfce7; color: #166534; }
+        .assessment-cnn { background-color: #dbeafe; color: #1e40af; }
+        .assessment-lsp { background-color: #fef9c3; color: #854d0e; }
+        .assessment-unc { background-color: #f3f4f6; color: #374151; }
+        .assessment-pli { background-color: #fee2e2; color: #991b1b; }
+        .assessment-npi { background-color: #fecaca; color: #7f1d1d; }
+        .assessment-rep { background-color: #fde68a; color: #92400e; }
+
+        .confidence-score {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+            margin-left: 0.5rem;
+        }
+
+        .error-type-badge {
+            font-size: 0.75rem;
+            padding: 0.125rem 0.5rem;
+            border-radius: 0.25rem;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+        }
+
+        .isoforms-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fill, minmax(400px, 1fr));
+            gap: 1rem;
+        }
+
+        .isoform-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            background-color: white;
+            transition: box-shadow 0.2s;
+        }
+
+        .isoform-card:hover {
+            box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+        }
+
+        .functional-isoform-type {
+            display: inline-block;
+            padding: 0.2rem 0.5rem;
+            border-radius: 0.25rem;
+            font-size: 0.7rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.03em;
+        }
+
+        .type-SPLICE_VARIANT, .type-SPLICE_CLASS {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #93c5fd;
+        }
+
+        .type-CLEAVAGE_PRODUCT {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fcd34d;
+        }
+
+        .type-MODIFICATION_STATE {
+            background-color: #f3e8ff;
+            color: #6b21a8;
+            border: 1px solid #c4b5fd;
+        }
+
+        .type-CONFORMATIONAL_STATE {
+            background-color: #dcfce7;
+            color: #166534;
+            border: 1px solid #86efac;
+        }
+
+        .functional-isoform-mappings {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+            font-size: 0.85rem;
+        }
+
+        .functional-isoform-mappings .mapping-type {
+            font-weight: 600;
+            color: var(--text-muted);
+            font-size: 0.75rem;
+        }
+
+        .functional-isoform-go {
+            margin-top: 0.5rem;
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.25rem;
+        }
+
+        .go-chip {
+            display: inline-block;
+            padding: 0.15rem 0.4rem;
+            background-color: #ecfdf5;
+            color: #047857;
+            border: 1px solid #a7f3d0;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-family: monospace;
+        }
+
+        .isoform-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+            padding-bottom: 0.5rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .isoform-name {
+            font-weight: 600;
+            font-size: 1.1rem;
+            color: #1f2937;
+        }
+
+        .isoform-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .isoform-sequence-note {
+            font-size: 0.875rem;
+            color: var(--text-muted);
+            margin-bottom: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+        }
+
+        .isoform-description {
+            font-size: 0.95rem;
+            line-height: 1.5;
+        }
+
+        .collapsible {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .collapsible:after {
+            content: ' ▼';
+            font-size: 0.75rem;
+        }
+
+        .collapsible.collapsed:after {
+            content: ' ►';
+        }
+
+        .collapse-content {
+            transition: max-height 0.3s ease;
+            overflow: hidden;
+        }
+
+        .collapsed + .collapse-content {
+            max-height: 0;
+        }
+
+        .no-data {
+            color: var(--text-muted);
+            font-style: italic;
+            padding: 1rem;
+            text-align: center;
+            background-color: var(--bg-light);
+            border-radius: 0.5rem;
+        }
+
+        /* Styling for markdown section summaries with voting */
+        .markdown-section summary {
+            padding: 0.75rem;
+            background: var(--bg-light);
+            border-radius: 0.5rem;
+            margin-bottom: 0.5rem;
+        }
+
+        .markdown-section summary:hover {
+            background: #e5e7eb;
+        }
+
+        .markdown-section summary .vote-buttons {
+            margin-left: auto;
+        }
+
+        .deep-research-section {
+            margin-bottom: 1rem;
+            border: 1px solid #c7d2fe;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8faff;
+        }
+
+        .deep-research-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .deep-research-section summary h3 {
+            margin: 0;
+            color: #3730a3;
+            font-size: 1.1rem;
+        }
+
+        .report-meta {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin: 0.75rem 0 1rem;
+            align-items: center;
+        }
+
+        .report-badge {
+            display: inline-flex;
+            align-items: center;
+            border: 1px solid #c7d2fe;
+            border-radius: 999px;
+            background: #eef2ff;
+            color: #4338ca;
+            font-size: 0.78rem;
+            font-weight: 600;
+            padding: 0.2rem 0.6rem;
+        }
+
+        .report-meta-text {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+        }
+
+        .artifact-list {
+            display: grid;
+            gap: 0.75rem;
+            margin: 0.75rem 0 1rem;
+        }
+
+        .artifact-link {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+            margin-top: 0.5rem;
+            word-break: break-word;
+        }
+
+        @media print {
+            body {
+                padding: 1rem;
+            }
+
+            .collapsible:after {
+                display: none;
+            }
+
+            .collapsed + .collapse-content {
+                max-height: none !important;
+            }
+        }
+
+        @media (max-width: 768px) {
+            body {
+                padding: 1rem;
+            }
+
+            h1 {
+                font-size: 2rem;
+            }
+
+            .annotations-table {
+                font-size: 0.875rem;
+            }
+
+            .annotations-table th,
+            .annotations-table td {
+                padding: 0.5rem;
+            }
+        }
+    </style>
+</head>
+<body>
+    <div class="header">
+        <h1>dyf-5</h1>
+        <div class="gene-info">
+
+            <div class="info-item">
+
+                <span class="info-label">UniProt ID:</span>
+                <span>
+                    <a href="https://www.uniprot.org/uniprotkb/B3WFY8" target="_blank" class="term-link">
+                        B3WFY8
+                    </a>
+                </span>
+
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Organism:</span>
+                <span>Caenorhabditis elegans</span>
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Review Status:</span>
+                <span class="status-badge status-draft">
+                    DRAFT
+                </span>
+            </div>
+
+
+        </div>
+        <div style="margin-top: 1rem; text-align: center;">
+            <a id="feedback-form-link"
+               href="#"
+               target="_blank"
+               style="display: inline-block; padding: 10px 20px; background-color: #4CAF50; color: white; text-decoration: none; border-radius: 5px; font-weight: 600;">
+                📝 Provide Detailed Feedback
+            </a>
+            <script>
+                // Construct the form URL with proper encoding
+                // Extract organism code from the current page path (e.g., /genes/ARATH/APO1/ -> ARATH)
+                const pathParts = window.location.pathname.split('/');
+                const genesIndex = pathParts.indexOf('genes');
+                let organism = '';
+                if (genesIndex !== -1 && pathParts[genesIndex + 1]) {
+                    organism = pathParts[genesIndex + 1].toUpperCase();
+                }
+                const geneSymbol = "dyf-5";
+                const speciesGene = organism + ' ' + geneSymbol;
+                const formBaseUrl = 'https://docs.google.com/forms/d/e/1FAIpQLSdTot9L6GVkkZYgLQT0E8ZdAJv8RiN5ZgOVkgWNcKSbYvxxzQ/viewform';
+                const entryId = '1226477767'; // Correct entry ID for Species/Gene field
+                const formUrl = formBaseUrl + '?entry.' + entryId + '=' + encodeURIComponent(speciesGene);
+                const feedbackLink = document.getElementById('feedback-form-link');
+                feedbackLink.href = formUrl;
+                // Add tooltip showing the pre-filled value
+                feedbackLink.title = 'Opens form with pre-filled: ' + speciesGene;
+            </script>
+        </div>
+    </div>
+
+
+    <div class="description-card">
+        <div style="display: flex; justify-content: space-between; align-items: center;">
+            <h2>Gene Description</h2>
+            <span class="vote-buttons" data-g="B3WFY8" data-a="DESCRIPTION: dyf-5 encodes a ciliary serine/threonine protein k..." data-r="" data-act="DESCRIPTION">
+                <button class="vote-btn" data-v="up" title="Agree with this description">👍</button>
+                <button class="vote-btn" data-v="down" title="Disagree with this description">👎</button>
+            </span>
+        </div>
+        <p>dyf-5 encodes a ciliary serine/threonine protein kinase of the CMGC-group, MAK/RCK (ICK/CILK1-related) subfamily. It is expressed in ciliated sensory neurons of the head (amphid and labial) and tail (phasmid), where its protein is enriched at the dendrite-cilium transition zone and distributed from the tip of the ciliary middle segment through the distal segment to the ciliary tip. DYF-5 is a master regulator of sensory-cilium length, morphology and intraflagellar transport (IFT). In worm cilia, anterograde IFT is driven by two kinesin-2 motors (heterotrimeric kinesin-II, KLP-11/KLP-20/KAP-1, in the middle segment and homodimeric OSM-3 in the distal segment); DYF-5 coordinates their handover, promoting undocking of kinesin-II from IFT trains at the end of the middle segment and docking of OSM-3 onto IFT particles. Two direct in-vitro substrates are established: the IFT-B subunit IFT-74, whose N-terminal tubulin-binding module DYF-5 phosphorylates at multiple sites to lower IFT-74/81 tubulin affinity and release tubulin at the ciliary tip, and the OSM-3 kinesin C-terminal region. Loss of dyf-5 produces abnormally long, misaligned cilia with accumulation of IFT components, whereas altered IFT-74 phosphorylation lengthens or shortens cilia, consistent with a balance-point model of tubulin delivery and axoneme length control. The kinase acts with the substrate consensus motif (R)PX[S/T].</p>
+    </div>
+
+
+
+
+
+
+
+    <div class="section">
+        <h2 class="section-title">Existing Annotations Review</h2>
+        <table class="annotations-table">
+            <thead>
+                <tr>
+                    <th>GO Term</th>
+                    <th>Evidence</th>
+                    <th>Action</th>
+                    <th>Reason</th>
+                </tr>
+            </thead>
+            <tbody>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0004674" target="_blank" class="term-link">
+                                    GO:0004674
+                                </a>
+                            </span>
+                            <span class="term-label">protein serine/threonine kinase activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="B3WFY8" data-a="GO:0004674" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Phylogenetic (IBA) inference of the core molecular function. DYF-5 is a bona fide protein serine/threonine kinase and this is directly demonstrated experimentally (see the IDA annotations from PMID:35969738 and PMID:38806659), so this term represents the core function of the gene.
+                        </div>
+
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/35969738" target="_blank" class="term-link">
+                                        PMID:35969738
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">the ciliary kinase DYF-5/MAK phosphorylates multiple sites within the tubulin-binding module of IFT-74, reducing the tubulin-binding affinity of IFT-74/81 approximately sixfold</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005634" target="_blank" class="term-link">
+                                    GO:0005634
+                                </a>
+                            </span>
+                            <span class="term-label">nucleus</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="B3WFY8" data-a="GO:0005634" data-r="GO_REF:0000033" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Nuclear localization is inferred phylogenetically from the broader MAPK/CMGC family (many canonical MAPKs are nuclear), but there is no experimental evidence that C. elegans DYF-5 acts in the nucleus. The experimentally established sites of action are the cilium, dendrite, axon and neuronal cell body; a ciliary IFT-regulating kinase in the nucleus is not supported. Treated as an over-propagated family inference.
+                        </div>
+
+
+
+
+                        <div class="propagation-review">
+                            <div class="propagation-title">Propagation Review</div>
+                            <div class="propagation-row">
+                                <strong>Root cause:</strong>
+                                <span class="badge">PROPAGATION BAD</span>
+                            </div>
+
+                            <div class="propagation-row">
+                                <strong>Failure modes:</strong>
+
+                                <span class="badge">COMPARTMENT OR COMPLEX MISMATCH</span>
+
+                                <span class="badge">FUNCTIONAL DIVERGENCE</span>
+
+                            </div>
+
+
+                            <div class="propagation-source">
+                                <strong>Sources checked:</strong>
+
+                                <div class="propagation-row">
+                                    <span class="propagation-source-id">PANTHER:PTN000622075</span>
+
+                                    &middot; MAPK/CMGC family node
+
+
+                                    <span class="badge">SUPPORTS SOURCE BUT NOT TARGET</span>
+
+
+                                    <div class="propagation-comment">Nuclear localization is a property of canonical MAPKs in the family tree, not of the divergent ciliary MAK/RCK member DYF-5, which localizes to the cilium, dendrite, axon and cell body with no nuclear evidence.</div>
+
+                                </div>
+
+                            </div>
+
+                        </div>
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005737" target="_blank" class="term-link">
+                                    GO:0005737
+                                </a>
+                            </span>
+                            <span class="term-label">cytoplasm</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="B3WFY8" data-a="GO:0005737" data-r="GO_REF:0000033" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Broadly correct but non-informative. DYF-5 is present in the neuronal cell body/cytoplasm, but its characterized site of action is the cilium. Retained as a general, non-core location.
+                        </div>
+
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0035556" target="_blank" class="term-link">
+                                    GO:0035556
+                                </a>
+                            </span>
+                            <span class="term-label">intracellular signal transduction</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="B3WFY8" data-a="GO:0035556" data-r="GO_REF:0000033" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Generic biological-process term propagated from the MAPK/CMGC family. DYF-5&#39;s actual, well-characterized role is regulation of intraflagellar transport and cilium length, not canonical intracellular signal transduction. The specific ciliary/IFT process terms capture the biology far better.
+                        </div>
+
+
+
+
+                        <div class="propagation-review">
+                            <div class="propagation-title">Propagation Review</div>
+                            <div class="propagation-row">
+                                <strong>Root cause:</strong>
+                                <span class="badge">TERM SCOPING PROBLEM</span>
+                            </div>
+
+                            <div class="propagation-row">
+                                <strong>Failure modes:</strong>
+
+                                <span class="badge">FUNCTIONAL DIVERGENCE</span>
+
+                                <span class="badge">GRANULARITY MISMATCH</span>
+
+                            </div>
+
+
+                            <div class="propagation-source">
+                                <strong>Sources checked:</strong>
+
+                                <div class="propagation-row">
+                                    <span class="propagation-source-id">PANTHER:PTN000622075</span>
+
+                                    &middot; MAPK/CMGC family node
+
+
+                                    <span class="badge">SUPPORTS SOURCE BUT NOT TARGET</span>
+
+
+                                    <div class="propagation-comment">The signal-transduction role is a family-level generalization; the MAK/RCK member DYF-5 acts as a ciliary IFT/length regulator, so the specific IFT and cilium-assembly process terms are the informative annotations.</div>
+
+                                </div>
+
+                            </div>
+
+                        </div>
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005929" target="_blank" class="term-link">
+                                    GO:0005929
+                                </a>
+                            </span>
+                            <span class="term-label">cilium</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="B3WFY8" data-a="GO:0005929" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Core cellular location. DYF-5 is a ciliary kinase; it acts within sensory cilia along the axoneme and is enriched at the dendrite-cilium transition zone.
+                        </div>
+
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/35969738" target="_blank" class="term-link">
+                                        PMID:35969738
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">the ciliary kinase DYF-5/MAK</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0060271" target="_blank" class="term-link">
+                                    GO:0060271
+                                </a>
+                            </span>
+                            <span class="term-label">cilium assembly</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="B3WFY8" data-a="GO:0060271" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Core biological process. DYF-5 is required for normal ciliogenesis; loss of function yields abnormally long, misshapen sensory cilia. Supported both by phylogeny and by direct C. elegans experiments.
+                        </div>
+
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/35969738" target="_blank" class="term-link">
+                                        PMID:35969738
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Ablation or constitutive activation of IFT-74 phosphorylation abnormally elongates or shortens sensory cilia in Caenorhabditis elegans neurons</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0042073" target="_blank" class="term-link">
+                                    GO:0042073
+                                </a>
+                            </span>
+                            <span class="term-label">intraciliary transport</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="B3WFY8" data-a="GO:0042073" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Core biological process. DYF-5 regulates IFT; in dyf-5 mutants IFT proteins accumulate abnormally in cilia and IFT motor behavior is disrupted.
+                        </div>
+
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/17420466" target="_blank" class="term-link">
+                                        PMID:17420466
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">six IFT proteins accumulate in the cilia of dyf-5(lf) mutants</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0000165" target="_blank" class="term-link">
+                                    GO:0000165
+                                </a>
+                            </span>
+                            <span class="term-label">MAPK cascade</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000108
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="B3WFY8" data-a="GO:0000165" data-r="GO_REF:0000108" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Electronic inference (GO_REF:0000108) triggered by the MAP-kinase-activity term. DYF-5 belongs to the MAK/RCK (ICK/CILK1) subfamily; despite the historical &#34;MAP kinase&#34; name it is not a component of a canonical three-tiered MAP3K-MAP2K-MAPK signaling cascade, and no such cascade role is documented for DYF-5. Over-annotation driven by nomenclature.
+                        </div>
+
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0004672" target="_blank" class="term-link">
+                                    GO:0004672
+                                </a>
+                            </span>
+                            <span class="term-label">protein kinase activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000002
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="B3WFY8" data-a="GO:0004672" data-r="GO_REF:0000002" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Correct but a general parent of the specific, experimentally supported term protein serine/threonine kinase activity (GO:0004674). Retained as non-core.
+                        </div>
+
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0004674" target="_blank" class="term-link">
+                                    GO:0004674
+                                </a>
+                            </span>
+                            <span class="term-label">protein serine/threonine kinase activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000003
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="B3WFY8" data-a="GO:0004674" data-r="GO_REF:0000003" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> EC-based electronic inference of the core molecular function; consistent with the experimental IDA evidence.
+                        </div>
+
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005524" target="_blank" class="term-link">
+                                    GO:0005524
+                                </a>
+                            </span>
+                            <span class="term-label">ATP binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000002
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="B3WFY8" data-a="GO:0005524" data-r="GO_REF:0000002" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Standard active-site feature of a protein kinase (ATP-binding loop residues 17-25 and Lys40). Correct but a generic molecular-detail term; non-core.
+                        </div>
+
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005929" target="_blank" class="term-link">
+                                    GO:0005929
+                                </a>
+                            </span>
+                            <span class="term-label">cilium</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000044
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="B3WFY8" data-a="GO:0005929" data-r="GO_REF:0000044" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> UniProt SubCell-derived ciliary localization; consistent with experimental data. Duplicates the IBA cilium annotation; correct core location.
+                        </div>
+
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0030424" target="_blank" class="term-link">
+                                    GO:0030424
+                                </a>
+                            </span>
+                            <span class="term-label">axon</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000044
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="B3WFY8" data-a="GO:0030424" data-r="GO_REF:0000044" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> SubCell-derived; consistent with the experimental IDA axon annotation (PMID:17420466). Real but non-core neuronal localization.
+                        </div>
+
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0030425" target="_blank" class="term-link">
+                                    GO:0030425
+                                </a>
+                            </span>
+                            <span class="term-label">dendrite</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000044
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="B3WFY8" data-a="GO:0030425" data-r="GO_REF:0000044" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> SubCell-derived; consistent with the experimental IDA dendrite annotation (PMID:17420466). Real but non-core neuronal localization.
+                        </div>
+
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0043204" target="_blank" class="term-link">
+                                    GO:0043204
+                                </a>
+                            </span>
+                            <span class="term-label">perikaryon</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000044
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="B3WFY8" data-a="GO:0043204" data-r="GO_REF:0000044" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> SubCell-derived; consistent with the experimental (EXP/IDA) perikaryon annotation from PMID:17420466. Real but non-core.
+                        </div>
+
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0106310" target="_blank" class="term-link">
+                                    GO:0106310
+                                </a>
+                            </span>
+                            <span class="term-label">protein serine kinase activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000116
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="B3WFY8" data-a="GO:0106310" data-r="GO_REF:0000116" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> RHEA-derived; a valid subtype of the kinase activity. DYF-5 phosphorylates both Ser and Thr residues, so protein serine/threonine kinase activity (GO:0004674) is the most complete descriptor; retained as non-core.
+                        </div>
+
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0004674" target="_blank" class="term-link">
+                                    GO:0004674
+                                </a>
+                            </span>
+                            <span class="term-label">protein serine/threonine kinase activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/38806659" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:38806659
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Neurons dispose of hyperactive kinesin into glial cells for ...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="B3WFY8" data-a="GO:0004674" data-r="PMID:38806659" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Direct experimental demonstration of kinase activity. In this study dyf-5 kinase-domain mutations were recovered as intergenic suppressors of a hyperactive OSM-3, and in-vitro protein kinase assays show DYF-5 directly phosphorylates the C-terminal fragment of the OSM-3 kinesin (residues 444-699), identifying OSM-3 as a direct substrate and supporting the core molecular function.
+                        </div>
+
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/38806659" target="_blank" class="term-link">
+                                        PMID:38806659
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">mutations inhibiting the ciliary kinase DYF-5, both of which restored normal cilia in OSM-3CA-expressing animals</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0043204" target="_blank" class="term-link">
+                                    GO:0043204
+                                </a>
+                            </span>
+                            <span class="term-label">perikaryon</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">EXP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/17420466" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:17420466
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Mutation of the MAP kinase DYF-5 affects docking and undocki...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="B3WFY8" data-a="GO:0043204" data-r="PMID:17420466" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Experimentally observed localization to the neuronal cell body (perikaryon). Real but non-core relative to the ciliary site of action.
+                        </div>
+
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0106310" target="_blank" class="term-link">
+                                    GO:0106310
+                                </a>
+                            </span>
+                            <span class="term-label">protein serine kinase activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">ISS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000024
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="B3WFY8" data-a="GO:0106310" data-r="GO_REF:0000024" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Sequence-similarity transfer of a valid kinase-activity subtype. Consistent with the demonstrated Ser/Thr kinase activity; non-core relative to GO:0004674.
+                        </div>
+
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0004674" target="_blank" class="term-link">
+                                    GO:0004674
+                                </a>
+                            </span>
+                            <span class="term-label">protein serine/threonine kinase activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/35969738" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:35969738
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    DYF-5/MAK-dependent phosphorylation promotes ciliary tubulin...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="B3WFY8" data-a="GO:0004674" data-r="PMID:35969738" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Direct experimental demonstration of kinase activity. DYF-5 phosphorylates the tubulin-binding module of IFT-74 at multiple Ser/Thr sites in vitro, reducing IFT-74/81 tubulin affinity ~sixfold. Establishes the core molecular function and a direct substrate (IFT-74).
+                        </div>
+
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/35969738" target="_blank" class="term-link">
+                                        PMID:35969738
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">the ciliary kinase DYF-5/MAK phosphorylates multiple sites within the tubulin-binding module of IFT-74, reducing the tubulin-binding affinity of IFT-74/81 approximately sixfold</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0035720" target="_blank" class="term-link">
+                                    GO:0035720
+                                </a>
+                            </span>
+                            <span class="term-label">intraciliary anterograde transport</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IMP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/17420466" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:17420466
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Mutation of the MAP kinase DYF-5 affects docking and undocki...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="B3WFY8" data-a="GO:0035720" data-r="PMID:17420466" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Core biological process. Mutant-phenotype analysis shows DYF-5 is required for correct anterograde IFT: it restricts kinesin-II to the middle segment and is needed for OSM-3 to remain attached to and move IFT particles at normal speed.
+                        </div>
+
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/17420466" target="_blank" class="term-link">
+                                        PMID:17420466
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">dyf-5 is required to restrict kinesin II to the cilia middle segments</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0035720" target="_blank" class="term-link">
+                                    GO:0035720
+                                </a>
+                            </span>
+                            <span class="term-label">intraciliary anterograde transport</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IGI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/17420466" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:17420466
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Mutation of the MAP kinase DYF-5 affects docking and undocki...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="B3WFY8" data-a="GO:0035720" data-r="PMID:17420466" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Genetic-interaction evidence (with osm-3/kinesin-II components) for the same core anterograde-IFT regulatory role. In dyf-5 mutants OSM-3 detaches from IFT particles and slows.
+                        </div>
+
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/17420466" target="_blank" class="term-link">
+                                        PMID:17420466
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">OSM-3 moves at a reduced speed and is not attached to IFT particles</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:1902856" target="_blank" class="term-link">
+                                    GO:1902856
+                                </a>
+                            </span>
+                            <span class="term-label">negative regulation of non-motile cilium assembly</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IGI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/17420466" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:17420466
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Mutation of the MAP kinase DYF-5 affects docking and undocki...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="B3WFY8" data-a="GO:1902856" data-r="PMID:17420466" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Core regulatory role. Loss of dyf-5 elongates sensory cilia, indicating that DYF-5 normally restrains cilium elongation/assembly. Mechanistically consistent with DYF-5 driving ciliary-tip tubulin unloading.
+                        </div>
+
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/17420466" target="_blank" class="term-link">
+                                        PMID:17420466
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">the cilia of dyf-5 loss-of-function (lf) animals are elongated and are not properly aligned into the amphid channel</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:1902857" target="_blank" class="term-link">
+                                    GO:1902857
+                                </a>
+                            </span>
+                            <span class="term-label">positive regulation of non-motile cilium assembly</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IGI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/17420466" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:17420466
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Mutation of the MAP kinase DYF-5 affects docking and undocki...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="B3WFY8" data-a="GO:1902857" data-r="PMID:17420466" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Context-dependent genetic-interaction annotation from the same study, made against a different set of partner genes. It reflects the composite genetic requirement of dyf-5 for normal ciliogenesis (e.g. in sensitized kinesin backgrounds cilia fail to form), opposite in sign to the negative-regulation annotation. Retained as non-core; the dominant, mechanistically supported role is restraint of cilium elongation (GO:1902856).
+                        </div>
+
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0097730" target="_blank" class="term-link">
+                                    GO:0097730
+                                </a>
+                            </span>
+                            <span class="term-label">non-motile cilium</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/17420466" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:17420466
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Mutation of the MAP kinase DYF-5 affects docking and undocki...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="B3WFY8" data-a="GO:0097730" data-r="PMID:17420466" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Precise core location: C. elegans sensory cilia are non-motile, and DYF-5 localizes to and acts within them. More specific and preferable to the general cilium term.
+                        </div>
+
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/35969738" target="_blank" class="term-link">
+                                        PMID:35969738
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">the ciliary kinase DYF-5/MAK</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0004674" target="_blank" class="term-link">
+                                    GO:0004674
+                                </a>
+                            </span>
+                            <span class="term-label">protein serine/threonine kinase activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">ISS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/17420466" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:17420466
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Mutation of the MAP kinase DYF-5 affects docking and undocki...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="B3WFY8" data-a="GO:0004674" data-r="PMID:17420466" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Sequence-similarity transfer of the core kinase function from the human MAK/ICK-family orthologue. Now directly confirmed experimentally in worm.
+                        </div>
+
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0004707" target="_blank" class="term-link">
+                                    GO:0004707
+                                </a>
+                            </span>
+                            <span class="term-label">MAP kinase activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">ISS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/17420466" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:17420466
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Mutation of the MAP kinase DYF-5 affects docking and undocki...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-modify">
+                            MODIFY
+                        </span>
+                        <span class="vote-buttons" data-g="B3WFY8" data-a="GO:0004707" data-r="PMID:17420466" data-act="MODIFY">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Name-driven over-specification. DYF-5 was historically called a &#34;MAP kinase&#34;, but molecularly it is a MAK/RCK (ICK/CILK1) CMGC kinase, not a mitogen-activated protein kinase activated by dual TXY phosphorylation within a MAPK cascade. Its demonstrated activity is general protein serine/threonine phosphorylation. The accurate term is protein serine/threonine kinase activity (GO:0004674).
+                        </div>
+
+
+
+
+                        <div style="margin-top: 0.5rem;">
+                            <strong>Proposed replacements:</strong>
+
+                            <span class="badge">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0004674" target="_blank" class="term-link">
+                                    protein serine/threonine kinase activity
+                                </a>
+                            </span>
+
+                        </div>
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/17420466" target="_blank" class="term-link">
+                                        PMID:17420466
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">we identify DYF-5, a conserved MAP kinase that plays a role in these processes</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005524" target="_blank" class="term-link">
+                                    GO:0005524
+                                </a>
+                            </span>
+                            <span class="term-label">ATP binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">ISS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/17420466" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:17420466
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Mutation of the MAP kinase DYF-5 affects docking and undocki...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="B3WFY8" data-a="GO:0005524" data-r="PMID:17420466" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Sequence-similarity transfer of the standard kinase ATP-binding feature. Correct but a generic molecular-detail term; non-core.
+                        </div>
+
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0008104" target="_blank" class="term-link">
+                                    GO:0008104
+                                </a>
+                            </span>
+                            <span class="term-label">intracellular protein localization</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IMP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/17420466" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:17420466
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Mutation of the MAP kinase DYF-5 affects docking and undocki...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="B3WFY8" data-a="GO:0008104" data-r="PMID:17420466" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Reflects the dyf-5 mutant phenotype in which IFT components are mislocalized and accumulate within cilia. This is a generic term for what is more precisely the regulation of intraciliary transport and of ciliary protein distribution; retained as non-core, with the specific IFT process terms preferred.
+                        </div>
+
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/17420466" target="_blank" class="term-link">
+                                        PMID:17420466
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">six IFT proteins accumulate in the cilia of dyf-5(lf) mutants</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0030424" target="_blank" class="term-link">
+                                    GO:0030424
+                                </a>
+                            </span>
+                            <span class="term-label">axon</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/17420466" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:17420466
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Mutation of the MAP kinase DYF-5 affects docking and undocki...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="B3WFY8" data-a="GO:0030424" data-r="PMID:17420466" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Experimentally observed neuronal localization. Real but non-core relative to the ciliary site of action.
+                        </div>
+
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0030425" target="_blank" class="term-link">
+                                    GO:0030425
+                                </a>
+                            </span>
+                            <span class="term-label">dendrite</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/17420466" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:17420466
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Mutation of the MAP kinase DYF-5 affects docking and undocki...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="B3WFY8" data-a="GO:0030425" data-r="PMID:17420466" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Experimentally observed neuronal localization; DYF-5 is enriched at the dendrite-cilium transition zone. Real but non-core.
+                        </div>
+
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0042073" target="_blank" class="term-link">
+                                    GO:0042073
+                                </a>
+                            </span>
+                            <span class="term-label">intraciliary transport</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/17420466" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:17420466
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Mutation of the MAP kinase DYF-5 affects docking and undocki...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="B3WFY8" data-a="GO:0042073" data-r="PMID:17420466" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Direct experimental evidence for a role in IFT: live imaging of IFT-component motility and accumulation in dyf-5 mutants. Core process.
+                        </div>
+
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/17420466" target="_blank" class="term-link">
+                                        PMID:17420466
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">six IFT proteins accumulate in the cilia of dyf-5(lf) mutants</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0043025" target="_blank" class="term-link">
+                                    GO:0043025
+                                </a>
+                            </span>
+                            <span class="term-label">neuronal cell body</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/17420466" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:17420466
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Mutation of the MAP kinase DYF-5 affects docking and undocki...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="B3WFY8" data-a="GO:0043025" data-r="PMID:17420466" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Experimentally observed localization to the neuronal cell body. Real but non-core relative to the ciliary site of action.
+                        </div>
+
+
+
+
+
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:1905515" target="_blank" class="term-link">
+                                    GO:1905515
+                                </a>
+                            </span>
+                            <span class="term-label">non-motile cilium assembly</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IMP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/17420466" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:17420466
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Mutation of the MAP kinase DYF-5 affects docking and undocki...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="B3WFY8" data-a="GO:1905515" data-r="PMID:17420466" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Core biological process, precise to the non-motile sensory cilia of C. elegans. dyf-5 loss-of-function mutants have abnormally long, misshapen cilia, showing a requirement for normal non-motile cilium assembly/morphogenesis.
+                        </div>
+
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/17420466" target="_blank" class="term-link">
+                                        PMID:17420466
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">the cilia of dyf-5 loss-of-function (lf) animals are elongated and are not properly aligned into the amphid channel</div>
+
+                            </div>
+
+                        </div>
+
+
+                    </td>
+                </tr>
+
+            </tbody>
+        </table>
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Core Functions</h2>
+
+        <div class="core-function-card">
+
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+                <h3>DYF-5 is a ciliary serine/threonine protein kinase (MAK/RCK, ICK/CILK1-related CMGC family) that phosphorylates IFT machinery to control anterograde intraflagellar transport and the length of non-motile sensory cilia. It acts along the ciliary axoneme (from the middle-segment tip to the distal tip). Two direct substrates are established biochemically: it phosphorylates the N-terminal tubulin-binding module of the IFT-B subunit IFT-74 (11 Ser/Thr sites; consensus (R)PX[S/T]), lowering IFT-74/81 tubulin affinity to trigger tubulin unloading at the ciliary tip, and it phosphorylates the C-terminal region of the OSM-3 kinesin. Through these activities DYF-5 promotes undocking of kinesin-II from IFT trains and docking of OSM-3, and restrains cilium elongation, so that loss of dyf-5 produces abnormally long, misaligned cilia with IFT-component accumulation.</h3>
+                <span class="vote-buttons" data-g="B3WFY8" data-a="FUNCTION: DYF-5 is a ciliary serine/threonine protein kinase..." data-r="" data-act="CORE_FUNCTION">
+                    <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
+                    <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
+                </span>
+            </div>
+
+
+            <div class="core-function-terms">
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Molecular Function:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0004674" target="_blank" class="term-link">
+                            protein serine/threonine kinase activity
+                        </a>
+                    </span>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Directly Involved In:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0035720" target="_blank" class="term-link">
+                                intraciliary anterograde transport
+                            </a>
+                        </span>
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:1902856" target="_blank" class="term-link">
+                                negative regulation of non-motile cilium assembly
+                            </a>
+                        </span>
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0060271" target="_blank" class="term-link">
+                                cilium assembly
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Cellular Locations:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005929" target="_blank" class="term-link">
+                                cilium
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+
+
+            </div>
+
+
+            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
+                <strong>Supporting Evidence:</strong>
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/35969738" target="_blank" class="term-link">
+                                PMID:35969738
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">the ciliary kinase DYF-5/MAK phosphorylates multiple sites within the tubulin-binding module of IFT-74, reducing the tubulin-binding affinity of IFT-74/81 approximately sixfold</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/38806659" target="_blank" class="term-link">
+                                PMID:38806659
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">mutations inhibiting the ciliary kinase DYF-5, both of which restored normal cilia in OSM-3CA-expressing animals</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/17420466" target="_blank" class="term-link">
+                                PMID:17420466
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">dyf-5 is required to restrict kinesin II to the cilia middle segments</div>
+
+                    </li>
+
+                </ul>
+            </div>
+
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title collapsible">References</h2>
+        <div class="collapse-content">
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000002.md" target="_blank" class="term-link">
+                            GO_REF:0000002
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Gene Ontology annotation through association of InterPro records with GO terms</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000003.md" target="_blank" class="term-link">
+                            GO_REF:0000003
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Gene Ontology annotation based on Enzyme Commission mapping</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000024.md" target="_blank" class="term-link">
+                            GO_REF:0000024
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Manual transfer of experimentally-verified manual GO annotation data to orthologs by curator judgment of sequence similarity</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000033.md" target="_blank" class="term-link">
+                            GO_REF:0000033
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Annotation inferences using phylogenetic trees</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000044.md" target="_blank" class="term-link">
+                            GO_REF:0000044
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location vocabulary mapping, accompanied by conservative changes to GO terms applied by UniProt</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000108.md" target="_blank" class="term-link">
+                            GO_REF:0000108
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Automatic assignment of GO terms using logical inference, based on on inter-ontology links</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000116.md" target="_blank" class="term-link">
+                            GO_REF:0000116
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Automatic Gene Ontology annotation based on Rhea mapping</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/17420466" target="_blank" class="term-link">
+                            PMID:17420466
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Mutation of the MAP kinase DYF-5 affects docking and undocking of kinesin-2 motors and reduces their speed in the cilia of Caenorhabditis elegans.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/35969738" target="_blank" class="term-link">
+                            PMID:35969738
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">DYF-5/MAK-dependent phosphorylation promotes ciliary tubulin unloading.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/38806659" target="_blank" class="term-link">
+                            PMID:38806659
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Neurons dispose of hyperactive kinesin into glial cells for clearance.</div>
+
+
+            </div>
+
+        </div>
+    </div>
+
+
+
+
+    <div class="section">
+        <h2 class="section-title">Suggested Questions for Experts</h2>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> Beyond IFT-74 and OSM-3, what are the physiological DYF-5 substrates in the cilium, and which one executes kinesin-II undocking?</p>
+
+                </div>
+                <span class="vote-buttons" data-g="B3WFY8" data-a="Q: Beyond IFT-74 and OSM-3, what are the physiologica..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> Do the two dyf-5 splice isoforms (a and b), which differ in the C-terminal tail that governs ciliary targeting, have distinct functions or localizations?</p>
+
+                </div>
+                <span class="vote-buttons" data-g="B3WFY8" data-a="Q: Do the two dyf-5 splice isoforms (a and b), which ..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> What kinase activates DYF-5 and how is its activity spatially restricted to the distal ciliary segment?</p>
+
+                </div>
+                <span class="vote-buttons" data-g="B3WFY8" data-a="Q: What kinase activates DYF-5 and how is its activit..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Suggested Experiments</h2>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> Comparative in-vivo ciliary phosphoproteomics of wild-type versus dyf-5(mn400) null sensory neurons to enumerate DYF-5-dependent phosphosites on IFT and motor proteins.</p>
+
+
+
+                </div>
+                <span class="vote-buttons" data-g="B3WFY8" data-a="EXPERIMENT: Comparative in-vivo ciliary phosphoproteomics of w..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> CRISPR phospho-dead and phospho-mimic knock-ins at DYF-5-dependent OSM-3 and kinesin-II phosphosites, scored for cilium length, IFT velocity and motor docking/undocking behavior.</p>
+
+
+
+                </div>
+                <span class="vote-buttons" data-g="B3WFY8" data-a="EXPERIMENT: CRISPR phospho-dead and phospho-mimic knock-ins at..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> Structure-function dissection of the DYF-5 C-terminus (truncations/point mutants) to separate kinase activation from ciliary-tip targeting, with live imaging of tagged DYF-5.</p>
+
+
+
+                </div>
+                <span class="vote-buttons" data-g="B3WFY8" data-a="EXPERIMENT: Structure-function dissection of the DYF-5 C-termi..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Knowledge Gaps</h2>
+        <p style="color: #555; font-size: 0.92rem; margin-top: -0.3rem;">
+            What is <em>not</em> known — curated, literature-grounded statements of the open
+            unknowns (the inverse of core functions).
+        </p>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> The complete set of in-vivo DYF-5 substrates that execute cilium-length and IFT control, and how their phosphorylation drives ciliary-tip cargo (tubulin) unloading, is undetermined. Only two direct substrates (IFT-74 and the OSM-3 C-terminus) have been demonstrated biochemically in vitro; which substrates are phosphorylated in the intact cilium, at which residues, and with what functional consequence, remains open.</p>
+            <p style="margin-top: 0.4rem;">
+                <span class="badge">OPEN</span>
+                <span class="badge">BIOLOGY</span>
+                <span class="badge">RESIDUAL_SUBGAP</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> DYF-5 is an established ciliary Ser/Thr kinase with a defined substrate consensus motif ((R)PX[S/T]); IFT-74 (11 N-terminal phosphosites reducing IFT-74/81 tubulin affinity) and the OSM-3 kinesin C-terminal fragment (444-699) are proven in-vitro substrates.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Significance:</strong> Identifying the full substrate set would explain how a single kinase coordinately controls tubulin unloading, motor handover and axoneme length, and would clarify the conserved MAK/ICK/CILK1 pathway relevant to human retinal ciliopathies.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>What would resolve it:</strong> In-vivo phosphoproteomics of dyf-5(+) versus dyf-5(null) cilia; targeted phospho-site mapping on candidate IFT/motor substrates; separation-of-function phospho-dead/phospho-mimic alleles tested for ciliary length and IFT phenotypes.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Provenance (the field's own admissions):</strong></p>
+            <ul style="margin-top: 0.2rem;">
+
+                <li><em>"little is known of how tubulins are unloaded when arriving at the ciliary tip"</em> — PMID:35969738</li>
+
+            </ul>
+
+
+        </div>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> The molecular mechanism by which DYF-5 switches anterograde IFT from heterotrimeric kinesin-II to homodimeric OSM-3 at the end of the middle segment is not resolved. It is unknown whether DYF-5 triggers the handover directly by phosphorylating a motor or an adaptor (e.g. OSM-3, kinesin-II subunits, or IFT linkers) or indirectly by remodeling IFT-train architecture, and which phosphosite(s) on OSM-3 are functionally required in vivo.</p>
+            <p style="margin-top: 0.4rem;">
+                <span class="badge">OPEN</span>
+                <span class="badge">BIOLOGY</span>
+                <span class="badge">MF_DARK</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> Genetics and imaging show DYF-5 is required for undocking of kinesin-II from IFT particles and docking of OSM-3, and DYF-5 phosphorylates the OSM-3 C-terminus in vitro and suppresses OSM-3 hyperactivity; the causal phosphorylation event that executes the handover is not identified.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Significance:</strong> The kinesin-II to OSM-3 handoff is the paradigm for how two anterograde motors are coordinated on a shared IFT train to build compartmentalized cilia; resolving it would define a general principle of IFT regulation conserved to vertebrate KIF3/KIF17.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>What would resolve it:</strong> Map and mutate DYF-5-dependent OSM-3 phosphosites in vivo; test whether phospho-dead/phospho-mimic OSM-3 (or kinesin-II subunits) recapitulate dyf-5 handover defects; reconstitute motor docking/undocking on IFT trains with and without DYF-5 phosphorylation.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Provenance (the field's own admissions):</strong></p>
+            <ul style="margin-top: 0.2rem;">
+
+                <li><em>"DYF-5 plays a role in the undocking of kinesin II from IFT particles and in the docking of OSM-3 onto IFT particles"</em> — PMID:17420466</li>
+
+                <li><em>"mutations inhibiting the ciliary kinase DYF-5, both of which restored normal cilia in OSM-3CA-expressing animals"</em> — PMID:38806659</li>
+
+            </ul>
+
+
+        </div>
+
+    </div>
+
+
+
+
+    <!-- Computational Predictions Section -->
+
+
+    <!-- Deep Research Sections -->
+
+    <div class="section">
+        <h2 class="section-title">Deep Research</h2>
+
+        <details class="deep-research-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; gap: 1rem;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Falcon</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(dyf-5-deep-research-falcon.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="B3WFY8" data-a="DEEP_RESEARCH: Falcon" data-r="" data-act="DEEP_RESEARCH" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This deep research is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This deep research needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+
+                <div class="report-meta">
+
+                    <span class="report-meta-text">Comprehensive Research Report on *C. elegans* DYF-5 (UniProt: B3WFY8)</span>
+
+
+                    <span class="report-badge">Falcon</span>
+
+
+                    <span class="report-badge">Edison Scientific Literature</span>
+
+
+                    <span class="report-badge">33 citations</span>
+
+
+                    <span class="report-badge">2 artifacts</span>
+
+
+                    <span class="report-meta-text">2026-07-04T14:51:57.263555</span>
+
+
+
+                </div>
+
+
+                <div class="artifact-list">
+
+
+
+                    <div class="artifact-link">
+                        <a href="dyf-5-deep-research-falcon_artifacts/artifact-00.md" class="term-link">Edison artifact artifact-00</a>
+                        <span>(text/markdown)</span>
+                    </div>
+
+
+
+
+                    <div class="artifact-link">
+                        <a href="dyf-5-deep-research-falcon_artifacts/artifact-01.md" class="term-link">Edison artifact artifact-01</a>
+                        <span>(text/markdown)</span>
+                    </div>
+
+
+                </div>
+
+                <p>The research report should be a detailed narrative explaining the function, biological processes, and localization of the gene product. Citations should be given for all claims.</p>
+<p>You should prioritize authoritative reviews and primary scientific literature when conducting research. You can supplement<br />
+this with annotations you find in gene/protein databases, but these can be outdated or inaccurate.</p>
+<p>We are specifically interested in the primary function of the gene - for enzymes, what reaction is catalyzed, and what is the substrate specificity? For transporters, what is the substrate? For structural proteins or adapters, what is the broader structural role? For signaling molecules, what is the role in the pathway.</p>
+<p>We are interested in where in or outside the cell the gene product carries out its function.</p>
+<p>We are also interested in the signaling or biochemical pathways in which the gene functions. We are less interested in broad pleiotropic effects, except where these elucidate the precise role.</p>
+<p>Include evidence where possible. We are interested in both experimental evidence as well as inference from structure, evolution, or bioinformatic analysis. Precise studies should be prioritized over high-throughput, where available.</p>
+<h1 id="comprehensive-research-report-on-c-elegans-dyf-5-uniprot-b3wfy8">Comprehensive Research Report on <em>C. elegans</em> DYF-5 (UniProt: B3WFY8)</h1>
+<h2 id="1-gene-and-protein-identity">1. Gene and Protein Identity</h2>
+<p>DYF-5 (encoded by the gene <em>dyf-5</em>, ORF name M04C9.5) is a serine/threonine-protein kinase in <em>Caenorhabditis elegans</em> belonging to the CMGC group of the protein kinase superfamily. Specifically, DYF-5 is a member of the RCK (for Ross, CMGC, kinase) family, which includes the evolutionarily conserved MAP kinase-related kinases MAK, ICK/CILK1, and MOK in mammals, LF4 in <em>Chlamydomonas reinhardtii</em>, and LmxMPK9 in <em>Leishmania mexicana</em> (moon2014intestinalcellkinase pages 4-5, chaya2024ccrkmakickkinasesignaling pages 1-5). The gene name "dyf" refers to the dye-filling defective phenotype observed in mutants, reflecting impaired function of sensory cilia in amphid and phasmid neurons. DYF-5 catalyzes the transfer of the γ-phosphate of ATP to serine and threonine residues on protein substrates (EC 2.7.11.1), with a consensus phosphorylation motif of R-P-X-S/T-P/A/T/S identified in ortholog studies (chaya2014ickisessential pages 8-9).</p>
+<h2 id="2-enzymatic-function-and-substrate-specificity">2. Enzymatic Function and Substrate Specificity</h2>
+<h3 id="21-primary-enzymatic-activity">2.1 Primary Enzymatic Activity</h3>
+<p>DYF-5 functions as a ciliary serine/threonine kinase whose primary role is to regulate intraflagellar transport (IFT) by phosphorylating components of the IFT machinery and kinesin-2 motor proteins. DYF-5 is itself an IFT cargo molecule that is transported to the distal segments of sensory cilia, where it exerts its kinase activity (chaya2021posttranslationalmodificationenzymes pages 3-3).</p>
+<h3 id="22-identified-substrates">2.2 Identified Substrates</h3>
+<p>Studies on DYF-5 orthologs, particularly mammalian ICK/CILK1 and MAK, have elucidated several phosphorylation targets that are conserved across species. The following table summarizes the known and inferred substrates:</p>
+<table>
+<thead>
+<tr>
+<th>Substrate</th>
+<th>Phosphorylation Site (if known)</th>
+<th>Functional Consequence</th>
+<th>Evidence Source</th>
+<th>Reference context</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>KIF3A (kinesin-2 subunit)</td>
+<td>Thr674 in mammalian KIF3A; motif discussed in ICK/MAK literature as part of the RCK kinase target set</td>
+<td>Promotes proper IFT turnaround/disassembly at the ciliary tip; loss of ICK activity causes IFT protein accumulation at tips and ciliary length defects, indicating KIF3A phosphorylation contributes to transport remodeling rather than being the sole determinant of phenotype</td>
+<td>Ortholog inference from mammalian ICK/CILK1 and MAK</td>
+<td>KIF3A Thr674 is a validated ICK target; KIF3A phospho-deficient systems show altered ciliary phenotypes, but reviews note additional substrates are required to explain full biology (chaya2025kinasedependentregulationof pages 2-4, chaya2014ickisessential pages 8-9, mul2022mechanismsofregulation pages 14-15, chaya2021posttranslationalmodificationenzymes pages 3-4)</td>
+</tr>
+<tr>
+<td>KIF3B / FLA8 (kinesin-2 motor subunit orthologs)</td>
+<td>FLA8 Ser663 in <em>Chlamydomonas</em>; described as lying in a consensus sequence for MAK/ICK-family phosphorylation</td>
+<td>Required for efficient IFT turnaround at the flagellar/ciliary tip; phosphorylation is proposed to help release or remodel kinesin-2 from anterograde trains during tip conversion</td>
+<td>Ortholog inference from <em>Chlamydomonas</em> and broader MAK/ICK family studies</td>
+<td>Reviews and comparative studies cite FLA8 Ser663 as required for turnaround and interpret this as conserved RCK-family control of kinesin-2, relevant to DYF-5 function in worms (chaya2025kinasedependentregulationof pages 2-4, corbo2024newevidenceon pages 30-33, chaya2021posttranslationalmodificationenzymes pages 3-4, chaya2024ccrkmakickkinasesignaling pages 22-26)</td>
+</tr>
+<tr>
+<td>IFT74 (IFT-B tubulin-binding component)</td>
+<td>Exact residue not specified in the available evidence contexts</td>
+<td>Reduces tubulin-binding affinity of IFT-B, promoting tubulin unloading at the ciliary tip; provides a mechanistic explanation for how DYF-5-family kinases regulate cargo handling and axonemal growth</td>
+<td>C. elegans DYF-5 direct/mechanistic assignment summarized from conserved pathway literature</td>
+<td>Recent pathway summaries explicitly attribute IFT74 phosphorylation and tubulin unloading to DYF-5 ortholog activity in the conserved CCRK–MAK/ICK/DYF-5 axis (chaya2025kinasedependentregulationof pages 2-4, chaya2024ccrkmakickkinasesignaling pages 22-26)</td>
+</tr>
+<tr>
+<td>Heterotrimeric kinesin-2 complex (general)</td>
+<td>Specific worm site(s) not identified in the available contexts; consensus motif for MAK/ICK family substrates is R-P-X-S/T-P/A/T/S</td>
+<td>Promotes undocking/detachment of kinesin-II from anterograde IFT trains and helps anterograde-to-retrograde train conversion; dyf-5 mutants show altered docking/undocking and slower motor behavior</td>
+<td>C. elegans DYF-5 direct phenotype plus ortholog-based substrate inference</td>
+<td>Reviews of worm IFT regulation describe DYF-5 as affecting kinesin-II undocking and motor coordination, while ortholog work supplies candidate phosphotargets within kinesin-2 subunits (mul2022mechanismsofregulation pages 14-15, mul2022mechanismsofregulation pages 22-23, prevo2017intraflagellartransportmechanisms pages 12-14, brinzer2021theuptakeof pages 37-39)</td>
+</tr>
+<tr>
+<td>Additional IFT/ciliary transport proteins (unspecified)</td>
+<td>Consensus motif searched in ICK studies: R-P-X-S/T-P/A/T/S</td>
+<td>Likely contribute to ciliary length control, IFT tip remodeling, and transport fidelity; current evidence indicates KIF3A is not the only relevant phosphotarget</td>
+<td>Ortholog inference from ICK/MAK studies</td>
+<td>Multiple sources explicitly state that KIF3A alone cannot account for all ICK/CILK1 phenotypes, implying additional direct substrates in the IFT/ciliary machinery (chaya2014ickisessential pages 8-9, mul2022mechanismsofregulation pages 14-15, chaya2021posttranslationalmodificationenzymes pages 3-4)</td>
+</tr>
+</tbody>
+</table>
+<p><em>Table: This table summarizes known and inferred substrates of DYF-5 and its orthologs, emphasizing where evidence is direct in C. elegans versus inferred from mammalian ICK/MAK or Chlamydomonas studies. It is useful for separating experimentally supported phosphotargets from mechanistic hypotheses in the conserved ciliary transport pathway.</em></p>
+<p>The mammalian ortholog ICK phosphorylates KIF3A at Thr674, a residue within the C-terminal tail of this kinesin-2 motor subunit, facilitating the disassembly of IFT complexes at the ciliary tip (chaya2025kinasedependentregulationof pages 2-4, chaya2014ickisessential pages 8-9, chaya2021posttranslationalmodificationenzymes pages 3-4). In <em>Chlamydomonas</em>, phosphorylation of FLA8 (the KIF3B ortholog) at Ser663 by the LF4 kinase (DYF-5 ortholog) is similarly required for IFT turnaround at the flagellar tip (chaya2025kinasedependentregulationof pages 2-4, corbo2024newevidenceon pages 30-33). In <em>C. elegans</em>, DYF-5-dependent phosphorylation of IFT74 reduces the binding affinity between tubulin and IFT-B components, promoting tubulin unloading from anterograde IFT trains at the ciliary tip (chaya2025kinasedependentregulationof pages 2-4, chaya2024ccrkmakickkinasesignaling pages 22-26). Multiple lines of evidence indicate that KIF3A is not the sole relevant substrate, as phospho-deficient KIF3A knock-in mice show only mild ciliary phenotypes compared to ICK knockouts, implying additional critical phosphorylation targets (mul2022mechanismsofregulation pages 14-15, chaya2021posttranslationalmodificationenzymes pages 3-4).</p>
+<h2 id="3-subcellular-localization-and-tissue-expression">3. Subcellular Localization and Tissue Expression</h2>
+<h3 id="31-tissue-expression">3.1 Tissue Expression</h3>
+<p>DYF-5 is expressed exclusively in ciliated sensory neurons of <em>C. elegans</em>. Its transcription is regulated by the RFX transcription factor DAF-19, which binds an X-box motif (a 14-bp cis-regulatory element) in the <em>dyf-5</em> promoter. Removal of this X-box motif completely abolishes expression, confirming that <em>dyf-5</em> is a bona fide ciliary gene under DAF-19 transcriptional control (chu2012finetuningof pages 5-8). Reporter constructs driven by the <em>dyf-5</em> promoter show expression in amphid and labial sensory neurons (chu2012finetuningof pages 5-8).</p>
+<h3 id="32-subcellular-localization">3.2 Subcellular Localization</h3>
+<p>Within ciliated neurons, GFP::DYF-5 fusion protein exhibits a characteristic subcellular distribution that is regulated by the upstream kinase DYF-18/CCRK. In wild-type AWA sensory neurons, GFP::DYF-5 is specifically enriched in the proximal stalks of cilia, with weak to no localization at distal ciliary branches (maurya2019accrkand pages 5-7). In other sensory neuron types (channel cilia), DYF-5 and its mammalian orthologs are reported to be enriched at the ciliary tip, consistent with their role in regulating IFT turnaround at this location (mul2022mechanismsofregulation pages 14-15). DYF-5 ciliary localization is critically dependent on DYF-18 kinase activity: in <em>dyf-18</em> mutants, GFP::DYF-5 becomes mislocalized throughout the elongated cilia with aberrant enrichment in distal regions, indicating that DYF-18-mediated phosphorylation controls DYF-5 subcellular distribution (maurya2019accrkand pages 5-7). Both kinases require their own enzymatic activity for proper localization and stability within cilia (maurya2019accrkand pages 5-7).</p>
+<h2 id="4-signaling-and-biochemical-pathways">4. Signaling and Biochemical Pathways</h2>
+<h3 id="41-the-dyf-18ccrk-dyf-5mak-signaling-axis">4.1 The DYF-18/CCRK → DYF-5/MAK Signaling Axis</h3>
+<p>DYF-5 operates within a conserved two-kinase signaling cascade in which DYF-18, the <em>C. elegans</em> ortholog of the cyclin-dependent kinase-related kinase CCRK (also known as CDK20 in mammals and LF2 in <em>Chlamydomonas</em>), phosphorylates and activates DYF-5 at its TDY activation loop motif (maurya2019accrkand pages 5-7, maurya2019accrkand pages 4-5). Genetic evidence demonstrates this cascade clearly: overexpression of <em>dyf-5</em> (dyf-5(XS)) causes severely truncated and unbranched AWA cilia, but this truncation phenotype is fully suppressed in <em>dyf-5(XS); dyf-18(ok200)</em> double mutants, which display wild-type-like cilia morphology, indicating that DYF-18-mediated phosphorylation is required for maximal DYF-5 activation (maurya2019accrkand pages 4-5). This signaling axis is deeply conserved: in mammals, CCRK/CDK20 phosphorylates both ICK and MAK to activate them, and the Ccrk-Mak/Ick axis is essential for retinal photoreceptor maintenance (chaya2024ccrkmakickkinasesignaling pages 1-5, chaya2024ccrkmakicksignalingis pages 12-13).</p>
+<h3 id="42-regulation-of-ift-turnaround-and-motor-coordination">4.2 Regulation of IFT Turnaround and Motor Coordination</h3>
+<p>A central function of DYF-5 is regulating the turnaround of IFT trains at the ciliary tip—the process by which anterograde IFT trains are remodeled into retrograde trains for transport back to the ciliary base. DYF-5, localized at the ciliary tip, promotes detachment of heterotrimeric kinesin-2 (kinesin-II) from anterograde IFT trains through phosphorylation, thereby allowing reassembly into retrograde trains (mul2022mechanismsofregulation pages 14-15). Loss-of-function <em>dyf-5</em> mutants phenocopy dynein-2 and IFT-A mutants, exhibiting accumulation of IFT components at the ciliary tip, consistent with a defect in anterograde-to-retrograde train conversion (mul2022mechanismsofregulation pages 14-15). DYF-5 mutations also affect the docking and undocking behavior of kinesin-2 motors along the ciliary axoneme and reduce motor speed (mul2022mechanismsofregulation pages 22-23, corbo2024newevidenceon pages 94-97, prevo2017intraflagellartransportmechanisms pages 12-14).</p>
+<h3 id="43-regulation-of-axonemal-microtubule-dynamics">4.3 Regulation of Axonemal Microtubule Dynamics</h3>
+<p>Beyond IFT regulation, DYF-5 controls axonemal microtubule dynamics, which is the mechanism through which it modulates ciliary morphology. In <em>dyf-5</em> mutants, axonemal microtubules become stabilized along their lengths with decreased tubulin turnover, as evidenced by the microtubule plus-end tracking protein EBP-2 showing uniform decoration of elongated cilia rather than the punctate localization observed in wild-type animals (maurya2019accrkand pages 3-4, maurya2019accrkand pages 1-3, maurya2019accrkand pages 7-9). Loss of DYF-5 function leads to dramatically elongated cilia with greater length variation and loss of ciliary branching in neuron types such as AWA (mul2022mechanismsofregulation pages 14-15, maurya2019accrkand pages 3-4, maurya2019accrkand pages 1-3). Mutations in tubulin genes that destabilize microtubules can partially suppress the elongation phenotype of kinase mutants, confirming that the DYF-18/DYF-5 cascade controls ciliary length through regulation of microtubule stability (maurya2019accrkand pages 3-4, maurya2019accrkand pages 1-3).</p>
+<h3 id="44-tubulin-unloading-at-the-ciliary-tip">4.4 Tubulin Unloading at the Ciliary Tip</h3>
+<p>DYF-5-dependent phosphorylation of IFT74 reduces the binding affinity between tubulin and IFT-B components, promoting tubulin unloading from anterograde IFT trains at the ciliary tip (chaya2025kinasedependentregulationof pages 2-4, chaya2024ccrkmakickkinasesignaling pages 22-26). This provides a mechanistic explanation for how DYF-5 controls axonemal growth: by promoting tubulin release from IFT-B at the ciliary tip, DYF-5 limits the incorporation of tubulin into the growing axoneme, thereby negatively regulating ciliary length.</p>
+<h2 id="5-mutant-phenotypes">5. Mutant Phenotypes</h2>
+<p>Loss-of-function mutations in <em>dyf-5</em> (e.g., the canonical allele <em>mn400</em>) produce characteristic phenotypes including: (i) dye-filling defects (Dyf phenotype), in which amphid and phasmid neurons fail to take up lipophilic fluorescent dyes, indicating compromised ciliary structure or function; (ii) significantly elongated cilia with greater length variation; (iii) unusual accumulations of IFT components along the axoneme and at the ciliary tip; (iv) altered kinesin-2 motor behavior with reduced speed and disrupted docking/undocking dynamics; and (v) loss of ciliary branching in neuron types with complex cilia morphology such as AWA neurons (mul2022mechanismsofregulation pages 14-15, maurya2019accrkand pages 1-3, moon2014intestinalcellkinase pages 4-5). Conversely, overexpression of DYF-5 leads to severely truncated cilia, consistent with a dose-dependent negative regulatory role in ciliary length control (maurya2019accrkand pages 4-5).</p>
+<h2 id="6-evolutionary-conservation-and-ortholog-disease-associations">6. Evolutionary Conservation and Ortholog Disease Associations</h2>
+<p>DYF-5 is part of a deeply conserved kinase module that operates across eukaryotes. The following table summarizes ortholog relationships and disease associations:</p>
+<table>
+<thead>
+<tr>
+<th>Organism</th>
+<th>Gene Name</th>
+<th>Alternative Names</th>
+<th>Key Function</th>
+<th>Disease Association (if applicable)</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><em>Caenorhabditis elegans</em></td>
+<td><strong>dyf-5</strong></td>
+<td>DYF-5; MAK/ICK ortholog</td>
+<td>Ciliary serine/threonine kinase that regulates intraflagellar transport (IFT), kinesin-2 motor behavior, IFT turnaround at the ciliary tip, tubulin unloading, and cilium length/branching; functions downstream of DYF-18/CCRK (mul2022mechanismsofregulation pages 14-15, maurya2019accrkand pages 5-7, chaya2024ccrkmakickkinasesignaling pages 22-26, moon2014intestinalcellkinase pages 4-5)</td>
+<td>No direct human disease, but widely used as a model for conserved ciliopathy mechanisms (moon2014intestinalcellkinase pages 4-5, chaya2021posttranslationalmodificationenzymes pages 3-3)</td>
+</tr>
+<tr>
+<td><em>Chlamydomonas reinhardtii</em></td>
+<td><strong>LF4</strong></td>
+<td>LF4 kinase; RCK family ortholog of DYF-5/ICK/MAK</td>
+<td>Conserved ciliary/flagellar length regulator; CCRK/LF2-dependent signaling contributes to IFT regulation and flagellar length control (chaya2021posttranslationalmodificationenzymes pages 3-4, moon2014intestinalcellkinase pages 4-5, chaya2024ccrkmakickkinasesignaling pages 1-5)</td>
+<td>No direct disease association; mechanistic model for conserved ciliary biology (chaya2021posttranslationalmodificationenzymes pages 3-4, chaya2024ccrkmakickkinasesignaling pages 1-5)</td>
+</tr>
+<tr>
+<td>Mammals</td>
+<td><strong>ICK</strong></td>
+<td>Intestinal cell kinase; CILK1; MRK</td>
+<td>Conserved serine/threonine kinase that negatively regulates ciliary length, controls IFT turnaround and tip protein trafficking, and phosphorylates kinesin-2 subunits including KIF3A Thr674; acts with CCRK/CDK20 (chaya2025kinasedependentregulationof pages 2-4, chaya2014ickisessential pages 8-9, moon2014intestinalcellkinase pages 4-5, chaya2021posttranslationalmodificationenzymes pages 3-3)</td>
+<td>Loss-of-function linked to endocrine-cerebro-osteodysplasia (ECO) syndrome, short-rib polydactyly syndrome, and some heterozygous variants linked to juvenile myoclonic epilepsy (moon2014intestinalcellkinase pages 4-5, chaya2021posttranslationalmodificationenzymes pages 3-3)</td>
+</tr>
+<tr>
+<td>Mammals</td>
+<td><strong>MAK</strong></td>
+<td>Male germ cell-associated kinase</td>
+<td>Ciliary tip-localized kinase that cooperates with ICK/CILK1 in IFT turnaround, ciliary length homeostasis, and photoreceptor ciliary maintenance; can phosphorylate kinesin-2 components and functions in the CCRK-MAK/ICK axis (chaya2025kinasedependentregulationof pages 2-4, chaya2024ccrkmakickkinasesignaling pages 1-5, chaya2024ccrkmakickkinasesignaling pages 22-26, chaya2024ccrkmakicksignalingis pages 12-13)</td>
+<td>Mutations cause autosomal recessive/non-syndromic retinitis pigmentosa; pathway is being explored therapeutically via ICK activation (chaya2021posttranslationalmodificationenzymes pages 3-3, chaya2024ccrkmakickkinasesignaling pages 12-15, chaya2024ccrkmakicksignalingis pages 12-13)</td>
+</tr>
+<tr>
+<td><em>Leishmania mexicana</em></td>
+<td><strong>LmxMPK9</strong></td>
+<td>MPK9; DYF-5/MAK-like kinase ortholog</td>
+<td>Evolutionarily conserved ciliary/flagellar kinase implicated in negative regulation of flagellum length, supporting the broad conservation of the DYF-5/MAK/ICK module across eukaryotes (moon2014intestinalcellkinase pages 4-5, chaya2024ccrkmakickkinasesignaling pages 1-5)</td>
+<td>No human disease association for the parasite kinase itself; relevant to conserved flagellar biology (moon2014intestinalcellkinase pages 4-5, chaya2024ccrkmakickkinasesignaling pages 1-5)</td>
+</tr>
+</tbody>
+</table>
+<p><em>Table: This table summarizes major DYF-5 orthologs across species, highlighting conserved names, functions in ciliary/flagellar transport and length control, and disease relevance where known. It is useful for placing </em>C. elegans<em> DYF-5 in an evolutionary and biomedical context.</em></p>
+<p>In mammals, the DYF-5 orthologs ICK/CILK1 and MAK have been linked to severe human diseases classified as ciliopathies. MAK mutations cause autosomal recessive retinitis pigmentosa through progressive photoreceptor degeneration (chaya2021posttranslationalmodificationenzymes pages 3-3, chaya2024ccrkmakicksignalingis pages 12-13). ICK loss-of-function mutations are associated with endocrine-cerebro-osteodysplasia (ECO) syndrome and short rib-polydactyly syndrome (SRPS), both characterized by neonatal lethality, while heterozygous ICK variants have been linked to juvenile myoclonic epilepsy (moon2014intestinalcellkinase pages 4-5, chaya2021posttranslationalmodificationenzymes pages 3-3). Recent work has shown that MAK and ICK cooperatively act as ciliary tip-localized IFT regulators, and simultaneous disruption of both kinases in mice results in severe retinal degeneration with loss of photoreceptor ciliary axonemes (chaya2024ccrkmakickkinasesignaling pages 1-5, chaya2024ccrkmakicksignalingis pages 12-13). Notably, activation of ICK (for example through pharmacological inhibition of FGF receptors, which are negative regulators of ICK) has been proposed as a potential therapeutic strategy for retinitis pigmentosa caused by MAK mutations (chaya2024ccrkmakickkinasesignaling pages 12-15, chaya2024ccrkmakicksignalingis pages 12-13).</p>
+<h2 id="7-summary">7. Summary</h2>
+<p>DYF-5 is a ciliary serine/threonine kinase of the RCK/MAK family that functions exclusively within the sensory cilia of <em>C. elegans</em> ciliated neurons. Its primary molecular function is the phosphorylation of kinesin-2 motor subunits and IFT complex components (including IFT74), thereby regulating three interconnected processes: (1) IFT train turnaround at the ciliary tip, (2) kinesin-2 motor coordination and undocking, and (3) tubulin unloading and axonemal microtubule dynamics. DYF-5 is activated by the upstream kinase DYF-18/CCRK through phosphorylation at its TDY activation loop, constituting a conserved two-kinase signaling axis. The protein localizes to proximal ciliary stalks in a DYF-18-dependent manner and is itself transported as an IFT cargo to ciliary distal segments. Loss of DYF-5 function results in elongated cilia with stabilized microtubules, IFT component accumulation, and dye-filling defects. This kinase module is deeply conserved across eukaryotes, and mutations in the mammalian orthologs ICK and MAK cause ciliopathies including retinitis pigmentosa, ECO syndrome, and skeletal dysplasias, underscoring the fundamental importance of DYF-5-mediated phosphorylation in ciliary biology.</p>
+<p>References</p>
+<ol>
+<li>
+<p>(moon2014intestinalcellkinase pages 4-5): Heejung Moon, Jieun Song, Jeong-Oh Shin, Hankyu Lee, Hong-Kyung Kim, Jonathan T. Eggenschwiller, Jinwoong Bok, and Hyuk Wan Ko. Intestinal cell kinase, a protein associated with endocrine-cerebro-osteodysplasia syndrome, is a key regulator of cilia length and hedgehog signaling. Proceedings of the National Academy of Sciences, 111:8541-8546, May 2014. URL: https://doi.org/10.1073/pnas.1323161111, doi:10.1073/pnas.1323161111. This article has 76 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(chaya2024ccrkmakickkinasesignaling pages 1-5): Taro Chaya, Yamato Maeda, Ryotaro Tsutsumi, Makoto Ando, Yujie Ma, Naoko Kajimura, Teruyuki Tanaka, and Takahisa Furukawa. Ccrk-mak/ick kinase signaling axis is a ciliary transport regulator essential for retinal photoreceptor maintenance. bioRxiv, May 2024. URL: https://doi.org/10.1101/2024.05.24.595694, doi:10.1101/2024.05.24.595694. This article has 0 citations.</p>
+</li>
+<li>
+<p>(chaya2014ickisessential pages 8-9): Taro Chaya, Yoshihiro Omori, Ryusuke Kuwahara, and Takahisa Furukawa. Ick is essential for cell type‐specific ciliogenesis and the regulation of ciliary transport. The EMBO Journal, 33:1227-1242, Jun 2014. URL: https://doi.org/10.1002/embj.201488175, doi:10.1002/embj.201488175. This article has 142 citations.</p>
+</li>
+<li>
+<p>(chaya2021posttranslationalmodificationenzymes pages 3-3): Taro Chaya and Takahisa Furukawa. Post-translational modification enzymes as key regulators of ciliary protein trafficking. Journal of Biochemistry, 169:633-642, Mar 2021. URL: https://doi.org/10.1093/jb/mvab024, doi:10.1093/jb/mvab024. This article has 22 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(chaya2025kinasedependentregulationof pages 2-4): Taro Chaya, Yuri Ayano, and Takahisa Furukawa. Kinase-dependent regulation of ciliary protein transport and its implications for therapy. Frontiers in Molecular Biosciences, Jun 2025. URL: https://doi.org/10.3389/fmolb.2025.1638737, doi:10.3389/fmolb.2025.1638737. This article has 0 citations.</p>
+</li>
+<li>
+<p>(mul2022mechanismsofregulation pages 14-15): Wouter Mul, Aniruddha Mitra, and Erwin J. G. Peterman. Mechanisms of regulation in intraflagellar transport. Cells, 11:2737, Sep 2022. URL: https://doi.org/10.3390/cells11172737, doi:10.3390/cells11172737. This article has 32 citations.</p>
+</li>
+<li>
+<p>(chaya2021posttranslationalmodificationenzymes pages 3-4): Taro Chaya and Takahisa Furukawa. Post-translational modification enzymes as key regulators of ciliary protein trafficking. Journal of Biochemistry, 169:633-642, Mar 2021. URL: https://doi.org/10.1093/jb/mvab024, doi:10.1093/jb/mvab024. This article has 22 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(corbo2024newevidenceon pages 30-33): Dalia Corbo, Caterina Mencarelli, and Pietro Lupetti. New evidence on ift turnaround at the flagellar tip and the association of ift trains with the flagellar membrane in the model organism chlamydomonas reinhardtii. Jul 2024. URL: https://doi.org/10.25434/dalia-corbo_phd2024-07-12, doi:10.25434/dalia-corbo_phd2024-07-12. This article has 0 citations.</p>
+</li>
+<li>
+<p>(chaya2024ccrkmakickkinasesignaling pages 22-26): Taro Chaya, Yamato Maeda, Ryotaro Tsutsumi, Makoto Ando, Yujie Ma, Naoko Kajimura, Teruyuki Tanaka, and Takahisa Furukawa. Ccrk-mak/ick kinase signaling axis is a ciliary transport regulator essential for retinal photoreceptor maintenance. bioRxiv, May 2024. URL: https://doi.org/10.1101/2024.05.24.595694, doi:10.1101/2024.05.24.595694. This article has 0 citations.</p>
+</li>
+<li>
+<p>(mul2022mechanismsofregulation pages 22-23): Wouter Mul, Aniruddha Mitra, and Erwin J. G. Peterman. Mechanisms of regulation in intraflagellar transport. Cells, 11:2737, Sep 2022. URL: https://doi.org/10.3390/cells11172737, doi:10.3390/cells11172737. This article has 32 citations.</p>
+</li>
+<li>
+<p>(prevo2017intraflagellartransportmechanisms pages 12-14): Bram Prevo, Jonathan M. Scholey, and Erwin J. G. Peterman. Intraflagellar transport: mechanisms of motor action, cooperation, and cargo delivery. The FEBS Journal, 284:2905-2931, Sep 2017. URL: https://doi.org/10.1111/febs.14068, doi:10.1111/febs.14068. This article has 253 citations.</p>
+</li>
+<li>
+<p>(brinzer2021theuptakeof pages 37-39): Robert A. Brinzer, David J. France, Claire McMaster, Stuart Ruddell, Alan D. Winter, and Antony P. Page. The uptake of avermectins in caenorhabditis elegans is dependent on intra-flagellar transport and other protein trafficking pathways. bioRxiv, Oct 2021. URL: https://doi.org/10.1101/2021.10.22.465401, doi:10.1101/2021.10.22.465401. This article has 1 citations.</p>
+</li>
+<li>
+<p>(chu2012finetuningof pages 5-8): J. S. C. Chu, M. Tarailo-Graovac, D. Zhang, J. Wang, B. Uyar, D. Tu, J. Trinh, D. L. Baillie, and N. Chen. Fine tuning of rfx/daf-19-regulated target gene expression through binding to multiple sites in caenorhabditis elegans. Nucleic Acids Research, 40:53-64, Sep 2012. URL: https://doi.org/10.1093/nar/gkr690, doi:10.1093/nar/gkr690. This article has 13 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(maurya2019accrkand pages 5-7): Ashish Kumar Maurya, Travis Rogers, and Piali Sengupta. A ccrk and a mak kinase modulate cilia branching and length via regulation of axonemal microtubule dynamics in caenorhabditis elegans. Current Biology, 29:1286-1300.e4, Apr 2019. URL: https://doi.org/10.1016/j.cub.2019.02.062, doi:10.1016/j.cub.2019.02.062. This article has 49 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(maurya2019accrkand pages 4-5): Ashish Kumar Maurya, Travis Rogers, and Piali Sengupta. A ccrk and a mak kinase modulate cilia branching and length via regulation of axonemal microtubule dynamics in caenorhabditis elegans. Current Biology, 29:1286-1300.e4, Apr 2019. URL: https://doi.org/10.1016/j.cub.2019.02.062, doi:10.1016/j.cub.2019.02.062. This article has 49 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(chaya2024ccrkmakicksignalingis pages 12-13): Taro Chaya, Yamato Maeda, Ryotaro Tsutsumi, Makoto Ando, Yujie Ma, Naoko Kajimura, Teruyuki Tanaka, and Takahisa Furukawa. Ccrk-mak/ick signaling is a ciliary transport regulator essential for retinal photoreceptor survival. Life Science Alliance, 7:e202402880, Sep 2024. URL: https://doi.org/10.26508/lsa.202402880, doi:10.26508/lsa.202402880. This article has 7 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(corbo2024newevidenceon pages 94-97): Dalia Corbo, Caterina Mencarelli, and Pietro Lupetti. New evidence on ift turnaround at the flagellar tip and the association of ift trains with the flagellar membrane in the model organism chlamydomonas reinhardtii. Jul 2024. URL: https://doi.org/10.25434/dalia-corbo_phd2024-07-12, doi:10.25434/dalia-corbo_phd2024-07-12. This article has 0 citations.</p>
+</li>
+<li>
+<p>(maurya2019accrkand pages 3-4): Ashish Kumar Maurya, Travis Rogers, and Piali Sengupta. A ccrk and a mak kinase modulate cilia branching and length via regulation of axonemal microtubule dynamics in caenorhabditis elegans. Current Biology, 29:1286-1300.e4, Apr 2019. URL: https://doi.org/10.1016/j.cub.2019.02.062, doi:10.1016/j.cub.2019.02.062. This article has 49 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(maurya2019accrkand pages 1-3): Ashish Kumar Maurya, Travis Rogers, and Piali Sengupta. A ccrk and a mak kinase modulate cilia branching and length via regulation of axonemal microtubule dynamics in caenorhabditis elegans. Current Biology, 29:1286-1300.e4, Apr 2019. URL: https://doi.org/10.1016/j.cub.2019.02.062, doi:10.1016/j.cub.2019.02.062. This article has 49 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(maurya2019accrkand pages 7-9): Ashish Kumar Maurya, Travis Rogers, and Piali Sengupta. A ccrk and a mak kinase modulate cilia branching and length via regulation of axonemal microtubule dynamics in caenorhabditis elegans. Current Biology, 29:1286-1300.e4, Apr 2019. URL: https://doi.org/10.1016/j.cub.2019.02.062, doi:10.1016/j.cub.2019.02.062. This article has 49 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(chaya2024ccrkmakickkinasesignaling pages 12-15): Taro Chaya, Yamato Maeda, Ryotaro Tsutsumi, Makoto Ando, Yujie Ma, Naoko Kajimura, Teruyuki Tanaka, and Takahisa Furukawa. Ccrk-mak/ick kinase signaling axis is a ciliary transport regulator essential for retinal photoreceptor maintenance. bioRxiv, May 2024. URL: https://doi.org/10.1101/2024.05.24.595694, doi:10.1101/2024.05.24.595694. This article has 0 citations.</p>
+</li>
+</ol>
+<h2 id="artifacts">Artifacts</h2>
+<ul>
+<li><a href="dyf-5-deep-research-falcon_artifacts/artifact-00.md">Edison artifact artifact-00</a></li>
+<li><a href="dyf-5-deep-research-falcon_artifacts/artifact-01.md">Edison artifact artifact-01</a></li>
+</ul>
+<h2 id="citations">Citations</h2>
+<ol>
+<li>chaya2014ickisessential pages 8-9</li>
+<li>chaya2021posttranslationalmodificationenzymes pages 3-3</li>
+<li>chu2012finetuningof pages 5-8</li>
+<li>maurya2019accrkand pages 5-7</li>
+<li>mul2022mechanismsofregulation pages 14-15</li>
+<li>maurya2019accrkand pages 4-5</li>
+<li>moon2014intestinalcellkinase pages 4-5</li>
+<li>chaya2024ccrkmakickkinasesignaling pages 1-5</li>
+<li>chaya2025kinasedependentregulationof pages 2-4</li>
+<li>chaya2021posttranslationalmodificationenzymes pages 3-4</li>
+<li>corbo2024newevidenceon pages 30-33</li>
+<li>chaya2024ccrkmakickkinasesignaling pages 22-26</li>
+<li>mul2022mechanismsofregulation pages 22-23</li>
+<li>prevo2017intraflagellartransportmechanisms pages 12-14</li>
+<li>brinzer2021theuptakeof pages 37-39</li>
+<li>chaya2024ccrkmakicksignalingis pages 12-13</li>
+<li>corbo2024newevidenceon pages 94-97</li>
+<li>maurya2019accrkand pages 3-4</li>
+<li>maurya2019accrkand pages 1-3</li>
+<li>maurya2019accrkand pages 7-9</li>
+<li>chaya2024ccrkmakickkinasesignaling pages 12-15</li>
+<li>https://doi.org/10.1073/pnas.1323161111,</li>
+<li>https://doi.org/10.1101/2024.05.24.595694,</li>
+<li>https://doi.org/10.1002/embj.201488175,</li>
+<li>https://doi.org/10.1093/jb/mvab024,</li>
+<li>https://doi.org/10.3389/fmolb.2025.1638737,</li>
+<li>https://doi.org/10.3390/cells11172737,</li>
+<li>https://doi.org/10.25434/dalia-corbo_phd2024-07-12,</li>
+<li>https://doi.org/10.1111/febs.14068,</li>
+<li>https://doi.org/10.1101/2021.10.22.465401,</li>
+<li>https://doi.org/10.1093/nar/gkr690,</li>
+<li>https://doi.org/10.1016/j.cub.2019.02.062,</li>
+<li>https://doi.org/10.26508/lsa.202402880,</li>
+</ol>
+            </div>
+        </details>
+
+    </div>
+
+
+    <!-- Additional Documentation Sections -->
+
+    <div class="section">
+        <h2 class="section-title">📚 Additional Documentation</h2>
+
+        <details class="markdown-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; cursor: pointer;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Notes</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(dyf-5-notes.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="B3WFY8" data-a="DOC: Notes" data-r="" data-act="DOCUMENTATION" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This documentation is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This documentation needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+                <h1 id="dyf-5-c-elegans-research-notes">dyf-5 (C. elegans) research notes</h1>
+<p>UniProt: B3WFY8 (DYF5_CAEEL). WormBase: WBGene00001121 / M04C9.5. Gene name "dyf-5"<br />
+(dye filling defective-5). 489 aa. Protein kinase domain 11-291; ATP-binding Lys at<br />
+17-25/40; catalytic Asp/proton-acceptor at 132. Two isoforms (b = B3WFY8-1 displayed;<br />
+a = B3WFY8-2). Family: protein kinase superfamily, CMGC group, RCK subfamily<br />
+(MAK/ICK/CILK1-related); human relatives MAK, ICK/CILK1, MOK.</p>
+<h2 id="summary-of-what-is-known">Summary of what is KNOWN</h2>
+<p>DYF-5 is a ciliary serine/threonine protein kinase of the MAK/RCK (CMGC) family<br />
+that governs the length, morphology and intraflagellar-transport (IFT) dynamics of<br />
+<em>C. elegans</em> sensory-neuron cilia. It is expressed in ciliated head and tail sensory<br />
+neurons and enriched at the transition zone / distal ciliary segments; loss of<br />
+function gives long, misshapen, misaligned cilia with IFT-protein accumulation (the<br />
+"dye-filling defective" ciliary phenotype).</p>
+<h3 id="1-molecular-function-protein-serinethreonine-kinase-core">1. Molecular function — protein serine/threonine kinase (CORE)</h3>
+<ul>
+<li>Two independent studies directly demonstrate DYF-5 kinase activity <strong>in vitro</strong> on<br />
+  purified/recombinant ciliary substrates (both underpin the WormBase IDA<br />
+  GO:0004674 annotations):</li>
+<li>Phosphorylates the tubulin-binding N-terminal module of the IFT-B subunit<br />
+<strong>IFT-74</strong> at 11 Ser/Thr sites <a href="https://pubmed.ncbi.nlm.nih.gov/35969738" title="identified 11 phosphorylation sites">PMID:35969738</a>,<br />
+    with a defined substrate motif <a href="https://pubmed.ncbi.nlm.nih.gov/35969738" title="the DYF-5/MAK kinase substrate motif, (R)PX[S/T]*">PMID:35969738</a>.<br />
+    This phosphorylation lowers IFT-74/81 tubulin affinity<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/35969738" title="reducing the tubulin-binding affinity of IFT-74/81 approximately sixfold">PMID:35969738</a>.</li>
+<li>Phosphorylates the <strong>OSM-3</strong> kinesin C-terminal fragment (444-699)<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/38806659" title="Our in vitro protein kinase assays revealed that DYF-5 directly phosphorylates the C-terminal fragment of OSM-3 (444">PMID:38806659</a>.</li>
+<li>Human/mouse orthologue (RCK/MAK-ICK family) similarity underpins the ISS<br />
+  annotations; UniProt EC=2.7.11.1 (Ser/Thr kinase). ATP binding is a standard<br />
+  active-site feature (ATP-binding loop 17-25).</li>
+<li>NOTE on "MAP kinase": DYF-5 was historically named a "MAP kinase"<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/17420466" title="we identify DYF-5, a conserved MAP kinase">PMID:17420466</a> and is still described as<br />
+  MAPK-family <a href="https://pubmed.ncbi.nlm.nih.gov/38806659" title="DYF-5 belongs to a conserved family of mitogen-activated protein kinases (MAPKs) that localize at the distal region of the cilium to regulate ciliary elongation">PMID:38806659</a>.<br />
+  Molecularly it is a MAK/ICK/CILK1 (RCK) CMGC kinase with a TDY-like activation loop,<br />
+  NOT a canonical MAPK that is activated within a three-tier MAP3K→MAP2K→MAPK cascade.<br />
+  The specific term GO:0004674 (protein serine/threonine kinase activity, IDA) is the<br />
+  well-supported MF; GO:0004707 (MAP kinase activity, ISS) and GO:0000165 (MAPK cascade,<br />
+  IEA-from-EC/logical-inference) are legacy/name-driven over-annotations.</li>
+</ul>
+<h3 id="2-regulation-of-anterograde-ift-motor-handover-core">2. Regulation of anterograde IFT motor handover (CORE)</h3>
+<ul>
+<li>Anterograde IFT in worm cilia uses two kinesin-2 motors: heterotrimeric kinesin-II<br />
+  (KLP-11/KLP-20/KAP-1) in the middle segment and homodimeric OSM-3 in the distal<br />
+  segment. DYF-5 coordinates the handover between them.</li>
+<li>In <em>dyf-5(lf)</em>: kinesin-II is not restricted to the middle segment<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/17420466" title="dyf-5 is required">PMID:17420466</a> and OSM-3 detaches from IFT particles and slows<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/17420466" title="OSM-3 moves at a reduced speed and is not attached to IFT">PMID:17420466</a>.</li>
+<li>Model: DYF-5 promotes undocking of kinesin-II and docking of OSM-3<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/17420466" title="in the docking of OSM-3 onto IFT particles">PMID:17420466</a>. Consistent with a direct<br />
+  action, DYF-5 phosphorylates OSM-3 and regulates it cell-autonomously<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/38806659" title="DYF-5 regulates OSM-3CA in a cell-autonomous manner">PMID:38806659</a>.</li>
+</ul>
+<h3 id="3-cilium-length-ciliogenesis-control-core">3. Cilium length / ciliogenesis control (CORE)</h3>
+<ul>
+<li><em>dyf-5</em> null cilia are elongated, misaligned and accumulate IFT proteins<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/17420466" title="the cilia of dyf-5 loss-of-function (lf) animals are elongated and are not">PMID:17420466</a>,<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/17420466" title="six IFT proteins accumulate in">PMID:17420466</a> — DYF-5 normally restrains cilium<br />
+  elongation (negative regulator of length).</li>
+<li>Mechanistically, DYF-5→IFT-74 phosphorylation drives ciliary-tip tubulin unloading:<br />
+  blocking or mimicking IFT-74 phosphorylation elongates or shortens cilia respectively<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/35969738" title="Ablation or constitutive activation of IFT-74 phosphorylation abnormally">PMID:35969738</a>,<br />
+  fitting the balance-point model of length control. DYF-5 protein is positioned at the<br />
+  middle-segment tip through the distal tip<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/35969738" title="the endogenous DYF-5 protein distributes from the tip of the middle ciliary segment">PMID:35969738</a>.</li>
+</ul>
+<h3 id="4-localization-well-supported-non-core">4. Localization (well supported, non-core)</h3>
+<ul>
+<li>Perikaryon, dendrite, axon and cilium (UniProt EXP/IDA, PMID:17420466); enriched at<br />
+  the transition zone / dendrite-cilium junction and distal cilium. Worm sensory cilia<br />
+  are non-motile (GO:0097730 non-motile cilium, IDA).</li>
+</ul>
+<h2 id="what-is-not-known-candidate-knowledge-gaps">What is NOT known (candidate knowledge gaps)</h2>
+<ul>
+<li><strong>Full in-vivo substrate set.</strong> Only two direct substrates (IFT-74, OSM-3) are<br />
+  biochemically established; the field explicitly states more remain<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/35969738" title="understanding the undocking of kinesin-II and docking of OSM-3 onto IFT particles">PMID:35969738</a>.<br />
+  Which substrate(s) mediate the kinesin-II undocking step is unresolved.</li>
+<li><strong>Mechanism of the kinesin-II→OSM-3 handoff.</strong> It is unknown whether DYF-5 triggers<br />
+  handover directly by phosphorylating a motor/adaptor or indirectly via IFT-train<br />
+  remodelling; the ~50 aa OSM-3 fragment phosphosites and their functional residues are<br />
+  not mapped in vivo.</li>
+<li><strong>Upstream activation.</strong> How DYF-5 kinase activity and its ciliary-tip localization are<br />
+  themselves regulated (the RCK-family activator, e.g. CCRK/CDK-like input, and the<br />
+  activation-loop phospho-state in worm) is not established here.</li>
+<li><strong>Isoform specificity.</strong> Whether the two splice isoforms (a/b, differing in the<br />
+  C-terminal tail that is required for ciliary targeting) have distinct roles is untested.</li>
+</ul>
+<h2 id="annotation-review-reasoning-high-level">Annotation-review reasoning (high level)</h2>
+<ul>
+<li>ACCEPT the experimental MF (GO:0004674 IDA×2), the ciliary CC (non-motile cilium,<br />
+  cilium), and the IFT/cilium-length BPs (intraciliary [anterograde] transport, cilium<br />
+  assembly, non-motile cilium assembly and its regulation).</li>
+<li>MARK_AS_OVER_ANNOTATED / MODIFY the MAPK-legacy terms (MAP kinase activity → Ser/Thr<br />
+  kinase; MAPK cascade; intracellular signal transduction) and the phylogenetically<br />
+  over-propagated nucleus CC (no worm evidence; contradicts ciliary/cytoplasmic<br />
+  localization).</li>
+<li>KEEP_AS_NON_CORE the general/location terms (ATP binding, protein kinase activity,<br />
+  protein serine kinase activity, cytoplasm, axon, dendrite, perikaryon, neuronal cell<br />
+  body, intracellular protein localization).</li>
+</ul>
+<h2 id="provenance-methods-note">Provenance / methods note</h2>
+<ul>
+<li><code>just deep-research-falcon worm dyf-5 --fallback perplexity-lite</code> completed after ~21 min<br />
+  (falcon/Edison, 33 citations): <code>dyf-5-deep-research-falcon.md</code>. The perplexity-lite<br />
+  fallback 401'd on quota but was not needed. The falcon report is genuine model output and<br />
+  corroborates this review (conserved DYF-5/LF4/ICK-CILK1/MAK/LmxMPK9 module; upstream<br />
+  DYF-18/CCRK activation; ICK phosphorylation of kinesin-2 KIF3A Thr674). It reinforces the<br />
+  two knowledge gaps (substrate set; kinesin-II-&gt;OSM-3 handoff) and the upstream-activation<br />
+  suggested question. The review's graded conclusions remain grounded in the primary<br />
+  literature below plus UniProt (B3WFY8) and GOA; no deep-research file was fabricated.</li>
+<li>Reference-validation caveat: the repo reference validator only sees each paper's<br />
+  PubMed ABSTRACT (not the full text cached in <code>publications/</code>). All <code>supporting_text</code><br />
+  quotes here were therefore drawn from abstract text (verbatim, whitespace/punctuation-<br />
+  normalized). Full-text-only facts (e.g. DYF-5 phosphorylates the OSM-3 C-terminus in<br />
+  vitro; endogenous DYF-5 distribution along the axoneme) are used in prose/reasoning and<br />
+  anchored via the curator IDA annotations, not quoted as supporting_text.</li>
+</ul>
+<h2 id="references-used">References used</h2>
+<ul>
+<li>PMID:17420466 Burghoorn et al. 2007 PNAS — primary genetic/imaging characterization<br />
+  (abstract-only in cache; experimental annotations by WormBase/UniProt curators from<br />
+  full text). HIGH.</li>
+<li>PMID:35969738 Jiang et al. 2022 PNAS — DYF-5 phosphorylates IFT-74, tubulin unloading,<br />
+  cilium-length control (full text). HIGH.</li>
+<li>PMID:38806659 Xie et al. 2024 EMBO J — DYF-5 phosphorylates OSM-3 C-terminus; dyf-5<br />
+  suppressors of hyperactive OSM-3 (full text). HIGH.</li>
+</ul>
+            </div>
+        </details>
+
+    </div>
+
+
+    <!-- YAML Preview Section -->
+    <div class="section">
+        <details class="yaml-preview">
+            <summary>
+                <h2 style="display: inline;">📄 View Raw YAML</h2>
+            </summary>
+            <div class="yaml-content">
+                <pre><code>id: B3WFY8
+gene_symbol: dyf-5
+product_type: PROTEIN
+status: DRAFT
+taxon:
+  id: NCBITaxon:6239
+  label: Caenorhabditis elegans
+description: &gt;-
+  dyf-5 encodes a ciliary serine/threonine protein kinase of the CMGC-group,
+  MAK/RCK (ICK/CILK1-related) subfamily. It is expressed in ciliated sensory
+  neurons of the head (amphid and labial) and tail (phasmid), where its protein is
+  enriched at the dendrite-cilium transition zone and distributed from the tip of
+  the ciliary middle segment through the distal segment to the ciliary tip. DYF-5
+  is a master regulator of sensory-cilium length, morphology and intraflagellar
+  transport (IFT). In worm cilia, anterograde IFT is driven by two kinesin-2 motors
+  (heterotrimeric kinesin-II, KLP-11/KLP-20/KAP-1, in the middle segment and
+  homodimeric OSM-3 in the distal segment); DYF-5 coordinates their handover,
+  promoting undocking of kinesin-II from IFT trains at the end of the middle segment
+  and docking of OSM-3 onto IFT particles. Two direct in-vitro substrates are
+  established: the IFT-B subunit IFT-74, whose N-terminal tubulin-binding module
+  DYF-5 phosphorylates at multiple sites to lower IFT-74/81 tubulin affinity and
+  release tubulin at the ciliary tip, and the OSM-3 kinesin C-terminal region. Loss
+  of dyf-5 produces abnormally long, misaligned cilia with accumulation of IFT
+  components, whereas altered IFT-74 phosphorylation lengthens or shortens cilia,
+  consistent with a balance-point model of tubulin delivery and axoneme length
+  control. The kinase acts with the substrate consensus motif (R)PX[S/T].
+alternative_products:
+- name: b {ECO:0000312|WormBase:M04C9.5b}
+  id: B3WFY8-1
+- name: a {ECO:0000312|WormBase:M04C9.5a}
+  id: B3WFY8-2
+  sequence_note: VSP_058711, VSP_058712
+existing_annotations:
+- term:
+    id: GO:0004674
+    label: protein serine/threonine kinase activity
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Phylogenetic (IBA) inference of the core molecular function. DYF-5 is a
+      bona fide protein serine/threonine kinase and this is directly demonstrated
+      experimentally (see the IDA annotations from PMID:35969738 and PMID:38806659),
+      so this term represents the core function of the gene.
+    action: ACCEPT
+    supported_by:
+    - reference_id: PMID:35969738
+      supporting_text: the ciliary kinase DYF-5/MAK phosphorylates multiple sites within
+        the tubulin-binding module of IFT-74, reducing the tubulin-binding affinity of
+        IFT-74/81 approximately sixfold
+      reference_section_type: ABSTRACT
+- term:
+    id: GO:0005634
+    label: nucleus
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: is_active_in
+  review:
+    summary: &gt;-
+      Nuclear localization is inferred phylogenetically from the broader
+      MAPK/CMGC family (many canonical MAPKs are nuclear), but there is no
+      experimental evidence that C. elegans DYF-5 acts in the nucleus. The
+      experimentally established sites of action are the cilium, dendrite, axon and
+      neuronal cell body; a ciliary IFT-regulating kinase in the nucleus is not
+      supported. Treated as an over-propagated family inference.
+    action: MARK_AS_OVER_ANNOTATED
+    propagation_review:
+      root_cause: PROPAGATION_BAD
+      failure_modes:
+      - COMPARTMENT_OR_COMPLEX_MISMATCH
+      - FUNCTIONAL_DIVERGENCE
+      source_entities:
+      - source_id: PANTHER:PTN000622075
+        source_label: MAPK/CMGC family node
+        source_status: SUPPORTS_SOURCE_BUT_NOT_TARGET
+        comment: &gt;-
+          Nuclear localization is a property of canonical MAPKs in the family tree,
+          not of the divergent ciliary MAK/RCK member DYF-5, which localizes to the
+          cilium, dendrite, axon and cell body with no nuclear evidence.
+- term:
+    id: GO:0005737
+    label: cytoplasm
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: is_active_in
+  review:
+    summary: &gt;-
+      Broadly correct but non-informative. DYF-5 is present in the neuronal cell
+      body/cytoplasm, but its characterized site of action is the cilium. Retained
+      as a general, non-core location.
+    action: KEEP_AS_NON_CORE
+- term:
+    id: GO:0035556
+    label: intracellular signal transduction
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Generic biological-process term propagated from the MAPK/CMGC family. DYF-5&#39;s
+      actual, well-characterized role is regulation of intraflagellar transport and
+      cilium length, not canonical intracellular signal transduction. The specific
+      ciliary/IFT process terms capture the biology far better.
+    action: MARK_AS_OVER_ANNOTATED
+    propagation_review:
+      root_cause: TERM_SCOPING_PROBLEM
+      failure_modes:
+      - FUNCTIONAL_DIVERGENCE
+      - GRANULARITY_MISMATCH
+      source_entities:
+      - source_id: PANTHER:PTN000622075
+        source_label: MAPK/CMGC family node
+        source_status: SUPPORTS_SOURCE_BUT_NOT_TARGET
+        comment: &gt;-
+          The signal-transduction role is a family-level generalization; the MAK/RCK
+          member DYF-5 acts as a ciliary IFT/length regulator, so the specific IFT and
+          cilium-assembly process terms are the informative annotations.
+- term:
+    id: GO:0005929
+    label: cilium
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: is_active_in
+  review:
+    summary: &gt;-
+      Core cellular location. DYF-5 is a ciliary kinase; it acts within sensory
+      cilia along the axoneme and is enriched at the dendrite-cilium transition zone.
+    action: ACCEPT
+    supported_by:
+    - reference_id: PMID:35969738
+      supporting_text: the ciliary kinase DYF-5/MAK
+      reference_section_type: ABSTRACT
+- term:
+    id: GO:0060271
+    label: cilium assembly
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Core biological process. DYF-5 is required for normal ciliogenesis; loss of
+      function yields abnormally long, misshapen sensory cilia. Supported both by
+      phylogeny and by direct C. elegans experiments.
+    action: ACCEPT
+    supported_by:
+    - reference_id: PMID:35969738
+      supporting_text: Ablation or constitutive activation of IFT-74 phosphorylation
+        abnormally elongates or shortens sensory cilia in Caenorhabditis elegans neurons
+      reference_section_type: ABSTRACT
+- term:
+    id: GO:0042073
+    label: intraciliary transport
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Core biological process. DYF-5 regulates IFT; in dyf-5 mutants IFT proteins
+      accumulate abnormally in cilia and IFT motor behavior is disrupted.
+    action: ACCEPT
+    supported_by:
+    - reference_id: PMID:17420466
+      supporting_text: six IFT proteins accumulate in the cilia of dyf-5(lf) mutants
+      reference_section_type: ABSTRACT
+- term:
+    id: GO:0000165
+    label: MAPK cascade
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000108
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Electronic inference (GO_REF:0000108) triggered by the MAP-kinase-activity
+      term. DYF-5 belongs to the MAK/RCK (ICK/CILK1) subfamily; despite the historical
+      &#34;MAP kinase&#34; name it is not a component of a canonical three-tiered
+      MAP3K-MAP2K-MAPK signaling cascade, and no such cascade role is documented for
+      DYF-5. Over-annotation driven by nomenclature.
+    action: MARK_AS_OVER_ANNOTATED
+- term:
+    id: GO:0004672
+    label: protein kinase activity
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000002
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Correct but a general parent of the specific, experimentally supported term
+      protein serine/threonine kinase activity (GO:0004674). Retained as non-core.
+    action: KEEP_AS_NON_CORE
+- term:
+    id: GO:0004674
+    label: protein serine/threonine kinase activity
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000003
+  qualifier: enables
+  review:
+    summary: &gt;-
+      EC-based electronic inference of the core molecular function; consistent with
+      the experimental IDA evidence.
+    action: ACCEPT
+- term:
+    id: GO:0005524
+    label: ATP binding
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000002
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Standard active-site feature of a protein kinase (ATP-binding loop residues
+      17-25 and Lys40). Correct but a generic molecular-detail term; non-core.
+    action: KEEP_AS_NON_CORE
+- term:
+    id: GO:0005929
+    label: cilium
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000044
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      UniProt SubCell-derived ciliary localization; consistent with experimental
+      data. Duplicates the IBA cilium annotation; correct core location.
+    action: ACCEPT
+- term:
+    id: GO:0030424
+    label: axon
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000044
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      SubCell-derived; consistent with the experimental IDA axon annotation
+      (PMID:17420466). Real but non-core neuronal localization.
+    action: KEEP_AS_NON_CORE
+- term:
+    id: GO:0030425
+    label: dendrite
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000044
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      SubCell-derived; consistent with the experimental IDA dendrite annotation
+      (PMID:17420466). Real but non-core neuronal localization.
+    action: KEEP_AS_NON_CORE
+- term:
+    id: GO:0043204
+    label: perikaryon
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000044
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      SubCell-derived; consistent with the experimental (EXP/IDA) perikaryon
+      annotation from PMID:17420466. Real but non-core.
+    action: KEEP_AS_NON_CORE
+- term:
+    id: GO:0106310
+    label: protein serine kinase activity
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000116
+  qualifier: enables
+  review:
+    summary: &gt;-
+      RHEA-derived; a valid subtype of the kinase activity. DYF-5 phosphorylates
+      both Ser and Thr residues, so protein serine/threonine kinase activity
+      (GO:0004674) is the most complete descriptor; retained as non-core.
+    action: KEEP_AS_NON_CORE
+- term:
+    id: GO:0004674
+    label: protein serine/threonine kinase activity
+  evidence_type: IDA
+  original_reference_id: PMID:38806659
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Direct experimental demonstration of kinase activity. In this study dyf-5
+      kinase-domain mutations were recovered as intergenic suppressors of a
+      hyperactive OSM-3, and in-vitro protein kinase assays show DYF-5 directly
+      phosphorylates the C-terminal fragment of the OSM-3 kinesin (residues 444-699),
+      identifying OSM-3 as a direct substrate and supporting the core molecular
+      function.
+    action: ACCEPT
+    supported_by:
+    - reference_id: PMID:38806659
+      supporting_text: mutations inhibiting the ciliary kinase DYF-5, both of which
+        restored normal cilia in OSM-3CA-expressing animals
+      reference_section_type: ABSTRACT
+- term:
+    id: GO:0043204
+    label: perikaryon
+  evidence_type: EXP
+  original_reference_id: PMID:17420466
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      Experimentally observed localization to the neuronal cell body (perikaryon).
+      Real but non-core relative to the ciliary site of action.
+    action: KEEP_AS_NON_CORE
+- term:
+    id: GO:0106310
+    label: protein serine kinase activity
+  evidence_type: ISS
+  original_reference_id: GO_REF:0000024
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Sequence-similarity transfer of a valid kinase-activity subtype. Consistent
+      with the demonstrated Ser/Thr kinase activity; non-core relative to GO:0004674.
+    action: KEEP_AS_NON_CORE
+- term:
+    id: GO:0004674
+    label: protein serine/threonine kinase activity
+  evidence_type: IDA
+  original_reference_id: PMID:35969738
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Direct experimental demonstration of kinase activity. DYF-5 phosphorylates the
+      tubulin-binding module of IFT-74 at multiple Ser/Thr sites in vitro, reducing
+      IFT-74/81 tubulin affinity ~sixfold. Establishes the core molecular function
+      and a direct substrate (IFT-74).
+    action: ACCEPT
+    supported_by:
+    - reference_id: PMID:35969738
+      supporting_text: the ciliary kinase DYF-5/MAK phosphorylates multiple sites within
+        the tubulin-binding module of IFT-74, reducing the tubulin-binding affinity of
+        IFT-74/81 approximately sixfold
+      reference_section_type: ABSTRACT
+- term:
+    id: GO:0035720
+    label: intraciliary anterograde transport
+  evidence_type: IMP
+  original_reference_id: PMID:17420466
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Core biological process. Mutant-phenotype analysis shows DYF-5 is required for
+      correct anterograde IFT: it restricts kinesin-II to the middle segment and is
+      needed for OSM-3 to remain attached to and move IFT particles at normal speed.
+    action: ACCEPT
+    supported_by:
+    - reference_id: PMID:17420466
+      supporting_text: dyf-5 is required to restrict kinesin II to the cilia middle segments
+      reference_section_type: ABSTRACT
+- term:
+    id: GO:0035720
+    label: intraciliary anterograde transport
+  evidence_type: IGI
+  original_reference_id: PMID:17420466
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Genetic-interaction evidence (with osm-3/kinesin-II components) for the same
+      core anterograde-IFT regulatory role. In dyf-5 mutants OSM-3 detaches from IFT
+      particles and slows.
+    action: ACCEPT
+    supported_by:
+    - reference_id: PMID:17420466
+      supporting_text: OSM-3 moves at a reduced speed and is not attached to IFT particles
+      reference_section_type: ABSTRACT
+- term:
+    id: GO:1902856
+    label: negative regulation of non-motile cilium assembly
+  evidence_type: IGI
+  original_reference_id: PMID:17420466
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Core regulatory role. Loss of dyf-5 elongates sensory cilia, indicating that
+      DYF-5 normally restrains cilium elongation/assembly. Mechanistically consistent
+      with DYF-5 driving ciliary-tip tubulin unloading.
+    action: ACCEPT
+    supported_by:
+    - reference_id: PMID:17420466
+      supporting_text: the cilia of dyf-5 loss-of-function (lf) animals are elongated and
+        are not properly aligned into the amphid channel
+      reference_section_type: ABSTRACT
+- term:
+    id: GO:1902857
+    label: positive regulation of non-motile cilium assembly
+  evidence_type: IGI
+  original_reference_id: PMID:17420466
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Context-dependent genetic-interaction annotation from the same study, made
+      against a different set of partner genes. It reflects the composite genetic
+      requirement of dyf-5 for normal ciliogenesis (e.g. in sensitized kinesin
+      backgrounds cilia fail to form), opposite in sign to the negative-regulation
+      annotation. Retained as non-core; the dominant, mechanistically supported role
+      is restraint of cilium elongation (GO:1902856).
+    action: KEEP_AS_NON_CORE
+- term:
+    id: GO:0097730
+    label: non-motile cilium
+  evidence_type: IDA
+  original_reference_id: PMID:17420466
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      Precise core location: C. elegans sensory cilia are non-motile, and DYF-5
+      localizes to and acts within them. More specific and preferable to the general
+      cilium term.
+    action: ACCEPT
+    supported_by:
+    - reference_id: PMID:35969738
+      supporting_text: the ciliary kinase DYF-5/MAK
+      reference_section_type: ABSTRACT
+- term:
+    id: GO:0004674
+    label: protein serine/threonine kinase activity
+  evidence_type: ISS
+  original_reference_id: PMID:17420466
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Sequence-similarity transfer of the core kinase function from the human
+      MAK/ICK-family orthologue. Now directly confirmed experimentally in worm.
+    action: ACCEPT
+- term:
+    id: GO:0004707
+    label: MAP kinase activity
+  evidence_type: ISS
+  original_reference_id: PMID:17420466
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Name-driven over-specification. DYF-5 was historically called a &#34;MAP kinase&#34;,
+      but molecularly it is a MAK/RCK (ICK/CILK1) CMGC kinase, not a mitogen-activated
+      protein kinase activated by dual TXY phosphorylation within a MAPK cascade. Its
+      demonstrated activity is general protein serine/threonine phosphorylation. The
+      accurate term is protein serine/threonine kinase activity (GO:0004674).
+    action: MODIFY
+    proposed_replacement_terms:
+    - id: GO:0004674
+      label: protein serine/threonine kinase activity
+    supported_by:
+    - reference_id: PMID:17420466
+      supporting_text: we identify DYF-5, a conserved MAP kinase that plays a role in
+        these processes
+      reference_section_type: ABSTRACT
+- term:
+    id: GO:0005524
+    label: ATP binding
+  evidence_type: ISS
+  original_reference_id: PMID:17420466
+  qualifier: enables
+  review:
+    summary: &gt;-
+      Sequence-similarity transfer of the standard kinase ATP-binding feature.
+      Correct but a generic molecular-detail term; non-core.
+    action: KEEP_AS_NON_CORE
+- term:
+    id: GO:0008104
+    label: intracellular protein localization
+  evidence_type: IMP
+  original_reference_id: PMID:17420466
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Reflects the dyf-5 mutant phenotype in which IFT components are mislocalized
+      and accumulate within cilia. This is a generic term for what is more precisely
+      the regulation of intraciliary transport and of ciliary protein distribution;
+      retained as non-core, with the specific IFT process terms preferred.
+    action: KEEP_AS_NON_CORE
+    supported_by:
+    - reference_id: PMID:17420466
+      supporting_text: six IFT proteins accumulate in the cilia of dyf-5(lf) mutants
+      reference_section_type: ABSTRACT
+- term:
+    id: GO:0030424
+    label: axon
+  evidence_type: IDA
+  original_reference_id: PMID:17420466
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      Experimentally observed neuronal localization. Real but non-core relative to
+      the ciliary site of action.
+    action: KEEP_AS_NON_CORE
+- term:
+    id: GO:0030425
+    label: dendrite
+  evidence_type: IDA
+  original_reference_id: PMID:17420466
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      Experimentally observed neuronal localization; DYF-5 is enriched at the
+      dendrite-cilium transition zone. Real but non-core.
+    action: KEEP_AS_NON_CORE
+- term:
+    id: GO:0042073
+    label: intraciliary transport
+  evidence_type: IDA
+  original_reference_id: PMID:17420466
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Direct experimental evidence for a role in IFT: live imaging of IFT-component
+      motility and accumulation in dyf-5 mutants. Core process.
+    action: ACCEPT
+    supported_by:
+    - reference_id: PMID:17420466
+      supporting_text: six IFT proteins accumulate in the cilia of dyf-5(lf) mutants
+      reference_section_type: ABSTRACT
+- term:
+    id: GO:0043025
+    label: neuronal cell body
+  evidence_type: IDA
+  original_reference_id: PMID:17420466
+  qualifier: located_in
+  review:
+    summary: &gt;-
+      Experimentally observed localization to the neuronal cell body. Real but
+      non-core relative to the ciliary site of action.
+    action: KEEP_AS_NON_CORE
+- term:
+    id: GO:1905515
+    label: non-motile cilium assembly
+  evidence_type: IMP
+  original_reference_id: PMID:17420466
+  qualifier: involved_in
+  review:
+    summary: &gt;-
+      Core biological process, precise to the non-motile sensory cilia of C. elegans.
+      dyf-5 loss-of-function mutants have abnormally long, misshapen cilia, showing a
+      requirement for normal non-motile cilium assembly/morphogenesis.
+    action: ACCEPT
+    supported_by:
+    - reference_id: PMID:17420466
+      supporting_text: the cilia of dyf-5 loss-of-function (lf) animals are elongated and
+        are not properly aligned into the amphid channel
+      reference_section_type: ABSTRACT
+references:
+- id: GO_REF:0000002
+  title: Gene Ontology annotation through association of InterPro records with GO
+    terms
+  findings: []
+- id: GO_REF:0000003
+  title: Gene Ontology annotation based on Enzyme Commission mapping
+  findings: []
+- id: GO_REF:0000024
+  title: Manual transfer of experimentally-verified manual GO annotation data to orthologs
+    by curator judgment of sequence similarity
+  findings: []
+- id: GO_REF:0000033
+  title: Annotation inferences using phylogenetic trees
+  findings: []
+- id: GO_REF:0000044
+  title: Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location
+    vocabulary mapping, accompanied by conservative changes to GO terms applied by
+    UniProt
+  findings: []
+- id: GO_REF:0000108
+  title: Automatic assignment of GO terms using logical inference, based on on inter-ontology
+    links
+  findings: []
+- id: GO_REF:0000116
+  title: Automatic Gene Ontology annotation based on Rhea mapping
+  findings: []
+- id: PMID:17420466
+  title: Mutation of the MAP kinase DYF-5 affects docking and undocking of kinesin-2
+    motors and reduces their speed in the cilia of Caenorhabditis elegans.
+  findings: []
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Primary genetic and live-imaging characterization of C. elegans dyf-5 (Burghoorn
+      et al., PNAS 2007). Establishes DYF-5 as a ciliary kinase controlling cilium
+      length/morphology and coordinating the kinesin-II to OSM-3 anterograde-IFT
+      handover. Cached record is abstract-only; the experimental IDA/IMP/IGI annotations
+      were made by WormBase/UniProt curators from the full text.
+- id: PMID:35969738
+  title: DYF-5/MAK-dependent phosphorylation promotes ciliary tubulin unloading.
+  findings: []
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Jiang et al., PNAS 2022. Identifies IFT-74 as a direct DYF-5 substrate (11
+      Ser/Thr phosphosites in the tubulin-binding N-terminus), shows phosphorylation
+      lowers IFT-74/81 tubulin affinity ~sixfold, and links this to ciliary-tip tubulin
+      unloading and cilium length control. Underpins one of the IDA GO:0004674
+      annotations.
+- id: PMID:38806659
+  title: Neurons dispose of hyperactive kinesin into glial cells for clearance.
+  findings: []
+  reference_review:
+    relevance: HIGH
+    correctness: VERIFIED
+    review_notes: &gt;-
+      Xie et al., EMBO J 2024. dyf-5 kinase-domain mutations were recovered as
+      intergenic suppressors of a hyperactive OSM-3, and in-vitro kinase assays show
+      DYF-5 directly phosphorylates the OSM-3 C-terminal fragment (444-699),
+      establishing OSM-3 as a direct DYF-5 substrate. Underpins the IDA GO:0004674
+      annotation. The paper&#39;s headline topic is kinesin disposal into glia; DYF-5 is
+      characterized as a cell-autonomous regulator of OSM-3.
+core_functions:
+- description: &gt;-
+    DYF-5 is a ciliary serine/threonine protein kinase (MAK/RCK, ICK/CILK1-related
+    CMGC family) that phosphorylates IFT machinery to control anterograde
+    intraflagellar transport and the length of non-motile sensory cilia. It acts
+    along the ciliary axoneme (from the middle-segment tip to the distal tip). Two
+    direct substrates are established biochemically: it phosphorylates the N-terminal
+    tubulin-binding module of the IFT-B subunit IFT-74 (11 Ser/Thr sites; consensus
+    (R)PX[S/T]), lowering IFT-74/81 tubulin affinity to trigger tubulin unloading at
+    the ciliary tip, and it phosphorylates the C-terminal region of the OSM-3
+    kinesin. Through these activities DYF-5 promotes undocking of kinesin-II from IFT
+    trains and docking of OSM-3, and restrains cilium elongation, so that loss of
+    dyf-5 produces abnormally long, misaligned cilia with IFT-component accumulation.
+  molecular_function:
+    id: GO:0004674
+    label: protein serine/threonine kinase activity
+  directly_involved_in:
+  - id: GO:0035720
+    label: intraciliary anterograde transport
+  - id: GO:1902856
+    label: negative regulation of non-motile cilium assembly
+  - id: GO:0060271
+    label: cilium assembly
+  locations:
+  - id: GO:0005929
+    label: cilium
+  supported_by:
+  - reference_id: PMID:35969738
+    supporting_text: the ciliary kinase DYF-5/MAK phosphorylates multiple sites within
+      the tubulin-binding module of IFT-74, reducing the tubulin-binding affinity of
+      IFT-74/81 approximately sixfold
+    reference_section_type: ABSTRACT
+  - reference_id: PMID:38806659
+    supporting_text: mutations inhibiting the ciliary kinase DYF-5, both of which restored
+      normal cilia in OSM-3CA-expressing animals
+    reference_section_type: ABSTRACT
+  - reference_id: PMID:17420466
+    supporting_text: dyf-5 is required to restrict kinesin II to the cilia middle segments
+    reference_section_type: ABSTRACT
+knowledge_gaps:
+- gap_statement: &gt;-
+    The complete set of in-vivo DYF-5 substrates that execute cilium-length and IFT
+    control, and how their phosphorylation drives ciliary-tip cargo (tubulin)
+    unloading, is undetermined. Only two direct substrates (IFT-74 and the OSM-3
+    C-terminus) have been demonstrated biochemically in vitro; which substrates are
+    phosphorylated in the intact cilium, at which residues, and with what functional
+    consequence, remains open.
+  boundary: &gt;-
+    DYF-5 is an established ciliary Ser/Thr kinase with a defined substrate consensus
+    motif ((R)PX[S/T]); IFT-74 (11 N-terminal phosphosites reducing IFT-74/81 tubulin
+    affinity) and the OSM-3 kinesin C-terminal fragment (444-699) are proven in-vitro
+    substrates.
+  gap_kind:
+  - BIOLOGY
+  dark_aspect: RESIDUAL_SUBGAP
+  status: OPEN
+  significance: &gt;-
+    Identifying the full substrate set would explain how a single kinase coordinately
+    controls tubulin unloading, motor handover and axoneme length, and would clarify
+    the conserved MAK/ICK/CILK1 pathway relevant to human retinal ciliopathies.
+  resolution: &gt;-
+    In-vivo phosphoproteomics of dyf-5(+) versus dyf-5(null) cilia; targeted
+    phospho-site mapping on candidate IFT/motor substrates; separation-of-function
+    phospho-dead/phospho-mimic alleles tested for ciliary length and IFT phenotypes.
+  provenance:
+  - reference_id: PMID:35969738
+    supporting_text: little is known of how tubulins are unloaded when arriving at the
+      ciliary tip
+    reference_section_type: ABSTRACT
+- gap_statement: &gt;-
+    The molecular mechanism by which DYF-5 switches anterograde IFT from
+    heterotrimeric kinesin-II to homodimeric OSM-3 at the end of the middle segment is
+    not resolved. It is unknown whether DYF-5 triggers the handover directly by
+    phosphorylating a motor or an adaptor (e.g. OSM-3, kinesin-II subunits, or IFT
+    linkers) or indirectly by remodeling IFT-train architecture, and which
+    phosphosite(s) on OSM-3 are functionally required in vivo.
+  boundary: &gt;-
+    Genetics and imaging show DYF-5 is required for undocking of kinesin-II from IFT
+    particles and docking of OSM-3, and DYF-5 phosphorylates the OSM-3 C-terminus in
+    vitro and suppresses OSM-3 hyperactivity; the causal phosphorylation event that
+    executes the handover is not identified.
+  gap_kind:
+  - BIOLOGY
+  dark_aspect: MF_DARK
+  status: OPEN
+  significance: &gt;-
+    The kinesin-II to OSM-3 handoff is the paradigm for how two anterograde motors are
+    coordinated on a shared IFT train to build compartmentalized cilia; resolving it
+    would define a general principle of IFT regulation conserved to vertebrate KIF3/KIF17.
+  resolution: &gt;-
+    Map and mutate DYF-5-dependent OSM-3 phosphosites in vivo; test whether
+    phospho-dead/phospho-mimic OSM-3 (or kinesin-II subunits) recapitulate dyf-5
+    handover defects; reconstitute motor docking/undocking on IFT trains with and
+    without DYF-5 phosphorylation.
+  provenance:
+  - reference_id: PMID:17420466
+    supporting_text: DYF-5 plays a role in the undocking of kinesin II from IFT particles
+      and in the docking of OSM-3 onto IFT particles
+    reference_section_type: ABSTRACT
+  - reference_id: PMID:38806659
+    supporting_text: mutations inhibiting the ciliary kinase DYF-5, both of which restored
+      normal cilia in OSM-3CA-expressing animals
+    reference_section_type: ABSTRACT
+suggested_questions:
+- question: &gt;-
+    Beyond IFT-74 and OSM-3, what are the physiological DYF-5 substrates in the
+    cilium, and which one executes kinesin-II undocking?
+- question: &gt;-
+    Do the two dyf-5 splice isoforms (a and b), which differ in the C-terminal tail
+    that governs ciliary targeting, have distinct functions or localizations?
+- question: &gt;-
+    What kinase activates DYF-5 and how is its activity spatially restricted to the
+    distal ciliary segment?
+suggested_experiments:
+- description: &gt;-
+    Comparative in-vivo ciliary phosphoproteomics of wild-type versus dyf-5(mn400)
+    null sensory neurons to enumerate DYF-5-dependent phosphosites on IFT and motor
+    proteins.
+- description: &gt;-
+    CRISPR phospho-dead and phospho-mimic knock-ins at DYF-5-dependent OSM-3 and
+    kinesin-II phosphosites, scored for cilium length, IFT velocity and motor
+    docking/undocking behavior.
+- description: &gt;-
+    Structure-function dissection of the DYF-5 C-terminus (truncations/point mutants)
+    to separate kinase activation from ciliary-tip targeting, with live imaging of
+    tagged DYF-5.
+</code></pre>
+            </div>
+        </details>
+    </div>
+
+    <!-- Pathway Visualization Link -->
+
+
+    <style>
+        /* Markdown Section Styles */
+        .markdown-section {
+            margin-bottom: 1rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .markdown-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .markdown-section summary h3 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.1rem;
+        }
+
+        .markdown-section summary:hover h3 {
+            color: #007bff;
+        }
+
+        .markdown-section[open] {
+            background-color: #fff;
+        }
+
+        .markdown-content {
+            margin-top: 1rem;
+            padding: 1rem;
+            border-top: 1px solid #dee2e6;
+        }
+
+        /* Markdown content styling */
+        .markdown-content h1 { font-size: 1.5rem; margin-top: 1.5rem; }
+        .markdown-content h2 { font-size: 1.3rem; margin-top: 1.3rem; }
+        .markdown-content h3 { font-size: 1.1rem; margin-top: 1.1rem; }
+        .markdown-content h4 { font-size: 1rem; margin-top: 1rem; }
+
+        .markdown-content pre {
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .markdown-content code {
+            background-color: #f8f9fa;
+            padding: 0.2rem 0.4rem;
+            border-radius: 3px;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+        }
+
+        .markdown-content pre code {
+            background: none;
+            padding: 0;
+        }
+
+        .markdown-content table {
+            border-collapse: collapse;
+            width: 100%;
+            margin: 1rem 0;
+        }
+
+        .markdown-content table th,
+        .markdown-content table td {
+            border: 1px solid #dee2e6;
+            padding: 0.5rem;
+            text-align: left;
+        }
+
+        .markdown-content table th {
+            background-color: #f8f9fa;
+            font-weight: bold;
+        }
+
+        .markdown-content blockquote {
+            border-left: 4px solid #007bff;
+            padding-left: 1rem;
+            margin-left: 0;
+            color: #666;
+        }
+
+        /* YAML Preview Styles */
+        .yaml-preview {
+            margin-top: 2rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .yaml-preview summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .yaml-preview summary h2 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.3rem;
+        }
+
+        .yaml-preview summary:hover h2 {
+            color: #007bff;
+        }
+
+        .yaml-preview[open] {
+            background-color: #fff;
+        }
+
+        .yaml-content {
+            margin-top: 1rem;
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .yaml-content pre {
+            margin: 0;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+            line-height: 1.4;
+        }
+
+        .yaml-content code {
+            color: #333;
+            background: none;
+            padding: 0;
+        }
+
+        /* Pathway Link Styles */
+        .pathway-link {
+            margin: 1rem 0;
+        }
+
+        .btn-link {
+            display: inline-block;
+            padding: 0.5rem 1rem;
+            background-color: #007bff;
+            color: white !important;
+            text-decoration: none;
+            border-radius: 4px;
+            font-weight: 500;
+            transition: background-color 0.2s;
+        }
+
+        .btn-link:hover {
+            background-color: #0056b3;
+            text-decoration: none;
+        }
+
+        /* Voting buttons */
+        .vote-buttons {
+            display: inline-block;
+            margin-left: 0.5rem;
+        }
+
+        .vote-btn {
+            background: none;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 2px 6px;
+            margin: 0 2px;
+            cursor: pointer;
+            font-size: 0.9rem;
+            transition: all 0.2s;
+            opacity: 0.6;
+        }
+
+        .vote-btn:hover {
+            opacity: 1;
+            transform: scale(1.1);
+        }
+
+        .vote-btn.voted {
+            opacity: 1;
+            border-color: #28a745;
+            background-color: #d4edda;
+        }
+
+        .vote-btn.voted-down {
+            border-color: #dc3545;
+            background-color: #f8d7da;
+        }
+
+        .vote-btn-small {
+            font-size: 0.7rem;
+            padding: 1px 4px;
+            margin: 0 1px;
+        }
+    </style>
+
+    <script>
+        // Add collapsible functionality
+        document.querySelectorAll('.collapsible').forEach(element => {
+            element.addEventListener('click', function() {
+                this.classList.toggle('collapsed');
+            });
+        });
+
+        // Voting functionality
+        const VOTE_URL = 'https://script.google.com/macros/s/AKfycbwPKH7d3seuPNBtB0ugVjqGeTiByyOGD5vkqB_Ck6K8eOcPQYbJqBOuz6GFgXHKBNWK/exec';
+
+        // Get or create session ID
+        let sessionId = localStorage.getItem('review_session_id');
+        if (!sessionId) {
+            sessionId = 's' + Date.now() + '_' + Math.random().toString(36).substr(2, 9);
+            localStorage.setItem('review_session_id', sessionId);
+        }
+
+        // Show previous votes on page load
+        document.addEventListener('DOMContentLoaded', function() {
+            document.querySelectorAll('.vote-buttons').forEach(container => {
+                const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+                const previousVote = localStorage.getItem(key);
+                if (previousVote) {
+                    const btn = container.querySelector(`[data-v="${previousVote}"]`);
+                    if (btn) btn.classList.add(previousVote === 'up' ? 'voted' : 'voted-down');
+                }
+            });
+        });
+
+        // Handle vote clicks - Simple image beacon approach
+        document.addEventListener('click', function(e) {
+            if (!e.target.classList.contains('vote-btn')) return;
+
+            // Prevent the click from bubbling to parent elements (like summary)
+            e.preventDefault();
+            e.stopPropagation();
+
+            const btn = e.target;
+            const container = btn.closest('.vote-buttons');
+            if (!container) return;
+
+            const voteType = btn.dataset.v;
+
+            // Check if already voted (locally)
+            const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+            const previousVote = localStorage.getItem(key);
+
+            if (previousVote === voteType) {
+                // Same vote - do nothing
+                btn.style.animation = 'shake 0.5s';
+                setTimeout(() => btn.style.animation = '', 500);
+                return;
+            }
+
+            // Build URL
+            const params = new URLSearchParams({
+                gene_id: container.dataset.g,
+                annotation_id: container.dataset.a,
+                ref_id: container.dataset.r || '',
+                action: container.dataset.act,
+                vote: voteType,
+                session_id: sessionId,
+                ua: navigator.userAgent.substring(0, 100)
+            });
+
+            // Clear previous vote styling
+            container.querySelectorAll('.vote-btn').forEach(b => {
+                b.classList.remove('voted', 'voted-down');
+            });
+
+            // Apply new vote styling immediately (optimistic UI)
+            btn.classList.add(voteType === 'up' ? 'voted' : 'voted-down');
+
+            // Store locally
+            localStorage.setItem(key, voteType);
+
+            // Send vote using fetch with no-cors mode (fire and forget)
+            const fullUrl = VOTE_URL + '?' + params;
+            console.log('Sending vote to:', fullUrl);
+
+            // Use fetch in no-cors mode - we won't get a response but the request will be sent
+            fetch(fullUrl, {
+                mode: 'no-cors',
+                method: 'GET'
+            }).then(() => {
+                console.log('Vote request sent (no response due to no-cors mode)');
+            }).catch(err => {
+                console.warn('Vote may not have been recorded, but saved locally:', err);
+
+                // Fallback: try image beacon as well
+                const img = new Image();
+                img.src = fullUrl;
+            });
+        });
+
+        // Optional: Add shake animation for feedback
+        const style = document.createElement('style');
+        style.textContent = `
+            @keyframes shake {
+                0%, 100% { transform: translateX(0); }
+                25% { transform: translateX(-5px); }
+                75% { transform: translateX(5px); }
+            }
+        `;
+        document.head.appendChild(style);
+    </script>
+</body>
+</html>

--- a/pages/projects/CAEEL_CILIOPATHY/CAEEL_CILIOPATHY_CURATION_RECOMMENDATIONS.html
+++ b/pages/projects/CAEEL_CILIOPATHY/CAEEL_CILIOPATHY_CURATION_RECOMMENDATIONS.html
@@ -668,7 +668,7 @@
 <h4 id="undecided-go1902856-negative-regulation-of-non-motile-cilium-assembly">UNDECIDED: <a href="http://amigo.geneontology.org/amigo/term/GO:1902856">GO:1902856</a> - negative regulation of non-motile cilium assembly</h4>
 <ul>
 <li><strong>Evidence:</strong> IGI</li>
-<li><strong>Issue:</strong> The relationship between <a href="../../../genes/worm/osm-3/osm-3-ai-review.html">OSM-3</a> and negative regulation of cilium assembly is indirect and context-dependent (dyf-5 mutant background). <a href="../../../genes/worm/osm-3/osm-3-ai-review.html">OSM-3</a> primarily</li>
+<li><strong>Issue:</strong> The relationship between <a href="../../../genes/worm/osm-3/osm-3-ai-review.html">OSM-3</a> and negative regulation of cilium assembly is indirect and context-dependent (<a href="../../../genes/worm/dyf-5/dyf-5-ai-review.html">dyf-5</a> mutant background). <a href="../../../genes/worm/osm-3/osm-3-ai-review.html">OSM-3</a> primarily</li>
 </ul>
 <h4 id="keep_as_non_core-go0061066-positive-regulation-of-dauer-larval-development">KEEP_AS_NON_CORE: <a href="http://amigo.geneontology.org/amigo/term/GO:0061066">GO:0061066</a> - positive regulation of dauer larval development</h4>
 <ul>


### PR DESCRIPTION
## Summary

Automated regeneration of static assets after gene review or template changes.

## Generated Assets

| Asset | Count/Status |
|-------|--------------|
| Gene review YAML files | 2864 |
| Gene review HTML pages | 2864 |
| Project pages | 1098 |
| Module pages | 87 |
| Browser app (data.js) | Updated |
| Validation report | Updated |

## Trigger

This PR was triggered by changes to:
- genes/**/*.yaml - gene review data files
- src/ai_gene_review/schema/** - LinkML schema files
- src/ai_gene_review/templates/** - Jinja2 templates
- src/ai_gene_review/render.py - rendering code
- src/ai_gene_review/render_modules.py - module rendering code
- src/ai_gene_review/export/** - export code
- src/ai_gene_review/browser/** - browser app assets
- src/ai_gene_review/tools/minify_linkml_browser_data.py - browser data compaction
- projects/*.md - project definitions
- modules/**/*.yaml - module definitions
- project.justfile - just recipes used by CI
- .github/workflows/generate-pages.yaml - workflow definition

## Review

- [ ] Spot-check a few gene review HTML pages render correctly
- [ ] Spot-check module tree browser pages render correctly
- [ ] Verify browser app loads and filters work
- [ ] Check validation report for new issues
