### PR TITLE
[codex] Add HSPB9 knowledge gaps

### DIFF
--- a/genes/human/HSPB9/HSPB9-ai-review.html
+++ b/genes/human/HSPB9/HSPB9-ai-review.html
@@ -1940,6 +1940,106 @@
 
 
 
+    <div class="section">
+        <h2 class="section-title">Knowledge Gaps</h2>
+        <p style="color: #555; font-size: 0.92rem; margin-top: -0.3rem;">
+            What is <em>not</em> known — curated, literature-grounded statements of the open
+            unknowns (the inverse of core functions).
+        </p>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> Whether HSPB9 is a bona fide ATP-independent small-HSP holdase chaperone, and what clients or substrates it protects, remains experimentally unresolved.</p>
+            <p style="margin-top: 0.4rem;">
+                <span class="badge">OPEN</span>
+                <span class="badge">BIOLOGY</span><span class="badge">CURATION</span>
+                <span class="badge">MF_DARK</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> HSPB9 has the alpha-crystallin/HSP20 domain and is classified as a small heat shock protein, but the only experimentally supported molecular interaction is binding to the dynein light chain TCTEL1/DYNLT1. Direct holdase, anti-aggregation, oligomerization, and client-substrate evidence is still missing for this paralog.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Significance:</strong> This is the central molecular-function gap for HSPB9. A generic chaperone or foldase term should not be propagated from small-HSP family membership until HSPB9-specific holdase activity or clients are shown.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>What would resolve it:</strong> Purified-protein holdase/anti-aggregation assays, oligomer-state analysis, and substrate/client discovery under testis-relevant stress or germ-cell conditions.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Provenance (the field's own admissions):</strong></p>
+            <ul style="margin-top: 0.2rem;">
+
+                <li><em>"HSPB9 lacks any experimental validation of chaperone activity or substrate repertoire"</em> — file:human/HSPB9/HSPB9-deep-research-falcon.md</li>
+
+                <li><em>"no studies have examined HSPB9 oligomerization status, quaternary structure, or the influence of oligomeric state on potential chaperone function"</em> — file:human/HSPB9/HSPB9-deep-research-falcon.md</li>
+
+            </ul>
+
+
+        </div>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> The functional consequence of the HSPB9-TCTEL1/DYNLT1 interaction during spermatogenesis is unknown.</p>
+            <p style="margin-top: 0.4rem;">
+                <span class="badge">OPEN</span>
+                <span class="badge">BIOLOGY</span>
+                <span class="badge">BP_DARK</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> HSPB9 and TCTEL1/DYNLT1 interact in yeast two-hybrid and co-immunoprecipitation assays and are co-expressed in similar spermatogenic stages. What the interaction does for dynein transport, sperm-cell remodeling, flagellar assembly, or fertility has not been tested.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Significance:</strong> Dynein light-chain binding is the strongest HSPB9-specific molecular-function evidence, but the biological process enabled by that binding remains undefined.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>What would resolve it:</strong> Perturb HSPB9 in spermatogenic-cell or animal models and assay TCTEL1/DYNLT1 localization, dynein-dependent transport, sperm morphology, sperm motility, and male fertility.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Provenance (the field's own admissions):</strong></p>
+            <ul style="margin-top: 0.2rem;">
+
+                <li><em>"co-expression of HSPB9 and TCTEL1 in similar stages of spermatogenesis"</em> — PMID:15503857</li>
+
+                <li><em>"The possible functional significance of this interaction is discussed."</em> — PMID:15503857</li>
+
+                <li><em>"no functional studies have validated this hypothesis"</em> — file:human/HSPB9/HSPB9-deep-research-falcon.md</li>
+
+            </ul>
+
+
+        </div>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> The significance and mechanism of HSPB9 nuclear localization are unclear.</p>
+            <p style="margin-top: 0.4rem;">
+                <span class="badge">OPEN</span>
+                <span class="badge">BIOLOGY</span>
+                <span class="badge">CC_DARK</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> HSPB9 is experimentally observed in both cytoplasm and nucleus and can translocate to nuclear foci during heat shock, but it lacks a canonical nuclear-localization signal and no nuclear partner, import mechanism, or nuclear function has been established.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Significance:</strong> The localization annotations are well supported, but without a mechanism or nuclear role they do not explain whether HSPB9 acts as a stress-responsive nuclear chaperone, a partner-transported adaptor, or a non-chaperone binding protein.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>What would resolve it:</strong> Map the determinants of nuclear import and heat-shock foci formation, identify nuclear binding partners, and compare HSPB9-dependent phenotypes in nuclear versus cytoplasmic compartments.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Provenance (the field's own admissions):</strong></p>
+            <ul style="margin-top: 0.2rem;">
+
+                <li><em>"Note=Translocates to nuclear foci during heat shock."</em> — file:human/HSPB9/HSPB9-uniprot.txt</li>
+
+                <li><em>"HSPB9 lacks a canonical nuclear localization signal (NLS), suggesting that its nuclear translocation may depend on interaction with other proteins"</em> — file:human/HSPB9/HSPB9-deep-research-falcon.md</li>
+
+                <li><em>"the functional significance of nuclear versus cytoplasmic localization remains unexplored"</em> — file:human/HSPB9/HSPB9-deep-research-falcon.md</li>
+
+            </ul>
+
+
+        </div>
+
+    </div>
+
 
 
 
@@ -2709,6 +2809,96 @@ suggested_experiments:
     to test whether HSPB9 modulates dynein light chain TCTEL1/DYNLT1 function or localization.
 - description: Generation of HSPB9-null models to assess effects on spermatogenesis,
     sperm motility, and male fertility.
+
+knowledge_gaps:
+- gap_statement: &gt;-
+    Whether HSPB9 is a bona fide ATP-independent small-HSP holdase chaperone, and what
+    clients or substrates it protects, remains experimentally unresolved.
+  boundary: &gt;-
+    HSPB9 has the alpha-crystallin/HSP20 domain and is classified as a small heat
+    shock protein, but the only experimentally supported molecular interaction is
+    binding to the dynein light chain TCTEL1/DYNLT1. Direct holdase, anti-aggregation,
+    oligomerization, and client-substrate evidence is still missing for this paralog.
+  gap_kind:
+    - BIOLOGY
+    - CURATION
+  dark_aspect: MF_DARK
+  status: OPEN
+  significance: &gt;-
+    This is the central molecular-function gap for HSPB9. A generic chaperone or
+    foldase term should not be propagated from small-HSP family membership until
+    HSPB9-specific holdase activity or clients are shown.
+  resolution: &gt;-
+    Purified-protein holdase/anti-aggregation assays, oligomer-state analysis, and
+    substrate/client discovery under testis-relevant stress or germ-cell conditions.
+  provenance:
+    - reference_id: file:human/HSPB9/HSPB9-deep-research-falcon.md
+      supporting_text: &gt;-
+        HSPB9 lacks any experimental validation of chaperone activity or substrate
+        repertoire
+    - reference_id: file:human/HSPB9/HSPB9-deep-research-falcon.md
+      supporting_text: &gt;-
+        no studies have examined HSPB9 oligomerization status, quaternary structure,
+        or the influence of oligomeric state on potential chaperone function
+- gap_statement: &gt;-
+    The functional consequence of the HSPB9-TCTEL1/DYNLT1 interaction during
+    spermatogenesis is unknown.
+  boundary: &gt;-
+    HSPB9 and TCTEL1/DYNLT1 interact in yeast two-hybrid and co-immunoprecipitation
+    assays and are co-expressed in similar spermatogenic stages. What the interaction
+    does for dynein transport, sperm-cell remodeling, flagellar assembly, or fertility
+    has not been tested.
+  gap_kind:
+    - BIOLOGY
+  dark_aspect: BP_DARK
+  status: OPEN
+  significance: &gt;-
+    Dynein light-chain binding is the strongest HSPB9-specific molecular-function
+    evidence, but the biological process enabled by that binding remains undefined.
+  resolution: &gt;-
+    Perturb HSPB9 in spermatogenic-cell or animal models and assay TCTEL1/DYNLT1
+    localization, dynein-dependent transport, sperm morphology, sperm motility, and
+    male fertility.
+  provenance:
+    - reference_id: PMID:15503857
+      supporting_text: &gt;-
+        co-expression of HSPB9 and TCTEL1 in similar stages of spermatogenesis
+    - reference_id: PMID:15503857
+      supporting_text: The possible functional significance of this interaction is discussed.
+    - reference_id: file:human/HSPB9/HSPB9-deep-research-falcon.md
+      supporting_text: &gt;-
+        no functional studies have validated this hypothesis
+- gap_statement: &gt;-
+    The significance and mechanism of HSPB9 nuclear localization are unclear.
+  boundary: &gt;-
+    HSPB9 is experimentally observed in both cytoplasm and nucleus and can translocate
+    to nuclear foci during heat shock, but it lacks a canonical nuclear-localization
+    signal and no nuclear partner, import mechanism, or nuclear function has been
+    established.
+  gap_kind:
+    - BIOLOGY
+  dark_aspect: CC_DARK
+  status: OPEN
+  significance: &gt;-
+    The localization annotations are well supported, but without a mechanism or
+    nuclear role they do not explain whether HSPB9 acts as a stress-responsive
+    nuclear chaperone, a partner-transported adaptor, or a non-chaperone binding
+    protein.
+  resolution: &gt;-
+    Map the determinants of nuclear import and heat-shock foci formation, identify
+    nuclear binding partners, and compare HSPB9-dependent phenotypes in nuclear versus
+    cytoplasmic compartments.
+  provenance:
+    - reference_id: file:human/HSPB9/HSPB9-uniprot.txt
+      supporting_text: Note=Translocates to nuclear foci during heat shock.
+    - reference_id: file:human/HSPB9/HSPB9-deep-research-falcon.md
+      supporting_text: &gt;-
+        HSPB9 lacks a canonical nuclear localization signal (NLS), suggesting that its
+        nuclear translocation may depend on interaction with other proteins
+    - reference_id: file:human/HSPB9/HSPB9-deep-research-falcon.md
+      supporting_text: &gt;-
+        the functional significance of nuclear versus cytoplasmic localization remains
+        unexplored
 </code></pre>
             </div>
         </details>

--- a/genes/human/HSPB9/HSPB9-ai-review.yaml
+++ b/genes/human/HSPB9/HSPB9-ai-review.yaml
@@ -301,3 +301,93 @@ suggested_experiments:
     to test whether HSPB9 modulates dynein light chain TCTEL1/DYNLT1 function or localization.
 - description: Generation of HSPB9-null models to assess effects on spermatogenesis,
     sperm motility, and male fertility.
+
+knowledge_gaps:
+- gap_statement: >-
+    Whether HSPB9 is a bona fide ATP-independent small-HSP holdase chaperone, and what
+    clients or substrates it protects, remains experimentally unresolved.
+  boundary: >-
+    HSPB9 has the alpha-crystallin/HSP20 domain and is classified as a small heat
+    shock protein, but the only experimentally supported molecular interaction is
+    binding to the dynein light chain TCTEL1/DYNLT1. Direct holdase, anti-aggregation,
+    oligomerization, and client-substrate evidence is still missing for this paralog.
+  gap_kind:
+    - BIOLOGY
+    - CURATION
+  dark_aspect: MF_DARK
+  status: OPEN
+  significance: >-
+    This is the central molecular-function gap for HSPB9. A generic chaperone or
+    foldase term should not be propagated from small-HSP family membership until
+    HSPB9-specific holdase activity or clients are shown.
+  resolution: >-
+    Purified-protein holdase/anti-aggregation assays, oligomer-state analysis, and
+    substrate/client discovery under testis-relevant stress or germ-cell conditions.
+  provenance:
+    - reference_id: file:human/HSPB9/HSPB9-deep-research-falcon.md
+      supporting_text: >-
+        HSPB9 lacks any experimental validation of chaperone activity or substrate
+        repertoire
+    - reference_id: file:human/HSPB9/HSPB9-deep-research-falcon.md
+      supporting_text: >-
+        no studies have examined HSPB9 oligomerization status, quaternary structure,
+        or the influence of oligomeric state on potential chaperone function
+- gap_statement: >-
+    The functional consequence of the HSPB9-TCTEL1/DYNLT1 interaction during
+    spermatogenesis is unknown.
+  boundary: >-
+    HSPB9 and TCTEL1/DYNLT1 interact in yeast two-hybrid and co-immunoprecipitation
+    assays and are co-expressed in similar spermatogenic stages. What the interaction
+    does for dynein transport, sperm-cell remodeling, flagellar assembly, or fertility
+    has not been tested.
+  gap_kind:
+    - BIOLOGY
+  dark_aspect: BP_DARK
+  status: OPEN
+  significance: >-
+    Dynein light-chain binding is the strongest HSPB9-specific molecular-function
+    evidence, but the biological process enabled by that binding remains undefined.
+  resolution: >-
+    Perturb HSPB9 in spermatogenic-cell or animal models and assay TCTEL1/DYNLT1
+    localization, dynein-dependent transport, sperm morphology, sperm motility, and
+    male fertility.
+  provenance:
+    - reference_id: PMID:15503857
+      supporting_text: >-
+        co-expression of HSPB9 and TCTEL1 in similar stages of spermatogenesis
+    - reference_id: PMID:15503857
+      supporting_text: The possible functional significance of this interaction is discussed.
+    - reference_id: file:human/HSPB9/HSPB9-deep-research-falcon.md
+      supporting_text: >-
+        no functional studies have validated this hypothesis
+- gap_statement: >-
+    The significance and mechanism of HSPB9 nuclear localization are unclear.
+  boundary: >-
+    HSPB9 is experimentally observed in both cytoplasm and nucleus and can translocate
+    to nuclear foci during heat shock, but it lacks a canonical nuclear-localization
+    signal and no nuclear partner, import mechanism, or nuclear function has been
+    established.
+  gap_kind:
+    - BIOLOGY
+  dark_aspect: CC_DARK
+  status: OPEN
+  significance: >-
+    The localization annotations are well supported, but without a mechanism or
+    nuclear role they do not explain whether HSPB9 acts as a stress-responsive
+    nuclear chaperone, a partner-transported adaptor, or a non-chaperone binding
+    protein.
+  resolution: >-
+    Map the determinants of nuclear import and heat-shock foci formation, identify
+    nuclear binding partners, and compare HSPB9-dependent phenotypes in nuclear versus
+    cytoplasmic compartments.
+  provenance:
+    - reference_id: file:human/HSPB9/HSPB9-uniprot.txt
+      supporting_text: Note=Translocates to nuclear foci during heat shock.
+    - reference_id: file:human/HSPB9/HSPB9-deep-research-falcon.md
+      supporting_text: >-
+        HSPB9 lacks a canonical nuclear localization signal (NLS), suggesting that its
+        nuclear translocation may depend on interaction with other proteins
+    - reference_id: file:human/HSPB9/HSPB9-deep-research-falcon.md
+      supporting_text: >-
+        the functional significance of nuclear versus cytoplasmic localization remains
+        unexplored


### PR DESCRIPTION
## Summary
- add structured top-level knowledge gaps for HSPB9 covering unvalidated holdase/client activity, the unresolved DYNLT1-linked spermatogenesis role, and unclear nuclear localization mechanism
- render the updated HSPB9 review HTML

## Validation
- `just validate human HSPB9`
- `just render human HSPB9`
- `git diff --check`