### PR TITLE
[codex] Add DNAJC16 knowledge gaps

### DIFF
--- a/genes/human/DNAJC16/DNAJC16-ai-review.html
+++ b/genes/human/DNAJC16/DNAJC16-ai-review.html
@@ -1240,6 +1240,38 @@
 
             </div>
 
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        file:human/DNAJC16/DNAJC16-notes.md
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Manual DNAJC16 curation notes</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">Records that DNAJC16&#39;s core biological process is established, but the direct molecular function behind that process has not been demonstrated.</div>
+
+                        <div class="finding-text">"the precise molecular function (J-domain co-chaperone activity recruiting an ER Hsp70 such as BiP/HSPA5, and a redox/TRX activity) is not directly established"</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <div class="finding-statement">Records the current GO curation boundary: no molecular-function annotation should be asserted until the HSP70/co-chaperone or redox activity is experimentally shown.</div>
+
+                        <div class="finding-text">"Do not over-claim a specific MF."</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
         </div>
     </div>
 
@@ -1317,6 +1349,75 @@
     </div>
 
 
+
+    <div class="section">
+        <h2 class="section-title">Knowledge Gaps</h2>
+        <p style="color: #555; font-size: 0.92rem; margin-top: -0.3rem;">
+            What is <em>not</em> known — curated, literature-grounded statements of the open
+            unknowns (the inverse of core functions).
+        </p>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> The direct molecular activity of DNAJC16/ERdj8 is unresolved: it is not known whether its J domain directly recruits and stimulates a specific HSP70 partner, whether its TRX domain has redox activity, or whether these domains support autophagosome-size control through another effector mechanism.</p>
+            <p style="margin-top: 0.4rem;">
+                <span class="badge">OPEN</span>
+                <span class="badge">BIOLOGY</span><span class="badge">CURATION</span>
+                <span class="badge">MF_DARK</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> ERdj8 is experimentally localized to an ER membrane subdomain and regulates autophagosome size; both the DnaJ/J domain and TRX domain are required for the overexpression phenotype. The missing step is the biochemical activity linking those domains to the autophagosome-size readout.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Significance:</strong> The gene has a solid biological-process annotation but no experimentally supported molecular-function annotation. Adding HSP70 binding or TRX activity by domain inference alone would overstate the evidence.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>What would resolve it:</strong> In vitro ERdj8 J-domain assays for HSP70 ATPase stimulation and binding, direct identification of the relevant HSP70/effector partner, and biochemical testing of TRX-domain redox activity with H57Q and C174A/C177A controls.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Provenance (the field's own admissions):</strong></p>
+            <ul style="margin-top: 0.2rem;">
+
+                <li><em>"ERdj8 overexpression extended the size of the autophagosome through its DnaJ and TRX domains."</em> — PMID:32492081</li>
+
+                <li><em>"unidentified ERdj8 effector proteins and/or BiP may play important roles in this regulation."</em> — PMID:32492081</li>
+
+                <li><em>"the precise molecular function (J-domain co-chaperone activity recruiting an ER Hsp70 such as BiP/HSPA5, and a redox/TRX activity) is not directly established"</em> — file:human/DNAJC16/DNAJC16-notes.md</li>
+
+            </ul>
+
+
+        </div>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> The mechanism by which ERdj8-containing ER subdomains control autophagosome size and large-target engulfment is not defined.</p>
+            <p style="margin-top: 0.4rem;">
+                <span class="badge">OPEN</span>
+                <span class="badge">BIOLOGY</span>
+                <span class="badge">RESIDUAL_SUBGAP</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> ERdj8 colocalizes with PIS and autophagy-initiation machinery at a specialized ER subdomain; overexpression enlarges autophagosomes, while knockdown restricts engulfment of larger targets. The unresolved part is how ERdj8 organizes lipid supply, Atg machinery, HSP70/effector proteins, or membrane dynamics to set phagophore size.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Significance:</strong> The process term captures the phenotype but not the causal mechanism. Closing this gap would explain how an ER membrane J-protein tunes autophagosome capacity for large selective-autophagy cargo.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>What would resolve it:</strong> Proximity labeling or interaction proteomics at ERdj8-positive ER-phagophore subdomains, perturbation of candidate PIS/Atg/HSP70 effectors, and lipid-transfer or membrane-growth readouts during phagophore expansion.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Provenance (the field's own admissions):</strong></p>
+            <ul style="margin-top: 0.2rem;">
+
+                <li><em>"However, the mechanism by which autophagosome size is controlled remains elusive."</em> — PMID:32492081</li>
+
+                <li><em>"unidentified ERdj8 effector proteins and/or BiP may play important roles in this regulation."</em> — PMID:32492081</li>
+
+            </ul>
+
+
+        </div>
+
+    </div>
 
 
 
@@ -1566,6 +1667,19 @@ references:
   findings:
   - statement: Single-pass type IV ER membrane protein with an N-terminal J domain and a thioredoxin domain; regulates the size of autophagosomes during formation; J-domain (His-57) and thioredoxin (Cys-171/Cys-174) residues are required for the autophagosome-enlargement activity.
     reference_section_type: OTHER
+- id: file:human/DNAJC16/DNAJC16-notes.md
+  title: Manual DNAJC16 curation notes
+  findings:
+  - statement: &gt;-
+      Records that DNAJC16&#39;s core biological process is established, but the direct
+      molecular function behind that process has not been demonstrated.
+    supporting_text: &gt;-
+      the precise molecular function (J-domain co-chaperone activity recruiting an ER
+      Hsp70 such as BiP/HSPA5, and a redox/TRX activity) is not directly established
+  - statement: &gt;-
+      Records the current GO curation boundary: no molecular-function annotation should
+      be asserted until the HSP70/co-chaperone or redox activity is experimentally shown.
+    supporting_text: Do not over-claim a specific MF.
 core_functions:
 - description: ER membrane DnaJ/HSP40 protein that regulates the size of forming autophagosomes, enabling autophagic engulfment of large targets; activity requires both its J domain and its thioredoxin domain.
   locations:
@@ -1584,6 +1698,73 @@ suggested_questions:
 suggested_experiments:
 - description: Reconstitute and assay ERdj8 J-domain-stimulated HSP70 ATPase activity and test the redox activity of its thioredoxin domain in vitro, using the H57Q and C171A/C174A mutants as controls, to define the molecular function underlying autophagosome-size regulation.
 - description: Proximity labeling (BioID/APEX) from ERdj8 at the ER-phagophore subdomain to identify its HSP70 partner(s) and Atg/lipid-synthesis machinery it engages during autophagosome formation.
+
+knowledge_gaps:
+- gap_statement: &gt;-
+    The direct molecular activity of DNAJC16/ERdj8 is unresolved: it is not known whether
+    its J domain directly recruits and stimulates a specific HSP70 partner, whether its
+    TRX domain has redox activity, or whether these domains support autophagosome-size
+    control through another effector mechanism.
+  boundary: &gt;-
+    ERdj8 is experimentally localized to an ER membrane subdomain and regulates
+    autophagosome size; both the DnaJ/J domain and TRX domain are required for the
+    overexpression phenotype. The missing step is the biochemical activity linking those
+    domains to the autophagosome-size readout.
+  gap_kind:
+    - BIOLOGY
+    - CURATION
+  dark_aspect: MF_DARK
+  status: OPEN
+  significance: &gt;-
+    The gene has a solid biological-process annotation but no experimentally supported
+    molecular-function annotation. Adding HSP70 binding or TRX activity by domain
+    inference alone would overstate the evidence.
+  resolution: &gt;-
+    In vitro ERdj8 J-domain assays for HSP70 ATPase stimulation and binding, direct
+    identification of the relevant HSP70/effector partner, and biochemical testing of
+    TRX-domain redox activity with H57Q and C174A/C177A controls.
+  provenance:
+    - reference_id: PMID:32492081
+      supporting_text: &gt;-
+        ERdj8 overexpression extended the size of the autophagosome through its DnaJ
+        and TRX domains.
+    - reference_id: PMID:32492081
+      supporting_text: &gt;-
+        unidentified ERdj8 effector proteins and/or BiP may play important roles in this
+        regulation.
+    - reference_id: file:human/DNAJC16/DNAJC16-notes.md
+      supporting_text: &gt;-
+        the precise molecular function (J-domain co-chaperone activity recruiting an ER
+        Hsp70 such as BiP/HSPA5, and a redox/TRX activity) is not directly established
+- gap_statement: &gt;-
+    The mechanism by which ERdj8-containing ER subdomains control autophagosome size and
+    large-target engulfment is not defined.
+  boundary: &gt;-
+    ERdj8 colocalizes with PIS and autophagy-initiation machinery at a specialized ER
+    subdomain; overexpression enlarges autophagosomes, while knockdown restricts
+    engulfment of larger targets. The unresolved part is how ERdj8 organizes lipid supply,
+    Atg machinery, HSP70/effector proteins, or membrane dynamics to set phagophore size.
+  gap_kind:
+    - BIOLOGY
+  dark_aspect: RESIDUAL_SUBGAP
+  status: OPEN
+  significance: &gt;-
+    The process term captures the phenotype but not the causal mechanism. Closing this
+    gap would explain how an ER membrane J-protein tunes autophagosome capacity for
+    large selective-autophagy cargo.
+  resolution: &gt;-
+    Proximity labeling or interaction proteomics at ERdj8-positive ER-phagophore
+    subdomains, perturbation of candidate PIS/Atg/HSP70 effectors, and lipid-transfer
+    or membrane-growth readouts during phagophore expansion.
+  provenance:
+    - reference_id: PMID:32492081
+      supporting_text: &gt;-
+        However, the mechanism by which autophagosome size is controlled remains
+        elusive.
+    - reference_id: PMID:32492081
+      supporting_text: &gt;-
+        unidentified ERdj8 effector proteins and/or BiP may play important roles in this
+        regulation.
 </code></pre>
             </div>
         </details>

--- a/genes/human/DNAJC16/DNAJC16-ai-review.html
+++ b/genes/human/DNAJC16/DNAJC16-ai-review.html
@@ -1371,7 +1371,7 @@
             <p style="margin-top: 0.5rem;"><strong>Significance:</strong> The gene has a solid biological-process annotation but no experimentally supported molecular-function annotation. Adding HSP70 binding or TRX activity by domain inference alone would overstate the evidence.</p>
 
 
-            <p style="margin-top: 0.5rem;"><strong>What would resolve it:</strong> In vitro ERdj8 J-domain assays for HSP70 ATPase stimulation and binding, direct identification of the relevant HSP70/effector partner, and biochemical testing of TRX-domain redox activity with H57Q and C174A/C177A controls.</p>
+            <p style="margin-top: 0.5rem;"><strong>What would resolve it:</strong> In vitro ERdj8 J-domain assays for HSP70 ATPase stimulation and binding, direct identification of the relevant HSP70/effector partner, and biochemical testing of TRX-domain redox activity with H57Q and C171A/C174A controls.</p>
 
 
             <p style="margin-top: 0.5rem;"><strong>Provenance (the field's own admissions):</strong></p>
@@ -1722,7 +1722,7 @@ knowledge_gaps:
   resolution: &gt;-
     In vitro ERdj8 J-domain assays for HSP70 ATPase stimulation and binding, direct
     identification of the relevant HSP70/effector partner, and biochemical testing of
-    TRX-domain redox activity with H57Q and C174A/C177A controls.
+    TRX-domain redox activity with H57Q and C171A/C174A controls.
   provenance:
     - reference_id: PMID:32492081
       supporting_text: &gt;-

--- a/genes/human/DNAJC16/DNAJC16-ai-review.yaml
+++ b/genes/human/DNAJC16/DNAJC16-ai-review.yaml
@@ -70,6 +70,19 @@ references:
   findings:
   - statement: Single-pass type IV ER membrane protein with an N-terminal J domain and a thioredoxin domain; regulates the size of autophagosomes during formation; J-domain (His-57) and thioredoxin (Cys-171/Cys-174) residues are required for the autophagosome-enlargement activity.
     reference_section_type: OTHER
+- id: file:human/DNAJC16/DNAJC16-notes.md
+  title: Manual DNAJC16 curation notes
+  findings:
+  - statement: >-
+      Records that DNAJC16's core biological process is established, but the direct
+      molecular function behind that process has not been demonstrated.
+    supporting_text: >-
+      the precise molecular function (J-domain co-chaperone activity recruiting an ER
+      Hsp70 such as BiP/HSPA5, and a redox/TRX activity) is not directly established
+  - statement: >-
+      Records the current GO curation boundary: no molecular-function annotation should
+      be asserted until the HSP70/co-chaperone or redox activity is experimentally shown.
+    supporting_text: Do not over-claim a specific MF.
 core_functions:
 - description: ER membrane DnaJ/HSP40 protein that regulates the size of forming autophagosomes, enabling autophagic engulfment of large targets; activity requires both its J domain and its thioredoxin domain.
   locations:
@@ -88,3 +101,70 @@ suggested_questions:
 suggested_experiments:
 - description: Reconstitute and assay ERdj8 J-domain-stimulated HSP70 ATPase activity and test the redox activity of its thioredoxin domain in vitro, using the H57Q and C171A/C174A mutants as controls, to define the molecular function underlying autophagosome-size regulation.
 - description: Proximity labeling (BioID/APEX) from ERdj8 at the ER-phagophore subdomain to identify its HSP70 partner(s) and Atg/lipid-synthesis machinery it engages during autophagosome formation.
+
+knowledge_gaps:
+- gap_statement: >-
+    The direct molecular activity of DNAJC16/ERdj8 is unresolved: it is not known whether
+    its J domain directly recruits and stimulates a specific HSP70 partner, whether its
+    TRX domain has redox activity, or whether these domains support autophagosome-size
+    control through another effector mechanism.
+  boundary: >-
+    ERdj8 is experimentally localized to an ER membrane subdomain and regulates
+    autophagosome size; both the DnaJ/J domain and TRX domain are required for the
+    overexpression phenotype. The missing step is the biochemical activity linking those
+    domains to the autophagosome-size readout.
+  gap_kind:
+    - BIOLOGY
+    - CURATION
+  dark_aspect: MF_DARK
+  status: OPEN
+  significance: >-
+    The gene has a solid biological-process annotation but no experimentally supported
+    molecular-function annotation. Adding HSP70 binding or TRX activity by domain
+    inference alone would overstate the evidence.
+  resolution: >-
+    In vitro ERdj8 J-domain assays for HSP70 ATPase stimulation and binding, direct
+    identification of the relevant HSP70/effector partner, and biochemical testing of
+    TRX-domain redox activity with H57Q and C174A/C177A controls.
+  provenance:
+    - reference_id: PMID:32492081
+      supporting_text: >-
+        ERdj8 overexpression extended the size of the autophagosome through its DnaJ
+        and TRX domains.
+    - reference_id: PMID:32492081
+      supporting_text: >-
+        unidentified ERdj8 effector proteins and/or BiP may play important roles in this
+        regulation.
+    - reference_id: file:human/DNAJC16/DNAJC16-notes.md
+      supporting_text: >-
+        the precise molecular function (J-domain co-chaperone activity recruiting an ER
+        Hsp70 such as BiP/HSPA5, and a redox/TRX activity) is not directly established
+- gap_statement: >-
+    The mechanism by which ERdj8-containing ER subdomains control autophagosome size and
+    large-target engulfment is not defined.
+  boundary: >-
+    ERdj8 colocalizes with PIS and autophagy-initiation machinery at a specialized ER
+    subdomain; overexpression enlarges autophagosomes, while knockdown restricts
+    engulfment of larger targets. The unresolved part is how ERdj8 organizes lipid supply,
+    Atg machinery, HSP70/effector proteins, or membrane dynamics to set phagophore size.
+  gap_kind:
+    - BIOLOGY
+  dark_aspect: RESIDUAL_SUBGAP
+  status: OPEN
+  significance: >-
+    The process term captures the phenotype but not the causal mechanism. Closing this
+    gap would explain how an ER membrane J-protein tunes autophagosome capacity for
+    large selective-autophagy cargo.
+  resolution: >-
+    Proximity labeling or interaction proteomics at ERdj8-positive ER-phagophore
+    subdomains, perturbation of candidate PIS/Atg/HSP70 effectors, and lipid-transfer
+    or membrane-growth readouts during phagophore expansion.
+  provenance:
+    - reference_id: PMID:32492081
+      supporting_text: >-
+        However, the mechanism by which autophagosome size is controlled remains
+        elusive.
+    - reference_id: PMID:32492081
+      supporting_text: >-
+        unidentified ERdj8 effector proteins and/or BiP may play important roles in this
+        regulation.

--- a/genes/human/DNAJC16/DNAJC16-ai-review.yaml
+++ b/genes/human/DNAJC16/DNAJC16-ai-review.yaml
@@ -125,7 +125,7 @@ knowledge_gaps:
   resolution: >-
     In vitro ERdj8 J-domain assays for HSP70 ATPase stimulation and binding, direct
     identification of the relevant HSP70/effector partner, and biochemical testing of
-    TRX-domain redox activity with H57Q and C174A/C177A controls.
+    TRX-domain redox activity with H57Q and C171A/C174A controls.
   provenance:
     - reference_id: PMID:32492081
       supporting_text: >-


### PR DESCRIPTION
## Summary
- add structured top-level knowledge gaps for DNAJC16 covering the unresolved ERdj8 molecular activity and autophagosome-size mechanism
- add the manual DNAJC16 notes file as local curation provenance
- render the updated DNAJC16 review HTML

## Validation
- `just validate human DNAJC16`
- `just render human DNAJC16`
- `git diff --check`