### PR TITLE
[codex] Add ERVMER34-1 knowledge gaps

### DIFF
--- a/genes/human/ERVMER34-1/ERVMER34-1-ai-review.html
+++ b/genes/human/ERVMER34-1/ERVMER34-1-ai-review.html
@@ -1739,6 +1739,106 @@
 
 
 
+    <div class="section">
+        <h2 class="section-title">Knowledge Gaps</h2>
+        <p style="color: #555; font-size: 0.92rem; margin-top: -0.3rem;">
+            What is <em>not</em> known — curated, literature-grounded statements of the open
+            unknowns (the inverse of core functions).
+        </p>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> The primary biological function of ERVMER34-1/HEMO remains unknown. It is unresolved whether the shed ectodomain acts through a host receptor, whether membrane-bound HEMO has a distinct cell-surface role, and what downstream signaling pathway or cellular response, if any, is triggered by either form.</p>
+            <p style="margin-top: 0.4rem;">
+                <span class="badge">OPEN</span>
+                <span class="badge">BIOLOGY</span><span class="badge">ONTOLOGY</span>
+                <span class="badge">MF_DARK</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> HEMO is an ancient Env-like protein under purifying selection, is expressed in trophoblasts, stem/iPS cells, and tumors, and is actively shed into maternal blood during pregnancy. It lacks detectable fusogenic activity, and the current review supports only localization and shedding, not a receptor, signaling pathway, enzymatic activity, or specific biological process.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Significance:</strong> This is the central gap for HEMO curation: the protein is clearly expressed, processed, and evolutionarily retained, but there is no informative GO molecular-function or biological-process annotation for its host role.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>What would resolve it:</strong> Identify binding partners/receptors using secreted and membrane-tethered HEMO baits, then test candidate pathways by loss- and gain-of-function in trophoblast, pluripotent-stem-cell, and tumor models.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Provenance (the field's own admissions):</strong></p>
+            <ul style="margin-top: 0.2rem;">
+
+                <li><em>"ERVMER34-1 has no fusion activity, and its function is unknown; however, it localizes in a manner similar to ERVH48-1, suggesting that it may function as an inhibitor of cell fusion"</em> — PMID:37892164</li>
+
+                <li><em>"Specific receptor, downstream signaling pathway, and direct immunosuppressive function for HEMO remain unproven in the retrieved primary evidence"</em> — file:human/ERVMER34-1/ERVMER34-1-deep-research-falcon.md</li>
+
+            </ul>
+
+
+        </div>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> The proposed placental anti-fusion or immunomodulatory function of HEMO is untested. The Suppressyn-like localization and ISD-like sequence motivate hypotheses, but it is unknown whether HEMO blocks syncytin-mediated trophoblast fusion, acts through receptor interference, or suppresses maternal immune-cell activation.</p>
+            <p style="margin-top: 0.4rem;">
+                <span class="badge">OPEN</span>
+                <span class="badge">BIOLOGY</span>
+                <span class="badge">BP_DARK</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> HEMO localizes in early trophoblast lineages, is detected in pregnancy blood, has no fusion activity of its own, and retains an ISD-like motif. These data support a placental-function hypothesis, not a demonstrated molecular function or biological process.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Significance:</strong> Placental anti-fusion or immune-modulatory activity would explain why a non-fusogenic retroviral Env-like protein is retained and shed during early pregnancy, but current evidence is insufficient for GO process annotation.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>What would resolve it:</strong> Test purified and cell-associated HEMO in trophoblast fusion assays, ASCT2 or other receptor-competition assays, and maternal immune-cell activation assays with ISD-mutant HEMO controls.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Provenance (the field's own admissions):</strong></p>
+            <ul style="margin-top: 0.2rem;">
+
+                <li><em>"Suppressyn, the first ERV-derived protein shown to inhibit cell–cell fusion"</em> — PMID:37892164</li>
+
+                <li><em>"ERVMER34-1 has no fusion activity, and its function is unknown; however, it localizes in a manner similar to ERVH48-1, suggesting that it may function as an inhibitor of cell fusion"</em> — PMID:37892164</li>
+
+                <li><em>"Direct, HEMO-specific **immunosuppressive activity** in vitro or in vivo."</em> — file:human/ERVMER34-1/ERVMER34-1-deep-research-falcon.md</li>
+
+            </ul>
+
+
+        </div>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> The enzyme and regulatory logic responsible for HEMO ectodomain shedding are not known. Broad ADAM/MMP inhibitor sensitivity and mapped Q432/R433 cleavage sites show metalloproteinase-sensitive processing, but do not identify the in vivo protease or explain why shedding is developmentally and disease-context regulated.</p>
+            <p style="margin-top: 0.4rem;">
+                <span class="badge">OPEN</span>
+                <span class="badge">BIOLOGY</span>
+                <span class="badge">RESIDUAL_SUBGAP</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> HEMO is released from a membrane-anchored precursor as a major soluble ectodomain detected in maternal blood, and membrane anchoring is required for efficient shedding. The unresolved part is protease identity, cleavage-site regulation, and whether shedding itself controls HEMO activity.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Significance:</strong> Shedding is the best-defined biochemical event in HEMO biology; identifying its protease would turn a localization/processing observation into a regulated pathway that can be perturbed in placental and cancer contexts.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>What would resolve it:</strong> Combine targeted ADAM/MMP knockdown or CRISPR screens with Q432/R433 cleavage reporters, endogenous trophoblast models, and pregnancy or tumor samples to test protease identity and regulation.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Provenance (the field's own admissions):</strong></p>
+            <ul style="margin-top: 0.2rem;">
+
+                <li><em>"it is actively shed in the blood circulation in humans via specific cleavage of the precursor envelope protein upstream of the transmembrane domain"</em> — PMID:28739914</li>
+
+                <li><em>"Mass spectrometry mapped C-terminal truncation/cleavage mainly at **Q432** and **R433** (about **4:1** ratio)"</em> — file:human/ERVMER34-1/ERVMER34-1-deep-research-falcon.md</li>
+
+                <li><em>"Which metalloproteinases are responsible for HEMO cleavage? What are the signaling pathways that regulate this shedding?"</em> — file:human/ERVMER34-1/ERVMER34-1-deep-research-cyberian.md</li>
+
+            </ul>
+
+
+        </div>
+
+    </div>
+
 
 
 
@@ -2508,6 +2608,112 @@ core_functions:
       supporting_text: &#34;Shedding is **consistent with metalloproteinase-mediated processing** and is inhibited by broad-spectrum **ADAM/MMP inhibitors** (Batimastat, Marimastat, GM6001; dose range shown ~0.1–10 μM) in transfected cells&#34;
     - reference_id: PMID:37892164
       supporting_text: &#34;ERVMER34-1 has no fusion activity, and its function is unknown; however, it localizes in a manner similar to ERVH48-1, suggesting that it may function as an inhibitor of cell fusion&#34;
+knowledge_gaps:
+  - gap_statement: &gt;-
+      The primary biological function of ERVMER34-1/HEMO remains unknown. It is
+      unresolved whether the shed ectodomain acts through a host receptor, whether
+      membrane-bound HEMO has a distinct cell-surface role, and what downstream
+      signaling pathway or cellular response, if any, is triggered by either form.
+    boundary: &gt;-
+      HEMO is an ancient Env-like protein under purifying selection, is expressed
+      in trophoblasts, stem/iPS cells, and tumors, and is actively shed into maternal
+      blood during pregnancy. It lacks detectable fusogenic activity, and the
+      current review supports only localization and shedding, not a receptor,
+      signaling pathway, enzymatic activity, or specific biological process.
+    gap_kind:
+      - BIOLOGY
+      - ONTOLOGY
+    dark_aspect: MF_DARK
+    status: OPEN
+    significance: &gt;-
+      This is the central gap for HEMO curation: the protein is clearly expressed,
+      processed, and evolutionarily retained, but there is no informative GO
+      molecular-function or biological-process annotation for its host role.
+    resolution: &gt;-
+      Identify binding partners/receptors using secreted and membrane-tethered
+      HEMO baits, then test candidate pathways by loss- and gain-of-function in
+      trophoblast, pluripotent-stem-cell, and tumor models.
+    provenance:
+      - reference_id: PMID:37892164
+        supporting_text: &#34;ERVMER34-1 has no fusion activity, and its function is unknown; however, it localizes in a manner similar to ERVH48-1, suggesting that it may function as an inhibitor of cell fusion&#34;
+      - reference_id: file:human/ERVMER34-1/ERVMER34-1-deep-research-falcon.md
+        supporting_text: &gt;-
+          Specific receptor, downstream signaling pathway, and direct
+          immunosuppressive function for HEMO remain unproven in the retrieved
+          primary evidence
+  - gap_statement: &gt;-
+      The proposed placental anti-fusion or immunomodulatory function of HEMO is
+      untested. The Suppressyn-like localization and ISD-like sequence motivate
+      hypotheses, but it is unknown whether HEMO blocks syncytin-mediated trophoblast
+      fusion, acts through receptor interference, or suppresses maternal immune-cell
+      activation.
+    boundary: &gt;-
+      HEMO localizes in early trophoblast lineages, is detected in pregnancy blood,
+      has no fusion activity of its own, and retains an ISD-like motif. These data
+      support a placental-function hypothesis, not a demonstrated molecular function
+      or biological process.
+    gap_kind:
+      - BIOLOGY
+    dark_aspect: BP_DARK
+    status: OPEN
+    significance: &gt;-
+      Placental anti-fusion or immune-modulatory activity would explain why a
+      non-fusogenic retroviral Env-like protein is retained and shed during early
+      pregnancy, but current evidence is insufficient for GO process annotation.
+    resolution: &gt;-
+      Test purified and cell-associated HEMO in trophoblast fusion assays, ASCT2
+      or other receptor-competition assays, and maternal immune-cell activation
+      assays with ISD-mutant HEMO controls.
+    provenance:
+      - reference_id: PMID:37892164
+        supporting_text: &gt;-
+          Suppressyn, the first ERV-derived protein shown to inhibit cell–cell
+          fusion
+      - reference_id: PMID:37892164
+        supporting_text: &gt;-
+          ERVMER34-1 has no fusion activity, and its function is unknown; however,
+          it localizes in a manner similar to ERVH48-1, suggesting that it may
+          function as an inhibitor of cell fusion
+      - reference_id: file:human/ERVMER34-1/ERVMER34-1-deep-research-falcon.md
+        supporting_text: &gt;-
+          Direct, HEMO-specific **immunosuppressive activity** in vitro or in vivo.
+  - gap_statement: &gt;-
+      The enzyme and regulatory logic responsible for HEMO ectodomain shedding are
+      not known. Broad ADAM/MMP inhibitor sensitivity and mapped Q432/R433 cleavage
+      sites show metalloproteinase-sensitive processing, but do not identify the
+      in vivo protease or explain why shedding is developmentally and disease-context
+      regulated.
+    boundary: &gt;-
+      HEMO is released from a membrane-anchored precursor as a major soluble
+      ectodomain detected in maternal blood, and membrane anchoring is required for
+      efficient shedding. The unresolved part is protease identity, cleavage-site
+      regulation, and whether shedding itself controls HEMO activity.
+    gap_kind:
+      - BIOLOGY
+    dark_aspect: RESIDUAL_SUBGAP
+    status: OPEN
+    significance: &gt;-
+      Shedding is the best-defined biochemical event in HEMO biology; identifying
+      its protease would turn a localization/processing observation into a regulated
+      pathway that can be perturbed in placental and cancer contexts.
+    resolution: &gt;-
+      Combine targeted ADAM/MMP knockdown or CRISPR screens with Q432/R433 cleavage
+      reporters, endogenous trophoblast models, and pregnancy or tumor samples to
+      test protease identity and regulation.
+    provenance:
+      - reference_id: PMID:28739914
+        supporting_text: &gt;-
+          it is actively shed in the blood circulation in humans via specific
+          cleavage of the precursor envelope protein upstream of the transmembrane
+          domain
+      - reference_id: file:human/ERVMER34-1/ERVMER34-1-deep-research-falcon.md
+        supporting_text: &gt;-
+          Mass spectrometry mapped C-terminal truncation/cleavage mainly at **Q432**
+          and **R433** (about **4:1** ratio)
+      - reference_id: file:human/ERVMER34-1/ERVMER34-1-deep-research-cyberian.md
+        supporting_text: &gt;-
+          Which metalloproteinases are responsible for HEMO cleavage? What are the
+          signaling pathways that regulate this shedding?
 # Core-function entry for the HEMO-BACE2 interaction REMOVED per PR #691
 # review. The claim originates from the cyberian deep-research synthesis
 # only, is not corroborated by falcon&#39;s independent literature pass, and no

--- a/genes/human/ERVMER34-1/ERVMER34-1-ai-review.yaml
+++ b/genes/human/ERVMER34-1/ERVMER34-1-ai-review.yaml
@@ -197,6 +197,112 @@ core_functions:
       supporting_text: "Shedding is **consistent with metalloproteinase-mediated processing** and is inhibited by broad-spectrum **ADAM/MMP inhibitors** (Batimastat, Marimastat, GM6001; dose range shown ~0.1–10 μM) in transfected cells"
     - reference_id: PMID:37892164
       supporting_text: "ERVMER34-1 has no fusion activity, and its function is unknown; however, it localizes in a manner similar to ERVH48-1, suggesting that it may function as an inhibitor of cell fusion"
+knowledge_gaps:
+  - gap_statement: >-
+      The primary biological function of ERVMER34-1/HEMO remains unknown. It is
+      unresolved whether the shed ectodomain acts through a host receptor, whether
+      membrane-bound HEMO has a distinct cell-surface role, and what downstream
+      signaling pathway or cellular response, if any, is triggered by either form.
+    boundary: >-
+      HEMO is an ancient Env-like protein under purifying selection, is expressed
+      in trophoblasts, stem/iPS cells, and tumors, and is actively shed into maternal
+      blood during pregnancy. It lacks detectable fusogenic activity, and the
+      current review supports only localization and shedding, not a receptor,
+      signaling pathway, enzymatic activity, or specific biological process.
+    gap_kind:
+      - BIOLOGY
+      - ONTOLOGY
+    dark_aspect: MF_DARK
+    status: OPEN
+    significance: >-
+      This is the central gap for HEMO curation: the protein is clearly expressed,
+      processed, and evolutionarily retained, but there is no informative GO
+      molecular-function or biological-process annotation for its host role.
+    resolution: >-
+      Identify binding partners/receptors using secreted and membrane-tethered
+      HEMO baits, then test candidate pathways by loss- and gain-of-function in
+      trophoblast, pluripotent-stem-cell, and tumor models.
+    provenance:
+      - reference_id: PMID:37892164
+        supporting_text: "ERVMER34-1 has no fusion activity, and its function is unknown; however, it localizes in a manner similar to ERVH48-1, suggesting that it may function as an inhibitor of cell fusion"
+      - reference_id: file:human/ERVMER34-1/ERVMER34-1-deep-research-falcon.md
+        supporting_text: >-
+          Specific receptor, downstream signaling pathway, and direct
+          immunosuppressive function for HEMO remain unproven in the retrieved
+          primary evidence
+  - gap_statement: >-
+      The proposed placental anti-fusion or immunomodulatory function of HEMO is
+      untested. The Suppressyn-like localization and ISD-like sequence motivate
+      hypotheses, but it is unknown whether HEMO blocks syncytin-mediated trophoblast
+      fusion, acts through receptor interference, or suppresses maternal immune-cell
+      activation.
+    boundary: >-
+      HEMO localizes in early trophoblast lineages, is detected in pregnancy blood,
+      has no fusion activity of its own, and retains an ISD-like motif. These data
+      support a placental-function hypothesis, not a demonstrated molecular function
+      or biological process.
+    gap_kind:
+      - BIOLOGY
+    dark_aspect: BP_DARK
+    status: OPEN
+    significance: >-
+      Placental anti-fusion or immune-modulatory activity would explain why a
+      non-fusogenic retroviral Env-like protein is retained and shed during early
+      pregnancy, but current evidence is insufficient for GO process annotation.
+    resolution: >-
+      Test purified and cell-associated HEMO in trophoblast fusion assays, ASCT2
+      or other receptor-competition assays, and maternal immune-cell activation
+      assays with ISD-mutant HEMO controls.
+    provenance:
+      - reference_id: PMID:37892164
+        supporting_text: >-
+          Suppressyn, the first ERV-derived protein shown to inhibit cell–cell
+          fusion
+      - reference_id: PMID:37892164
+        supporting_text: >-
+          ERVMER34-1 has no fusion activity, and its function is unknown; however,
+          it localizes in a manner similar to ERVH48-1, suggesting that it may
+          function as an inhibitor of cell fusion
+      - reference_id: file:human/ERVMER34-1/ERVMER34-1-deep-research-falcon.md
+        supporting_text: >-
+          Direct, HEMO-specific **immunosuppressive activity** in vitro or in vivo.
+  - gap_statement: >-
+      The enzyme and regulatory logic responsible for HEMO ectodomain shedding are
+      not known. Broad ADAM/MMP inhibitor sensitivity and mapped Q432/R433 cleavage
+      sites show metalloproteinase-sensitive processing, but do not identify the
+      in vivo protease or explain why shedding is developmentally and disease-context
+      regulated.
+    boundary: >-
+      HEMO is released from a membrane-anchored precursor as a major soluble
+      ectodomain detected in maternal blood, and membrane anchoring is required for
+      efficient shedding. The unresolved part is protease identity, cleavage-site
+      regulation, and whether shedding itself controls HEMO activity.
+    gap_kind:
+      - BIOLOGY
+    dark_aspect: RESIDUAL_SUBGAP
+    status: OPEN
+    significance: >-
+      Shedding is the best-defined biochemical event in HEMO biology; identifying
+      its protease would turn a localization/processing observation into a regulated
+      pathway that can be perturbed in placental and cancer contexts.
+    resolution: >-
+      Combine targeted ADAM/MMP knockdown or CRISPR screens with Q432/R433 cleavage
+      reporters, endogenous trophoblast models, and pregnancy or tumor samples to
+      test protease identity and regulation.
+    provenance:
+      - reference_id: PMID:28739914
+        supporting_text: >-
+          it is actively shed in the blood circulation in humans via specific
+          cleavage of the precursor envelope protein upstream of the transmembrane
+          domain
+      - reference_id: file:human/ERVMER34-1/ERVMER34-1-deep-research-falcon.md
+        supporting_text: >-
+          Mass spectrometry mapped C-terminal truncation/cleavage mainly at **Q432**
+          and **R433** (about **4:1** ratio)
+      - reference_id: file:human/ERVMER34-1/ERVMER34-1-deep-research-cyberian.md
+        supporting_text: >-
+          Which metalloproteinases are responsible for HEMO cleavage? What are the
+          signaling pathways that regulate this shedding?
 # Core-function entry for the HEMO-BACE2 interaction REMOVED per PR #691
 # review. The claim originates from the cyberian deep-research synthesis
 # only, is not corroborated by falcon's independent literature pass, and no


### PR DESCRIPTION
## Summary
- Adds three structured top-level knowledge gaps for human ERVMER34-1/HEMO covering primary receptor/signaling/function, placental anti-fusion or immunomodulatory hypotheses, and the protease/regulation of ectodomain shedding.
- Regenerates the ERVMER34-1 review HTML so the new Knowledge Gaps section is rendered.

## Validation
- `just validate human ERVMER34-1`
- `just render human ERVMER34-1`
- `git diff --check`