### PR TITLE
[codex] Add KIAA1614 knowledge gaps

### DIFF
--- a/genes/human/KIAA1614/KIAA1614-ai-review.html
+++ b/genes/human/KIAA1614/KIAA1614-ai-review.html
@@ -1373,6 +1373,104 @@
 
 
 
+    <div class="section">
+        <h2 class="section-title">Knowledge Gaps</h2>
+        <p style="color: #555; font-size: 0.92rem; margin-top: -0.3rem;">
+            What is <em>not</em> known — curated, literature-grounded statements of the open
+            unknowns (the inverse of core functions).
+        </p>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> KIAA1614 has no experimentally established molecular function or interaction partners.</p>
+            <p style="margin-top: 0.4rem;">
+                <span class="badge">OPEN</span>
+                <span class="badge">BIOLOGY</span><span class="badge">CURATION</span>
+                <span class="badge">MF_DARK</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> KIAA1614 is a real human protein with DUF4685 and PAR6_homolog domain annotations. These domains support only hypotheses about adaptor or polarity-scaffold behavior; they do not establish biochemical activity, binding partners, or functional equivalence to canonical Par6 proteins.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Significance:</strong> All current process and localization annotations rest on phylogenetic/domain inference. Without a direct molecular activity or partner set, KIAA1614 remains function-unknown despite several plausible Par6-related hypotheses.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>What would resolve it:</strong> Affinity/proximity proteomics, co-IP against Par3/Par6/aPKC and other polarity factors, DUF4685/PAR6_homolog domain-deletion rescue, and structural/biochemical assays for conserved binding surfaces.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Provenance (the field's own admissions):</strong></p>
+            <ul style="margin-top: 0.2rem;">
+
+                <li><em>"KIAA1614 (UniProt Q5VZ46) encodes an uncharacterized human protein originally identified via large-scale cDNA sequencing. The protein currently lacks an experimentally validated molecular function and pathway assignment."</em> — file:human/KIAA1614/KIAA1614-deep-research-falcon.md</li>
+
+                <li><em>"DUF4685 (PF15737; InterPro IPR032756) is a Domain of Unknown Function; by definition, it has no established, conserved biochemical activity."</em> — file:human/KIAA1614/KIAA1614-deep-research-falcon.md</li>
+
+                <li><em>"No directly citable 2023–2024 primary studies conclusively define KIAA1614 protein function, localization, or interaction partners."</em> — file:human/KIAA1614/KIAA1614-deep-research-falcon.md</li>
+
+            </ul>
+
+
+        </div>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> KIAA1614 subcellular localization is unresolved.</p>
+            <p style="margin-top: 0.4rem;">
+                <span class="badge">OPEN</span>
+                <span class="badge">BIOLOGY</span><span class="badge">CURATION</span>
+                <span class="badge">CC_DARK</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> IBA annotations place KIAA1614 at the cell cortex, nucleus, and apical plasma membrane by transfer from related proteins, while other predicted resources suggest P-body localization. No validated antibody, microscopy, or endogenous tagging data establish where KIAA1614 acts.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Significance:</strong> The predicted polarity-scaffold hypothesis requires compartmental evidence. The difference between cortical/junctional, nuclear, apical-membrane, and P-body localization changes the plausible mechanism completely.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>What would resolve it:</strong> Endogenous tagging or validated-antibody imaging in polarized epithelial and retinal cell contexts, with orthogonal fractionation and perturbation of candidate domain determinants.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Provenance (the field's own admissions):</strong></p>
+            <ul style="margin-top: 0.2rem;">
+
+                <li><em>"Subcellular localization - Unresolved. Without validated antibodies and microscopy or tagged endogenous expression data, subcellular distribution is uncertain."</em> — file:human/KIAA1614/KIAA1614-deep-research-falcon.md</li>
+
+                <li><em>"If a polarity-related role exists, membrane-proximal/cortical or junctional localization would be plausible, but this is hypothetical."</em> — file:human/KIAA1614/KIAA1614-deep-research-falcon.md</li>
+
+            </ul>
+
+
+        </div>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> KIAA1614 has no validated pathway or biological-process assignment.</p>
+            <p style="margin-top: 0.4rem;">
+                <span class="badge">OPEN</span>
+                <span class="badge">BIOLOGY</span><span class="badge">CURATION</span>
+                <span class="badge">BP_DARK</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> The PAR6_homolog domain makes cell-polarity or centrosome-related hypotheses plausible, but existing GO process annotations are undecided because no experiment connects KIAA1614 to polarity complexes, centrosome biology, cellular localization, or any other pathway.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Significance:</strong> This is the process-level consequence of the MF and CC gaps: the gene cannot be confidently placed in a pathway until its molecular partners and site of action are known.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>What would resolve it:</strong> CRISPR perturbation and rescue in relevant cells, assaying epithelial polarity, junctional integrity, centrosome-cycle phenotypes, and any phenotype tied to validated KIAA1614 interaction partners.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Provenance (the field's own admissions):</strong></p>
+            <ul style="margin-top: 0.2rem;">
+
+                <li><em>"Pathways and interactions - Unresolved. No validated pathway membership can be assigned at this time."</em> — file:human/KIAA1614/KIAA1614-deep-research-falcon.md</li>
+
+                <li><em>"If the PAR6_homolog annotation reflects genuine homology, KIAA1614 may participate in cell polarity/signaling scaffolds."</em> — file:human/KIAA1614/KIAA1614-deep-research-falcon.md</li>
+
+            </ul>
+
+
+        </div>
+
+    </div>
+
 
 
 
@@ -2033,6 +2131,101 @@ references:
 - id: file:human/KIAA1614/KIAA1614-deep-research-cyberian.md
   title: Cyberian deep research on KIAA1614 function
   findings: []
+
+knowledge_gaps:
+- gap_statement: &gt;-
+    KIAA1614 has no experimentally established molecular function or interaction
+    partners.
+  boundary: &gt;-
+    KIAA1614 is a real human protein with DUF4685 and PAR6_homolog domain annotations.
+    These domains support only hypotheses about adaptor or polarity-scaffold behavior;
+    they do not establish biochemical activity, binding partners, or functional
+    equivalence to canonical Par6 proteins.
+  gap_kind:
+    - BIOLOGY
+    - CURATION
+  dark_aspect: MF_DARK
+  status: OPEN
+  significance: &gt;-
+    All current process and localization annotations rest on phylogenetic/domain
+    inference. Without a direct molecular activity or partner set, KIAA1614 remains
+    function-unknown despite several plausible Par6-related hypotheses.
+  resolution: &gt;-
+    Affinity/proximity proteomics, co-IP against Par3/Par6/aPKC and other polarity
+    factors, DUF4685/PAR6_homolog domain-deletion rescue, and structural/biochemical
+    assays for conserved binding surfaces.
+  provenance:
+    - reference_id: file:human/KIAA1614/KIAA1614-deep-research-falcon.md
+      supporting_text: &gt;-
+        KIAA1614 (UniProt Q5VZ46) encodes an uncharacterized human protein originally
+        identified via large-scale cDNA sequencing. The protein currently lacks an
+        experimentally validated molecular function and pathway assignment.
+    - reference_id: file:human/KIAA1614/KIAA1614-deep-research-falcon.md
+      supporting_text: &gt;-
+        DUF4685 (PF15737; InterPro IPR032756) is a Domain of Unknown Function; by
+        definition, it has no established, conserved biochemical activity.
+    - reference_id: file:human/KIAA1614/KIAA1614-deep-research-falcon.md
+      supporting_text: &gt;-
+        No directly citable 2023–2024 primary studies conclusively define KIAA1614
+        protein function, localization, or interaction partners.
+- gap_statement: &gt;-
+    KIAA1614 subcellular localization is unresolved.
+  boundary: &gt;-
+    IBA annotations place KIAA1614 at the cell cortex, nucleus, and apical plasma
+    membrane by transfer from related proteins, while other predicted resources suggest
+    P-body localization. No validated antibody, microscopy, or endogenous tagging data
+    establish where KIAA1614 acts.
+  gap_kind:
+    - BIOLOGY
+    - CURATION
+  dark_aspect: CC_DARK
+  status: OPEN
+  significance: &gt;-
+    The predicted polarity-scaffold hypothesis requires compartmental evidence. The
+    difference between cortical/junctional, nuclear, apical-membrane, and P-body
+    localization changes the plausible mechanism completely.
+  resolution: &gt;-
+    Endogenous tagging or validated-antibody imaging in polarized epithelial and retinal
+    cell contexts, with orthogonal fractionation and perturbation of candidate domain
+    determinants.
+  provenance:
+    - reference_id: file:human/KIAA1614/KIAA1614-deep-research-falcon.md
+      supporting_text: &gt;-
+        Subcellular localization - Unresolved. Without validated antibodies and microscopy
+        or tagged endogenous expression data, subcellular distribution is uncertain.
+    - reference_id: file:human/KIAA1614/KIAA1614-deep-research-falcon.md
+      supporting_text: &gt;-
+        If a polarity-related role exists, membrane-proximal/cortical or junctional
+        localization would be plausible, but this is hypothetical.
+- gap_statement: &gt;-
+    KIAA1614 has no validated pathway or biological-process assignment.
+  boundary: &gt;-
+    The PAR6_homolog domain makes cell-polarity or centrosome-related hypotheses
+    plausible, but existing GO process annotations are undecided because no experiment
+    connects KIAA1614 to polarity complexes, centrosome biology, cellular localization,
+    or any other pathway.
+  gap_kind:
+    - BIOLOGY
+    - CURATION
+  dark_aspect: BP_DARK
+  status: OPEN
+  significance: &gt;-
+    This is the process-level consequence of the MF and CC gaps: the gene cannot be
+    confidently placed in a pathway until its molecular partners and site of action
+    are known.
+  resolution: &gt;-
+    CRISPR perturbation and rescue in relevant cells, assaying epithelial polarity,
+    junctional integrity, centrosome-cycle phenotypes, and any phenotype tied to
+    validated KIAA1614 interaction partners.
+  provenance:
+    - reference_id: file:human/KIAA1614/KIAA1614-deep-research-falcon.md
+      supporting_text: &gt;-
+        Pathways and interactions - Unresolved. No validated pathway membership can be
+        assigned at this time.
+    - reference_id: file:human/KIAA1614/KIAA1614-deep-research-falcon.md
+      supporting_text: &gt;-
+        If the PAR6_homolog annotation reflects genuine homology, KIAA1614 may participate
+        in cell polarity/signaling scaffolds.
 </code></pre>
             </div>
         </details>

--- a/genes/human/KIAA1614/KIAA1614-ai-review.html
+++ b/genes/human/KIAA1614/KIAA1614-ai-review.html
@@ -1431,7 +1431,7 @@
             <p style="margin-top: 0.5rem;"><strong>Provenance (the field's own admissions):</strong></p>
             <ul style="margin-top: 0.2rem;">
 
-                <li><em>"Subcellular localization - Unresolved. Without validated antibodies and microscopy or tagged endogenous expression data, subcellular distribution is uncertain."</em> — file:human/KIAA1614/KIAA1614-deep-research-falcon.md</li>
+                <li><em>"Unresolved. Without validated antibodies and microscopy or tagged endogenous expression data, subcellular distribution is uncertain."</em> — file:human/KIAA1614/KIAA1614-deep-research-falcon.md</li>
 
                 <li><em>"If a polarity-related role exists, membrane-proximal/cortical or junctional localization would be plausible, but this is hypothetical."</em> — file:human/KIAA1614/KIAA1614-deep-research-falcon.md</li>
 
@@ -1460,7 +1460,7 @@
             <p style="margin-top: 0.5rem;"><strong>Provenance (the field's own admissions):</strong></p>
             <ul style="margin-top: 0.2rem;">
 
-                <li><em>"Pathways and interactions - Unresolved. No validated pathway membership can be assigned at this time."</em> — file:human/KIAA1614/KIAA1614-deep-research-falcon.md</li>
+                <li><em>"Unresolved. No validated pathway membership can be assigned at this time."</em> — file:human/KIAA1614/KIAA1614-deep-research-falcon.md</li>
 
                 <li><em>"If the PAR6_homolog annotation reflects genuine homology, KIAA1614 may participate in cell polarity/signaling scaffolds."</em> — file:human/KIAA1614/KIAA1614-deep-research-falcon.md</li>
 
@@ -2191,8 +2191,8 @@ knowledge_gaps:
   provenance:
     - reference_id: file:human/KIAA1614/KIAA1614-deep-research-falcon.md
       supporting_text: &gt;-
-        Subcellular localization - Unresolved. Without validated antibodies and microscopy
-        or tagged endogenous expression data, subcellular distribution is uncertain.
+        Unresolved. Without validated antibodies and microscopy or tagged endogenous
+        expression data, subcellular distribution is uncertain.
     - reference_id: file:human/KIAA1614/KIAA1614-deep-research-falcon.md
       supporting_text: &gt;-
         If a polarity-related role exists, membrane-proximal/cortical or junctional
@@ -2220,8 +2220,7 @@ knowledge_gaps:
   provenance:
     - reference_id: file:human/KIAA1614/KIAA1614-deep-research-falcon.md
       supporting_text: &gt;-
-        Pathways and interactions - Unresolved. No validated pathway membership can be
-        assigned at this time.
+        Unresolved. No validated pathway membership can be assigned at this time.
     - reference_id: file:human/KIAA1614/KIAA1614-deep-research-falcon.md
       supporting_text: &gt;-
         If the PAR6_homolog annotation reflects genuine homology, KIAA1614 may participate

--- a/genes/human/KIAA1614/KIAA1614-ai-review.yaml
+++ b/genes/human/KIAA1614/KIAA1614-ai-review.yaml
@@ -184,3 +184,98 @@ references:
 - id: file:human/KIAA1614/KIAA1614-deep-research-cyberian.md
   title: Cyberian deep research on KIAA1614 function
   findings: []
+
+knowledge_gaps:
+- gap_statement: >-
+    KIAA1614 has no experimentally established molecular function or interaction
+    partners.
+  boundary: >-
+    KIAA1614 is a real human protein with DUF4685 and PAR6_homolog domain annotations.
+    These domains support only hypotheses about adaptor or polarity-scaffold behavior;
+    they do not establish biochemical activity, binding partners, or functional
+    equivalence to canonical Par6 proteins.
+  gap_kind:
+    - BIOLOGY
+    - CURATION
+  dark_aspect: MF_DARK
+  status: OPEN
+  significance: >-
+    All current process and localization annotations rest on phylogenetic/domain
+    inference. Without a direct molecular activity or partner set, KIAA1614 remains
+    function-unknown despite several plausible Par6-related hypotheses.
+  resolution: >-
+    Affinity/proximity proteomics, co-IP against Par3/Par6/aPKC and other polarity
+    factors, DUF4685/PAR6_homolog domain-deletion rescue, and structural/biochemical
+    assays for conserved binding surfaces.
+  provenance:
+    - reference_id: file:human/KIAA1614/KIAA1614-deep-research-falcon.md
+      supporting_text: >-
+        KIAA1614 (UniProt Q5VZ46) encodes an uncharacterized human protein originally
+        identified via large-scale cDNA sequencing. The protein currently lacks an
+        experimentally validated molecular function and pathway assignment.
+    - reference_id: file:human/KIAA1614/KIAA1614-deep-research-falcon.md
+      supporting_text: >-
+        DUF4685 (PF15737; InterPro IPR032756) is a Domain of Unknown Function; by
+        definition, it has no established, conserved biochemical activity.
+    - reference_id: file:human/KIAA1614/KIAA1614-deep-research-falcon.md
+      supporting_text: >-
+        No directly citable 2023–2024 primary studies conclusively define KIAA1614
+        protein function, localization, or interaction partners.
+- gap_statement: >-
+    KIAA1614 subcellular localization is unresolved.
+  boundary: >-
+    IBA annotations place KIAA1614 at the cell cortex, nucleus, and apical plasma
+    membrane by transfer from related proteins, while other predicted resources suggest
+    P-body localization. No validated antibody, microscopy, or endogenous tagging data
+    establish where KIAA1614 acts.
+  gap_kind:
+    - BIOLOGY
+    - CURATION
+  dark_aspect: CC_DARK
+  status: OPEN
+  significance: >-
+    The predicted polarity-scaffold hypothesis requires compartmental evidence. The
+    difference between cortical/junctional, nuclear, apical-membrane, and P-body
+    localization changes the plausible mechanism completely.
+  resolution: >-
+    Endogenous tagging or validated-antibody imaging in polarized epithelial and retinal
+    cell contexts, with orthogonal fractionation and perturbation of candidate domain
+    determinants.
+  provenance:
+    - reference_id: file:human/KIAA1614/KIAA1614-deep-research-falcon.md
+      supporting_text: >-
+        Subcellular localization - Unresolved. Without validated antibodies and microscopy
+        or tagged endogenous expression data, subcellular distribution is uncertain.
+    - reference_id: file:human/KIAA1614/KIAA1614-deep-research-falcon.md
+      supporting_text: >-
+        If a polarity-related role exists, membrane-proximal/cortical or junctional
+        localization would be plausible, but this is hypothetical.
+- gap_statement: >-
+    KIAA1614 has no validated pathway or biological-process assignment.
+  boundary: >-
+    The PAR6_homolog domain makes cell-polarity or centrosome-related hypotheses
+    plausible, but existing GO process annotations are undecided because no experiment
+    connects KIAA1614 to polarity complexes, centrosome biology, cellular localization,
+    or any other pathway.
+  gap_kind:
+    - BIOLOGY
+    - CURATION
+  dark_aspect: BP_DARK
+  status: OPEN
+  significance: >-
+    This is the process-level consequence of the MF and CC gaps: the gene cannot be
+    confidently placed in a pathway until its molecular partners and site of action
+    are known.
+  resolution: >-
+    CRISPR perturbation and rescue in relevant cells, assaying epithelial polarity,
+    junctional integrity, centrosome-cycle phenotypes, and any phenotype tied to
+    validated KIAA1614 interaction partners.
+  provenance:
+    - reference_id: file:human/KIAA1614/KIAA1614-deep-research-falcon.md
+      supporting_text: >-
+        Pathways and interactions - Unresolved. No validated pathway membership can be
+        assigned at this time.
+    - reference_id: file:human/KIAA1614/KIAA1614-deep-research-falcon.md
+      supporting_text: >-
+        If the PAR6_homolog annotation reflects genuine homology, KIAA1614 may participate
+        in cell polarity/signaling scaffolds.

--- a/genes/human/KIAA1614/KIAA1614-ai-review.yaml
+++ b/genes/human/KIAA1614/KIAA1614-ai-review.yaml
@@ -244,8 +244,8 @@ knowledge_gaps:
   provenance:
     - reference_id: file:human/KIAA1614/KIAA1614-deep-research-falcon.md
       supporting_text: >-
-        Subcellular localization - Unresolved. Without validated antibodies and microscopy
-        or tagged endogenous expression data, subcellular distribution is uncertain.
+        Unresolved. Without validated antibodies and microscopy or tagged endogenous
+        expression data, subcellular distribution is uncertain.
     - reference_id: file:human/KIAA1614/KIAA1614-deep-research-falcon.md
       supporting_text: >-
         If a polarity-related role exists, membrane-proximal/cortical or junctional
@@ -273,8 +273,7 @@ knowledge_gaps:
   provenance:
     - reference_id: file:human/KIAA1614/KIAA1614-deep-research-falcon.md
       supporting_text: >-
-        Pathways and interactions - Unresolved. No validated pathway membership can be
-        assigned at this time.
+        Unresolved. No validated pathway membership can be assigned at this time.
     - reference_id: file:human/KIAA1614/KIAA1614-deep-research-falcon.md
       supporting_text: >-
         If the PAR6_homolog annotation reflects genuine homology, KIAA1614 may participate


### PR DESCRIPTION
## Summary
- add structured top-level knowledge gaps for KIAA1614 covering unresolved molecular function/partners, localization, and pathway assignment
- render the updated KIAA1614 review HTML

## Validation
- `just validate human KIAA1614` (passes with existing non-blocking warnings: undecided IBA propagation metadata and no core functions defined)
- `just render human KIAA1614`
- `git diff --check`