### PR TITLE
[codex] Add DNAJC4 knowledge gaps

### DIFF
--- a/genes/human/DNAJC4/DNAJC4-ai-review.html
+++ b/genes/human/DNAJC4/DNAJC4-ai-review.html
@@ -1557,6 +1557,52 @@
 
             </div>
 
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        file:human/DNAJC4/DNAJC4-notes.md
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Reviewer notes for DNAJC4</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">Local review notes emphasize that DNAJC4 is a Tdark J-domain protein with family-level HSP70 co-chaperone inference, predicted membrane localization, and no direct experimental characterization of chaperone activity, HSP70 partner, topology, or client repertoire.</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        file:human/DNAJC4/DNAJC4-pn-notes.md
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Proteostasis-network notes for DNAJC4</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">PN review notes flag that the HSP70 co-chaperone assignment is family-level and unverified experimentally, and that mitochondrial-branch placement is unsupported by the dossier.</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
         </div>
     </div>
 
@@ -1634,6 +1680,77 @@
     </div>
 
 
+
+    <div class="section">
+        <h2 class="section-title">Knowledge Gaps</h2>
+        <p style="color: #555; font-size: 0.92rem; margin-top: -0.3rem;">
+            What is <em>not</em> known — curated, literature-grounded statements of the open
+            unknowns (the inverse of core functions).
+        </p>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> DNAJC4&#39;s HSP70 co-chaperone activity is unverified. It is unresolved whether DNAJC4&#39;s J domain stimulates ATPase activity of a specific HSP70 paralog, what clients it recruits, and whether Hsp70 protein binding (GO:0030544) or unfolded protein binding (GO:0051082) is the better curation target for this family-level prediction.</p>
+            <p style="margin-top: 0.4rem;">
+                <span class="badge">OPEN</span>
+                <span class="badge">BIOLOGY</span><span class="badge">ONTOLOGY</span>
+                <span class="badge">MF_DARK</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> DNAJC4 has a predicted J domain and is annotated as a DnaJ-like HSPF2 protein, so an HSP70 co-chaperone role is plausible by family. Existing GO process terms for protein folding and unfolded-protein response are inference-level, and the observed HTT/WFS1 protein-binding annotations do not establish a client repertoire or chaperone mechanism.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Significance:</strong> This is the core dark-function issue for DNAJC4: without direct biochemical evidence, the review can only record a cautious family-level molecular-function prediction rather than a verified HSP70 co-chaperone activity.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>What would resolve it:</strong> Test purified DNAJC4 or its J domain in HSP70 ATPase assays against HSPA8, HSPA1A, and other likely partners; compare wild-type and HPD-motif mutants; and define clients by endogenous affinity proteomics plus substrate-folding assays.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Provenance (the field's own admissions):</strong></p>
+            <ul style="margin-top: 0.2rem;">
+
+                <li><em>"A J-domain protein, so by family it is an HSP70 (DnaJ/HSP40) co-chaperone, but there is essentially NO direct experimental characterization of its activity."</em> — file:human/DNAJC4/DNAJC4-notes.md</li>
+
+                <li><em>"No experimental chaperone data exist."</em> — file:human/DNAJC4/DNAJC4-pn-notes.md</li>
+
+                <li><em>"both are family-level/unverified; prefer GO:0030544 only if asserted as predicted, not experimental."</em> — file:human/DNAJC4/DNAJC4-pn-notes.md</li>
+
+            </ul>
+
+
+        </div>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> DNAJC4 membrane topology and subcellular destination are unresolved. The protein is predicted to be a single-pass membrane protein, but the membrane compartment, orientation of the J domain, and the validity of a mitochondrial proteostasis placement have not been experimentally established.</p>
+            <p style="margin-top: 0.4rem;">
+                <span class="badge">OPEN</span>
+                <span class="badge">BIOLOGY</span><span class="badge">CURATION</span>
+                <span class="badge">CC_DARK</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> UniProt and the current review support generic membrane localization from a predicted transmembrane helix. They do not establish whether DNAJC4 acts at the ER, mitochondria, plasma membrane, another organelle membrane, or multiple compartments, nor whether its J domain faces the cytosol or an organelle lumen.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Significance:</strong> Localization determines the relevant HSP70 partner and client class. It also controls whether proteostasis-network mitochondrial placement should be retained, revised, or treated as a generic J-domain grouping artifact.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>What would resolve it:</strong> Use endogenous tagging, organelle fractionation, protease-protection/topology assays, and proximity labeling to define the membrane compartment and orientation of DNAJC4 before assigning pathway-specific chaperone context.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Provenance (the field's own admissions):</strong></p>
+            <ul style="margin-top: 0.2rem;">
+
+                <li><em>"SUBCELLULAR LOCATION: Membrane {ECO:0000305}; Single-pass membrane"</em> — file:human/DNAJC4/DNAJC4-uniprot.txt</li>
+
+                <li><em>"PN places DNAJC4 in the **Mitochondrial** branch, but neither the review nor notes give any mitochondrial evidence"</em> — file:human/DNAJC4/DNAJC4-pn-notes.md</li>
+
+                <li><em>"Has a predicted single-pass transmembrane helix (TRANSMEM 156..175) and is annotated as a membrane / single-pass membrane protein"</em> — file:human/DNAJC4/DNAJC4-notes.md</li>
+
+            </ul>
+
+
+        </div>
+
+    </div>
 
 
 
@@ -1951,6 +2068,23 @@ references:
       assignment to this family is the basis for its inferred protein-folding/unfolded-protein-response
       and membrane annotations.
     reference_section_type: RESULTS
+- id: file:human/DNAJC4/DNAJC4-notes.md
+  title: Reviewer notes for DNAJC4
+  findings:
+  - statement: &gt;-
+      Local review notes emphasize that DNAJC4 is a Tdark J-domain protein with
+      family-level HSP70 co-chaperone inference, predicted membrane localization,
+      and no direct experimental characterization of chaperone activity, HSP70
+      partner, topology, or client repertoire.
+    reference_section_type: OTHER
+- id: file:human/DNAJC4/DNAJC4-pn-notes.md
+  title: Proteostasis-network notes for DNAJC4
+  findings:
+  - statement: &gt;-
+      PN review notes flag that the HSP70 co-chaperone assignment is family-level
+      and unverified experimentally, and that mitochondrial-branch placement is
+      unsupported by the dossier.
+    reference_section_type: OTHER
 core_functions:
 - description: Predicted HSP70 (DnaJ/HSP40) co-chaperone, defined by an N-terminal
     J domain that in characterized family members engages and stimulates HSP70 chaperones.
@@ -1965,6 +2099,78 @@ core_functions:
   supported_by:
   - reference_id: file:human/DNAJC4/DNAJC4-uniprot.txt
     supporting_text: DnaJ-like protein HSPF2
+knowledge_gaps:
+- gap_statement: &gt;-
+    DNAJC4&#39;s HSP70 co-chaperone activity is unverified. It is unresolved whether
+    DNAJC4&#39;s J domain stimulates ATPase activity of a specific HSP70 paralog, what
+    clients it recruits, and whether Hsp70 protein binding (GO:0030544) or unfolded
+    protein binding (GO:0051082) is the better curation target for this family-level
+    prediction.
+  boundary: &gt;-
+    DNAJC4 has a predicted J domain and is annotated as a DnaJ-like HSPF2 protein,
+    so an HSP70 co-chaperone role is plausible by family. Existing GO process terms
+    for protein folding and unfolded-protein response are inference-level, and the
+    observed HTT/WFS1 protein-binding annotations do not establish a client
+    repertoire or chaperone mechanism.
+  gap_kind:
+  - BIOLOGY
+  - ONTOLOGY
+  dark_aspect: MF_DARK
+  status: OPEN
+  significance: &gt;-
+    This is the core dark-function issue for DNAJC4: without direct biochemical
+    evidence, the review can only record a cautious family-level molecular-function
+    prediction rather than a verified HSP70 co-chaperone activity.
+  resolution: &gt;-
+    Test purified DNAJC4 or its J domain in HSP70 ATPase assays against HSPA8,
+    HSPA1A, and other likely partners; compare wild-type and HPD-motif mutants; and
+    define clients by endogenous affinity proteomics plus substrate-folding assays.
+  provenance:
+  - reference_id: file:human/DNAJC4/DNAJC4-notes.md
+    supporting_text: &gt;-
+      A J-domain protein, so by family it is an HSP70 (DnaJ/HSP40) co-chaperone,
+      but there is essentially NO direct experimental characterization of its
+      activity.
+  - reference_id: file:human/DNAJC4/DNAJC4-pn-notes.md
+    supporting_text: No experimental chaperone data exist.
+  - reference_id: file:human/DNAJC4/DNAJC4-pn-notes.md
+    supporting_text: &gt;-
+      both are family-level/unverified; prefer GO:0030544 only if asserted as
+      predicted, not experimental.
+- gap_statement: &gt;-
+    DNAJC4 membrane topology and subcellular destination are unresolved. The protein
+    is predicted to be a single-pass membrane protein, but the membrane compartment,
+    orientation of the J domain, and the validity of a mitochondrial proteostasis
+    placement have not been experimentally established.
+  boundary: &gt;-
+    UniProt and the current review support generic membrane localization from a
+    predicted transmembrane helix. They do not establish whether DNAJC4 acts at the
+    ER, mitochondria, plasma membrane, another organelle membrane, or multiple
+    compartments, nor whether its J domain faces the cytosol or an organelle lumen.
+  gap_kind:
+  - BIOLOGY
+  - CURATION
+  dark_aspect: CC_DARK
+  status: OPEN
+  significance: &gt;-
+    Localization determines the relevant HSP70 partner and client class. It also
+    controls whether proteostasis-network mitochondrial placement should be retained,
+    revised, or treated as a generic J-domain grouping artifact.
+  resolution: &gt;-
+    Use endogenous tagging, organelle fractionation, protease-protection/topology
+    assays, and proximity labeling to define the membrane compartment and orientation
+    of DNAJC4 before assigning pathway-specific chaperone context.
+  provenance:
+  - reference_id: file:human/DNAJC4/DNAJC4-uniprot.txt
+    supporting_text: &#34;SUBCELLULAR LOCATION: Membrane {ECO:0000305}; Single-pass membrane&#34;
+  - reference_id: file:human/DNAJC4/DNAJC4-pn-notes.md
+    supporting_text: &gt;-
+      PN places DNAJC4 in the **Mitochondrial** branch, but neither the review nor
+      notes give any mitochondrial evidence
+  - reference_id: file:human/DNAJC4/DNAJC4-notes.md
+    supporting_text: &gt;-
+      Has a predicted single-pass transmembrane helix (TRANSMEM 156..175) and is
+      annotated as a membrane / single-pass membrane protein
 proposed_new_terms: []
 suggested_questions:
 - question: Does DNAJC4 function as a bona fide HSP70 co-chaperone (i.e. does its J

--- a/genes/human/DNAJC4/DNAJC4-ai-review.yaml
+++ b/genes/human/DNAJC4/DNAJC4-ai-review.yaml
@@ -153,6 +153,23 @@ references:
       assignment to this family is the basis for its inferred protein-folding/unfolded-protein-response
       and membrane annotations.
     reference_section_type: RESULTS
+- id: file:human/DNAJC4/DNAJC4-notes.md
+  title: Reviewer notes for DNAJC4
+  findings:
+  - statement: >-
+      Local review notes emphasize that DNAJC4 is a Tdark J-domain protein with
+      family-level HSP70 co-chaperone inference, predicted membrane localization,
+      and no direct experimental characterization of chaperone activity, HSP70
+      partner, topology, or client repertoire.
+    reference_section_type: OTHER
+- id: file:human/DNAJC4/DNAJC4-pn-notes.md
+  title: Proteostasis-network notes for DNAJC4
+  findings:
+  - statement: >-
+      PN review notes flag that the HSP70 co-chaperone assignment is family-level
+      and unverified experimentally, and that mitochondrial-branch placement is
+      unsupported by the dossier.
+    reference_section_type: OTHER
 core_functions:
 - description: Predicted HSP70 (DnaJ/HSP40) co-chaperone, defined by an N-terminal
     J domain that in characterized family members engages and stimulates HSP70 chaperones.
@@ -167,6 +184,78 @@ core_functions:
   supported_by:
   - reference_id: file:human/DNAJC4/DNAJC4-uniprot.txt
     supporting_text: DnaJ-like protein HSPF2
+knowledge_gaps:
+- gap_statement: >-
+    DNAJC4's HSP70 co-chaperone activity is unverified. It is unresolved whether
+    DNAJC4's J domain stimulates ATPase activity of a specific HSP70 paralog, what
+    clients it recruits, and whether Hsp70 protein binding (GO:0030544) or unfolded
+    protein binding (GO:0051082) is the better curation target for this family-level
+    prediction.
+  boundary: >-
+    DNAJC4 has a predicted J domain and is annotated as a DnaJ-like HSPF2 protein,
+    so an HSP70 co-chaperone role is plausible by family. Existing GO process terms
+    for protein folding and unfolded-protein response are inference-level, and the
+    observed HTT/WFS1 protein-binding annotations do not establish a client
+    repertoire or chaperone mechanism.
+  gap_kind:
+  - BIOLOGY
+  - ONTOLOGY
+  dark_aspect: MF_DARK
+  status: OPEN
+  significance: >-
+    This is the core dark-function issue for DNAJC4: without direct biochemical
+    evidence, the review can only record a cautious family-level molecular-function
+    prediction rather than a verified HSP70 co-chaperone activity.
+  resolution: >-
+    Test purified DNAJC4 or its J domain in HSP70 ATPase assays against HSPA8,
+    HSPA1A, and other likely partners; compare wild-type and HPD-motif mutants; and
+    define clients by endogenous affinity proteomics plus substrate-folding assays.
+  provenance:
+  - reference_id: file:human/DNAJC4/DNAJC4-notes.md
+    supporting_text: >-
+      A J-domain protein, so by family it is an HSP70 (DnaJ/HSP40) co-chaperone,
+      but there is essentially NO direct experimental characterization of its
+      activity.
+  - reference_id: file:human/DNAJC4/DNAJC4-pn-notes.md
+    supporting_text: No experimental chaperone data exist.
+  - reference_id: file:human/DNAJC4/DNAJC4-pn-notes.md
+    supporting_text: >-
+      both are family-level/unverified; prefer GO:0030544 only if asserted as
+      predicted, not experimental.
+- gap_statement: >-
+    DNAJC4 membrane topology and subcellular destination are unresolved. The protein
+    is predicted to be a single-pass membrane protein, but the membrane compartment,
+    orientation of the J domain, and the validity of a mitochondrial proteostasis
+    placement have not been experimentally established.
+  boundary: >-
+    UniProt and the current review support generic membrane localization from a
+    predicted transmembrane helix. They do not establish whether DNAJC4 acts at the
+    ER, mitochondria, plasma membrane, another organelle membrane, or multiple
+    compartments, nor whether its J domain faces the cytosol or an organelle lumen.
+  gap_kind:
+  - BIOLOGY
+  - CURATION
+  dark_aspect: CC_DARK
+  status: OPEN
+  significance: >-
+    Localization determines the relevant HSP70 partner and client class. It also
+    controls whether proteostasis-network mitochondrial placement should be retained,
+    revised, or treated as a generic J-domain grouping artifact.
+  resolution: >-
+    Use endogenous tagging, organelle fractionation, protease-protection/topology
+    assays, and proximity labeling to define the membrane compartment and orientation
+    of DNAJC4 before assigning pathway-specific chaperone context.
+  provenance:
+  - reference_id: file:human/DNAJC4/DNAJC4-uniprot.txt
+    supporting_text: "SUBCELLULAR LOCATION: Membrane {ECO:0000305}; Single-pass membrane"
+  - reference_id: file:human/DNAJC4/DNAJC4-pn-notes.md
+    supporting_text: >-
+      PN places DNAJC4 in the **Mitochondrial** branch, but neither the review nor
+      notes give any mitochondrial evidence
+  - reference_id: file:human/DNAJC4/DNAJC4-notes.md
+    supporting_text: >-
+      Has a predicted single-pass transmembrane helix (TRANSMEM 156..175) and is
+      annotated as a membrane / single-pass membrane protein
 proposed_new_terms: []
 suggested_questions:
 - question: Does DNAJC4 function as a bona fide HSP70 co-chaperone (i.e. does its J


### PR DESCRIPTION
## Summary
- Adds two structured top-level knowledge gaps for human DNAJC4 covering unverified HSP70 co-chaperone/client activity and unresolved membrane topology/subcellular placement.
- Registers local DNAJC4 notes/PN notes as explicit file references for the gap provenance.
- Regenerates the DNAJC4 review HTML so the new Knowledge Gaps section is rendered.

## Validation
- `just validate human DNAJC4` passed with 1 warning: core function GO:0051082 is not reflected in `existing_annotations` as `NEW`.
- `just render human DNAJC4`
- `git diff --check`