### PR TITLE
[codex] Add PSEN1 knowledge gaps

### DIFF
--- a/genes/human/PSEN1/PSEN1-ai-review.html
+++ b/genes/human/PSEN1/PSEN1-ai-review.html
@@ -12973,6 +12973,20 @@
                 <div class="reference-header">
                     <span class="reference-id">
 
+                        file:human/PSEN1/PSEN1-notes.md
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Manual PSEN1 curation notes</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000002.md" target="_blank" class="term-link">
                             GO_REF:0000002
                         </a>
@@ -14283,6 +14297,100 @@
     </div>
 
 
+
+    <div class="section">
+        <h2 class="section-title">Knowledge Gaps</h2>
+        <p style="color: #555; font-size: 0.92rem; margin-top: -0.3rem;">
+            What is <em>not</em> known — curated, literature-grounded statements of the open
+            unknowns (the inverse of core functions).
+        </p>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> The complete normal in-vivo substrate scope of PSEN1-containing gamma-secretase across tissues is unresolved. APP and Notch are established substrates, but which additional candidate substrates or interactors should be treated as evolved PSEN1 functions rather than overexpression, disease-model, or context-specific cleavage events remains unsettled.</p>
+            <p style="margin-top: 0.4rem;">
+                <span class="badge">OPEN</span>
+                <span class="badge">BIOLOGY</span><span class="badge">CURATION</span>
+                <span class="badge">RESIDUAL_SUBGAP</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> PSEN1 is the catalytic presenilin subunit of the mature gamma-secretase complex, and the complex cleaves type I membrane-protein substrates including APP and Notch receptors.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Significance:</strong> PSEN1 has many GO annotations derived from substrate or interactor studies. Distinguishing conserved, normal substrate biology from context-specific cleavage or disease-model readouts is essential for deciding which biological-process annotations are core, non-core, or over-annotated.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>What would resolve it:</strong> Endogenous substrate profiling across relevant human cell types, paired with catalytically inactive PSEN1 controls and substrate-specific rescue/readout assays, would define which substrate cleavages represent normal PSEN1 biology.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Provenance (the field's own admissions):</strong></p>
+            <ul style="margin-top: 0.2rem;">
+
+                <li><em>"This enzyme cleaves many type I membrane proteins, including the amyloid beta-protein (Abeta) precursor (APP) and the Notch receptor."</em> — PMID:15274632</li>
+
+                <li><em>"may play a role in the relaxed substrate specificity of the complex"</em> — PMID:26280335</li>
+
+            </ul>
+
+
+        </div>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> The physiological scope of PSEN1-mediated ER calcium leak/homeostasis is unresolved. It is not yet clear which calcium-homeostasis annotations reflect a conserved normal presenilin function in vivo versus phenotypes of familial-Alzheimer variants, knockout systems, or cellular stress models.</p>
+            <p style="margin-top: 0.4rem;">
+                <span class="badge">OPEN</span>
+                <span class="badge">BIOLOGY</span><span class="badge">CURATION</span>
+                <span class="badge">RESIDUAL_SUBGAP</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> Presenilins can form ER Ca2+ leak channels in experimental systems, and this activity is separable from gamma-secretase proteolysis.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Significance:</strong> Calcium homeostasis is a real presenilin-associated activity but is secondary to the core gamma-secretase function in this review. Clarifying its normal in-vivo scope would determine whether calcium terms should remain non-core context or be promoted as a conserved PSEN1 function.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>What would resolve it:</strong> Knock-in comparison of wild-type, protease-dead, and calcium-leak-defective PSEN1 variants under baseline non-disease conditions, with ER calcium measurements in physiologic cell types, would separate normal calcium function from disease/stress phenotypes.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Provenance (the field's own admissions):</strong></p>
+            <ul style="margin-top: 0.2rem;">
+
+                <li><em>"The ER Ca(2+) leak function of presenilins is independent of their gamma-secretase activity."</em> — PMID:16959576</li>
+
+                <li><em>"FAD mutations and genetic deletions of presenilins have been associated with calcium (Ca(2+)) signaling abnormalities."</em> — PMID:16959576</li>
+
+            </ul>
+
+
+        </div>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> The compartment-specific map of endogenous active PSEN1/gamma-secretase is incomplete. Many location annotations refer to membranes compatible with PSEN1 trafficking, but unusual or low-specificity locations still need to be separated from overexpressed holoprotein, isolated interactor experiments, or inactive/non-mature presenilin pools.</p>
+            <p style="margin-top: 0.4rem;">
+                <span class="badge">OPEN</span>
+                <span class="badge">CURATION</span>
+                <span class="badge">CC_DARK</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> The review supports mature gamma-secretase activity in secretory, endosomal, and plasma-membrane compartments, and records several unusual location annotations as UNDECIDED rather than removing them without full-text review.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Significance:</strong> PSEN1 has many compartment annotations. A curated distinction between endogenous active gamma-secretase complexes and broader PSEN1 holoprotein or interactor localization would reduce over-annotation while preserving real trafficking biology.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>What would resolve it:</strong> Endogenous tagging combined with substrate-cleavage reporters and mature-complex markers should map active gamma-secretase compartments separately from total PSEN1 localization.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Provenance (the field's own admissions):</strong></p>
+            <ul style="margin-top: 0.2rem;">
+
+                <li><em>"The remaining UNDECIDED annotations are mostly unusual location terms such as kinetochore, nuclear membrane, centrosome, mitochondrial membrane, synaptic vesicle, neuromuscular junction, sarcolemma, and azurophil granule membrane."</em> — file:human/PSEN1/PSEN1-notes.md</li>
+
+            </ul>
+
+
+        </div>
+
+    </div>
 
 
 
@@ -16914,7 +17022,96 @@ suggested_experiments:
   hypothesis: ER calcium homeostasis is a separable normal presenilin activity rather than only a phenotype
     of familial Alzheimer variants or cellular stress.
   experiment_type: knock-in physiology/calcium imaging
+knowledge_gaps:
+- gap_statement: &gt;-
+    The complete normal in-vivo substrate scope of PSEN1-containing gamma-secretase across tissues
+    is unresolved. APP and Notch are established substrates, but which additional candidate substrates
+    or interactors should be treated as evolved PSEN1 functions rather than overexpression, disease-model,
+    or context-specific cleavage events remains unsettled.
+  boundary: &gt;-
+    PSEN1 is the catalytic presenilin subunit of the mature gamma-secretase complex, and the complex
+    cleaves type I membrane-protein substrates including APP and Notch receptors.
+  gap_kind:
+  - BIOLOGY
+  - CURATION
+  dark_aspect: RESIDUAL_SUBGAP
+  status: OPEN
+  significance: &gt;-
+    PSEN1 has many GO annotations derived from substrate or interactor studies. Distinguishing conserved,
+    normal substrate biology from context-specific cleavage or disease-model readouts is essential for
+    deciding which biological-process annotations are core, non-core, or over-annotated.
+  resolution: &gt;-
+    Endogenous substrate profiling across relevant human cell types, paired with catalytically inactive
+    PSEN1 controls and substrate-specific rescue/readout assays, would define which substrate cleavages
+    represent normal PSEN1 biology.
+  provenance:
+  - reference_id: PMID:15274632
+    supporting_text: &gt;-
+      This enzyme cleaves many type I membrane proteins, including the amyloid beta-protein (Abeta)
+      precursor (APP) and the Notch receptor.
+    reference_section_type: ABSTRACT
+  - reference_id: PMID:26280335
+    supporting_text: may play a role in the relaxed substrate specificity of the complex
+    reference_section_type: DISCUSSION
+- gap_statement: &gt;-
+    The physiological scope of PSEN1-mediated ER calcium leak/homeostasis is unresolved. It is not yet
+    clear which calcium-homeostasis annotations reflect a conserved normal presenilin function in vivo
+    versus phenotypes of familial-Alzheimer variants, knockout systems, or cellular stress models.
+  boundary: &gt;-
+    Presenilins can form ER Ca2+ leak channels in experimental systems, and this activity is separable
+    from gamma-secretase proteolysis.
+  gap_kind:
+  - BIOLOGY
+  - CURATION
+  dark_aspect: RESIDUAL_SUBGAP
+  status: OPEN
+  significance: &gt;-
+    Calcium homeostasis is a real presenilin-associated activity but is secondary to the core
+    gamma-secretase function in this review. Clarifying its normal in-vivo scope would determine whether
+    calcium terms should remain non-core context or be promoted as a conserved PSEN1 function.
+  resolution: &gt;-
+    Knock-in comparison of wild-type, protease-dead, and calcium-leak-defective PSEN1 variants under
+    baseline non-disease conditions, with ER calcium measurements in physiologic cell types, would
+    separate normal calcium function from disease/stress phenotypes.
+  provenance:
+  - reference_id: PMID:16959576
+    supporting_text: &gt;-
+      The ER Ca(2+) leak function of presenilins is independent of their gamma-secretase activity.
+    reference_section_type: ABSTRACT
+  - reference_id: PMID:16959576
+    supporting_text: &gt;-
+      FAD mutations and genetic deletions of presenilins have been associated with calcium (Ca(2+))
+      signaling abnormalities.
+    reference_section_type: ABSTRACT
+- gap_statement: &gt;-
+    The compartment-specific map of endogenous active PSEN1/gamma-secretase is incomplete. Many
+    location annotations refer to membranes compatible with PSEN1 trafficking, but unusual or
+    low-specificity locations still need to be separated from overexpressed holoprotein, isolated
+    interactor experiments, or inactive/non-mature presenilin pools.
+  boundary: &gt;-
+    The review supports mature gamma-secretase activity in secretory, endosomal, and plasma-membrane
+    compartments, and records several unusual location annotations as UNDECIDED rather than removing
+    them without full-text review.
+  gap_kind:
+  - CURATION
+  dark_aspect: CC_DARK
+  status: OPEN
+  significance: &gt;-
+    PSEN1 has many compartment annotations. A curated distinction between endogenous active
+    gamma-secretase complexes and broader PSEN1 holoprotein or interactor localization would reduce
+    over-annotation while preserving real trafficking biology.
+  resolution: &gt;-
+    Endogenous tagging combined with substrate-cleavage reporters and mature-complex markers should map
+    active gamma-secretase compartments separately from total PSEN1 localization.
+  provenance:
+  - reference_id: file:human/PSEN1/PSEN1-notes.md
+    supporting_text: &gt;-
+      The remaining UNDECIDED annotations are mostly unusual location terms such as kinetochore, nuclear
+      membrane, centrosome, mitochondrial membrane, synaptic vesicle, neuromuscular junction, sarcolemma,
+      and azurophil granule membrane.
 references:
+- id: file:human/PSEN1/PSEN1-notes.md
+  title: Manual PSEN1 curation notes
 - id: GO_REF:0000002
   title: Gene Ontology annotation through association of InterPro records with GO terms
   findings: []

--- a/genes/human/PSEN1/PSEN1-ai-review.yaml
+++ b/genes/human/PSEN1/PSEN1-ai-review.yaml
@@ -2529,7 +2529,96 @@ suggested_experiments:
   hypothesis: ER calcium homeostasis is a separable normal presenilin activity rather than only a phenotype
     of familial Alzheimer variants or cellular stress.
   experiment_type: knock-in physiology/calcium imaging
+knowledge_gaps:
+- gap_statement: >-
+    The complete normal in-vivo substrate scope of PSEN1-containing gamma-secretase across tissues
+    is unresolved. APP and Notch are established substrates, but which additional candidate substrates
+    or interactors should be treated as evolved PSEN1 functions rather than overexpression, disease-model,
+    or context-specific cleavage events remains unsettled.
+  boundary: >-
+    PSEN1 is the catalytic presenilin subunit of the mature gamma-secretase complex, and the complex
+    cleaves type I membrane-protein substrates including APP and Notch receptors.
+  gap_kind:
+  - BIOLOGY
+  - CURATION
+  dark_aspect: RESIDUAL_SUBGAP
+  status: OPEN
+  significance: >-
+    PSEN1 has many GO annotations derived from substrate or interactor studies. Distinguishing conserved,
+    normal substrate biology from context-specific cleavage or disease-model readouts is essential for
+    deciding which biological-process annotations are core, non-core, or over-annotated.
+  resolution: >-
+    Endogenous substrate profiling across relevant human cell types, paired with catalytically inactive
+    PSEN1 controls and substrate-specific rescue/readout assays, would define which substrate cleavages
+    represent normal PSEN1 biology.
+  provenance:
+  - reference_id: PMID:15274632
+    supporting_text: >-
+      This enzyme cleaves many type I membrane proteins, including the amyloid beta-protein (Abeta)
+      precursor (APP) and the Notch receptor.
+    reference_section_type: ABSTRACT
+  - reference_id: PMID:26280335
+    supporting_text: may play a role in the relaxed substrate specificity of the complex
+    reference_section_type: DISCUSSION
+- gap_statement: >-
+    The physiological scope of PSEN1-mediated ER calcium leak/homeostasis is unresolved. It is not yet
+    clear which calcium-homeostasis annotations reflect a conserved normal presenilin function in vivo
+    versus phenotypes of familial-Alzheimer variants, knockout systems, or cellular stress models.
+  boundary: >-
+    Presenilins can form ER Ca2+ leak channels in experimental systems, and this activity is separable
+    from gamma-secretase proteolysis.
+  gap_kind:
+  - BIOLOGY
+  - CURATION
+  dark_aspect: RESIDUAL_SUBGAP
+  status: OPEN
+  significance: >-
+    Calcium homeostasis is a real presenilin-associated activity but is secondary to the core
+    gamma-secretase function in this review. Clarifying its normal in-vivo scope would determine whether
+    calcium terms should remain non-core context or be promoted as a conserved PSEN1 function.
+  resolution: >-
+    Knock-in comparison of wild-type, protease-dead, and calcium-leak-defective PSEN1 variants under
+    baseline non-disease conditions, with ER calcium measurements in physiologic cell types, would
+    separate normal calcium function from disease/stress phenotypes.
+  provenance:
+  - reference_id: PMID:16959576
+    supporting_text: >-
+      The ER Ca(2+) leak function of presenilins is independent of their gamma-secretase activity.
+    reference_section_type: ABSTRACT
+  - reference_id: PMID:16959576
+    supporting_text: >-
+      FAD mutations and genetic deletions of presenilins have been associated with calcium (Ca(2+))
+      signaling abnormalities.
+    reference_section_type: ABSTRACT
+- gap_statement: >-
+    The compartment-specific map of endogenous active PSEN1/gamma-secretase is incomplete. Many
+    location annotations refer to membranes compatible with PSEN1 trafficking, but unusual or
+    low-specificity locations still need to be separated from overexpressed holoprotein, isolated
+    interactor experiments, or inactive/non-mature presenilin pools.
+  boundary: >-
+    The review supports mature gamma-secretase activity in secretory, endosomal, and plasma-membrane
+    compartments, and records several unusual location annotations as UNDECIDED rather than removing
+    them without full-text review.
+  gap_kind:
+  - CURATION
+  dark_aspect: CC_DARK
+  status: OPEN
+  significance: >-
+    PSEN1 has many compartment annotations. A curated distinction between endogenous active
+    gamma-secretase complexes and broader PSEN1 holoprotein or interactor localization would reduce
+    over-annotation while preserving real trafficking biology.
+  resolution: >-
+    Endogenous tagging combined with substrate-cleavage reporters and mature-complex markers should map
+    active gamma-secretase compartments separately from total PSEN1 localization.
+  provenance:
+  - reference_id: file:human/PSEN1/PSEN1-notes.md
+    supporting_text: >-
+      The remaining UNDECIDED annotations are mostly unusual location terms such as kinetochore, nuclear
+      membrane, centrosome, mitochondrial membrane, synaptic vesicle, neuromuscular junction, sarcolemma,
+      and azurophil granule membrane.
 references:
+- id: file:human/PSEN1/PSEN1-notes.md
+  title: Manual PSEN1 curation notes
 - id: GO_REF:0000002
   title: Gene Ontology annotation through association of InterPro records with GO terms
   findings: []


### PR DESCRIPTION
## Summary

- Add three structured `knowledge_gaps` entries to the PSEN1 review for substrate-scope, calcium-homeostasis, and localization/compartment curation gaps.
- Anchor the gaps to cached PMID provenance where available and to the existing PSEN1 notes for the review-specific localization audit.
- Regenerate the PSEN1 HTML review page so the new Knowledge Gaps section is visible.

## Validation

- `just validate human PSEN1`
- `just render human PSEN1`