### PR TITLE
[codex] Add SCP2D1 knowledge gaps

### DIFF
--- a/genes/human/SCP2D1/SCP2D1-ai-review.html
+++ b/genes/human/SCP2D1/SCP2D1-ai-review.html
@@ -1484,6 +1484,132 @@ non-core, expression-pattern observation rather than a molecular function.</div>
 
 
 
+    <div class="section">
+        <h2 class="section-title">Knowledge Gaps</h2>
+        <p style="color: #555; font-size: 0.92rem; margin-top: -0.3rem;">
+            What is <em>not</em> known — curated, literature-grounded statements of the open
+            unknowns (the inverse of core functions).
+        </p>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> SCP2D1&#39;s exact lipid-binding and transfer biochemistry remains unresolved. Current evidence supports
+multi-class lipid binding, but binding constants, transfer rates, lipid preferences, membrane-donor/
+acceptor requirements, and whether SCP2D1 functions as a transfer protein versus a lipid sensor or
+buffer are unknown.</p>
+            <p style="margin-top: 0.4rem;">
+                <span class="badge">OPEN</span>
+                <span class="badge">BIOLOGY</span><span class="badge">ONTOLOGY</span>
+                <span class="badge">RESIDUAL_SUBGAP</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> The review accepts broad lipid binding (GO:0008289) based on SCP2-domain homology and recent ligand-
+class mapping that includes fatty acids and several lysophospholipid/glycerophospholipid classes.
+The gap is not whether SCP2D1 plausibly binds lipids, but the quantitative specificity and mechanism
+needed to define a more precise molecular function.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Significance:</strong> Without biochemical specificity, SCP2D1 cannot be curated beyond a broad lipid-binding term, and the
+relationship between sterol-domain homology, fatty-acid/phospholipid associations, and cholesterol
+phenotypes remains mechanistically ambiguous.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>What would resolve it:</strong> Purify recombinant SCP2D1 and measure lipid binding and transfer using defined sterol, fatty-acid,
+lysophospholipid, phospholipid, and acyl-CoA panels; combine kinetics with structural mapping of the
+hydrophobic cavity and lipidomics after cellular perturbation.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Provenance (the field's own admissions):</strong></p>
+            <ul style="margin-top: 0.2rem;">
+
+                <li><em>"binding constants, transfer rates, and subcellular site of action"</em> — file:human/SCP2D1/SCP2D1-deep-research-falcon.md</li>
+
+                <li><em>"Biochemical specificity** (binding constants, lipid transfer rates; whether SCP2D1 transfers lipids between membranes vs binds as a sensor)."</em> — file:human/SCP2D1/SCP2D1-deep-research-falcon.md</li>
+
+                <li><em>"No retrieved source demonstrated SCP2D1 catalyzing a biochemical reaction (enzyme activity) or acting as a membrane transporter with defined substrate translocation kinetics."</em> — file:human/SCP2D1/SCP2D1-deep-research-falcon.md</li>
+
+            </ul>
+
+
+        </div>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> SCP2D1&#39;s direct subcellular localization and site of lipid action remain underdetermined. Cytosolic
+localization is currently inferred, while peroxisomal localization from SCP2/SCPX cannot be transferred
+to SCP2D1 and no endogenous SCP2D1 localization experiment has resolved where it acts.</p>
+            <p style="margin-top: 0.4rem;">
+                <span class="badge">OPEN</span>
+                <span class="badge">BIOLOGY</span><span class="badge">CURATION</span>
+                <span class="badge">CC_DARK</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> SCP2D1 is annotated to the cytosol by IBA/phylogenetic inference and lacks clear peroxisomal targeting
+evidence. The open issue is whether it acts diffusely in cytosol, at endomembranes, near lipid droplets,
+mitochondria, testis-specific membranes, or other lipid-trafficking interfaces.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Significance:</strong> Localization is essential for interpreting lipid-transfer partners, cholesterol/LDL phenotypes, and
+whether any SCP2-paralog or pathway annotation can be safely propagated to SCP2D1.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>What would resolve it:</strong> Use validated endogenous antibodies or epitope knock-in tags for immunofluorescence, organelle
+fractionation, proximity labeling, and lipid-droplet/endomembrane colocalization in testis-relevant
+and cholesterol-perturbation models.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Provenance (the field's own admissions):</strong></p>
+            <ul style="margin-top: 0.2rem;">
+
+                <li><em>"No retrieved SCP2D1-specific experiments provided definitive localization (e.g., immunofluorescence of endogenous SCP2D1, organelle fractionation, proximity labeling, or tagged SCP2D1 localization). Therefore, SCP2D1 localization remains **underdetermined** from this evidence set."</em> — file:human/SCP2D1/SCP2D1-deep-research-falcon.md</li>
+
+                <li><em>"these data apply to **SCP2**, not SCP2D1, and cannot be transferred as direct annotation for SCP2D1"</em> — file:human/SCP2D1/SCP2D1-deep-research-falcon.md</li>
+
+            </ul>
+
+
+        </div>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> The cellular and physiological pathway for SCP2D1 remains unknown: siRNA knockdown alters cholesterol
+staining and LDL uptake, and expression is enriched in testis and reactivated in some cancers, but it
+is unresolved whether these observations reflect one lipid-trafficking function, a testis-specific
+reproductive role, a cancer-testis biomarker state, or separate context-dependent effects.</p>
+            <p style="margin-top: 0.4rem;">
+                <span class="badge">OPEN</span>
+                <span class="badge">BIOLOGY</span>
+                <span class="badge">BP_DARK</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> Existing evidence connects SCP2D1 to lipid/cholesterol handling phenotypes and to testis/cancer-testis
+expression patterns. It does not establish the relevant cell type, pathway step, protein partners, or
+whether SCP2D1 is required for spermatogenesis, steroidogenesis, LDL receptor trafficking, endosomal
+cholesterol egress, or tumor biology.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Significance:</strong> This is the main biological-process gap: a broad lipid-binding MF is plausible, but the organismal and
+cellular process that needs SCP2D1 is still undefined.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>What would resolve it:</strong> Combine SCP2D1 knockout/knockdown with filipin/LDL uptake assays, lipidomics, rescue by lipid-binding
+mutants, and testis-focused models assessing germ-cell, Sertoli-cell, Leydig-cell, steroidogenesis,
+and sperm phenotypes.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Provenance (the field's own admissions):</strong></p>
+            <ul style="margin-top: 0.2rem;">
+
+                <li><em>"Mechanistic link to cholesterol/LDL phenotype** (e.g., LDLR pathway, endosome/lysosome cholesterol egress, ER lipid composition)."</em> — file:human/SCP2D1/SCP2D1-deep-research-falcon.md</li>
+
+                <li><em>"Direct perturbation evidence supports a role in lipid/cholesterol homeostasis, but mechanism, substrate specificity, and subcellular site of action were not resolved."</em> — file:human/SCP2D1/SCP2D1-deep-research-falcon.md</li>
+
+                <li><em>"However, SCP2D1’s exact **substrate specificity, interacting partners, and physiological role are open questions**."</em> — file:human/SCP2D1/SCP2D1-deep-research-openai.md</li>
+
+            </ul>
+
+
+        </div>
+
+    </div>
+
 
 
 
@@ -2618,6 +2744,98 @@ core_functions:
   - reference_id: file:human/SCP2D1/SCP2D1-deep-research-openai.md
     supporting_text: SCP2 domain forms compact globular fold with large hydrophobic cavity that accommodates
       lipid molecules. Predicted to bind cholesterol, sterol intermediates, long-chain fatty acyl-CoA.
+knowledge_gaps:
+- gap_statement: |-
+    SCP2D1&#39;s exact lipid-binding and transfer biochemistry remains unresolved. Current evidence supports
+    multi-class lipid binding, but binding constants, transfer rates, lipid preferences, membrane-donor/
+    acceptor requirements, and whether SCP2D1 functions as a transfer protein versus a lipid sensor or
+    buffer are unknown.
+  boundary: |-
+    The review accepts broad lipid binding (GO:0008289) based on SCP2-domain homology and recent ligand-
+    class mapping that includes fatty acids and several lysophospholipid/glycerophospholipid classes.
+    The gap is not whether SCP2D1 plausibly binds lipids, but the quantitative specificity and mechanism
+    needed to define a more precise molecular function.
+  gap_kind:
+  - BIOLOGY
+  - ONTOLOGY
+  dark_aspect: RESIDUAL_SUBGAP
+  status: OPEN
+  significance: |-
+    Without biochemical specificity, SCP2D1 cannot be curated beyond a broad lipid-binding term, and the
+    relationship between sterol-domain homology, fatty-acid/phospholipid associations, and cholesterol
+    phenotypes remains mechanistically ambiguous.
+  resolution: |-
+    Purify recombinant SCP2D1 and measure lipid binding and transfer using defined sterol, fatty-acid,
+    lysophospholipid, phospholipid, and acyl-CoA panels; combine kinetics with structural mapping of the
+    hydrophobic cavity and lipidomics after cellular perturbation.
+  provenance:
+  - reference_id: file:human/SCP2D1/SCP2D1-deep-research-falcon.md
+    supporting_text: |-
+      binding constants, transfer rates, and subcellular site of action
+  - reference_id: file:human/SCP2D1/SCP2D1-deep-research-falcon.md
+    supporting_text: |-
+      Biochemical specificity** (binding constants, lipid transfer rates; whether SCP2D1 transfers lipids between membranes vs binds as a sensor).
+  - reference_id: file:human/SCP2D1/SCP2D1-deep-research-falcon.md
+    supporting_text: |-
+      No retrieved source demonstrated SCP2D1 catalyzing a biochemical reaction (enzyme activity) or acting as a membrane transporter with defined substrate translocation kinetics.
+- gap_statement: |-
+    SCP2D1&#39;s direct subcellular localization and site of lipid action remain underdetermined. Cytosolic
+    localization is currently inferred, while peroxisomal localization from SCP2/SCPX cannot be transferred
+    to SCP2D1 and no endogenous SCP2D1 localization experiment has resolved where it acts.
+  boundary: |-
+    SCP2D1 is annotated to the cytosol by IBA/phylogenetic inference and lacks clear peroxisomal targeting
+    evidence. The open issue is whether it acts diffusely in cytosol, at endomembranes, near lipid droplets,
+    mitochondria, testis-specific membranes, or other lipid-trafficking interfaces.
+  gap_kind:
+  - BIOLOGY
+  - CURATION
+  dark_aspect: CC_DARK
+  status: OPEN
+  significance: |-
+    Localization is essential for interpreting lipid-transfer partners, cholesterol/LDL phenotypes, and
+    whether any SCP2-paralog or pathway annotation can be safely propagated to SCP2D1.
+  resolution: |-
+    Use validated endogenous antibodies or epitope knock-in tags for immunofluorescence, organelle
+    fractionation, proximity labeling, and lipid-droplet/endomembrane colocalization in testis-relevant
+    and cholesterol-perturbation models.
+  provenance:
+  - reference_id: file:human/SCP2D1/SCP2D1-deep-research-falcon.md
+    supporting_text: |-
+      No retrieved SCP2D1-specific experiments provided definitive localization (e.g., immunofluorescence of endogenous SCP2D1, organelle fractionation, proximity labeling, or tagged SCP2D1 localization). Therefore, SCP2D1 localization remains **underdetermined** from this evidence set.
+  - reference_id: file:human/SCP2D1/SCP2D1-deep-research-falcon.md
+    supporting_text: |-
+      these data apply to **SCP2**, not SCP2D1, and cannot be transferred as direct annotation for SCP2D1
+- gap_statement: |-
+    The cellular and physiological pathway for SCP2D1 remains unknown: siRNA knockdown alters cholesterol
+    staining and LDL uptake, and expression is enriched in testis and reactivated in some cancers, but it
+    is unresolved whether these observations reflect one lipid-trafficking function, a testis-specific
+    reproductive role, a cancer-testis biomarker state, or separate context-dependent effects.
+  boundary: |-
+    Existing evidence connects SCP2D1 to lipid/cholesterol handling phenotypes and to testis/cancer-testis
+    expression patterns. It does not establish the relevant cell type, pathway step, protein partners, or
+    whether SCP2D1 is required for spermatogenesis, steroidogenesis, LDL receptor trafficking, endosomal
+    cholesterol egress, or tumor biology.
+  gap_kind:
+  - BIOLOGY
+  dark_aspect: BP_DARK
+  status: OPEN
+  significance: |-
+    This is the main biological-process gap: a broad lipid-binding MF is plausible, but the organismal and
+    cellular process that needs SCP2D1 is still undefined.
+  resolution: |-
+    Combine SCP2D1 knockout/knockdown with filipin/LDL uptake assays, lipidomics, rescue by lipid-binding
+    mutants, and testis-focused models assessing germ-cell, Sertoli-cell, Leydig-cell, steroidogenesis,
+    and sperm phenotypes.
+  provenance:
+  - reference_id: file:human/SCP2D1/SCP2D1-deep-research-falcon.md
+    supporting_text: |-
+      Mechanistic link to cholesterol/LDL phenotype** (e.g., LDLR pathway, endosome/lysosome cholesterol egress, ER lipid composition).
+  - reference_id: file:human/SCP2D1/SCP2D1-deep-research-falcon.md
+    supporting_text: |-
+      Direct perturbation evidence supports a role in lipid/cholesterol homeostasis, but mechanism, substrate specificity, and subcellular site of action were not resolved.
+  - reference_id: file:human/SCP2D1/SCP2D1-deep-research-openai.md
+    supporting_text: |-
+      However, SCP2D1’s exact **substrate specificity, interacting partners, and physiological role are open questions**.
 proposed_new_terms: []
 suggested_questions:
 - question: What is the specific lipid substrate preference of SCP2D1 and does it differ from the paralog

--- a/genes/human/SCP2D1/SCP2D1-ai-review.yaml
+++ b/genes/human/SCP2D1/SCP2D1-ai-review.yaml
@@ -180,6 +180,98 @@ core_functions:
   - reference_id: file:human/SCP2D1/SCP2D1-deep-research-openai.md
     supporting_text: SCP2 domain forms compact globular fold with large hydrophobic cavity that accommodates
       lipid molecules. Predicted to bind cholesterol, sterol intermediates, long-chain fatty acyl-CoA.
+knowledge_gaps:
+- gap_statement: |-
+    SCP2D1's exact lipid-binding and transfer biochemistry remains unresolved. Current evidence supports
+    multi-class lipid binding, but binding constants, transfer rates, lipid preferences, membrane-donor/
+    acceptor requirements, and whether SCP2D1 functions as a transfer protein versus a lipid sensor or
+    buffer are unknown.
+  boundary: |-
+    The review accepts broad lipid binding (GO:0008289) based on SCP2-domain homology and recent ligand-
+    class mapping that includes fatty acids and several lysophospholipid/glycerophospholipid classes.
+    The gap is not whether SCP2D1 plausibly binds lipids, but the quantitative specificity and mechanism
+    needed to define a more precise molecular function.
+  gap_kind:
+  - BIOLOGY
+  - ONTOLOGY
+  dark_aspect: RESIDUAL_SUBGAP
+  status: OPEN
+  significance: |-
+    Without biochemical specificity, SCP2D1 cannot be curated beyond a broad lipid-binding term, and the
+    relationship between sterol-domain homology, fatty-acid/phospholipid associations, and cholesterol
+    phenotypes remains mechanistically ambiguous.
+  resolution: |-
+    Purify recombinant SCP2D1 and measure lipid binding and transfer using defined sterol, fatty-acid,
+    lysophospholipid, phospholipid, and acyl-CoA panels; combine kinetics with structural mapping of the
+    hydrophobic cavity and lipidomics after cellular perturbation.
+  provenance:
+  - reference_id: file:human/SCP2D1/SCP2D1-deep-research-falcon.md
+    supporting_text: |-
+      binding constants, transfer rates, and subcellular site of action
+  - reference_id: file:human/SCP2D1/SCP2D1-deep-research-falcon.md
+    supporting_text: |-
+      Biochemical specificity** (binding constants, lipid transfer rates; whether SCP2D1 transfers lipids between membranes vs binds as a sensor).
+  - reference_id: file:human/SCP2D1/SCP2D1-deep-research-falcon.md
+    supporting_text: |-
+      No retrieved source demonstrated SCP2D1 catalyzing a biochemical reaction (enzyme activity) or acting as a membrane transporter with defined substrate translocation kinetics.
+- gap_statement: |-
+    SCP2D1's direct subcellular localization and site of lipid action remain underdetermined. Cytosolic
+    localization is currently inferred, while peroxisomal localization from SCP2/SCPX cannot be transferred
+    to SCP2D1 and no endogenous SCP2D1 localization experiment has resolved where it acts.
+  boundary: |-
+    SCP2D1 is annotated to the cytosol by IBA/phylogenetic inference and lacks clear peroxisomal targeting
+    evidence. The open issue is whether it acts diffusely in cytosol, at endomembranes, near lipid droplets,
+    mitochondria, testis-specific membranes, or other lipid-trafficking interfaces.
+  gap_kind:
+  - BIOLOGY
+  - CURATION
+  dark_aspect: CC_DARK
+  status: OPEN
+  significance: |-
+    Localization is essential for interpreting lipid-transfer partners, cholesterol/LDL phenotypes, and
+    whether any SCP2-paralog or pathway annotation can be safely propagated to SCP2D1.
+  resolution: |-
+    Use validated endogenous antibodies or epitope knock-in tags for immunofluorescence, organelle
+    fractionation, proximity labeling, and lipid-droplet/endomembrane colocalization in testis-relevant
+    and cholesterol-perturbation models.
+  provenance:
+  - reference_id: file:human/SCP2D1/SCP2D1-deep-research-falcon.md
+    supporting_text: |-
+      No retrieved SCP2D1-specific experiments provided definitive localization (e.g., immunofluorescence of endogenous SCP2D1, organelle fractionation, proximity labeling, or tagged SCP2D1 localization). Therefore, SCP2D1 localization remains **underdetermined** from this evidence set.
+  - reference_id: file:human/SCP2D1/SCP2D1-deep-research-falcon.md
+    supporting_text: |-
+      these data apply to **SCP2**, not SCP2D1, and cannot be transferred as direct annotation for SCP2D1
+- gap_statement: |-
+    The cellular and physiological pathway for SCP2D1 remains unknown: siRNA knockdown alters cholesterol
+    staining and LDL uptake, and expression is enriched in testis and reactivated in some cancers, but it
+    is unresolved whether these observations reflect one lipid-trafficking function, a testis-specific
+    reproductive role, a cancer-testis biomarker state, or separate context-dependent effects.
+  boundary: |-
+    Existing evidence connects SCP2D1 to lipid/cholesterol handling phenotypes and to testis/cancer-testis
+    expression patterns. It does not establish the relevant cell type, pathway step, protein partners, or
+    whether SCP2D1 is required for spermatogenesis, steroidogenesis, LDL receptor trafficking, endosomal
+    cholesterol egress, or tumor biology.
+  gap_kind:
+  - BIOLOGY
+  dark_aspect: BP_DARK
+  status: OPEN
+  significance: |-
+    This is the main biological-process gap: a broad lipid-binding MF is plausible, but the organismal and
+    cellular process that needs SCP2D1 is still undefined.
+  resolution: |-
+    Combine SCP2D1 knockout/knockdown with filipin/LDL uptake assays, lipidomics, rescue by lipid-binding
+    mutants, and testis-focused models assessing germ-cell, Sertoli-cell, Leydig-cell, steroidogenesis,
+    and sperm phenotypes.
+  provenance:
+  - reference_id: file:human/SCP2D1/SCP2D1-deep-research-falcon.md
+    supporting_text: |-
+      Mechanistic link to cholesterol/LDL phenotype** (e.g., LDLR pathway, endosome/lysosome cholesterol egress, ER lipid composition).
+  - reference_id: file:human/SCP2D1/SCP2D1-deep-research-falcon.md
+    supporting_text: |-
+      Direct perturbation evidence supports a role in lipid/cholesterol homeostasis, but mechanism, substrate specificity, and subcellular site of action were not resolved.
+  - reference_id: file:human/SCP2D1/SCP2D1-deep-research-openai.md
+    supporting_text: |-
+      However, SCP2D1’s exact **substrate specificity, interacting partners, and physiological role are open questions**.
 proposed_new_terms: []
 suggested_questions:
 - question: What is the specific lipid substrate preference of SCP2D1 and does it differ from the paralog


### PR DESCRIPTION
## Summary
- Adds three structured top-level knowledge gaps for human SCP2D1 covering lipid-binding/transfer specificity, direct localization/site of action, and the cellular/physiological pathway behind cholesterol-LDL and testis/cancer-testis observations.
- Regenerates the SCP2D1 review HTML so the new Knowledge Gaps section is rendered.

## Validation
- `just validate human SCP2D1`
- `just render human SCP2D1`
- `git diff --check`