### PR TITLE
[codex] Add DCAF12L2 knowledge gaps

### DIFF
--- a/genes/human/DCAF12L2/DCAF12L2-ai-review.html
+++ b/genes/human/DCAF12L2/DCAF12L2-ai-review.html
@@ -1382,6 +1382,45 @@ values describe the inference style/source we are proposing.
 
             </div>
 
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        file:human/DCAF12L2/DCAF12L2-notes.md
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Manual DCAF12L2 curation notes</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">Records the conservative curation boundary for DCAF12L2: the gene is a Tdark DCAF12-family protein with indirect CRL4/substrate-adaptor support, but no direct biochemical paper, validated DDB1/CUL4 interaction, or confirmed substrate.</div>
+
+                        <div class="finding-text">"There is no direct DCAF12L2 biochemical paper, no validated DDB1/CUL4 binding experiment, and no confirmed DCAF12L2 substrate."</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <div class="finding-statement">Summarizes the DCAF12L2-specific experimental unknowns that define this gene as functionally dark despite family-level DCAF12 inference.</div>
+
+                        <div class="finding-text">"No direct experimental characterization of DCAF12L2 protein function exists"</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <div class="finding-statement">Notes the reproductive-expression clue that motivates, but does not resolve, a possible DCAF12L2 role in male germ-cell biology.</div>
+
+                        <div class="finding-text">"It is enriched in testis/epididymis"</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
         </div>
     </div>
 
@@ -1507,6 +1546,100 @@ values describe the inference style/source we are proposing.
     </div>
 
 
+
+    <div class="section">
+        <h2 class="section-title">Knowledge Gaps</h2>
+        <p style="color: #555; font-size: 0.92rem; margin-top: -0.3rem;">
+            What is <em>not</em> known — curated, literature-grounded statements of the open
+            unknowns (the inverse of core functions).
+        </p>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> Whether DCAF12L2 directly binds DDB1/CUL4 and assembles into a functional CRL4 ubiquitin ligase complex remains unresolved.</p>
+            <p style="margin-top: 0.4rem;">
+                <span class="badge">OPEN</span>
+                <span class="badge">BIOLOGY</span><span class="badge">CURATION</span>
+                <span class="badge">MF_DARK</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> DCAF12L2 is a WD40-repeat DCAF12-family protein with IBA support for membership in the Cul4-RING E3 ubiquitin ligase complex and thesis-level proteomics evidence for candidate CRL4^DCAF12L2 substrates. However, a separate assay reported no significant DDB1 binding for DCAF12L2, so the direct complex-assembly step is still unvalidated.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Significance:</strong> The current substrate-adaptor function depends on CRL4 assembly. Without direct DDB1/CUL4 engagement evidence, DCAF12L2 remains a family-inferred candidate rather than a biochemically established CRL4 substrate receptor.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>What would resolve it:</strong> Orthogonal DCAF12L2-DDB1/CUL4 interaction assays in relevant cells and purified reconstitution, ideally including DDA1/cofactor conditions and comparison with DCAF12.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Provenance (the field's own admissions):</strong></p>
+            <ul style="margin-top: 0.2rem;">
+
+                <li><em>"The authors also report **no significant binding of DDB1** to DCAF12L1 or DCAF12L2 in their assays, concluding it remains unclear whether these paralogs can assemble a fully functional CRL4 complex under those conditions."</em> — file:human/DCAF12L2/DCAF12L2-deep-research-falcon.md</li>
+
+                <li><em>"There is no direct DCAF12L2 biochemical paper, no validated DDB1/CUL4 binding experiment, and no confirmed DCAF12L2 substrate."</em> — file:human/DCAF12L2/DCAF12L2-notes.md</li>
+
+            </ul>
+
+
+        </div>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> The direct substrates and degron-recognition rules of DCAF12L2 are not established. It is unknown whether DCAF12L2 recognizes DCAF12-like C-terminal acidic degrons or has diverged to a distinct substrate-recognition mode.</p>
+            <p style="margin-top: 0.4rem;">
+                <span class="badge">OPEN</span>
+                <span class="badge">BIOLOGY</span><span class="badge">CURATION</span>
+                <span class="badge">MF_DARK</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> Parent DCAF12 has strong structural and biochemical evidence for C-terminal di-Glu degron recognition. For DCAF12L2, reported MEKK4 and WDR11/FAM91A1 substrate candidates come from limited proteomics/thesis-level evidence, while separate work reported no detectable binding to the DCAF12 substrate MCMBP.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Significance:</strong> Substrate specificity is the informative molecular function for a DCAF-family receptor. Until the substrates and degron rules are confirmed, DCAF12L2 should not be propagated to autophagy or named substrate-degradation terms by similarity alone.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>What would resolve it:</strong> Validate candidate substrates with DCAF12L2-dependent ubiquitination/degradation assays, degron mutagenesis, and direct binding assays against DCAF12 di-Glu substrates and DCAF12L2-specific candidates.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Provenance (the field's own admissions):</strong></p>
+            <ul style="margin-top: 0.2rem;">
+
+                <li><em>"No confirmed substrates for DCAF12L2"</em> — file:human/DCAF12L2/DCAF12L2-notes.md</li>
+
+                <li><em>"A separate experimental source (2025) tested DCAF12L2 (and DCAF12L1) for interaction with **MCMBP** (a known DCAF12 substrate in that research program) and found **no detectable binding**"</em> — file:human/DCAF12L2/DCAF12L2-deep-research-falcon.md</li>
+
+            </ul>
+
+
+        </div>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> The biological role of DCAF12L2 in testis-enriched or epididymal cell contexts is unknown.</p>
+            <p style="margin-top: 0.4rem;">
+                <span class="badge">OPEN</span>
+                <span class="badge">BIOLOGY</span>
+                <span class="badge">BP_DARK</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> DCAF12L2 is an X-linked intronless DCAF12 retrocopy with testis/epididymis-enriched expression evidence and conserved coding capacity, but no direct loss-of-function or substrate-based evidence connects it to spermatogenesis, fertility, or a specific germ-cell pathway.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Significance:</strong> Expression suggests the gene may have been retained for a reproductive function, but the relevant process, cell type, and substrate pathway remain undefined.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>What would resolve it:</strong> DCAF12L2 perturbation in germ-cell or epididymal models, ideally with fertility, testis histology, substrate proteomics, and DCAF12/DCAF12L1 redundancy controls.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Provenance (the field's own admissions):</strong></p>
+            <ul style="margin-top: 0.2rem;">
+
+                <li><em>"It is enriched in testis/epididymis"</em> — file:human/DCAF12L2/DCAF12L2-notes.md</li>
+
+            </ul>
+
+
+        </div>
+
+    </div>
 
 
 
@@ -2409,6 +2542,26 @@ references:
       **no significant binding of DDB1** to DCAF12L1 or DCAF12L2 in their assays, concluding
       it remains unclear whether these paralogs can assemble a fully functional CRL4 complex
       under those conditions.
+- id: file:human/DCAF12L2/DCAF12L2-notes.md
+  title: Manual DCAF12L2 curation notes
+  findings:
+  - statement: &gt;-
+      Records the conservative curation boundary for DCAF12L2: the gene is a Tdark
+      DCAF12-family protein with indirect CRL4/substrate-adaptor support, but no direct
+      biochemical paper, validated DDB1/CUL4 interaction, or confirmed substrate.
+    supporting_text: &gt;-
+      There is no direct DCAF12L2 biochemical paper, no validated DDB1/CUL4 binding
+      experiment, and no confirmed DCAF12L2 substrate.
+  - statement: &gt;-
+      Summarizes the DCAF12L2-specific experimental unknowns that define this gene as
+      functionally dark despite family-level DCAF12 inference.
+    supporting_text: &gt;-
+      No direct experimental characterization of DCAF12L2 protein function exists
+  - statement: &gt;-
+      Notes the reproductive-expression clue that motivates, but does not resolve, a
+      possible DCAF12L2 role in male germ-cell biology.
+    supporting_text: &gt;-
+      It is enriched in testis/epididymis
 
 core_functions:
 - description: &gt;-
@@ -2473,6 +2626,90 @@ suggested_experiments:
     peptides bearing C-terminal Glu-Glu motifs (MAGEA3, CCT5 C-terminal sequences)
     using fluorescence polarization. Compare affinity with DCAF12 to assess whether
     substrate specificity is conserved.
+
+knowledge_gaps:
+- gap_statement: &gt;-
+    Whether DCAF12L2 directly binds DDB1/CUL4 and assembles into a functional CRL4
+    ubiquitin ligase complex remains unresolved.
+  boundary: &gt;-
+    DCAF12L2 is a WD40-repeat DCAF12-family protein with IBA support for membership
+    in the Cul4-RING E3 ubiquitin ligase complex and thesis-level proteomics evidence
+    for candidate CRL4^DCAF12L2 substrates. However, a separate assay reported no
+    significant DDB1 binding for DCAF12L2, so the direct complex-assembly step is still
+    unvalidated.
+  gap_kind:
+    - BIOLOGY
+    - CURATION
+  dark_aspect: MF_DARK
+  status: OPEN
+  significance: &gt;-
+    The current substrate-adaptor function depends on CRL4 assembly. Without direct
+    DDB1/CUL4 engagement evidence, DCAF12L2 remains a family-inferred candidate rather
+    than a biochemically established CRL4 substrate receptor.
+  resolution: &gt;-
+    Orthogonal DCAF12L2-DDB1/CUL4 interaction assays in relevant cells and purified
+    reconstitution, ideally including DDA1/cofactor conditions and comparison with DCAF12.
+  provenance:
+    - reference_id: file:human/DCAF12L2/DCAF12L2-deep-research-falcon.md
+      supporting_text: &gt;-
+        The authors also report **no significant binding of DDB1** to DCAF12L1 or
+        DCAF12L2 in their assays, concluding it remains unclear whether these paralogs
+        can assemble a fully functional CRL4 complex under those conditions.
+    - reference_id: file:human/DCAF12L2/DCAF12L2-notes.md
+      supporting_text: &gt;-
+        There is no direct DCAF12L2 biochemical paper, no validated DDB1/CUL4 binding
+        experiment, and no confirmed DCAF12L2 substrate.
+- gap_statement: &gt;-
+    The direct substrates and degron-recognition rules of DCAF12L2 are not established.
+    It is unknown whether DCAF12L2 recognizes DCAF12-like C-terminal acidic degrons or
+    has diverged to a distinct substrate-recognition mode.
+  boundary: &gt;-
+    Parent DCAF12 has strong structural and biochemical evidence for C-terminal di-Glu
+    degron recognition. For DCAF12L2, reported MEKK4 and WDR11/FAM91A1 substrate
+    candidates come from limited proteomics/thesis-level evidence, while separate
+    work reported no detectable binding to the DCAF12 substrate MCMBP.
+  gap_kind:
+    - BIOLOGY
+    - CURATION
+  dark_aspect: MF_DARK
+  status: OPEN
+  significance: &gt;-
+    Substrate specificity is the informative molecular function for a DCAF-family
+    receptor. Until the substrates and degron rules are confirmed, DCAF12L2 should not
+    be propagated to autophagy or named substrate-degradation terms by similarity alone.
+  resolution: &gt;-
+    Validate candidate substrates with DCAF12L2-dependent ubiquitination/degradation
+    assays, degron mutagenesis, and direct binding assays against DCAF12 di-Glu
+    substrates and DCAF12L2-specific candidates.
+  provenance:
+    - reference_id: file:human/DCAF12L2/DCAF12L2-notes.md
+      supporting_text: No confirmed substrates for DCAF12L2
+    - reference_id: file:human/DCAF12L2/DCAF12L2-deep-research-falcon.md
+      supporting_text: &gt;-
+        A separate experimental source (2025) tested DCAF12L2 (and DCAF12L1) for
+        interaction with **MCMBP** (a known DCAF12 substrate in that research program)
+        and found **no detectable binding**
+- gap_statement: &gt;-
+    The biological role of DCAF12L2 in testis-enriched or epididymal cell contexts is
+    unknown.
+  boundary: &gt;-
+    DCAF12L2 is an X-linked intronless DCAF12 retrocopy with testis/epididymis-enriched
+    expression evidence and conserved coding capacity, but no direct loss-of-function
+    or substrate-based evidence connects it to spermatogenesis, fertility, or a specific
+    germ-cell pathway.
+  gap_kind:
+    - BIOLOGY
+  dark_aspect: BP_DARK
+  status: OPEN
+  significance: &gt;-
+    Expression suggests the gene may have been retained for a reproductive function,
+    but the relevant process, cell type, and substrate pathway remain undefined.
+  resolution: &gt;-
+    DCAF12L2 perturbation in germ-cell or epididymal models, ideally with fertility,
+    testis histology, substrate proteomics, and DCAF12/DCAF12L1 redundancy controls.
+  provenance:
+    - reference_id: file:human/DCAF12L2/DCAF12L2-notes.md
+      supporting_text: It is enriched in testis/epididymis
 </code></pre>
             </div>
         </details>

--- a/genes/human/DCAF12L2/DCAF12L2-ai-review.yaml
+++ b/genes/human/DCAF12L2/DCAF12L2-ai-review.yaml
@@ -232,6 +232,26 @@ references:
       **no significant binding of DDB1** to DCAF12L1 or DCAF12L2 in their assays, concluding
       it remains unclear whether these paralogs can assemble a fully functional CRL4 complex
       under those conditions.
+- id: file:human/DCAF12L2/DCAF12L2-notes.md
+  title: Manual DCAF12L2 curation notes
+  findings:
+  - statement: >-
+      Records the conservative curation boundary for DCAF12L2: the gene is a Tdark
+      DCAF12-family protein with indirect CRL4/substrate-adaptor support, but no direct
+      biochemical paper, validated DDB1/CUL4 interaction, or confirmed substrate.
+    supporting_text: >-
+      There is no direct DCAF12L2 biochemical paper, no validated DDB1/CUL4 binding
+      experiment, and no confirmed DCAF12L2 substrate.
+  - statement: >-
+      Summarizes the DCAF12L2-specific experimental unknowns that define this gene as
+      functionally dark despite family-level DCAF12 inference.
+    supporting_text: >-
+      No direct experimental characterization of DCAF12L2 protein function exists
+  - statement: >-
+      Notes the reproductive-expression clue that motivates, but does not resolve, a
+      possible DCAF12L2 role in male germ-cell biology.
+    supporting_text: >-
+      It is enriched in testis/epididymis
 
 core_functions:
 - description: >-
@@ -296,3 +316,87 @@ suggested_experiments:
     peptides bearing C-terminal Glu-Glu motifs (MAGEA3, CCT5 C-terminal sequences)
     using fluorescence polarization. Compare affinity with DCAF12 to assess whether
     substrate specificity is conserved.
+
+knowledge_gaps:
+- gap_statement: >-
+    Whether DCAF12L2 directly binds DDB1/CUL4 and assembles into a functional CRL4
+    ubiquitin ligase complex remains unresolved.
+  boundary: >-
+    DCAF12L2 is a WD40-repeat DCAF12-family protein with IBA support for membership
+    in the Cul4-RING E3 ubiquitin ligase complex and thesis-level proteomics evidence
+    for candidate CRL4^DCAF12L2 substrates. However, a separate assay reported no
+    significant DDB1 binding for DCAF12L2, so the direct complex-assembly step is still
+    unvalidated.
+  gap_kind:
+    - BIOLOGY
+    - CURATION
+  dark_aspect: MF_DARK
+  status: OPEN
+  significance: >-
+    The current substrate-adaptor function depends on CRL4 assembly. Without direct
+    DDB1/CUL4 engagement evidence, DCAF12L2 remains a family-inferred candidate rather
+    than a biochemically established CRL4 substrate receptor.
+  resolution: >-
+    Orthogonal DCAF12L2-DDB1/CUL4 interaction assays in relevant cells and purified
+    reconstitution, ideally including DDA1/cofactor conditions and comparison with DCAF12.
+  provenance:
+    - reference_id: file:human/DCAF12L2/DCAF12L2-deep-research-falcon.md
+      supporting_text: >-
+        The authors also report **no significant binding of DDB1** to DCAF12L1 or
+        DCAF12L2 in their assays, concluding it remains unclear whether these paralogs
+        can assemble a fully functional CRL4 complex under those conditions.
+    - reference_id: file:human/DCAF12L2/DCAF12L2-notes.md
+      supporting_text: >-
+        There is no direct DCAF12L2 biochemical paper, no validated DDB1/CUL4 binding
+        experiment, and no confirmed DCAF12L2 substrate.
+- gap_statement: >-
+    The direct substrates and degron-recognition rules of DCAF12L2 are not established.
+    It is unknown whether DCAF12L2 recognizes DCAF12-like C-terminal acidic degrons or
+    has diverged to a distinct substrate-recognition mode.
+  boundary: >-
+    Parent DCAF12 has strong structural and biochemical evidence for C-terminal di-Glu
+    degron recognition. For DCAF12L2, reported MEKK4 and WDR11/FAM91A1 substrate
+    candidates come from limited proteomics/thesis-level evidence, while separate
+    work reported no detectable binding to the DCAF12 substrate MCMBP.
+  gap_kind:
+    - BIOLOGY
+    - CURATION
+  dark_aspect: MF_DARK
+  status: OPEN
+  significance: >-
+    Substrate specificity is the informative molecular function for a DCAF-family
+    receptor. Until the substrates and degron rules are confirmed, DCAF12L2 should not
+    be propagated to autophagy or named substrate-degradation terms by similarity alone.
+  resolution: >-
+    Validate candidate substrates with DCAF12L2-dependent ubiquitination/degradation
+    assays, degron mutagenesis, and direct binding assays against DCAF12 di-Glu
+    substrates and DCAF12L2-specific candidates.
+  provenance:
+    - reference_id: file:human/DCAF12L2/DCAF12L2-notes.md
+      supporting_text: No confirmed substrates for DCAF12L2
+    - reference_id: file:human/DCAF12L2/DCAF12L2-deep-research-falcon.md
+      supporting_text: >-
+        A separate experimental source (2025) tested DCAF12L2 (and DCAF12L1) for
+        interaction with **MCMBP** (a known DCAF12 substrate in that research program)
+        and found **no detectable binding**
+- gap_statement: >-
+    The biological role of DCAF12L2 in testis-enriched or epididymal cell contexts is
+    unknown.
+  boundary: >-
+    DCAF12L2 is an X-linked intronless DCAF12 retrocopy with testis/epididymis-enriched
+    expression evidence and conserved coding capacity, but no direct loss-of-function
+    or substrate-based evidence connects it to spermatogenesis, fertility, or a specific
+    germ-cell pathway.
+  gap_kind:
+    - BIOLOGY
+  dark_aspect: BP_DARK
+  status: OPEN
+  significance: >-
+    Expression suggests the gene may have been retained for a reproductive function,
+    but the relevant process, cell type, and substrate pathway remain undefined.
+  resolution: >-
+    DCAF12L2 perturbation in germ-cell or epididymal models, ideally with fertility,
+    testis histology, substrate proteomics, and DCAF12/DCAF12L1 redundancy controls.
+  provenance:
+    - reference_id: file:human/DCAF12L2/DCAF12L2-notes.md
+      supporting_text: It is enriched in testis/epididymis


### PR DESCRIPTION
## Summary
- add structured top-level knowledge gaps for DCAF12L2 covering CRL4 assembly, substrate/degron specificity, and reproductive biological role
- add the manual DCAF12L2 notes file as a local reference for the conservative curation boundary
- render the updated DCAF12L2 review HTML

## Validation
- `just validate human DCAF12L2`
- `just render human DCAF12L2`
- `git diff --check`