### PR TITLE
[codex] Add DNAJC28 knowledge gaps

### DIFF
--- a/genes/human/DNAJC28/DNAJC28-ai-review.html
+++ b/genes/human/DNAJC28/DNAJC28-ai-review.html
@@ -1162,6 +1162,45 @@
 
             </div>
 
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        file:human/DNAJC28/DNAJC28-notes.md
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Manual DNAJC28 curation notes</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">Records the core unresolved experimental gap for DNAJC28: no direct assay has established co-chaperone activity, substrate, or compartment of action.</div>
+
+                        <div class="finding-text">"No experimental characterization of co-chaperone (HSP70 ATPase-stimulating) activity, substrate, or compartment of action."</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <div class="finding-statement">Records that the mitochondrial localization hypothesis is sequence-based and has not been experimentally confirmed.</div>
+
+                        <div class="finding-text">"this is a prediction, not experimentally confirmed in the UniProt record."</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <div class="finding-statement">Records that the phylogenetically transferred temperature-homeostasis process annotation has no reliable DNAJC28-specific evidence.</div>
+
+                        <div class="finding-text">"No reliable evidence for &#34;temperature homeostasis&#34; as a specific function."</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
         </div>
     </div>
 
@@ -1255,6 +1294,104 @@
     </div>
 
 
+
+    <div class="section">
+        <h2 class="section-title">Knowledge Gaps</h2>
+        <p style="color: #555; font-size: 0.92rem; margin-top: -0.3rem;">
+            What is <em>not</em> known — curated, literature-grounded statements of the open
+            unknowns (the inverse of core functions).
+        </p>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> DNAJC28&#39;s direct HSP70 co-chaperone activity, obligate HSP70 partner, and client substrates have not been experimentally established.</p>
+            <p style="margin-top: 0.4rem;">
+                <span class="badge">OPEN</span>
+                <span class="badge">BIOLOGY</span><span class="badge">CURATION</span>
+                <span class="badge">MF_DARK</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> The J-domain is structurally competent, with an intact conserved HPD motif and an HSP70-interaction surface consistent with co-chaperone function. This supports inferred protein-folding chaperone binding, but it does not identify the partner HSP70, demonstrate ATPase stimulation, or reveal client proteins.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Significance:</strong> DNAJC28&#39;s current molecular function is domain-inferred. Closing this gap would determine whether the protein is an active HSP70 co-chaperone and which chaperone system it belongs to.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>What would resolve it:</strong> Test recombinant DNAJC28 in HSP70 ATPase-stimulation and binding assays against candidate HSP70s, including HSPA9/mortalin if mitochondrial targeting is confirmed, and identify candidate clients by interaction proteomics.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Provenance (the field's own admissions):</strong></p>
+            <ul style="margin-top: 0.2rem;">
+
+                <li><em>"DNAJC28 is a structurally competent Hsp70 co-chaperone, not a degenerate J-domain protein."</em> — file:human/DNAJC28/DNAJC28-hypotheses/jdomain-hpd-motif/openscientist.md</li>
+
+                <li><em>"no direct biochemical assay of DNAJC28-stimulated Hsp70 ATPase activity has been published."</em> — file:human/DNAJC28/DNAJC28-hypotheses/jdomain-hpd-motif/openscientist.md</li>
+
+                <li><em>"No experimental characterization of co-chaperone (HSP70 ATPase-stimulating) activity, substrate, or compartment of action."</em> — file:human/DNAJC28/DNAJC28-notes.md</li>
+
+            </ul>
+
+
+        </div>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> DNAJC28&#39;s compartment of action is unresolved.</p>
+            <p style="margin-top: 0.4rem;">
+                <span class="badge">OPEN</span>
+                <span class="badge">BIOLOGY</span><span class="badge">CURATION</span>
+                <span class="badge">CC_DARK</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> Sequence features suggest a mitochondrial-targeting presequence, while project-level proteostasis placement has treated it as an ER/HSP70-system J-domain protein. Neither mitochondrial nor ER localization has been experimentally demonstrated for DNAJC28.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Significance:</strong> The compartment determines which HSP70 partner and client pathway are plausible. A mitochondrial DNAJC28 would imply a different chaperone system than an ER proteostasis assignment.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>What would resolve it:</strong> Fluorescent-protein localization, organelle fractionation, protease-protection/import assays, and N-terminal presequence deletion or mutation experiments.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Provenance (the field's own admissions):</strong></p>
+            <ul style="margin-top: 0.2rem;">
+
+                <li><em>"N-terminus (MNTMYVMMAQ ILRSHLIKAT VIPNRVKMLP...) resembles a mitochondrial-targeting presequence"</em> — file:human/DNAJC28/DNAJC28-notes.md</li>
+
+                <li><em>"this is a prediction, not experimentally confirmed in the UniProt record."</em> — file:human/DNAJC28/DNAJC28-notes.md</li>
+
+            </ul>
+
+
+        </div>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> No DNAJC28-specific cellular process or physiological role has been established.</p>
+            <p style="margin-top: 0.4rem;">
+                <span class="badge">OPEN</span>
+                <span class="badge">BIOLOGY</span>
+                <span class="badge">BP_DARK</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> The current GOA process annotation to temperature homeostasis is marked as over-annotated, and the single ASC/PYCARD protein-binding record is non-core. Expression and phosphorylation are recorded, but they do not define a process.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Significance:</strong> Without a cellular-process anchor, DNAJC28 remains an uncharacterized J-domain protein with a plausible molecular activity but no demonstrated biological role.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>What would resolve it:</strong> Loss-of-function and rescue experiments in cells or organisms, prioritized after compartment and HSP70-partner identification, with readouts chosen for the confirmed organelle and client pathway.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Provenance (the field's own admissions):</strong></p>
+            <ul style="margin-top: 0.2rem;">
+
+                <li><em>"No reliable evidence for &#34;temperature homeostasis&#34; as a specific function."</em> — file:human/DNAJC28/DNAJC28-notes.md</li>
+
+                <li><em>"No experimental characterization of co-chaperone (HSP70 ATPase-stimulating) activity, substrate, or compartment of action."</em> — file:human/DNAJC28/DNAJC28-notes.md</li>
+
+            </ul>
+
+
+        </div>
+
+    </div>
 
 
 
@@ -2069,6 +2206,23 @@ references:
       vertebrate orthologs; it is not a degenerate pseudo-co-chaperone. Caveat - no
       direct Hsp70 ATPase-stimulation assay has been published.
     supporting_text: DNAJC28 is a structurally competent Hsp70 co-chaperone, not a degenerate J-domain protein.
+- id: file:human/DNAJC28/DNAJC28-notes.md
+  title: Manual DNAJC28 curation notes
+  findings:
+  - statement: &gt;-
+      Records the core unresolved experimental gap for DNAJC28: no direct assay has
+      established co-chaperone activity, substrate, or compartment of action.
+    supporting_text: &gt;-
+      No experimental characterization of co-chaperone (HSP70 ATPase-stimulating)
+      activity, substrate, or compartment of action.
+  - statement: &gt;-
+      Records that the mitochondrial localization hypothesis is sequence-based and
+      has not been experimentally confirmed.
+    supporting_text: this is a prediction, not experimentally confirmed in the UniProt record.
+  - statement: &gt;-
+      Records that the phylogenetically transferred temperature-homeostasis process
+      annotation has no reliable DNAJC28-specific evidence.
+    supporting_text: No reliable evidence for &#34;temperature homeostasis&#34; as a specific function.
 core_functions:
 - description: J-domain (HSP40) co-chaperone. The J domain is structurally confirmed
     competent (intact HPD motif and canonical fold; sub-2 Angstrom RMSD to the Hsp70
@@ -2098,6 +2252,91 @@ suggested_experiments:
     HPD-motif mutant) to test whether the J domain is a functional co-chaperone.
 - description: Affinity purification-mass spectrometry of DNAJC28 to identify its chaperone
     partners and candidate clients beyond the single reported ASC interaction.
+
+knowledge_gaps:
+- gap_statement: &gt;-
+    DNAJC28&#39;s direct HSP70 co-chaperone activity, obligate HSP70 partner, and client
+    substrates have not been experimentally established.
+  boundary: &gt;-
+    The J-domain is structurally competent, with an intact conserved HPD motif and an
+    HSP70-interaction surface consistent with co-chaperone function. This supports
+    inferred protein-folding chaperone binding, but it does not identify the partner
+    HSP70, demonstrate ATPase stimulation, or reveal client proteins.
+  gap_kind:
+    - BIOLOGY
+    - CURATION
+  dark_aspect: MF_DARK
+  status: OPEN
+  significance: &gt;-
+    DNAJC28&#39;s current molecular function is domain-inferred. Closing this gap would
+    determine whether the protein is an active HSP70 co-chaperone and which chaperone
+    system it belongs to.
+  resolution: &gt;-
+    Test recombinant DNAJC28 in HSP70 ATPase-stimulation and binding assays against
+    candidate HSP70s, including HSPA9/mortalin if mitochondrial targeting is confirmed,
+    and identify candidate clients by interaction proteomics.
+  provenance:
+    - reference_id: file:human/DNAJC28/DNAJC28-hypotheses/jdomain-hpd-motif/openscientist.md
+      supporting_text: &gt;-
+        DNAJC28 is a structurally competent Hsp70 co-chaperone, not a degenerate J-domain
+        protein.
+    - reference_id: file:human/DNAJC28/DNAJC28-hypotheses/jdomain-hpd-motif/openscientist.md
+      supporting_text: &gt;-
+        no direct biochemical assay of DNAJC28-stimulated Hsp70 ATPase activity has been
+        published.
+    - reference_id: file:human/DNAJC28/DNAJC28-notes.md
+      supporting_text: &gt;-
+        No experimental characterization of co-chaperone (HSP70 ATPase-stimulating)
+        activity, substrate, or compartment of action.
+- gap_statement: &gt;-
+    DNAJC28&#39;s compartment of action is unresolved.
+  boundary: &gt;-
+    Sequence features suggest a mitochondrial-targeting presequence, while project-level
+    proteostasis placement has treated it as an ER/HSP70-system J-domain protein. Neither
+    mitochondrial nor ER localization has been experimentally demonstrated for DNAJC28.
+  gap_kind:
+    - BIOLOGY
+    - CURATION
+  dark_aspect: CC_DARK
+  status: OPEN
+  significance: &gt;-
+    The compartment determines which HSP70 partner and client pathway are plausible.
+    A mitochondrial DNAJC28 would imply a different chaperone system than an ER
+    proteostasis assignment.
+  resolution: &gt;-
+    Fluorescent-protein localization, organelle fractionation, protease-protection/import
+    assays, and N-terminal presequence deletion or mutation experiments.
+  provenance:
+    - reference_id: file:human/DNAJC28/DNAJC28-notes.md
+      supporting_text: &gt;-
+        N-terminus (MNTMYVMMAQ ILRSHLIKAT VIPNRVKMLP...) resembles a mitochondrial-targeting
+        presequence
+    - reference_id: file:human/DNAJC28/DNAJC28-notes.md
+      supporting_text: this is a prediction, not experimentally confirmed in the UniProt record.
+- gap_statement: &gt;-
+    No DNAJC28-specific cellular process or physiological role has been established.
+  boundary: &gt;-
+    The current GOA process annotation to temperature homeostasis is marked as
+    over-annotated, and the single ASC/PYCARD protein-binding record is non-core.
+    Expression and phosphorylation are recorded, but they do not define a process.
+  gap_kind:
+    - BIOLOGY
+  dark_aspect: BP_DARK
+  status: OPEN
+  significance: &gt;-
+    Without a cellular-process anchor, DNAJC28 remains an uncharacterized J-domain
+    protein with a plausible molecular activity but no demonstrated biological role.
+  resolution: &gt;-
+    Loss-of-function and rescue experiments in cells or organisms, prioritized after
+    compartment and HSP70-partner identification, with readouts chosen for the confirmed
+    organelle and client pathway.
+  provenance:
+    - reference_id: file:human/DNAJC28/DNAJC28-notes.md
+      supporting_text: No reliable evidence for &#34;temperature homeostasis&#34; as a specific function.
+    - reference_id: file:human/DNAJC28/DNAJC28-notes.md
+      supporting_text: &gt;-
+        No experimental characterization of co-chaperone (HSP70 ATPase-stimulating)
+        activity, substrate, or compartment of action.
 </code></pre>
             </div>
         </details>

--- a/genes/human/DNAJC28/DNAJC28-ai-review.yaml
+++ b/genes/human/DNAJC28/DNAJC28-ai-review.yaml
@@ -77,6 +77,23 @@ references:
       vertebrate orthologs; it is not a degenerate pseudo-co-chaperone. Caveat - no
       direct Hsp70 ATPase-stimulation assay has been published.
     supporting_text: DNAJC28 is a structurally competent Hsp70 co-chaperone, not a degenerate J-domain protein.
+- id: file:human/DNAJC28/DNAJC28-notes.md
+  title: Manual DNAJC28 curation notes
+  findings:
+  - statement: >-
+      Records the core unresolved experimental gap for DNAJC28: no direct assay has
+      established co-chaperone activity, substrate, or compartment of action.
+    supporting_text: >-
+      No experimental characterization of co-chaperone (HSP70 ATPase-stimulating)
+      activity, substrate, or compartment of action.
+  - statement: >-
+      Records that the mitochondrial localization hypothesis is sequence-based and
+      has not been experimentally confirmed.
+    supporting_text: this is a prediction, not experimentally confirmed in the UniProt record.
+  - statement: >-
+      Records that the phylogenetically transferred temperature-homeostasis process
+      annotation has no reliable DNAJC28-specific evidence.
+    supporting_text: No reliable evidence for "temperature homeostasis" as a specific function.
 core_functions:
 - description: J-domain (HSP40) co-chaperone. The J domain is structurally confirmed
     competent (intact HPD motif and canonical fold; sub-2 Angstrom RMSD to the Hsp70
@@ -106,3 +123,88 @@ suggested_experiments:
     HPD-motif mutant) to test whether the J domain is a functional co-chaperone.
 - description: Affinity purification-mass spectrometry of DNAJC28 to identify its chaperone
     partners and candidate clients beyond the single reported ASC interaction.
+
+knowledge_gaps:
+- gap_statement: >-
+    DNAJC28's direct HSP70 co-chaperone activity, obligate HSP70 partner, and client
+    substrates have not been experimentally established.
+  boundary: >-
+    The J-domain is structurally competent, with an intact conserved HPD motif and an
+    HSP70-interaction surface consistent with co-chaperone function. This supports
+    inferred protein-folding chaperone binding, but it does not identify the partner
+    HSP70, demonstrate ATPase stimulation, or reveal client proteins.
+  gap_kind:
+    - BIOLOGY
+    - CURATION
+  dark_aspect: MF_DARK
+  status: OPEN
+  significance: >-
+    DNAJC28's current molecular function is domain-inferred. Closing this gap would
+    determine whether the protein is an active HSP70 co-chaperone and which chaperone
+    system it belongs to.
+  resolution: >-
+    Test recombinant DNAJC28 in HSP70 ATPase-stimulation and binding assays against
+    candidate HSP70s, including HSPA9/mortalin if mitochondrial targeting is confirmed,
+    and identify candidate clients by interaction proteomics.
+  provenance:
+    - reference_id: file:human/DNAJC28/DNAJC28-hypotheses/jdomain-hpd-motif/openscientist.md
+      supporting_text: >-
+        DNAJC28 is a structurally competent Hsp70 co-chaperone, not a degenerate J-domain
+        protein.
+    - reference_id: file:human/DNAJC28/DNAJC28-hypotheses/jdomain-hpd-motif/openscientist.md
+      supporting_text: >-
+        no direct biochemical assay of DNAJC28-stimulated Hsp70 ATPase activity has been
+        published.
+    - reference_id: file:human/DNAJC28/DNAJC28-notes.md
+      supporting_text: >-
+        No experimental characterization of co-chaperone (HSP70 ATPase-stimulating)
+        activity, substrate, or compartment of action.
+- gap_statement: >-
+    DNAJC28's compartment of action is unresolved.
+  boundary: >-
+    Sequence features suggest a mitochondrial-targeting presequence, while project-level
+    proteostasis placement has treated it as an ER/HSP70-system J-domain protein. Neither
+    mitochondrial nor ER localization has been experimentally demonstrated for DNAJC28.
+  gap_kind:
+    - BIOLOGY
+    - CURATION
+  dark_aspect: CC_DARK
+  status: OPEN
+  significance: >-
+    The compartment determines which HSP70 partner and client pathway are plausible.
+    A mitochondrial DNAJC28 would imply a different chaperone system than an ER
+    proteostasis assignment.
+  resolution: >-
+    Fluorescent-protein localization, organelle fractionation, protease-protection/import
+    assays, and N-terminal presequence deletion or mutation experiments.
+  provenance:
+    - reference_id: file:human/DNAJC28/DNAJC28-notes.md
+      supporting_text: >-
+        N-terminus (MNTMYVMMAQ ILRSHLIKAT VIPNRVKMLP...) resembles a mitochondrial-targeting
+        presequence
+    - reference_id: file:human/DNAJC28/DNAJC28-notes.md
+      supporting_text: this is a prediction, not experimentally confirmed in the UniProt record.
+- gap_statement: >-
+    No DNAJC28-specific cellular process or physiological role has been established.
+  boundary: >-
+    The current GOA process annotation to temperature homeostasis is marked as
+    over-annotated, and the single ASC/PYCARD protein-binding record is non-core.
+    Expression and phosphorylation are recorded, but they do not define a process.
+  gap_kind:
+    - BIOLOGY
+  dark_aspect: BP_DARK
+  status: OPEN
+  significance: >-
+    Without a cellular-process anchor, DNAJC28 remains an uncharacterized J-domain
+    protein with a plausible molecular activity but no demonstrated biological role.
+  resolution: >-
+    Loss-of-function and rescue experiments in cells or organisms, prioritized after
+    compartment and HSP70-partner identification, with readouts chosen for the confirmed
+    organelle and client pathway.
+  provenance:
+    - reference_id: file:human/DNAJC28/DNAJC28-notes.md
+      supporting_text: No reliable evidence for "temperature homeostasis" as a specific function.
+    - reference_id: file:human/DNAJC28/DNAJC28-notes.md
+      supporting_text: >-
+        No experimental characterization of co-chaperone (HSP70 ATPase-stimulating)
+        activity, substrate, or compartment of action.


### PR DESCRIPTION
## Summary
- add structured top-level knowledge gaps for DNAJC28 covering unresolved HSP70 co-chaperone biochemistry, compartment of action, and cellular-process evidence
- add manual DNAJC28 notes as local provenance
- render the updated DNAJC28 review HTML

## Validation
- `just validate human DNAJC28` (passes with two non-blocking pre-existing best-practice warnings)
- `just render human DNAJC28`
- `git diff --check`