### PR TITLE
[codex] Add TXNDC16 knowledge gaps

### DIFF
--- a/genes/human/TXNDC16/TXNDC16-ai-review.html
+++ b/genes/human/TXNDC16/TXNDC16-ai-review.html
@@ -1709,6 +1709,104 @@
 
 
 
+    <div class="section">
+        <h2 class="section-title">Knowledge Gaps</h2>
+        <p style="color: #555; font-size: 0.92rem; margin-top: -0.3rem;">
+            What is <em>not</em> known — curated, literature-grounded statements of the open
+            unknowns (the inverse of core functions).
+        </p>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> It is unresolved whether TXNDC16/ERp90 is a purely non-catalytic PDI-family scaffold/adaptor or whether it performs a CXXC-independent redox activity using conserved noncanonical cysteines.</p>
+            <p style="margin-top: 0.4rem;">
+                <span class="badge">OPEN</span>
+                <span class="badge">BIOLOGY</span><span class="badge">ONTOLOGY</span>
+                <span class="badge">MF_DARK</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> ERp90 is a soluble ER-luminal PDI-family glycoprotein with five Trx-like domains and no canonical Cys-Xaa-Xaa-Cys active-site motif; some cysteines form intramolecular disulfides. The open question is whether those noncanonical cysteines are structural only or contribute directly to redox chemistry.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Significance:</strong> The molecular function cannot be curated more specifically than ER-lumen localization and ERFAD binding until this distinction is resolved; a catalytic oxidoreductase role and a non-catalytic substrate-adaptor role imply different GO molecular functions.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>What would resolve it:</strong> Purify full-length ERp90 and cysteine mutants for redox assays, disulfide-state mapping, and ERFAD-dependent substrate handoff assays in parallel with cellular rescue experiments.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Provenance (the field's own admissions):</strong></p>
+            <ul style="margin-top: 0.2rem;">
+
+                <li><em>"While none of the Trx domains contain a canonical Cys-Xaa-Xaa-Cys active-site motif, other conserved cysteines could endow the protein with redox activity."</em> — PMID:21359175</li>
+
+                <li><em>"Finally, ERp90 could perform a CXXC-independent redox function, conceivably in collaboration with the redox-active ERFAD, through the conserved C664 or even the CX9C motif in the Trx2."</em> — PMID:21359175</li>
+
+            </ul>
+
+
+        </div>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> The ERAD substrate set and pathway step that depend on TXNDC16 remain unknown. ERp90 is proposed to help ERFAD recruit or deliver substrates to the retrotranslocation machinery, but no endogenous substrates or loss-of-function ERAD defects have been demonstrated.</p>
+            <p style="margin-top: 0.4rem;">
+                <span class="badge">OPEN</span>
+                <span class="badge">BIOLOGY</span>
+                <span class="badge">BP_DARK</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> TXNDC16/ERp90 physically associates with ERFAD/FOXRED2 and is positioned in the ERAD luminal network. What is missing is functional evidence that specific glycoprotein or disulfide-containing ERAD clients require TXNDC16 for recognition, reduction, handoff to SEL1L/OS-9, retrotranslocation, or degradation.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Significance:</strong> This gap separates an interaction-based ERAD hypothesis from a process annotation. Resolving it would define whether TXNDC16 is a core ERAD factor, a client-specific cofactor, or a bystander in an ERFAD-containing complex.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>What would resolve it:</strong> Generate TXNDC16 knockout/rescue cells and measure degradation, disulfide status, and retrotranslocation of model and proteome-wide ERAD substrates, including ERFAD-dependent and ERFAD-independent contexts.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Provenance (the field's own admissions):</strong></p>
+            <ul style="margin-top: 0.2rem;">
+
+                <li><em>"Since we did not succeed in performing siRNA-mediated knockdown experiments of ERp90 to study an involvement of ERp90 in ERAD, we can presently only speculate about the function of ERp90 in relation to ERFAD."</em> — PMID:21359175</li>
+
+                <li><em>"Future work should allow us to distinguish between these various possibilities."</em> — PMID:21359175</li>
+
+            </ul>
+
+
+        </div>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> The biological significance of TXNDC16 secretion and meningioma-associated autoantibodies is unclear. TXNDC16 is secreted because its ER-retrieval motif is masked, and antibodies can distinguish meningioma sera, but it is not known whether extracellular TXNDC16 has a function or is mainly a biomarker/immunogenic byproduct of leakage from the ER-lumen pool.</p>
+            <p style="margin-top: 0.4rem;">
+                <span class="badge">OPEN</span>
+                <span class="badge">BIOLOGY</span><span class="badge">CURATION</span>
+                <span class="badge">RESIDUAL_SUBGAP</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> Secretion from multiple human cell lines and circulating immune complexes are documented, while exosomal secretion was not confirmed in HEK293 cells. The unresolved part is whether secreted TXNDC16 participates in disease biology, antigen presentation, or immune-complex formation beyond diagnostic association.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Significance:</strong> This limits curation of extracellular annotations: secretion is real and should be retained, but disease-associated immunogenicity should not be interpreted as a normal extracellular molecular function without mechanistic evidence.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>What would resolve it:</strong> Determine the source and form of serum TXNDC16 in meningioma and controls, test whether immune complexes contain intact secreted protein or fragments, and assess any extracellular effects on immune or tumor cells.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Provenance (the field's own admissions):</strong></p>
+            <ul style="margin-top: 0.2rem;">
+
+                <li><em>"We were able to show TXNDC16 secretion in different human cell lines due to masked and therefore nonfunctional ER retrieval motif."</em> — PMID:25122923</li>
+
+                <li><em>"The secreted serum protein TXNDC16 is bound in circulating immune complexes, which were found both in meningioma and healthy blood donor sera."</em> — PMID:25122923</li>
+
+                <li><em>"A previously indicated exosomal TXNDC16 secretion could not be confirmed in HEK293 cells."</em> — PMID:25122923</li>
+
+            </ul>
+
+
+        </div>
+
+    </div>
+
 
 
 
@@ -2311,6 +2409,116 @@ core_functions:
     supporting_text: &gt;-
       We propose that the function of ERp90 is related to substrate recruitment or delivery to
       the ERAD retrotranslocation machinery by ERFAD.
+knowledge_gaps:
+- gap_statement: &gt;-
+    It is unresolved whether TXNDC16/ERp90 is a purely non-catalytic PDI-family
+    scaffold/adaptor or whether it performs a CXXC-independent redox activity using
+    conserved noncanonical cysteines.
+  boundary: &gt;-
+    ERp90 is a soluble ER-luminal PDI-family glycoprotein with five Trx-like domains
+    and no canonical Cys-Xaa-Xaa-Cys active-site motif; some cysteines form
+    intramolecular disulfides. The open question is whether those noncanonical
+    cysteines are structural only or contribute directly to redox chemistry.
+  gap_kind:
+  - BIOLOGY
+  - ONTOLOGY
+  dark_aspect: MF_DARK
+  status: OPEN
+  significance: &gt;-
+    The molecular function cannot be curated more specifically than ER-lumen
+    localization and ERFAD binding until this distinction is resolved; a catalytic
+    oxidoreductase role and a non-catalytic substrate-adaptor role imply different
+    GO molecular functions.
+  resolution: &gt;-
+    Purify full-length ERp90 and cysteine mutants for redox assays, disulfide-state
+    mapping, and ERFAD-dependent substrate handoff assays in parallel with cellular
+    rescue experiments.
+  provenance:
+  - reference_id: PMID:21359175
+    supporting_text: &gt;-
+      While none of the Trx domains contain a canonical Cys-Xaa-Xaa-Cys active-site
+      motif, other conserved cysteines could endow the protein with redox activity.
+    reference_section_type: ABSTRACT
+  - reference_id: PMID:21359175
+    supporting_text: &gt;-
+      Finally, ERp90 could perform a CXXC-independent redox function, conceivably
+      in collaboration with the redox-active ERFAD, through the conserved C664 or
+      even the CX9C motif in the Trx2.
+    reference_section_type: DISCUSSION
+- gap_statement: &gt;-
+    The ERAD substrate set and pathway step that depend on TXNDC16 remain unknown.
+    ERp90 is proposed to help ERFAD recruit or deliver substrates to the
+    retrotranslocation machinery, but no endogenous substrates or loss-of-function
+    ERAD defects have been demonstrated.
+  boundary: &gt;-
+    TXNDC16/ERp90 physically associates with ERFAD/FOXRED2 and is positioned in the
+    ERAD luminal network. What is missing is functional evidence that specific
+    glycoprotein or disulfide-containing ERAD clients require TXNDC16 for
+    recognition, reduction, handoff to SEL1L/OS-9, retrotranslocation, or degradation.
+  gap_kind:
+  - BIOLOGY
+  dark_aspect: BP_DARK
+  status: OPEN
+  significance: &gt;-
+    This gap separates an interaction-based ERAD hypothesis from a process
+    annotation. Resolving it would define whether TXNDC16 is a core ERAD factor,
+    a client-specific cofactor, or a bystander in an ERFAD-containing complex.
+  resolution: &gt;-
+    Generate TXNDC16 knockout/rescue cells and measure degradation, disulfide status,
+    and retrotranslocation of model and proteome-wide ERAD substrates, including
+    ERFAD-dependent and ERFAD-independent contexts.
+  provenance:
+  - reference_id: PMID:21359175
+    supporting_text: &gt;-
+      Since we did not succeed in performing siRNA-mediated knockdown experiments
+      of ERp90 to study an involvement of ERp90 in ERAD, we can presently only
+      speculate about the function of ERp90 in relation to ERFAD.
+    reference_section_type: DISCUSSION
+  - reference_id: PMID:21359175
+    supporting_text: &gt;-
+      Future work should allow us to distinguish between these various
+      possibilities.
+    reference_section_type: DISCUSSION
+- gap_statement: &gt;-
+    The biological significance of TXNDC16 secretion and meningioma-associated
+    autoantibodies is unclear. TXNDC16 is secreted because its ER-retrieval motif is
+    masked, and antibodies can distinguish meningioma sera, but it is not known
+    whether extracellular TXNDC16 has a function or is mainly a biomarker/immunogenic
+    byproduct of leakage from the ER-lumen pool.
+  boundary: &gt;-
+    Secretion from multiple human cell lines and circulating immune complexes are
+    documented, while exosomal secretion was not confirmed in HEK293 cells. The
+    unresolved part is whether secreted TXNDC16 participates in disease biology,
+    antigen presentation, or immune-complex formation beyond diagnostic association.
+  gap_kind:
+  - BIOLOGY
+  - CURATION
+  dark_aspect: RESIDUAL_SUBGAP
+  status: OPEN
+  significance: &gt;-
+    This limits curation of extracellular annotations: secretion is real and should
+    be retained, but disease-associated immunogenicity should not be interpreted as
+    a normal extracellular molecular function without mechanistic evidence.
+  resolution: &gt;-
+    Determine the source and form of serum TXNDC16 in meningioma and controls,
+    test whether immune complexes contain intact secreted protein or fragments, and
+    assess any extracellular effects on immune or tumor cells.
+  provenance:
+  - reference_id: PMID:25122923
+    supporting_text: &gt;-
+      We were able to show TXNDC16 secretion in different human cell lines due to
+      masked and therefore nonfunctional ER retrieval motif.
+    reference_section_type: ABSTRACT
+  - reference_id: PMID:25122923
+    supporting_text: &gt;-
+      The secreted serum protein TXNDC16 is bound in circulating immune complexes,
+      which were found both in meningioma and healthy blood donor sera.
+    reference_section_type: ABSTRACT
+  - reference_id: PMID:25122923
+    supporting_text: &gt;-
+      A previously indicated exosomal TXNDC16 secretion could not be confirmed in
+      HEK293 cells.
+    reference_section_type: ABSTRACT
 proposed_new_terms: []
 references:
 - id: GO_REF:0000044

--- a/genes/human/TXNDC16/TXNDC16-ai-review.yaml
+++ b/genes/human/TXNDC16/TXNDC16-ai-review.yaml
@@ -160,6 +160,116 @@ core_functions:
     supporting_text: >-
       We propose that the function of ERp90 is related to substrate recruitment or delivery to
       the ERAD retrotranslocation machinery by ERFAD.
+knowledge_gaps:
+- gap_statement: >-
+    It is unresolved whether TXNDC16/ERp90 is a purely non-catalytic PDI-family
+    scaffold/adaptor or whether it performs a CXXC-independent redox activity using
+    conserved noncanonical cysteines.
+  boundary: >-
+    ERp90 is a soluble ER-luminal PDI-family glycoprotein with five Trx-like domains
+    and no canonical Cys-Xaa-Xaa-Cys active-site motif; some cysteines form
+    intramolecular disulfides. The open question is whether those noncanonical
+    cysteines are structural only or contribute directly to redox chemistry.
+  gap_kind:
+  - BIOLOGY
+  - ONTOLOGY
+  dark_aspect: MF_DARK
+  status: OPEN
+  significance: >-
+    The molecular function cannot be curated more specifically than ER-lumen
+    localization and ERFAD binding until this distinction is resolved; a catalytic
+    oxidoreductase role and a non-catalytic substrate-adaptor role imply different
+    GO molecular functions.
+  resolution: >-
+    Purify full-length ERp90 and cysteine mutants for redox assays, disulfide-state
+    mapping, and ERFAD-dependent substrate handoff assays in parallel with cellular
+    rescue experiments.
+  provenance:
+  - reference_id: PMID:21359175
+    supporting_text: >-
+      While none of the Trx domains contain a canonical Cys-Xaa-Xaa-Cys active-site
+      motif, other conserved cysteines could endow the protein with redox activity.
+    reference_section_type: ABSTRACT
+  - reference_id: PMID:21359175
+    supporting_text: >-
+      Finally, ERp90 could perform a CXXC-independent redox function, conceivably
+      in collaboration with the redox-active ERFAD, through the conserved C664 or
+      even the CX9C motif in the Trx2.
+    reference_section_type: DISCUSSION
+- gap_statement: >-
+    The ERAD substrate set and pathway step that depend on TXNDC16 remain unknown.
+    ERp90 is proposed to help ERFAD recruit or deliver substrates to the
+    retrotranslocation machinery, but no endogenous substrates or loss-of-function
+    ERAD defects have been demonstrated.
+  boundary: >-
+    TXNDC16/ERp90 physically associates with ERFAD/FOXRED2 and is positioned in the
+    ERAD luminal network. What is missing is functional evidence that specific
+    glycoprotein or disulfide-containing ERAD clients require TXNDC16 for
+    recognition, reduction, handoff to SEL1L/OS-9, retrotranslocation, or degradation.
+  gap_kind:
+  - BIOLOGY
+  dark_aspect: BP_DARK
+  status: OPEN
+  significance: >-
+    This gap separates an interaction-based ERAD hypothesis from a process
+    annotation. Resolving it would define whether TXNDC16 is a core ERAD factor,
+    a client-specific cofactor, or a bystander in an ERFAD-containing complex.
+  resolution: >-
+    Generate TXNDC16 knockout/rescue cells and measure degradation, disulfide status,
+    and retrotranslocation of model and proteome-wide ERAD substrates, including
+    ERFAD-dependent and ERFAD-independent contexts.
+  provenance:
+  - reference_id: PMID:21359175
+    supporting_text: >-
+      Since we did not succeed in performing siRNA-mediated knockdown experiments
+      of ERp90 to study an involvement of ERp90 in ERAD, we can presently only
+      speculate about the function of ERp90 in relation to ERFAD.
+    reference_section_type: DISCUSSION
+  - reference_id: PMID:21359175
+    supporting_text: >-
+      Future work should allow us to distinguish between these various
+      possibilities.
+    reference_section_type: DISCUSSION
+- gap_statement: >-
+    The biological significance of TXNDC16 secretion and meningioma-associated
+    autoantibodies is unclear. TXNDC16 is secreted because its ER-retrieval motif is
+    masked, and antibodies can distinguish meningioma sera, but it is not known
+    whether extracellular TXNDC16 has a function or is mainly a biomarker/immunogenic
+    byproduct of leakage from the ER-lumen pool.
+  boundary: >-
+    Secretion from multiple human cell lines and circulating immune complexes are
+    documented, while exosomal secretion was not confirmed in HEK293 cells. The
+    unresolved part is whether secreted TXNDC16 participates in disease biology,
+    antigen presentation, or immune-complex formation beyond diagnostic association.
+  gap_kind:
+  - BIOLOGY
+  - CURATION
+  dark_aspect: RESIDUAL_SUBGAP
+  status: OPEN
+  significance: >-
+    This limits curation of extracellular annotations: secretion is real and should
+    be retained, but disease-associated immunogenicity should not be interpreted as
+    a normal extracellular molecular function without mechanistic evidence.
+  resolution: >-
+    Determine the source and form of serum TXNDC16 in meningioma and controls,
+    test whether immune complexes contain intact secreted protein or fragments, and
+    assess any extracellular effects on immune or tumor cells.
+  provenance:
+  - reference_id: PMID:25122923
+    supporting_text: >-
+      We were able to show TXNDC16 secretion in different human cell lines due to
+      masked and therefore nonfunctional ER retrieval motif.
+    reference_section_type: ABSTRACT
+  - reference_id: PMID:25122923
+    supporting_text: >-
+      The secreted serum protein TXNDC16 is bound in circulating immune complexes,
+      which were found both in meningioma and healthy blood donor sera.
+    reference_section_type: ABSTRACT
+  - reference_id: PMID:25122923
+    supporting_text: >-
+      A previously indicated exosomal TXNDC16 secretion could not be confirmed in
+      HEK293 cells.
+    reference_section_type: ABSTRACT
 proposed_new_terms: []
 references:
 - id: GO_REF:0000044


### PR DESCRIPTION
## Summary
- Adds three structured top-level knowledge gaps for human TXNDC16 covering CXXC-independent redox vs scaffold function, ERAD substrate/pathway dependence, and the significance of secretion/meningioma-associated immune complexes.
- Regenerates the TXNDC16 review HTML so the new Knowledge Gaps section is rendered.

## Validation
- `just validate human TXNDC16` passed with 1 warning: existing annotations do not reference the available `TXNDC16-deep-research-falcon.md` file.
- `just render human TXNDC16`
- `git diff --check`