### PR TITLE
[codex] Add CACUL1 knowledge gaps

### DIFF
--- a/genes/human/CACUL1/CACUL1-ai-review.html
+++ b/genes/human/CACUL1/CACUL1-ai-review.html
@@ -2654,6 +2654,102 @@
 
 
 
+    <div class="section">
+        <h2 class="section-title">Knowledge Gaps</h2>
+        <p style="color: #555; font-size: 0.92rem; margin-top: -0.3rem;">
+            What is <em>not</em> known — curated, literature-grounded statements of the open
+            unknowns (the inverse of core functions).
+        </p>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> The direct biochemical mechanism by which CACUL1 promotes CDK2 kinase activity remains unresolved: it is unclear whether CACUL1 allosterically activates CDK2, alters cyclin/CDK-inhibitor availability, changes substrate engagement, or acts through another cell-cycle regulatory complex.</p>
+            <p style="margin-top: 0.4rem;">
+                <span class="badge">OPEN</span>
+                <span class="badge">BIOLOGY</span>
+                <span class="badge">RESIDUAL_SUBGAP</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> CACUL1 physically associates with CDK2, promotes CDK2 kinase activity, is expressed in a cell-cycle-dependent manner, and RNAi knockdown causes reduced proliferation with G1/S arrest. The unresolved part is the immediate molecular mechanism connecting CACUL1 binding to increased CDK2 activity.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Significance:</strong> CDK2 regulation is the best-supported CACUL1 activity, but without a mechanism it is hard to distinguish a direct CDK2 co-regulator from an indirect cell-cycle phenotype.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>What would resolve it:</strong> Reconstitute purified CACUL1-CDK2-cyclin complexes for kinase kinetics, map the binding interface, and test whether CACUL1 changes cyclin binding, CDK-inhibitor binding, or substrate phosphorylation in cells.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Provenance (the field's own admissions):</strong></p>
+            <ul style="margin-top: 0.2rem;">
+
+                <li><em>"but how CDK2 is regulated is still incompletely understood"</em> — PMID:19829063</li>
+
+                <li><em>"provide insight into the mechanism by which CDK2 is regulated"</em> — PMID:19829063</li>
+
+            </ul>
+
+
+        </div>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> The role of CACUL1&#39;s cullin-repeat-like domain in CRL3-Keap1/Nrf2 regulation is unresolved, and CACUL1 should not be curated as a bona fide cullin-RING scaffold unless future experiments show that it assembles or positions an E3 ubiquitin ligase complex.</p>
+            <p style="margin-top: 0.4rem;">
+                <span class="badge">OPEN</span>
+                <span class="badge">BIOLOGY</span><span class="badge">CURATION</span>
+                <span class="badge">RESIDUAL_SUBGAP</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> CACUL1 binds Keap1, Cul3, and Rbx1 and attenuates Nrf2 ubiquitination, supporting ubiquitin-ligase binding and negative regulation of Nrf2 ubiquitination. The gap is whether the short cullin-like region is the binding/regulatory interface and whether CACUL1 modulates only CRL3-Keap1/Nrf2 or broader CRL3 substrate ubiquitination.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Significance:</strong> This boundary prevents domain-only over-propagation of cullin scaffold activity while preserving the experimentally supported CRL3-Keap1/Nrf2 regulatory role.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>What would resolve it:</strong> Map CACUL1 deletion mutants against Keap1, Cul3, Rbx1, and Nrf2; assay CRL3 ubiquitination activity with purified components; and test whether CACUL1 affects other CRL3-Keap1 or Cul3 substrates.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Provenance (the field's own admissions):</strong></p>
+            <ul style="margin-top: 0.2rem;">
+
+                <li><em>"CACUL1 is a regulator of Nrf2 ubiquitination, adding another regulatory layer to the Nrf2 antioxidant stress response."</em> — PMID:26238671</li>
+
+                <li><em>"there is no experimental evidence that it nucleates a functional cullin-RING ubiquitin ligase or carries a neddylation/RBX module"</em> — file:human/CACUL1/CACUL1-pn-notes.md</li>
+
+            </ul>
+
+
+        </div>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> The physiological context and directionality of CACUL1 nuclear-receptor coregulation remain only partly defined, especially whether ERalpha, androgen receptor, and PPARgamma effects represent one general chromatin mechanism or distinct receptor- and cell-type-specific activities.</p>
+            <p style="margin-top: 0.4rem;">
+                <span class="badge">OPEN</span>
+                <span class="badge">BIOLOGY</span>
+                <span class="badge">RESIDUAL_SUBGAP</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> CACUL1 can bind nuclear receptors and repress ERalpha- and PPARgamma-dependent transcription with LSD1/SIRT1-linked chromatin changes. The unresolved part is which tissues and metabolic or hormonal states require this activity in vivo, and when CACUL1 acts as a corepressor versus a co-regulator with different directionality.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Significance:</strong> Nuclear-receptor corepression is experimentally supported but may be highly context-dependent; resolving context will determine whether CACUL1 should be treated as a broadly relevant transcriptional regulator or a narrower adipocyte and hormone-response modulator.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>What would resolve it:</strong> Combine receptor-specific ChIP-seq/CUT&amp;RUN, transcriptomics, and CACUL1 loss- and gain-of-function in relevant adipocyte and hormone-responsive models, followed by in vivo perturbation where feasible.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Provenance (the field's own admissions):</strong></p>
+            <ul style="margin-top: 0.2rem;">
+
+                <li><em>"The physiological significance of CACUL1-mediated PPARγ repression under different dietary conditions is of potential interest."</em> — PMID:29233982</li>
+
+                <li><em>"Therefore, adipogenesis may be fine-tuned by dynamic regulation of PPARγ in response to different dietary conditions."</em> — PMID:29233982</li>
+
+            </ul>
+
+
+        </div>
+
+    </div>
+
 
 
 
@@ -3616,6 +3712,106 @@ core_functions:
       components of the Ubiquitin ligase responsible for Nrf2 ubiquitination.
   - reference_id: PMID:26238671
     supporting_text: CACUL1 attenuates Nrf2 ubiquitination
+knowledge_gaps:
+- gap_statement: &gt;-
+    The direct biochemical mechanism by which CACUL1 promotes CDK2 kinase activity
+    remains unresolved: it is unclear whether CACUL1 allosterically activates CDK2,
+    alters cyclin/CDK-inhibitor availability, changes substrate engagement, or acts
+    through another cell-cycle regulatory complex.
+  boundary: &gt;-
+    CACUL1 physically associates with CDK2, promotes CDK2 kinase activity, is
+    expressed in a cell-cycle-dependent manner, and RNAi knockdown causes reduced
+    proliferation with G1/S arrest. The unresolved part is the immediate molecular
+    mechanism connecting CACUL1 binding to increased CDK2 activity.
+  gap_kind:
+  - BIOLOGY
+  dark_aspect: RESIDUAL_SUBGAP
+  status: OPEN
+  significance: &gt;-
+    CDK2 regulation is the best-supported CACUL1 activity, but without a mechanism
+    it is hard to distinguish a direct CDK2 co-regulator from an indirect cell-cycle
+    phenotype.
+  resolution: &gt;-
+    Reconstitute purified CACUL1-CDK2-cyclin complexes for kinase kinetics, map the
+    binding interface, and test whether CACUL1 changes cyclin binding, CDK-inhibitor
+    binding, or substrate phosphorylation in cells.
+  provenance:
+  - reference_id: PMID:19829063
+    supporting_text: &gt;-
+      but how CDK2 is regulated is still incompletely understood
+    reference_section_type: ABSTRACT
+  - reference_id: PMID:19829063
+    supporting_text: &gt;-
+      provide insight into the mechanism by which CDK2 is regulated
+    reference_section_type: ABSTRACT
+- gap_statement: &gt;-
+    The role of CACUL1&#39;s cullin-repeat-like domain in CRL3-Keap1/Nrf2 regulation
+    is unresolved, and CACUL1 should not be curated as a bona fide cullin-RING
+    scaffold unless future experiments show that it assembles or positions an E3
+    ubiquitin ligase complex.
+  boundary: &gt;-
+    CACUL1 binds Keap1, Cul3, and Rbx1 and attenuates Nrf2 ubiquitination, supporting
+    ubiquitin-ligase binding and negative regulation of Nrf2 ubiquitination. The gap
+    is whether the short cullin-like region is the binding/regulatory interface and
+    whether CACUL1 modulates only CRL3-Keap1/Nrf2 or broader CRL3 substrate
+    ubiquitination.
+  gap_kind:
+  - BIOLOGY
+  - CURATION
+  dark_aspect: RESIDUAL_SUBGAP
+  status: OPEN
+  significance: &gt;-
+    This boundary prevents domain-only over-propagation of cullin scaffold activity
+    while preserving the experimentally supported CRL3-Keap1/Nrf2 regulatory role.
+  resolution: &gt;-
+    Map CACUL1 deletion mutants against Keap1, Cul3, Rbx1, and Nrf2; assay CRL3
+    ubiquitination activity with purified components; and test whether CACUL1 affects
+    other CRL3-Keap1 or Cul3 substrates.
+  provenance:
+  - reference_id: PMID:26238671
+    supporting_text: &gt;-
+      CACUL1 is a regulator of Nrf2 ubiquitination, adding another regulatory layer
+      to the Nrf2 antioxidant stress response.
+    reference_section_type: ABSTRACT
+  - reference_id: file:human/CACUL1/CACUL1-pn-notes.md
+    supporting_text: &gt;-
+      there is no experimental evidence that it nucleates a functional cullin-RING
+      ubiquitin ligase or carries a neddylation/RBX module
+- gap_statement: &gt;-
+    The physiological context and directionality of CACUL1 nuclear-receptor
+    coregulation remain only partly defined, especially whether ERalpha, androgen
+    receptor, and PPARgamma effects represent one general chromatin mechanism or
+    distinct receptor- and cell-type-specific activities.
+  boundary: &gt;-
+    CACUL1 can bind nuclear receptors and repress ERalpha- and PPARgamma-dependent
+    transcription with LSD1/SIRT1-linked chromatin changes. The unresolved part is
+    which tissues and metabolic or hormonal states require this activity in vivo,
+    and when CACUL1 acts as a corepressor versus a co-regulator with different
+    directionality.
+  gap_kind:
+  - BIOLOGY
+  dark_aspect: RESIDUAL_SUBGAP
+  status: OPEN
+  significance: &gt;-
+    Nuclear-receptor corepression is experimentally supported but may be highly
+    context-dependent; resolving context will determine whether CACUL1 should be
+    treated as a broadly relevant transcriptional regulator or a narrower adipocyte
+    and hormone-response modulator.
+  resolution: &gt;-
+    Combine receptor-specific ChIP-seq/CUT&amp;RUN, transcriptomics, and CACUL1 loss-
+    and gain-of-function in relevant adipocyte and hormone-responsive models,
+    followed by in vivo perturbation where feasible.
+  provenance:
+  - reference_id: PMID:29233982
+    supporting_text: &gt;-
+      The physiological significance of CACUL1-mediated PPARγ repression under
+      different dietary conditions is of potential interest.
+    reference_section_type: DISCUSSION
+  - reference_id: PMID:29233982
+    supporting_text: &gt;-
+      Therefore, adipogenesis may be fine-tuned by dynamic regulation of PPARγ in
+      response to different dietary conditions.
+    reference_section_type: DISCUSSION
 proposed_new_terms: []
 suggested_questions:
 - question: &gt;-

--- a/genes/human/CACUL1/CACUL1-ai-review.yaml
+++ b/genes/human/CACUL1/CACUL1-ai-review.yaml
@@ -432,6 +432,106 @@ core_functions:
       components of the Ubiquitin ligase responsible for Nrf2 ubiquitination.
   - reference_id: PMID:26238671
     supporting_text: CACUL1 attenuates Nrf2 ubiquitination
+knowledge_gaps:
+- gap_statement: >-
+    The direct biochemical mechanism by which CACUL1 promotes CDK2 kinase activity
+    remains unresolved: it is unclear whether CACUL1 allosterically activates CDK2,
+    alters cyclin/CDK-inhibitor availability, changes substrate engagement, or acts
+    through another cell-cycle regulatory complex.
+  boundary: >-
+    CACUL1 physically associates with CDK2, promotes CDK2 kinase activity, is
+    expressed in a cell-cycle-dependent manner, and RNAi knockdown causes reduced
+    proliferation with G1/S arrest. The unresolved part is the immediate molecular
+    mechanism connecting CACUL1 binding to increased CDK2 activity.
+  gap_kind:
+  - BIOLOGY
+  dark_aspect: RESIDUAL_SUBGAP
+  status: OPEN
+  significance: >-
+    CDK2 regulation is the best-supported CACUL1 activity, but without a mechanism
+    it is hard to distinguish a direct CDK2 co-regulator from an indirect cell-cycle
+    phenotype.
+  resolution: >-
+    Reconstitute purified CACUL1-CDK2-cyclin complexes for kinase kinetics, map the
+    binding interface, and test whether CACUL1 changes cyclin binding, CDK-inhibitor
+    binding, or substrate phosphorylation in cells.
+  provenance:
+  - reference_id: PMID:19829063
+    supporting_text: >-
+      but how CDK2 is regulated is still incompletely understood
+    reference_section_type: ABSTRACT
+  - reference_id: PMID:19829063
+    supporting_text: >-
+      provide insight into the mechanism by which CDK2 is regulated
+    reference_section_type: ABSTRACT
+- gap_statement: >-
+    The role of CACUL1's cullin-repeat-like domain in CRL3-Keap1/Nrf2 regulation
+    is unresolved, and CACUL1 should not be curated as a bona fide cullin-RING
+    scaffold unless future experiments show that it assembles or positions an E3
+    ubiquitin ligase complex.
+  boundary: >-
+    CACUL1 binds Keap1, Cul3, and Rbx1 and attenuates Nrf2 ubiquitination, supporting
+    ubiquitin-ligase binding and negative regulation of Nrf2 ubiquitination. The gap
+    is whether the short cullin-like region is the binding/regulatory interface and
+    whether CACUL1 modulates only CRL3-Keap1/Nrf2 or broader CRL3 substrate
+    ubiquitination.
+  gap_kind:
+  - BIOLOGY
+  - CURATION
+  dark_aspect: RESIDUAL_SUBGAP
+  status: OPEN
+  significance: >-
+    This boundary prevents domain-only over-propagation of cullin scaffold activity
+    while preserving the experimentally supported CRL3-Keap1/Nrf2 regulatory role.
+  resolution: >-
+    Map CACUL1 deletion mutants against Keap1, Cul3, Rbx1, and Nrf2; assay CRL3
+    ubiquitination activity with purified components; and test whether CACUL1 affects
+    other CRL3-Keap1 or Cul3 substrates.
+  provenance:
+  - reference_id: PMID:26238671
+    supporting_text: >-
+      CACUL1 is a regulator of Nrf2 ubiquitination, adding another regulatory layer
+      to the Nrf2 antioxidant stress response.
+    reference_section_type: ABSTRACT
+  - reference_id: file:human/CACUL1/CACUL1-pn-notes.md
+    supporting_text: >-
+      there is no experimental evidence that it nucleates a functional cullin-RING
+      ubiquitin ligase or carries a neddylation/RBX module
+- gap_statement: >-
+    The physiological context and directionality of CACUL1 nuclear-receptor
+    coregulation remain only partly defined, especially whether ERalpha, androgen
+    receptor, and PPARgamma effects represent one general chromatin mechanism or
+    distinct receptor- and cell-type-specific activities.
+  boundary: >-
+    CACUL1 can bind nuclear receptors and repress ERalpha- and PPARgamma-dependent
+    transcription with LSD1/SIRT1-linked chromatin changes. The unresolved part is
+    which tissues and metabolic or hormonal states require this activity in vivo,
+    and when CACUL1 acts as a corepressor versus a co-regulator with different
+    directionality.
+  gap_kind:
+  - BIOLOGY
+  dark_aspect: RESIDUAL_SUBGAP
+  status: OPEN
+  significance: >-
+    Nuclear-receptor corepression is experimentally supported but may be highly
+    context-dependent; resolving context will determine whether CACUL1 should be
+    treated as a broadly relevant transcriptional regulator or a narrower adipocyte
+    and hormone-response modulator.
+  resolution: >-
+    Combine receptor-specific ChIP-seq/CUT&RUN, transcriptomics, and CACUL1 loss-
+    and gain-of-function in relevant adipocyte and hormone-responsive models,
+    followed by in vivo perturbation where feasible.
+  provenance:
+  - reference_id: PMID:29233982
+    supporting_text: >-
+      The physiological significance of CACUL1-mediated PPARγ repression under
+      different dietary conditions is of potential interest.
+    reference_section_type: DISCUSSION
+  - reference_id: PMID:29233982
+    supporting_text: >-
+      Therefore, adipogenesis may be fine-tuned by dynamic regulation of PPARγ in
+      response to different dietary conditions.
+    reference_section_type: DISCUSSION
 proposed_new_terms: []
 suggested_questions:
 - question: >-


### PR DESCRIPTION
## Summary
- Adds three structured top-level knowledge gaps for human CACUL1 covering CDK2 activation mechanism, CRL3-Keap1/Nrf2 cullin-like regulatory boundaries, and nuclear-receptor coregulation context.
- Regenerates the CACUL1 review HTML so the new Knowledge Gaps section is rendered.

## Validation
- `just validate human CACUL1` passed with 1 existing warning: `core_functions[0].directly_involved_in[1]` GO:0000082 is not reflected in `existing_annotations` as `NEW`.
- `just render human CACUL1`
- `git diff --check`