### PR TITLE
Regenerate pages and browser app

### DIFF
--- a/genes/worm/fndc-1/fndc-1-ai-review.html
+++ b/genes/worm/fndc-1/fndc-1-ai-review.html
@@ -825,12 +825,12 @@
     <div class="description-card">
         <div style="display: flex; justify-content: space-between; align-items: center;">
             <h2>Gene Description</h2>
-            <span class="vote-buttons" data-g="Q22252" data-a="DESCRIPTION: FNDC-1 is the C. elegans ortholog of mammalian FUN..." data-r="" data-act="DESCRIPTION">
+            <span class="vote-buttons" data-g="Q22252" data-a="DESCRIPTION: FNDC-1 is the Caenorhabditis elegans ortholog of m..." data-r="" data-act="DESCRIPTION">
                 <button class="vote-btn" data-v="up" title="Agree with this description">👍</button>
                 <button class="vote-btn" data-v="down" title="Disagree with this description">👎</button>
             </span>
         </div>
-        <p>FNDC-1 is the C. elegans ortholog of mammalian FUNDC1, a mitophagy receptor that resides on the mitochondrial outer membrane and mediates selective autophagy of mitochondria. FNDC-1 belongs to the conserved FUN14 family characterized by an LC3-interacting region (LIR) motif that enables binding to ATG8/LC3 family proteins to target mitochondria for autophagic degradation. FNDC-1 functions in multiple physiological contexts: (1) it mediates hypoxia-reoxygenation-induced mitophagy in somatic tissues such as body wall muscle (PMID:33416042), (2) it contributes to paternal mitochondria elimination after fertilization as a ubiquitin-independent mechanism (PMID:31233739, PMID:31153831), and (3) recent studies suggest it is required for developmentally programmed mitophagy at the oocyte-to-zygote transition. FNDC-1 localizes to the mitochondrial outer membrane and can be found at mitochondria-associated membrane (MAM) contact sites where it recruits the fission factor DRP-1. Unlike the PINK1/Parkin pathway, FNDC-1 represents a receptor-mediated, ubiquitin-independent mitophagy mechanism. The deep research report (fndc-1-deep-research-falcon.md) provides comprehensive literature evidence supporting these functions.
+        <p>FNDC-1 is the Caenorhabditis elegans ortholog of mammalian FUNDC1 and a member of the conserved FUN14 family. It is a small (138-residue) multi-pass protein of the mitochondrial outer membrane. FNDC-1 acts as a receptor/adaptor for selective autophagy of mitochondria (mitophagy): loss of fndc-1 impairs mitochondrial clearance in two characterized contexts. First, in the early embryo it contributes to the elimination of sperm-derived (paternal) mitochondria after fertilization, providing a second, ubiquitin-independent route that acts redundantly with, and later than, an initial ubiquitination-dependent mechanism; loss of fndc-1 delays paternal-mitochondria degradation and allows paternal mitochondrial DNA to persist in cross-progeny. Second, in body-wall muscle it mediates mitophagy triggered by hypoxia-reoxygenation, and its loss engages an ATFS-1/UPRmt stress program that is protective against reoxygenation injury. By analogy to mammalian FUNDC1, FNDC-1 is expected to recruit autophagosomal ATG8/LC3 proteins (LGG-1/LGG-2 in the worm) through an LC3-interacting region (LIR) motif, but the LIR and a direct ATG8 interaction have not yet been demonstrated in C. elegans. FNDC-1 thus represents a receptor-mediated, ubiquitin-independent branch of mitochondrial quality control, distinct from the PINK-1/PDR-1 (PINK1/Parkin) pathway.
 </p>
     </div>
 
@@ -932,17 +932,6 @@
 
                                 <div class="support-text">If paternal mitochondria are not eliminated via this early process, they are eventually removed from the embryo in a process that depends on the mitophagy adaptor protein, fndc-1.
 </div>
-
-                            </div>
-
-                            <div class="support-item">
-                                <span class="support-ref">
-
-                                    file:worm/fndc-1/fndc-1-deep-research-falcon.md
-
-                                </span>
-
-                                <div class="support-text">model: Edison Scientific Literature</div>
 
                             </div>
 
@@ -1372,7 +1361,7 @@
                         </div>
                     </td>
                     <td>
-                        <span class="evidence-code">IDA</span>
+                        <span class="evidence-code">ISS</span>
 
 
 
@@ -1407,13 +1396,13 @@
                     <td>
 
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> NEW annotation proposed for the molecular function of FNDC-1 as a mitophagy receptor/adaptor. GO:0140580 describes the binding activity that brings together mitochondrial membrane and autophagosome during mitophagy, which precisely matches FNDC-1&#39;s characterized function.
+                            <strong>Summary:</strong> NEW annotation proposed for the molecular function of FNDC-1 as a mitophagy receptor/adaptor. GO:0140580 describes the binding activity that brings together a mitochondrial membrane and an autophagosome during mitophagy, which fits FNDC-1&#39;s genetically defined role. It is coded ISS rather than IDA because the adaptor activity is inferred from orthology to mammalian FUNDC1 together with the worm loss-of-function mitophagy phenotype; a direct FNDC-1-ATG8 (LGG-1/LGG-2) binding assay has not been reported in C. elegans.
 
                         </div>
 
 
                         <div>
-                            <strong>Reason:</strong> The existing annotations lack a molecular function (MF) term. FNDC-1 functions as a mitophagy receptor that bridges mitochondria to autophagosomes via its LIR motif interaction with LC3/ATG8. GO:0140580 (mitochondrion autophagosome adaptor activity) is defined as &#34;The binding activity of a molecule that brings together a mitochondrial membrane and an autophagosome during mitophagy.&#34; This precisely describes FNDC-1&#39;s role. The evidence is strong: FNDC-1 localizes to OMM, mediates mitophagy, and the mammalian ortholog FUNDC1 has a well-characterized LIR motif for LC3 binding.
+                            <strong>Reason:</strong> The existing annotations lack a molecular function (MF) term. FNDC-1 is required for mitophagy in two worm contexts (paternal-mitochondria elimination and hypoxia-reoxygenation) and sits on the mitochondrial outer membrane, consistent with a mitophagy receptor/adaptor that bridges mitochondria to autophagosomes. GO:0140580 (mitochondrion autophagosome adaptor activity) is defined as &#34;The binding activity of a molecule that brings together a mitochondrial membrane and an autophagosome during mitophagy,&#34; which precisely names this role. The molecular mechanism itself - an LC3-interacting region (LIR) binding ATG8/LC3 - is established for mammalian FUNDC1 but not yet demonstrated for worm FNDC-1, so ISS (from the FUNDC1 ortholog) is the appropriate evidence basis rather than a direct assay code. The worm ATG8-binding partner (LGG-1/LGG-2) and LIR motif remain to be identified (see knowledge_gaps).
 
                         </div>
 
@@ -1443,7 +1432,7 @@
 
                                 </span>
 
-                                <div class="support-text">FUNDC1 (FUN14 domain containing 1) is a mammalian mitophagy receptor expressed on the mitochondrial outer membrane...This is the first example of a ubiquitin-independent mitophagy receptor playing a role in the selective degradation of sperm mitochondria.
+                                <div class="support-text">This is the first example of a ubiquitin-independent mitophagy receptor playing a role in the selective degradation of sperm mitochondria.
 </div>
 
                             </div>
@@ -1459,6 +1448,17 @@
 
                                 <div class="support-text">If paternal mitochondria are not eliminated via this early process, they are eventually removed from the embryo in a process that depends on the mitophagy adaptor protein, fndc-1.
 </div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:worm/fndc-1/fndc-1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">encodes the C. elegans ortholog of mammalian FUNDC1, a conserved FUN14-domain protein functioning as a mitophagy receptor</div>
 
                             </div>
 
@@ -1523,7 +1523,7 @@
 
 
                         <div>
-                            <strong>Reason:</strong> FNDC-1 mediates mitophagy specifically triggered by hypoxia-reoxygenation stress. The Lim et al. 2021 study showed that FNDC-1 promotes receptor-mediated mitophagy after short HR exposure, with loss of fndc-1 delaying HR-induced mitophagy. This represents a cellular response to hypoxia that should be captured by annotation to GO:0071456. The deep research report notes that fndc-1 loss-of-function significantly reduced mitophagy under HR conditions.
+                            <strong>Reason:</strong> In the worm, loss of fndc-1 changes the outcome of hypoxia-reoxygenation (HR): Lim et al. 2021 show FNDC-1 mediates HR-induced mitophagy in body-wall muscle and that its loss protects against HR injury via an ATFS-1/UPRmt program, establishing FNDC-1 as a component of the cellular response to changing oxygen availability (GO:0071456). Note the stimulus studied is hypoxia-reoxygenation specifically; no reoxygenation-specific GO term exists, so GO:0071456 (cellular response to hypoxia) is used as the appropriate parent. IMP is justified by the fndc-1 loss-of-function HR phenotype.
 
                         </div>
 
@@ -1543,6 +1543,20 @@
 
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/33416042" target="_blank" class="term-link">
+                                        PMID:33416042
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Here, we provide evidence that FNDC-1 is the C. elegans ortholog of FUNDC1, and that its loss protects against injury in a worm model of HR.
+</div>
+
+                            </div>
 
                             <div class="support-item">
                                 <span class="support-ref">
@@ -1590,7 +1604,7 @@
         <div class="core-function-card">
 
             <div style="display: flex; justify-content: space-between; align-items: center;">
-                <h3>FNDC-1 functions as a mitophagy receptor/adaptor that bridges mitochondria to autophagosomes. As a member of the FUN14 family, it contains an LIR motif for binding LC3/ATG8 family proteins and localizes to the mitochondrial outer membrane where it targets mitochondria for selective autophagy. This is demonstrated in both hypoxia-reoxygenation response (PMID:33416042) and paternal mitochondria elimination (PMID:31233739, PMID:31153831).
+                <h3>FNDC-1 functions as a mitophagy receptor/adaptor that bridges mitochondria to autophagosomes. It localizes to the mitochondrial outer membrane, and genetic loss-of-function shows it is required for selective autophagy of mitochondria in two worm contexts: hypoxia-reoxygenation-induced mitophagy in body-wall muscle (PMID:33416042) and paternal-mitochondria elimination after fertilization (PMID:31233739, PMID:31153831). As a FUN14-family protein it is predicted (by orthology to mammalian FUNDC1) to recruit ATG8/LC3 proteins (LGG-1/LGG-2) via an LC3-interacting region (LIR); the worm LIR and a direct ATG8 interaction have not yet been demonstrated experimentally.
 </h3>
                 <span class="vote-buttons" data-g="Q22252" data-a="FUNCTION: FNDC-1 functions as a mitophagy receptor/adaptor t..." data-r="" data-act="CORE_FUNCTION">
                     <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
@@ -2048,6 +2062,102 @@
 
 
 
+    <div class="section">
+        <h2 class="section-title">Knowledge Gaps</h2>
+        <p style="color: #555; font-size: 0.92rem; margin-top: -0.3rem;">
+            What is <em>not</em> known — curated, literature-grounded statements of the open
+            unknowns (the inverse of core functions).
+        </p>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> The molecular activity of FNDC-1 as a mitophagy receptor is not experimentally established in C. elegans. Its LC3-interacting region (LIR) motif has not been identified or mutated, and a direct physical interaction between FNDC-1 and the worm ATG8 orthologs LGG-1/LGG-2 has not been demonstrated. Whether receptor/adaptor function requires an intact LIR is therefore inferred from mammalian FUNDC1 rather than shown in worm.</p>
+            <p style="margin-top: 0.4rem;">
+                <span class="badge">OPEN</span>
+                <span class="badge">BIOLOGY</span><span class="badge">CURATION</span>
+                <span class="badge">MF_DARK</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> Genetic loss-of-function establishes that FNDC-1 is required for hypoxia-reoxygenation mitophagy in body-wall muscle and contributes to paternal-mitochondria elimination, and biochemical fractionation/proteinase-K accessibility place it on the mitochondrial outer membrane. The receptor/adaptor role is thus supported genetically and by orthology, but not by any direct binding assay in the worm.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Significance:</strong> FNDC-1 is the founding example of a ubiquitin-independent mitophagy receptor for sperm-mitochondria degradation; identifying its ATG8 partner and LIR would define the molecular mechanism and put the GO molecular-function annotation (currently ISS-level, GO:0140580) on direct experimental footing.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>What would resolve it:</strong> Identify and mutate the FNDC-1 LIR; test FNDC-1-LGG-1/LGG-2 interaction by co-immunoprecipitation, peptide-array/ITC, or split-GFP in vivo, with LIR-mutant rescue of paternal-mitochondria elimination and HR-induced mitophagy.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Provenance (the field's own admissions):</strong></p>
+            <ul style="margin-top: 0.2rem;">
+
+                <li><em>"This is the first example of a ubiquitin-independent mitophagy receptor playing a role in the selective degradation of sperm mitochondria."</em> — PMID:31233739</li>
+
+                <li><em>"LIR validation for C. elegans FNDC-1 remain to be fully elucidated"</em> — file:worm/fndc-1/fndc-1-deep-research-falcon.md</li>
+
+            </ul>
+
+
+        </div>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> How FNDC-1 receptor activity is switched on and off in C. elegans is unknown. No phosphorylation or ubiquitination sites have been mapped on the worm protein, and the kinases, phosphatases, and E3 ligases that gate mammalian FUNDC1 (SRC, CK2, ULK1, PGAM5, MARCH5) have no demonstrated counterparts acting on FNDC-1.</p>
+            <p style="margin-top: 0.4rem;">
+                <span class="badge">OPEN</span>
+                <span class="badge">BIOLOGY</span>
+                <span class="badge">RESIDUAL_SUBGAP</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> In mammals, reversible LIR phosphorylation and MARCH5-mediated ubiquitination regulate FUNDC1 activity and abundance. In worm, hypoxia-reoxygenation engages FNDC-1-dependent mitophagy and loss of fndc-1 triggers an ATFS-1/UPRmt program, so the downstream stress response is defined, but the upstream regulatory inputs onto FNDC-1 itself are uncharacterized.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Significance:</strong> Post-translational control determines when and where FNDC-1 triggers mitophagy; resolving it is needed to place FNDC-1 downstream of hypoxia signaling and to test whether the mammalian regulatory logic is conserved.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>What would resolve it:</strong> Phosphoproteomic/ubiquitinomic mapping of FNDC-1 under normoxia versus hypoxia-reoxygenation, plus genetic epistasis against candidate worm orthologs of the mammalian regulators.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Provenance (the field's own admissions):</strong></p>
+            <ul style="margin-top: 0.2rem;">
+
+                <li><em>"Direct phosphorylation/ubiquitination mapping and LIR validation for C. elegans FNDC-1 remain to be fully elucidated"</em> — file:worm/fndc-1/fndc-1-deep-research-falcon.md</li>
+
+                <li><em>"This protection depends upon ATFS-1, a transcription factor that is central to the mitochondrial unfolded protein response (UPRmt)."</em> — PMID:33416042</li>
+
+            </ul>
+
+
+        </div>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> Whether FNDC-1 is a broadly-acting mitophagy receptor in C. elegans (beyond the two described contexts of paternal-mitochondria elimination and hypoxia-reoxygenation) is unresolved, as is its epistatic relationship to the PINK-1/PDR-1 and DCT-1/NIX pathways. The loss-of-function phenotype is mild and context-restricted, and under some stresses mitochondrial remodeling proceeds without fndc-1.</p>
+            <p style="margin-top: 0.4rem;">
+                <span class="badge">OPEN</span>
+                <span class="badge">BIOLOGY</span>
+                <span class="badge">RESIDUAL_SUBGAP</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> Loss of fndc-1 delays but does not abolish paternal-mitochondria elimination because a redundant ubiquitin-dependent pathway acts first and earlier, and it reduces HR-induced mitophagy; no null lethality or gross organismal phenotype is reported.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Significance:</strong> Clarifying FNDC-1&#39;s physiological scope and its ordering relative to the other worm mitophagy receptors would establish whether it is a general quality-control receptor or a specialist for selective/developmental mitochondrial clearance.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>What would resolve it:</strong> Systematic mito-mKeima/mito-Keima flux measurements across tissues, ages, and stressors in fndc-1 single and pink-1/pdr-1 or dct-1 double mutants to define genetic-interaction structure.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Provenance (the field's own admissions):</strong></p>
+            <ul style="margin-top: 0.2rem;">
+
+                <li><em>"Thus, there are two redundant, but temporally distinct mechanisms that target paternal mitochondria for elimination in C. elegans."</em> — PMID:31153831</li>
+
+                <li><em>"loss of fndc-1 retards the rate of paternal mitochondria degradation"</em> — PMID:31233739</li>
+
+            </ul>
+
+
+        </div>
+
+    </div>
+
 
 
 
@@ -2224,6 +2334,179 @@ this with annotations you find in gene/protein databases, but these can be outda
 
     <!-- Additional Documentation Sections -->
 
+    <div class="section">
+        <h2 class="section-title">📚 Additional Documentation</h2>
+
+        <details class="markdown-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; cursor: pointer;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Notes</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(fndc-1-notes.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="Q22252" data-a="DOC: Notes" data-r="" data-act="DOCUMENTATION" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This documentation is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This documentation needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+                <h1 id="fndc-1-c-elegans-research-notes">fndc-1 (C. elegans) research notes</h1>
+<p>UniProt: <strong>Q22252</strong> (FNDC1_CAEEL) · WormBase: <strong>WBGene00011528</strong> / locus <strong>T06D8.7</strong> ·<br />
+mammalian ortholog: FUNDC1 · Family: FUN14 (Pfam PF04930, InterPro IPR007014).</p>
+<blockquote>
+<p>Naming note: the task/flagship project refers to this gene as "fundc-1" (after<br />
+mammalian <em>FUNDC1</em>). The <strong>official WormBase symbol is <code>fndc-1</code></strong> (used by UniProt with<br />
+ECO:0000303|PubMed:31233739 and ECO:0000312|WormBase:T06D8.7). All work here uses the<br />
+correct WormBase symbol <code>fndc-1</code>. The earlier project note ("no clear C. elegans<br />
+ortholog in UniProt") reflects a symbol mismatch, not a missing gene — Q22252 is a<br />
+reviewed Swiss-Prot entry.</p>
+</blockquote>
+<h2 id="protein-identity-established">Protein / identity (established)</h2>
+<ul>
+<li>138-aa integral membrane protein with <strong>two predicted TM helices</strong> (residues 37–56,<br />
+  61–78; ECO:0000255) and UniProt subcellular location <strong>"Mitochondrion outer membrane …<br />
+  Multi-pass membrane protein"</strong> (ECO:0000305|PubMed:31233739). Small multi-pass OMM<br />
+  topology is the hallmark of the FUN14/FUNDC1 family.</li>
+<li>Sole informative domain: FUN14 (the FUNDC1 family fold). No enzymatic domain — this is<br />
+  an adaptor/receptor-type protein, not an enzyme.</li>
+</ul>
+<h2 id="what-is-known-in-c-elegans-peer-reviewed-worm-established">What is KNOWN in <em>C. elegans</em> (peer-reviewed, worm-established)</h2>
+<ol>
+<li><strong>Contributes to paternal-mitochondria elimination after fertilization.</strong></li>
+<li><a href="https://pubmed.ncbi.nlm.nih.gov/31233739" title="FNDC-1 is strongly expressed in sperm but not oocytes and contributes to paternal mitochondria elimination">PMID:31233739</a></li>
+<li><a href="https://pubmed.ncbi.nlm.nih.gov/31233739" title="loss of fndc-1 retards the rate of paternal mitochondria degradation, but not that of membranous organelles, a nematode specific membrane compartment whose fusion is required for sperm motility">PMID:31233739</a></li>
+<li>Functional read-out that paternal mtDNA persists without fndc-1:<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/31233739" title="Paternal mitochondrial DNA is normally undetectable in wildtype larva, but can be detected in the cross-progeny of fndc-1 mutant males">PMID:31233739</a></li>
+<li>The authors frame this as the <strong>first ubiquitin-independent mitophagy receptor</strong> for<br />
+     sperm-mitochondria degradation:<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/31233739" title="This is the first example of a ubiquitin-independent mitophagy receptor playing a role in the selective degradation of sperm mitochondria">PMID:31233739</a></li>
+<li>fndc-1 is a <strong>second, temporally distinct</strong> route, redundant with an earlier<br />
+     ubiquitin-dependent (ubc-18/ubc-16 → proteasome/LGG-1) mechanism:<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/31153831" title="If paternal mitochondria are not eliminated via this early process, they are eventually removed from the embryo in a process that depends on the mitophagy adaptor protein, fndc-1">PMID:31153831</a><br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/31153831" title="Thus, there are two redundant, but temporally distinct mechanisms that target paternal mitochondria for elimination in C. elegans">PMID:31153831</a></li>
+<li>
+<p>The phenotype is a <strong>delay, not a block</strong> (redundancy) → mild loss-of-function.</p>
+</li>
+<li>
+<p><strong>Mediates hypoxia-reoxygenation (HR)-induced mitophagy in somatic tissue (body-wall muscle).</strong></p>
+</li>
+<li>Establishes the worm ortholog identity explicitly:<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/33416042" title="Here, we provide evidence that FNDC-1 is the C. elegans ortholog of FUNDC1, and that its loss protects against injury in a worm model of HR">PMID:33416042</a></li>
+<li>Protection on <em>loss</em> depends on the UPRmt transcription factor ATFS-1:<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/33416042" title="This protection depends upon ATFS-1, a transcription factor that is central to the mitochondrial unfolded protein response (UPRmt)">PMID:33416042</a></li>
+<li>FNDC-1 also has a role in non-hypoxic (basal) mitochondrial quality control:<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/33416042" title="These data support a role for FNDC-1 in non-hypoxic MQC, and further suggest that these changes are prophylactic in relation to subsequent HR">PMID:33416042</a></li>
+<li>
+<p>(Quantitative HR-mitophagy data — mito-mKeima, mRuby3::FNDC-1 co-localization,<br />
+     proteinase-K OMM topology — are in the Lim 2021 full text, not the cached abstract.)</p>
+</li>
+<li>
+<p><strong>Localization: mitochondrial outer membrane.</strong></p>
+</li>
+<li>UniProt curated from primary lit (PubMed:31233739); GOA carries IBA (GO_REF:0000033)<br />
+     and IEA (GO_REF:0000044, UniProt-SubCell) OMM annotations. TM topology + FUN14 family<br />
+     are consistent. Established.</li>
+</ol>
+<h2 id="what-is-inferred-from-mammalian-fundc1-not-directly-shown-in-worm">What is INFERRED from mammalian FUNDC1 (NOT directly shown in worm)</h2>
+<ul>
+<li><strong>LC3-interacting region (LIR) motif and direct ATG8 binding.</strong> Mammalian FUNDC1 uses a<br />
+  phospho-regulated LIR to bind LC3/GABARAP. In worm, <strong>no LIR has been mapped/mutated and<br />
+  no direct FNDC-1–LGG-1/LGG-2 (ATG8) interaction has been demonstrated.</strong> The<br />
+  "receptor/adaptor" molecular activity in worm rests on genetic loss-of-function +<br />
+  orthology, i.e. it is an <strong>ISS-level</strong> MF claim, not a direct assay.</li>
+<li><strong>Phospho/ubiquitin regulation</strong> (SRC, CK2, ULK1, PGAM5, MARCH5 acting on the LIR in<br />
+  mammals) — none demonstrated for worm FNDC-1.</li>
+<li><strong>MAM enrichment / DRP-1 recruitment / oocyte-to-zygote-transition (MOZT) developmental<br />
+  mitophagy.</strong> These appear only in <strong>2025 preprints</strong> (bioRxiv 2025.02.01.636045;<br />
+  Research Square rs.3.rs-6330979) — treated here as preliminary and deliberately kept out<br />
+  of the top-level <code>description</code> and out of any peer-reviewed annotation. Documented as an<br />
+  open/narrowing knowledge gap only.</li>
+</ul>
+<h2 id="existing-goa-annotations-6-and-disposition">Existing GOA annotations (6) and disposition</h2>
+<table>
+<thead>
+<tr>
+<th>GO term</th>
+<th>Aspect</th>
+<th>Evidence</th>
+<th>Ref</th>
+<th>Action</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>GO:0000422 autophagy of mitochondrion</td>
+<td>BP</td>
+<td>IBA</td>
+<td>GO_REF:0000033</td>
+<td>ACCEPT</td>
+</tr>
+<tr>
+<td>GO:0005741 mitochondrial outer membrane</td>
+<td>CC</td>
+<td>IBA</td>
+<td>GO_REF:0000033</td>
+<td>ACCEPT</td>
+</tr>
+<tr>
+<td>GO:0005741 mitochondrial outer membrane</td>
+<td>CC</td>
+<td>IEA</td>
+<td>GO_REF:0000044</td>
+<td>ACCEPT</td>
+</tr>
+<tr>
+<td>GO:0006914 autophagy</td>
+<td>BP</td>
+<td>IEA</td>
+<td>GO_REF:0000043</td>
+<td>ACCEPT (general parent; subsumed by mitophagy terms)</td>
+</tr>
+<tr>
+<td>GO:0000423 mitophagy</td>
+<td>BP</td>
+<td>IMP</td>
+<td>PMID:31153831</td>
+<td>ACCEPT</td>
+</tr>
+<tr>
+<td>GO:0000423 mitophagy</td>
+<td>BP</td>
+<td>IMP</td>
+<td>PMID:31233739</td>
+<td>ACCEPT</td>
+</tr>
+</tbody>
+</table>
+<p>Proposed NEW (not in GOA):<br />
+- <strong>GO:0140580 mitochondrion autophagosome adaptor activity</strong> — the missing MF term.<br />
+  Coded <strong>ISS</strong> (not IDA): the adaptor/bridging activity is inferred from mammalian FUNDC1<br />
+  orthology + worm genetic phenotype; direct LGG-1/LGG-2 binding is not shown in worm.<br />
+- <strong>GO:0071456 cellular response to hypoxia</strong> — IMP from Lim 2021 HR model<br />
+  (fndc-1 loss changes HR outcome). Worm-established.</p>
+<h2 id="knowledge-gaps-see-yaml-knowledge_gaps">Knowledge gaps (see YAML <code>knowledge_gaps</code>)</h2>
+<ol>
+<li>Molecular adaptor mechanism / LIR + LGG-1/LGG-2 partner not experimentally established in worm.</li>
+<li>Regulation of FNDC-1 (post-translational switches) uncharacterized in worm.</li>
+<li>Physiological scope / pathway placement (vs PINK-1/PDR-1, DCT-1/NIX) unresolved; phenotype<br />
+   mild/context-restricted; some stresses (acute heat) remodel mitochondria independently of fndc-1.</li>
+</ol>
+<p>Explicit field admission (deep-research synthesis, grep-verified in the falcon report):<br />
+"Direct phosphorylation/ubiquitination mapping and LIR validation for C. elegans FNDC-1<br />
+remain to be fully elucidated."</p>
+<h2 id="provenance-sources">Provenance / sources</h2>
+<ul>
+<li>Cached abstracts (abstract-only, <code>full_text_available: false</code>):<br />
+  publications/PMID_31233739.md, PMID_31153831.md, PMID_33416042.md.</li>
+<li>Deep research: genes/worm/fndc-1/fndc-1-deep-research-falcon.md (Edison Scientific,<br />
+  real run, 27 citations). Review/preprint claims (Ganguly 2024; Choubey 2021; Liu 2020;<br />
+  Haeussler 2020; Thendral/Sherwood 2025 preprints) used only for context/inference, not<br />
+  for peer-reviewed annotation.</li>
+</ul>
+            </div>
+        </details>
+
+    </div>
+
 
     <!-- YAML Preview Section -->
     <div class="section">
@@ -2240,31 +2523,22 @@ taxon:
   id: NCBITaxon:6239
   label: Caenorhabditis elegans
 description: &gt;
-  FNDC-1 is the C. elegans ortholog of mammalian FUNDC1, a mitophagy receptor that
-  resides on the
-  mitochondrial outer membrane and mediates selective autophagy of mitochondria. FNDC-1
-  belongs to
-  the conserved FUN14 family characterized by an LC3-interacting region (LIR) motif
-  that enables
-  binding to ATG8/LC3 family proteins to target mitochondria for autophagic degradation.
-  FNDC-1
-  functions in multiple physiological contexts: (1) it mediates hypoxia-reoxygenation-induced
-  mitophagy in somatic tissues such as body wall muscle (PMID:33416042), (2) it contributes
-  to
-  paternal mitochondria elimination after fertilization as a ubiquitin-independent
-  mechanism
-  (PMID:31233739, PMID:31153831), and (3) recent studies suggest it is required for
-  developmentally
-  programmed mitophagy at the oocyte-to-zygote transition. FNDC-1 localizes to the
-  mitochondrial
-  outer membrane and can be found at mitochondria-associated membrane (MAM) contact
-  sites where it
-  recruits the fission factor DRP-1. Unlike the PINK1/Parkin pathway, FNDC-1 represents
-  a
-  receptor-mediated, ubiquitin-independent mitophagy mechanism. The deep research
-  report
-  (fndc-1-deep-research-falcon.md) provides comprehensive literature evidence supporting
-  these functions.
+  FNDC-1 is the Caenorhabditis elegans ortholog of mammalian FUNDC1 and a member of the
+  conserved FUN14 family. It is a small (138-residue) multi-pass protein of the
+  mitochondrial outer membrane. FNDC-1 acts as a receptor/adaptor for selective autophagy
+  of mitochondria (mitophagy): loss of fndc-1 impairs mitochondrial clearance in two
+  characterized contexts. First, in the early embryo it contributes to the elimination of
+  sperm-derived (paternal) mitochondria after fertilization, providing a second,
+  ubiquitin-independent route that acts redundantly with, and later than, an initial
+  ubiquitination-dependent mechanism; loss of fndc-1 delays paternal-mitochondria
+  degradation and allows paternal mitochondrial DNA to persist in cross-progeny. Second,
+  in body-wall muscle it mediates mitophagy triggered by hypoxia-reoxygenation, and its
+  loss engages an ATFS-1/UPRmt stress program that is protective against reoxygenation
+  injury. By analogy to mammalian FUNDC1, FNDC-1 is expected to recruit autophagosomal
+  ATG8/LC3 proteins (LGG-1/LGG-2 in the worm) through an LC3-interacting region (LIR)
+  motif, but the LIR and a direct ATG8 interaction have not yet been demonstrated in
+  C. elegans. FNDC-1 thus represents a receptor-mediated, ubiquitin-independent branch of
+  mitochondrial quality control, distinct from the PINK-1/PDR-1 (PINK1/Parkin) pathway.
 existing_annotations:
   - term:
       id: GO:0000422
@@ -2311,9 +2585,6 @@ existing_annotations:
             are eventually
             removed from the embryo in a process that depends on the mitophagy adaptor
             protein, fndc-1.
-
-        - reference_id: file:worm/fndc-1/fndc-1-deep-research-falcon.md
-          supporting_text: &#39;model: Edison Scientific Literature&#39;
   - term:
       id: GO:0005741
       label: mitochondrial outer membrane
@@ -2491,30 +2762,31 @@ existing_annotations:
   - term:
       id: GO:0140580
       label: mitochondrion autophagosome adaptor activity
-    evidence_type: IDA
+    evidence_type: ISS
     original_reference_id: PMID:31233739
     review:
       summary: &gt;
         NEW annotation proposed for the molecular function of FNDC-1 as a mitophagy
-        receptor/adaptor.
-        GO:0140580 describes the binding activity that brings together mitochondrial
-        membrane and
-        autophagosome during mitophagy, which precisely matches FNDC-1&#39;s characterized
-        function.
+        receptor/adaptor. GO:0140580 describes the binding activity that brings together a
+        mitochondrial membrane and an autophagosome during mitophagy, which fits FNDC-1&#39;s
+        genetically defined role. It is coded ISS rather than IDA because the adaptor
+        activity is inferred from orthology to mammalian FUNDC1 together with the worm
+        loss-of-function mitophagy phenotype; a direct FNDC-1-ATG8 (LGG-1/LGG-2) binding
+        assay has not been reported in C. elegans.
       action: NEW
       reason: &gt;
-        The existing annotations lack a molecular function (MF) term. FNDC-1 functions
-        as a mitophagy
-        receptor that bridges mitochondria to autophagosomes via its LIR motif interaction
-        with LC3/ATG8.
+        The existing annotations lack a molecular function (MF) term. FNDC-1 is required
+        for mitophagy in two worm contexts (paternal-mitochondria elimination and
+        hypoxia-reoxygenation) and sits on the mitochondrial outer membrane, consistent
+        with a mitophagy receptor/adaptor that bridges mitochondria to autophagosomes.
         GO:0140580 (mitochondrion autophagosome adaptor activity) is defined as &#34;The
-        binding activity
-        of a molecule that brings together a mitochondrial membrane and an autophagosome
-        during mitophagy.&#34;
-        This precisely describes FNDC-1&#39;s role. The evidence is strong: FNDC-1 localizes
-        to OMM, mediates
-        mitophagy, and the mammalian ortholog FUNDC1 has a well-characterized LIR
-        motif for LC3 binding.
+        binding activity of a molecule that brings together a mitochondrial membrane and
+        an autophagosome during mitophagy,&#34; which precisely names this role. The molecular
+        mechanism itself - an LC3-interacting region (LIR) binding ATG8/LC3 - is
+        established for mammalian FUNDC1 but not yet demonstrated for worm FNDC-1, so ISS
+        (from the FUNDC1 ortholog) is the appropriate evidence basis rather than a direct
+        assay code. The worm ATG8-binding partner (LGG-1/LGG-2) and LIR motif remain to be
+        identified (see knowledge_gaps).
       proposed_replacement_terms:
         - id: GO:0140580
           label: mitochondrion autophagosome adaptor activity
@@ -2523,9 +2795,7 @@ existing_annotations:
       supported_by:
         - reference_id: PMID:31233739
           supporting_text: &gt;
-            FUNDC1 (FUN14 domain containing 1) is a mammalian mitophagy receptor expressed
-            on the
-            mitochondrial outer membrane...This is the first example of a ubiquitin-independent
+            This is the first example of a ubiquitin-independent
             mitophagy receptor playing a role in the selective degradation of sperm
             mitochondria.
         - reference_id: PMID:31153831
@@ -2534,6 +2804,10 @@ existing_annotations:
             are eventually
             removed from the embryo in a process that depends on the mitophagy adaptor
             protein, fndc-1.
+        - reference_id: file:worm/fndc-1/fndc-1-deep-research-falcon.md
+          supporting_text: &gt;-
+            encodes the C. elegans ortholog of mammalian FUNDC1, a conserved FUN14-domain
+            protein functioning as a mitophagy receptor
 
   - term:
       id: GO:0071456
@@ -2549,21 +2823,26 @@ existing_annotations:
         specifically in response to hypoxia-reoxygenation stress in body wall muscle.
       action: NEW
       reason: &gt;
-        FNDC-1 mediates mitophagy specifically triggered by hypoxia-reoxygenation
-        stress. The Lim et al.
-        2021 study showed that FNDC-1 promotes receptor-mediated mitophagy after short
-        HR exposure,
-        with loss of fndc-1 delaying HR-induced mitophagy. This represents a cellular
-        response to
-        hypoxia that should be captured by annotation to GO:0071456. The deep research
-        report notes
-        that fndc-1 loss-of-function significantly reduced mitophagy under HR conditions.
+        In the worm, loss of fndc-1 changes the outcome of hypoxia-reoxygenation (HR):
+        Lim et al. 2021 show FNDC-1 mediates HR-induced mitophagy in body-wall muscle and
+        that its loss protects against HR injury via an ATFS-1/UPRmt program, establishing
+        FNDC-1 as a component of the cellular response to changing oxygen availability
+        (GO:0071456). Note the stimulus studied is hypoxia-reoxygenation specifically; no
+        reoxygenation-specific GO term exists, so GO:0071456 (cellular response to hypoxia)
+        is used as the appropriate parent. IMP is justified by the fndc-1 loss-of-function
+        HR phenotype.
       proposed_replacement_terms:
         - id: GO:0071456
           label: cellular response to hypoxia
       additional_reference_ids:
         - PMID:31233739
       supported_by:
+        - reference_id: PMID:33416042
+          supporting_text: &gt;
+            Here, we provide evidence that FNDC-1
+            is the C. elegans
+            ortholog of FUNDC1, and that its loss protects against injury in a worm
+            model of HR.
         - reference_id: PMID:33416042
           supporting_text: &gt;
             FUNDC1 (FUN14 domain containing 1) is a mammalian mitophagy receptor that
@@ -2600,6 +2879,15 @@ references:
   - id: PMID:31153831
     title: Ubiquitination is required for the initial removal of paternal
       organelles in C. elegans.
+    reference_review:
+      relevance: HIGH
+      correctness: VERIFIED
+      review_notes: &gt;
+        Abstract-only in cache but PubMed-verified (Molina, Lim &amp; Boyd, Dev Biol 2019).
+        Establishes fndc-1 as the mitophagy adaptor for the second, ubiquitin-independent
+        route of paternal-mitochondria elimination that acts redundantly with an initial
+        ubc-18/ubc-16-dependent mechanism. Directly supports the mitophagy (GO:0000423) IMP
+        annotation attributed to this PMID in GOA.
     findings:
       - statement: Demonstrated two redundant mechanisms for paternal
           mitochondria elimination
@@ -2624,6 +2912,17 @@ references:
   - id: PMID:31233739
     title: Fndc-1 contributes to paternal mitochondria elimination in C.
       elegans.
+    reference_review:
+      relevance: HIGH
+      correctness: VERIFIED
+      review_notes: &gt;
+        Abstract-only in cache but PubMed-verified (Lim et al., Dev Biol 2019). The
+        defining primary paper for worm fndc-1: names it the C. elegans FUNDC1 ortholog,
+        localizes it to the mitochondrial outer membrane, and shows loss of fndc-1 delays
+        paternal-mitochondria degradation with paternal mtDNA persisting in cross-progeny.
+        Supports the OMM (GO:0005741), mitophagy (GO:0000423) and proposed adaptor-activity
+        (GO:0140580) annotations. Note the receptor/adaptor claim is genetic/phenotypic;
+        the direct ATG8 interaction is not assayed here.
     findings:
       - statement: FNDC-1 is expressed in sperm but not oocytes
         supporting_text: &gt;
@@ -2654,6 +2953,17 @@ references:
   - id: PMID:33416042
     title: FNDC-1-mediated mitophagy and ATFS-1 coordinate to protect against
       hypoxia-reoxygenation.
+    reference_review:
+      relevance: HIGH
+      correctness: VERIFIED
+      review_notes: &gt;
+        Abstract-only in cache but PubMed-verified (Lim et al., Autophagy 2021).
+        Independently confirms FNDC-1 as the C. elegans FUNDC1 ortholog and shows it
+        mediates hypoxia-reoxygenation-induced mitophagy in body-wall muscle, with loss
+        engaging an ATFS-1/UPRmt program that is protective. Supports the proposed
+        cellular-response-to-hypoxia (GO:0071456) annotation and the mitophagy-receptor
+        role. Mechanistic detail (mito-mKeima quantification, proteinase-K OMM topology) is
+        in the full text, not the cached abstract.
     findings:
       - statement: FNDC-1 is the C. elegans ortholog of FUNDC1 and mediates
           mitophagy under hypoxia-reoxygenation stress
@@ -2686,14 +2996,14 @@ core_functions:
       label: mitochondrion autophagosome adaptor activity
     description: &gt;
       FNDC-1 functions as a mitophagy receptor/adaptor that bridges mitochondria to
-      autophagosomes.
-      As a member of the FUN14 family, it contains an LIR motif for binding LC3/ATG8
-      family proteins
-      and localizes to the mitochondrial outer membrane where it targets mitochondria
-      for selective
-      autophagy. This is demonstrated in both hypoxia-reoxygenation response (PMID:33416042)
-      and
-      paternal mitochondria elimination (PMID:31233739, PMID:31153831).
+      autophagosomes. It localizes to the mitochondrial outer membrane, and genetic
+      loss-of-function shows it is required for selective autophagy of mitochondria in two
+      worm contexts: hypoxia-reoxygenation-induced mitophagy in body-wall muscle
+      (PMID:33416042) and paternal-mitochondria elimination after fertilization
+      (PMID:31233739, PMID:31153831). As a FUN14-family protein it is predicted (by
+      orthology to mammalian FUNDC1) to recruit ATG8/LC3 proteins (LGG-1/LGG-2) via an
+      LC3-interacting region (LIR); the worm LIR and a direct ATG8 interaction have not yet
+      been demonstrated experimentally.
     directly_involved_in:
       - id: GO:0000423
         label: mitophagy
@@ -2773,6 +3083,109 @@ suggested_experiments:
       in C. elegans.
     hypothesis: FNDC-1 activity is regulated by hypoxia-dependent
       phosphorylation changes
+
+knowledge_gaps:
+  - gap_statement: &gt;-
+      The molecular activity of FNDC-1 as a mitophagy receptor is not experimentally
+      established in C. elegans. Its LC3-interacting region (LIR) motif has not been
+      identified or mutated, and a direct physical interaction between FNDC-1 and the worm
+      ATG8 orthologs LGG-1/LGG-2 has not been demonstrated. Whether receptor/adaptor
+      function requires an intact LIR is therefore inferred from mammalian FUNDC1 rather
+      than shown in worm.
+    boundary: &gt;-
+      Genetic loss-of-function establishes that FNDC-1 is required for hypoxia-reoxygenation
+      mitophagy in body-wall muscle and contributes to paternal-mitochondria elimination,
+      and biochemical fractionation/proteinase-K accessibility place it on the mitochondrial
+      outer membrane. The receptor/adaptor role is thus supported genetically and by
+      orthology, but not by any direct binding assay in the worm.
+    gap_kind:
+      - BIOLOGY
+      - CURATION
+    dark_aspect: MF_DARK
+    status: OPEN
+    significance: &gt;-
+      FNDC-1 is the founding example of a ubiquitin-independent mitophagy receptor for
+      sperm-mitochondria degradation; identifying its ATG8 partner and LIR would define the
+      molecular mechanism and put the GO molecular-function annotation (currently ISS-level,
+      GO:0140580) on direct experimental footing.
+    resolution: &gt;-
+      Identify and mutate the FNDC-1 LIR; test FNDC-1-LGG-1/LGG-2 interaction by
+      co-immunoprecipitation, peptide-array/ITC, or split-GFP in vivo, with LIR-mutant
+      rescue of paternal-mitochondria elimination and HR-induced mitophagy.
+    provenance:
+      - reference_id: PMID:31233739
+        supporting_text: &gt;-
+          This is the first example of a ubiquitin-independent mitophagy receptor playing a
+          role in the selective degradation of sperm mitochondria.
+        reference_section_type: ABSTRACT
+      - reference_id: file:worm/fndc-1/fndc-1-deep-research-falcon.md
+        supporting_text: &gt;-
+          LIR validation for C. elegans FNDC-1 remain to be fully elucidated
+  - gap_statement: &gt;-
+      How FNDC-1 receptor activity is switched on and off in C. elegans is unknown. No
+      phosphorylation or ubiquitination sites have been mapped on the worm protein, and the
+      kinases, phosphatases, and E3 ligases that gate mammalian FUNDC1 (SRC, CK2, ULK1,
+      PGAM5, MARCH5) have no demonstrated counterparts acting on FNDC-1.
+    boundary: &gt;-
+      In mammals, reversible LIR phosphorylation and MARCH5-mediated ubiquitination regulate
+      FUNDC1 activity and abundance. In worm, hypoxia-reoxygenation engages
+      FNDC-1-dependent mitophagy and loss of fndc-1 triggers an ATFS-1/UPRmt program, so the
+      downstream stress response is defined, but the upstream regulatory inputs onto FNDC-1
+      itself are uncharacterized.
+    gap_kind:
+      - BIOLOGY
+    dark_aspect: RESIDUAL_SUBGAP
+    status: OPEN
+    significance: &gt;-
+      Post-translational control determines when and where FNDC-1 triggers mitophagy;
+      resolving it is needed to place FNDC-1 downstream of hypoxia signaling and to test
+      whether the mammalian regulatory logic is conserved.
+    resolution: &gt;-
+      Phosphoproteomic/ubiquitinomic mapping of FNDC-1 under normoxia versus
+      hypoxia-reoxygenation, plus genetic epistasis against candidate worm orthologs of the
+      mammalian regulators.
+    provenance:
+      - reference_id: file:worm/fndc-1/fndc-1-deep-research-falcon.md
+        supporting_text: &gt;-
+          Direct phosphorylation/ubiquitination mapping and LIR validation for C. elegans
+          FNDC-1 remain to be fully elucidated
+      - reference_id: PMID:33416042
+        supporting_text: &gt;-
+          This protection depends upon ATFS-1, a transcription factor that is central to the
+          mitochondrial unfolded protein response (UPRmt).
+        reference_section_type: ABSTRACT
+  - gap_statement: &gt;-
+      Whether FNDC-1 is a broadly-acting mitophagy receptor in C. elegans (beyond the two
+      described contexts of paternal-mitochondria elimination and hypoxia-reoxygenation) is
+      unresolved, as is its epistatic relationship to the PINK-1/PDR-1 and DCT-1/NIX
+      pathways. The loss-of-function phenotype is mild and context-restricted, and under
+      some stresses mitochondrial remodeling proceeds without fndc-1.
+    boundary: &gt;-
+      Loss of fndc-1 delays but does not abolish paternal-mitochondria elimination because a
+      redundant ubiquitin-dependent pathway acts first and earlier, and it reduces
+      HR-induced mitophagy; no null lethality or gross organismal phenotype is reported.
+    gap_kind:
+      - BIOLOGY
+    dark_aspect: RESIDUAL_SUBGAP
+    status: OPEN
+    significance: &gt;-
+      Clarifying FNDC-1&#39;s physiological scope and its ordering relative to the other worm
+      mitophagy receptors would establish whether it is a general quality-control receptor
+      or a specialist for selective/developmental mitochondrial clearance.
+    resolution: &gt;-
+      Systematic mito-mKeima/mito-Keima flux measurements across tissues, ages, and
+      stressors in fndc-1 single and pink-1/pdr-1 or dct-1 double mutants to define
+      genetic-interaction structure.
+    provenance:
+      - reference_id: PMID:31153831
+        supporting_text: &gt;-
+          Thus, there are two redundant, but temporally distinct mechanisms that target
+          paternal mitochondria for elimination in C. elegans.
+        reference_section_type: ABSTRACT
+      - reference_id: PMID:31233739
+        supporting_text: &gt;-
+          loss of fndc-1 retards the rate of paternal mitochondria degradation
+        reference_section_type: ABSTRACT
 </code></pre>
             </div>
         </details>


### PR DESCRIPTION
## Summary

Automated regeneration of static assets after gene review or template changes.

## Generated Assets

| Asset | Count/Status |
|-------|--------------|
| Gene review YAML files | 2864 |
| Gene review HTML pages | 2864 |
| Project pages | 1098 |
| Module pages | 87 |
| Browser app (data.js) | Updated |
| Validation report | Updated |

## Trigger

This PR was triggered by changes to:
- genes/**/*.yaml - gene review data files
- src/ai_gene_review/schema/** - LinkML schema files
- src/ai_gene_review/templates/** - Jinja2 templates
- src/ai_gene_review/render.py - rendering code
- src/ai_gene_review/render_modules.py - module rendering code
- src/ai_gene_review/export/** - export code
- src/ai_gene_review/browser/** - browser app assets
- src/ai_gene_review/tools/minify_linkml_browser_data.py - browser data compaction
- projects/*.md - project definitions
- modules/**/*.yaml - module definitions
- project.justfile - just recipes used by CI
- .github/workflows/generate-pages.yaml - workflow definition

## Review

- [ ] Spot-check a few gene review HTML pages render correctly
- [ ] Spot-check module tree browser pages render correctly
- [ ] Verify browser app loads and filters work
- [ ] Check validation report for new issues
