### PR TITLE
Add SFT2D3 knowledge gaps

### DIFF
--- a/genes/human/SFT2D3/SFT2D3-ai-review.html
+++ b/genes/human/SFT2D3/SFT2D3-ai-review.html
@@ -1863,7 +1863,7 @@
                     <li class="finding-item">
                         <div class="finding-statement">SFT2D3 nominated in pancreatic cancer TWAS</div>
 
-                        <div class="finding-text">"A 2020 TWAS implicating pancreatic cancer risk identified 13 genes at FDR &lt;= 0.05, including SFT2D3 listed among vesicle-fusion-related genes"</div>
+                        <div class="finding-text">"A 2020 TWAS implicating pancreatic cancer risk identified 13 genes at FDR ≤ 0.05, including SFT2D3 listed among vesicle-fusion–related genes"</div>
 
                     </li>
 
@@ -2110,7 +2110,7 @@
             <p style="margin-top: 0.5rem;"><strong>Provenance (the field's own admissions):</strong></p>
             <ul style="margin-top: 0.2rem;">
 
-                <li><em>"A 2020 TWAS implicating pancreatic cancer risk identified 13 genes at FDR &lt;= 0.05, including SFT2D3 listed among vesicle-fusion-related genes"</em> — file:human/SFT2D3/SFT2D3-deep-research-falcon.md</li>
+                <li><em>"A 2020 TWAS implicating pancreatic cancer risk identified 13 genes at FDR ≤ 0.05, including SFT2D3 listed among vesicle-fusion–related genes"</em> — file:human/SFT2D3/SFT2D3-deep-research-falcon.md</li>
 
                 <li><em>"this nominates SFT2D3 for functional follow-up in pancreatic cancer biology."</em> — file:human/SFT2D3/SFT2D3-deep-research-falcon.md</li>
 
@@ -2731,7 +2731,7 @@ references:
       SNARE (Snc1/Tlg1) recycling at the late-Golgi/TGN under ER stress
   - statement: SFT2D3 nominated in pancreatic cancer TWAS
     supporting_text: A 2020 TWAS implicating pancreatic cancer risk identified 13
-      genes at FDR &lt;= 0.05, including SFT2D3 listed among vesicle-fusion-related genes
+      genes at FDR ≤ 0.05, including SFT2D3 listed among vesicle-fusion–related genes
   - statement: Localization inferred to late-Golgi/TGN based on orthologs
     supporting_text: Localization is inferred to late-Golgi/TGN and endosome-to-Golgi
       recycling compartments based on yeast Sft2 cycling between endosomes and late-Golgi
@@ -2868,7 +2868,7 @@ knowledge_gaps:
     roles.
   provenance:
   - reference_id: file:human/SFT2D3/SFT2D3-deep-research-falcon.md
-    supporting_text: A 2020 TWAS implicating pancreatic cancer risk identified 13 genes at FDR &lt;= 0.05, including SFT2D3 listed among vesicle-fusion-related genes
+    supporting_text: A 2020 TWAS implicating pancreatic cancer risk identified 13 genes at FDR ≤ 0.05, including SFT2D3 listed among vesicle-fusion–related genes
   - reference_id: file:human/SFT2D3/SFT2D3-deep-research-falcon.md
     supporting_text: this nominates SFT2D3 for functional follow-up in pancreatic cancer biology.
   - reference_id: file:human/SFT2D3/SFT2D3-deep-research-falcon.md

--- a/genes/human/SFT2D3/SFT2D3-ai-review.html
+++ b/genes/human/SFT2D3/SFT2D3-ai-review.html
@@ -1863,7 +1863,7 @@
                     <li class="finding-item">
                         <div class="finding-statement">SFT2D3 nominated in pancreatic cancer TWAS</div>
 
-                        <div class="finding-text">"A 2020 TWAS implicating pancreatic cancer risk identified 13 genes at FDR ≤ 0.05, including SFT2D3 listed among vesicle-fusion–related genes"</div>
+                        <div class="finding-text">"A TWAS implicating pancreatic cancer risk identified 13 genes at FDR ≤ 0.05, including SFT2D3 listed among vesicle-fusion–related genes"</div>
 
                     </li>
 
@@ -2110,7 +2110,7 @@
             <p style="margin-top: 0.5rem;"><strong>Provenance (the field's own admissions):</strong></p>
             <ul style="margin-top: 0.2rem;">
 
-                <li><em>"A 2020 TWAS implicating pancreatic cancer risk identified 13 genes at FDR ≤ 0.05, including SFT2D3 listed among vesicle-fusion–related genes"</em> — file:human/SFT2D3/SFT2D3-deep-research-falcon.md</li>
+                <li><em>"A TWAS implicating pancreatic cancer risk identified 13 genes at FDR ≤ 0.05, including SFT2D3 listed among vesicle-fusion–related genes"</em> — file:human/SFT2D3/SFT2D3-deep-research-falcon.md</li>
 
                 <li><em>"this nominates SFT2D3 for functional follow-up in pancreatic cancer biology."</em> — file:human/SFT2D3/SFT2D3-deep-research-falcon.md</li>
 
@@ -2730,7 +2730,7 @@ references:
     supporting_text: yeast Sft2p is a SNARE-associated factor required for Imh1-mediated
       SNARE (Snc1/Tlg1) recycling at the late-Golgi/TGN under ER stress
   - statement: SFT2D3 nominated in pancreatic cancer TWAS
-    supporting_text: A 2020 TWAS implicating pancreatic cancer risk identified 13
+    supporting_text: A TWAS implicating pancreatic cancer risk identified 13
       genes at FDR ≤ 0.05, including SFT2D3 listed among vesicle-fusion–related genes
   - statement: Localization inferred to late-Golgi/TGN based on orthologs
     supporting_text: Localization is inferred to late-Golgi/TGN and endosome-to-Golgi
@@ -2868,7 +2868,7 @@ knowledge_gaps:
     roles.
   provenance:
   - reference_id: file:human/SFT2D3/SFT2D3-deep-research-falcon.md
-    supporting_text: A 2020 TWAS implicating pancreatic cancer risk identified 13 genes at FDR ≤ 0.05, including SFT2D3 listed among vesicle-fusion–related genes
+    supporting_text: A TWAS implicating pancreatic cancer risk identified 13 genes at FDR ≤ 0.05, including SFT2D3 listed among vesicle-fusion–related genes
   - reference_id: file:human/SFT2D3/SFT2D3-deep-research-falcon.md
     supporting_text: this nominates SFT2D3 for functional follow-up in pancreatic cancer biology.
   - reference_id: file:human/SFT2D3/SFT2D3-deep-research-falcon.md

--- a/genes/human/SFT2D3/SFT2D3-ai-review.html
+++ b/genes/human/SFT2D3/SFT2D3-ai-review.html
@@ -2021,6 +2021,108 @@
 
 
 
+    <div class="section">
+        <h2 class="section-title">Knowledge Gaps</h2>
+        <p style="color: #555; font-size: 0.92rem; margin-top: -0.3rem;">
+            What is <em>not</em> known — curated, literature-grounded statements of the open
+            unknowns (the inverse of core functions).
+        </p>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> The direct molecular activity of human SFT2D3 is unresolved. It is not known whether SFT2D3 directly binds SNAREs, acts through GARP/COG/golgin-associated tethering machinery, regulates SNARE localization indirectly, or has a distinct cargo- or stress-specific role separable from SFT2D1 and SFT2D2.</p>
+            <p style="margin-top: 0.4rem;">
+                <span class="badge">OPEN</span>
+                <span class="badge">BIOLOGY</span><span class="badge">CURATION</span>
+                <span class="badge">MF_DARK</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> SFT2D3 is a conserved tetra-span SFT2/Got1-family membrane protein. Yeast Sft2 functions in Golgi vesicle fusion/SNARE recycling, and human paralog SFT2D2 is required for endosome-to-Golgi retrieval and affects post-Golgi SNARE distribution; however, those data do not directly establish SFT2D3&#39;s molecular partners or mechanism.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Significance:</strong> The current SNARE-binding core-function assignment is a plausible family-level inference rather than a demonstrated SFT2D3 molecular function. Resolving this gap would determine whether SFT2D3 should be annotated to SNARE binding, a more specific tether/SNARE-regulatory activity, or only to biological-process terms.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>What would resolve it:</strong> Endogenous SFT2D3 affinity/proximity proteomics, reciprocal validation with candidate SNAREs and tether/golgin factors, SFT2D3 knockout/rescue trafficking assays, and in vitro binding or vesicle-fusion reconstitution would test whether SFT2D3 has direct SNARE-associated activity.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Provenance (the field's own admissions):</strong></p>
+            <ul style="margin-top: 0.2rem;">
+
+                <li><em>"Direct human functional studies on SFT2D3 remain limited in the accessible record."</em> — file:human/SFT2D3/SFT2D3-deep-research-falcon.md</li>
+
+                <li><em>"assertions about specific SNARE partners or tether interactions for human SFT2D3 are inferences awaiting direct experimental confirmation in human systems."</em> — file:human/SFT2D3/SFT2D3-deep-research-falcon.md</li>
+
+                <li><em>"However, the mammalian homologs (SFT2D1, SFT2D2, and SFT2D3) are uncharacterized."</em> — PMID:25464851</li>
+
+            </ul>
+
+
+        </div>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> The endogenous subcellular location and trafficking itinerary of human SFT2D3 remain incompletely mapped. It is unclear which Golgi subcompartment(s), endosomal populations, or stress-induced vesicle intermediates contain active SFT2D3, and whether the protein cycles dynamically between these membranes.</p>
+            <p style="margin-top: 0.4rem;">
+                <span class="badge">OPEN</span>
+                <span class="badge">BIOLOGY</span><span class="badge">CURATION</span>
+                <span class="badge">CC_DARK</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> SFT2D3 is an integral membrane protein and was detected in Golgi-derived vesicle proteomics, while yeast Sft2 and human SFT2D2 support a late-Golgi/TGN and endosome-to-Golgi context. Current localization calls are therefore plausible but mostly inferred rather than based on endogenous human SFT2D3 imaging.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Significance:</strong> The biological-process and molecular-function interpretation depends on where SFT2D3 acts. Distinguishing Golgi cisternal, TGN, retromer-positive endosomal, and stress-responsive pools would sharpen cellular-component annotation and define which trafficking step is relevant.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>What would resolve it:</strong> Endogenous tagging or validated antibody imaging, organelle fractionation, proximity labeling, and live-cell perturbation of retromer/GARP/SNARE pathways would establish SFT2D3&#39;s compartment-specific localization and dynamics.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Provenance (the field's own admissions):</strong></p>
+            <ul style="margin-top: 0.2rem;">
+
+                <li><em>"Human SFT2D3’s detection in Golgi-derived vesicles supports a similar Golgi/TGN and endosome-to-Golgi localization, though direct human imaging/localization evidence was not captured in our sources."</em> — file:human/SFT2D3/SFT2D3-deep-research-falcon.md</li>
+
+                <li><em>"SFT2D3 was detected as enriched (~12-fold) in Golgi-derived vesicle proteomes, suggesting association with intra-Golgi trafficking vesicles."</em> — file:human/SFT2D3/SFT2D3-deep-research-falcon.md</li>
+
+                <li><em>"Localization is inferred to late-Golgi/TGN and endosome-to-Golgi recycling compartments based on yeast Sft2 cycling between endosomes and late-Golgi"</em> — file:human/SFT2D3/SFT2D3-deep-research-falcon.md</li>
+
+            </ul>
+
+
+        </div>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> The physiological and disease-relevant role of SFT2D3 is unresolved. It is not known which endogenous cargoes, cell types, stress conditions, or disease contexts require SFT2D3 specifically, as opposed to redundant or compensatory activity from SFT2D1/SFT2D2 or general endosome-to-Golgi machinery.</p>
+            <p style="margin-top: 0.4rem;">
+                <span class="badge">OPEN</span>
+                <span class="badge">BIOLOGY</span><span class="badge">CURATION</span>
+                <span class="badge">BP_DARK</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> The SFT2 family is linked to conserved endosome-to-Golgi and Golgi SNARE-recycling biology, and SFT2D3 has been nominated in a pancreatic-cancer TWAS as a vesicle-fusion-related gene. These observations support functional follow-up but do not define a direct SFT2D3-dependent pathway or phenotype.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Significance:</strong> Without a direct phenotype, SFT2D3 can only be curated to broad trafficking processes by inference. Defining SFT2D3-specific cargoes and cellular contexts would distinguish a core housekeeping trafficking role from conditional, paralog-buffered, or disease-associated biology.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>What would resolve it:</strong> Single and combinatorial SFT2D1/SFT2D2/SFT2D3 knockouts, endogenous cargo-retrieval assays, stress-response experiments, and follow-up of the pancreatic-cancer TWAS locus with expression and rescue studies would establish SFT2D3-specific biological roles.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Provenance (the field's own admissions):</strong></p>
+            <ul style="margin-top: 0.2rem;">
+
+                <li><em>"A 2020 TWAS implicating pancreatic cancer risk identified 13 genes at FDR &lt;= 0.05, including SFT2D3 listed among vesicle-fusion-related genes"</em> — file:human/SFT2D3/SFT2D3-deep-research-falcon.md</li>
+
+                <li><em>"this nominates SFT2D3 for functional follow-up in pancreatic cancer biology."</em> — file:human/SFT2D3/SFT2D3-deep-research-falcon.md</li>
+
+                <li><em>"Direct, human experimental literature specific to SFT2D3 remains sparse"</em> — file:human/SFT2D3/SFT2D3-deep-research-falcon.md</li>
+
+            </ul>
+
+
+        </div>
+
+    </div>
+
 
 
 
@@ -2674,6 +2776,103 @@ suggested_experiments:
     to assess functional redundancy and trafficking defects
 - description: Assess whether SFT2D3 knockdown affects endosome-to-Golgi retrieval
     of cargo proteins similar to SFT2D2
+knowledge_gaps:
+- gap_statement: &gt;-
+    The direct molecular activity of human SFT2D3 is unresolved. It is not known
+    whether SFT2D3 directly binds SNAREs, acts through GARP/COG/golgin-associated
+    tethering machinery, regulates SNARE localization indirectly, or has a distinct
+    cargo- or stress-specific role separable from SFT2D1 and SFT2D2.
+  boundary: &gt;-
+    SFT2D3 is a conserved tetra-span SFT2/Got1-family membrane protein. Yeast Sft2
+    functions in Golgi vesicle fusion/SNARE recycling, and human paralog SFT2D2 is
+    required for endosome-to-Golgi retrieval and affects post-Golgi SNARE distribution;
+    however, those data do not directly establish SFT2D3&#39;s molecular partners or
+    mechanism.
+  gap_kind:
+  - BIOLOGY
+  - CURATION
+  dark_aspect: MF_DARK
+  status: OPEN
+  significance: &gt;-
+    The current SNARE-binding core-function assignment is a plausible family-level
+    inference rather than a demonstrated SFT2D3 molecular function. Resolving this
+    gap would determine whether SFT2D3 should be annotated to SNARE binding, a more
+    specific tether/SNARE-regulatory activity, or only to biological-process terms.
+  resolution: &gt;-
+    Endogenous SFT2D3 affinity/proximity proteomics, reciprocal validation with
+    candidate SNAREs and tether/golgin factors, SFT2D3 knockout/rescue trafficking
+    assays, and in vitro binding or vesicle-fusion reconstitution would test whether
+    SFT2D3 has direct SNARE-associated activity.
+  provenance:
+  - reference_id: file:human/SFT2D3/SFT2D3-deep-research-falcon.md
+    supporting_text: Direct human functional studies on SFT2D3 remain limited in the accessible record.
+  - reference_id: file:human/SFT2D3/SFT2D3-deep-research-falcon.md
+    supporting_text: assertions about specific SNARE partners or tether interactions for human SFT2D3 are inferences awaiting direct experimental confirmation in human systems.
+  - reference_id: PMID:25464851
+    supporting_text: However, the mammalian homologs (SFT2D1, SFT2D2, and SFT2D3) are uncharacterized.
+- gap_statement: &gt;-
+    The endogenous subcellular location and trafficking itinerary of human SFT2D3
+    remain incompletely mapped. It is unclear which Golgi subcompartment(s), endosomal
+    populations, or stress-induced vesicle intermediates contain active SFT2D3, and
+    whether the protein cycles dynamically between these membranes.
+  boundary: &gt;-
+    SFT2D3 is an integral membrane protein and was detected in Golgi-derived vesicle
+    proteomics, while yeast Sft2 and human SFT2D2 support a late-Golgi/TGN and
+    endosome-to-Golgi context. Current localization calls are therefore plausible but
+    mostly inferred rather than based on endogenous human SFT2D3 imaging.
+  gap_kind:
+  - BIOLOGY
+  - CURATION
+  dark_aspect: CC_DARK
+  status: OPEN
+  significance: &gt;-
+    The biological-process and molecular-function interpretation depends on where
+    SFT2D3 acts. Distinguishing Golgi cisternal, TGN, retromer-positive endosomal,
+    and stress-responsive pools would sharpen cellular-component annotation and
+    define which trafficking step is relevant.
+  resolution: &gt;-
+    Endogenous tagging or validated antibody imaging, organelle fractionation,
+    proximity labeling, and live-cell perturbation of retromer/GARP/SNARE pathways
+    would establish SFT2D3&#39;s compartment-specific localization and dynamics.
+  provenance:
+  - reference_id: file:human/SFT2D3/SFT2D3-deep-research-falcon.md
+    supporting_text: Human SFT2D3’s detection in Golgi-derived vesicles supports a similar Golgi/TGN and endosome-to-Golgi localization, though direct human imaging/localization evidence was not captured in our sources.
+  - reference_id: file:human/SFT2D3/SFT2D3-deep-research-falcon.md
+    supporting_text: SFT2D3 was detected as enriched (~12-fold) in Golgi-derived vesicle proteomes, suggesting association with intra-Golgi trafficking vesicles.
+  - reference_id: file:human/SFT2D3/SFT2D3-deep-research-falcon.md
+    supporting_text: Localization is inferred to late-Golgi/TGN and endosome-to-Golgi recycling compartments based on yeast Sft2 cycling between endosomes and late-Golgi
+- gap_statement: &gt;-
+    The physiological and disease-relevant role of SFT2D3 is unresolved. It is not
+    known which endogenous cargoes, cell types, stress conditions, or disease contexts
+    require SFT2D3 specifically, as opposed to redundant or compensatory activity from
+    SFT2D1/SFT2D2 or general endosome-to-Golgi machinery.
+  boundary: &gt;-
+    The SFT2 family is linked to conserved endosome-to-Golgi and Golgi SNARE-recycling
+    biology, and SFT2D3 has been nominated in a pancreatic-cancer TWAS as a
+    vesicle-fusion-related gene. These observations support functional follow-up but
+    do not define a direct SFT2D3-dependent pathway or phenotype.
+  gap_kind:
+  - BIOLOGY
+  - CURATION
+  dark_aspect: BP_DARK
+  status: OPEN
+  significance: &gt;-
+    Without a direct phenotype, SFT2D3 can only be curated to broad trafficking
+    processes by inference. Defining SFT2D3-specific cargoes and cellular contexts
+    would distinguish a core housekeeping trafficking role from conditional,
+    paralog-buffered, or disease-associated biology.
+  resolution: &gt;-
+    Single and combinatorial SFT2D1/SFT2D2/SFT2D3 knockouts, endogenous cargo-retrieval
+    assays, stress-response experiments, and follow-up of the pancreatic-cancer TWAS
+    locus with expression and rescue studies would establish SFT2D3-specific biological
+    roles.
+  provenance:
+  - reference_id: file:human/SFT2D3/SFT2D3-deep-research-falcon.md
+    supporting_text: A 2020 TWAS implicating pancreatic cancer risk identified 13 genes at FDR &lt;= 0.05, including SFT2D3 listed among vesicle-fusion-related genes
+  - reference_id: file:human/SFT2D3/SFT2D3-deep-research-falcon.md
+    supporting_text: this nominates SFT2D3 for functional follow-up in pancreatic cancer biology.
+  - reference_id: file:human/SFT2D3/SFT2D3-deep-research-falcon.md
+    supporting_text: Direct, human experimental literature specific to SFT2D3 remains sparse
 status: COMPLETE
 </code></pre>
             </div>

--- a/genes/human/SFT2D3/SFT2D3-ai-review.yaml
+++ b/genes/human/SFT2D3/SFT2D3-ai-review.yaml
@@ -291,7 +291,7 @@ references:
       SNARE (Snc1/Tlg1) recycling at the late-Golgi/TGN under ER stress
   - statement: SFT2D3 nominated in pancreatic cancer TWAS
     supporting_text: A 2020 TWAS implicating pancreatic cancer risk identified 13
-      genes at FDR <= 0.05, including SFT2D3 listed among vesicle-fusion-related genes
+      genes at FDR ≤ 0.05, including SFT2D3 listed among vesicle-fusion–related genes
   - statement: Localization inferred to late-Golgi/TGN based on orthologs
     supporting_text: Localization is inferred to late-Golgi/TGN and endosome-to-Golgi
       recycling compartments based on yeast Sft2 cycling between endosomes and late-Golgi
@@ -428,7 +428,7 @@ knowledge_gaps:
     roles.
   provenance:
   - reference_id: file:human/SFT2D3/SFT2D3-deep-research-falcon.md
-    supporting_text: A 2020 TWAS implicating pancreatic cancer risk identified 13 genes at FDR <= 0.05, including SFT2D3 listed among vesicle-fusion-related genes
+    supporting_text: A 2020 TWAS implicating pancreatic cancer risk identified 13 genes at FDR ≤ 0.05, including SFT2D3 listed among vesicle-fusion–related genes
   - reference_id: file:human/SFT2D3/SFT2D3-deep-research-falcon.md
     supporting_text: this nominates SFT2D3 for functional follow-up in pancreatic cancer biology.
   - reference_id: file:human/SFT2D3/SFT2D3-deep-research-falcon.md

--- a/genes/human/SFT2D3/SFT2D3-ai-review.yaml
+++ b/genes/human/SFT2D3/SFT2D3-ai-review.yaml
@@ -336,4 +336,101 @@ suggested_experiments:
     to assess functional redundancy and trafficking defects
 - description: Assess whether SFT2D3 knockdown affects endosome-to-Golgi retrieval
     of cargo proteins similar to SFT2D2
+knowledge_gaps:
+- gap_statement: >-
+    The direct molecular activity of human SFT2D3 is unresolved. It is not known
+    whether SFT2D3 directly binds SNAREs, acts through GARP/COG/golgin-associated
+    tethering machinery, regulates SNARE localization indirectly, or has a distinct
+    cargo- or stress-specific role separable from SFT2D1 and SFT2D2.
+  boundary: >-
+    SFT2D3 is a conserved tetra-span SFT2/Got1-family membrane protein. Yeast Sft2
+    functions in Golgi vesicle fusion/SNARE recycling, and human paralog SFT2D2 is
+    required for endosome-to-Golgi retrieval and affects post-Golgi SNARE distribution;
+    however, those data do not directly establish SFT2D3's molecular partners or
+    mechanism.
+  gap_kind:
+  - BIOLOGY
+  - CURATION
+  dark_aspect: MF_DARK
+  status: OPEN
+  significance: >-
+    The current SNARE-binding core-function assignment is a plausible family-level
+    inference rather than a demonstrated SFT2D3 molecular function. Resolving this
+    gap would determine whether SFT2D3 should be annotated to SNARE binding, a more
+    specific tether/SNARE-regulatory activity, or only to biological-process terms.
+  resolution: >-
+    Endogenous SFT2D3 affinity/proximity proteomics, reciprocal validation with
+    candidate SNAREs and tether/golgin factors, SFT2D3 knockout/rescue trafficking
+    assays, and in vitro binding or vesicle-fusion reconstitution would test whether
+    SFT2D3 has direct SNARE-associated activity.
+  provenance:
+  - reference_id: file:human/SFT2D3/SFT2D3-deep-research-falcon.md
+    supporting_text: Direct human functional studies on SFT2D3 remain limited in the accessible record.
+  - reference_id: file:human/SFT2D3/SFT2D3-deep-research-falcon.md
+    supporting_text: assertions about specific SNARE partners or tether interactions for human SFT2D3 are inferences awaiting direct experimental confirmation in human systems.
+  - reference_id: PMID:25464851
+    supporting_text: However, the mammalian homologs (SFT2D1, SFT2D2, and SFT2D3) are uncharacterized.
+- gap_statement: >-
+    The endogenous subcellular location and trafficking itinerary of human SFT2D3
+    remain incompletely mapped. It is unclear which Golgi subcompartment(s), endosomal
+    populations, or stress-induced vesicle intermediates contain active SFT2D3, and
+    whether the protein cycles dynamically between these membranes.
+  boundary: >-
+    SFT2D3 is an integral membrane protein and was detected in Golgi-derived vesicle
+    proteomics, while yeast Sft2 and human SFT2D2 support a late-Golgi/TGN and
+    endosome-to-Golgi context. Current localization calls are therefore plausible but
+    mostly inferred rather than based on endogenous human SFT2D3 imaging.
+  gap_kind:
+  - BIOLOGY
+  - CURATION
+  dark_aspect: CC_DARK
+  status: OPEN
+  significance: >-
+    The biological-process and molecular-function interpretation depends on where
+    SFT2D3 acts. Distinguishing Golgi cisternal, TGN, retromer-positive endosomal,
+    and stress-responsive pools would sharpen cellular-component annotation and
+    define which trafficking step is relevant.
+  resolution: >-
+    Endogenous tagging or validated antibody imaging, organelle fractionation,
+    proximity labeling, and live-cell perturbation of retromer/GARP/SNARE pathways
+    would establish SFT2D3's compartment-specific localization and dynamics.
+  provenance:
+  - reference_id: file:human/SFT2D3/SFT2D3-deep-research-falcon.md
+    supporting_text: Human SFT2D3’s detection in Golgi-derived vesicles supports a similar Golgi/TGN and endosome-to-Golgi localization, though direct human imaging/localization evidence was not captured in our sources.
+  - reference_id: file:human/SFT2D3/SFT2D3-deep-research-falcon.md
+    supporting_text: SFT2D3 was detected as enriched (~12-fold) in Golgi-derived vesicle proteomes, suggesting association with intra-Golgi trafficking vesicles.
+  - reference_id: file:human/SFT2D3/SFT2D3-deep-research-falcon.md
+    supporting_text: Localization is inferred to late-Golgi/TGN and endosome-to-Golgi recycling compartments based on yeast Sft2 cycling between endosomes and late-Golgi
+- gap_statement: >-
+    The physiological and disease-relevant role of SFT2D3 is unresolved. It is not
+    known which endogenous cargoes, cell types, stress conditions, or disease contexts
+    require SFT2D3 specifically, as opposed to redundant or compensatory activity from
+    SFT2D1/SFT2D2 or general endosome-to-Golgi machinery.
+  boundary: >-
+    The SFT2 family is linked to conserved endosome-to-Golgi and Golgi SNARE-recycling
+    biology, and SFT2D3 has been nominated in a pancreatic-cancer TWAS as a
+    vesicle-fusion-related gene. These observations support functional follow-up but
+    do not define a direct SFT2D3-dependent pathway or phenotype.
+  gap_kind:
+  - BIOLOGY
+  - CURATION
+  dark_aspect: BP_DARK
+  status: OPEN
+  significance: >-
+    Without a direct phenotype, SFT2D3 can only be curated to broad trafficking
+    processes by inference. Defining SFT2D3-specific cargoes and cellular contexts
+    would distinguish a core housekeeping trafficking role from conditional,
+    paralog-buffered, or disease-associated biology.
+  resolution: >-
+    Single and combinatorial SFT2D1/SFT2D2/SFT2D3 knockouts, endogenous cargo-retrieval
+    assays, stress-response experiments, and follow-up of the pancreatic-cancer TWAS
+    locus with expression and rescue studies would establish SFT2D3-specific biological
+    roles.
+  provenance:
+  - reference_id: file:human/SFT2D3/SFT2D3-deep-research-falcon.md
+    supporting_text: A 2020 TWAS implicating pancreatic cancer risk identified 13 genes at FDR <= 0.05, including SFT2D3 listed among vesicle-fusion-related genes
+  - reference_id: file:human/SFT2D3/SFT2D3-deep-research-falcon.md
+    supporting_text: this nominates SFT2D3 for functional follow-up in pancreatic cancer biology.
+  - reference_id: file:human/SFT2D3/SFT2D3-deep-research-falcon.md
+    supporting_text: Direct, human experimental literature specific to SFT2D3 remains sparse
 status: COMPLETE

--- a/genes/human/SFT2D3/SFT2D3-ai-review.yaml
+++ b/genes/human/SFT2D3/SFT2D3-ai-review.yaml
@@ -290,7 +290,7 @@ references:
     supporting_text: yeast Sft2p is a SNARE-associated factor required for Imh1-mediated
       SNARE (Snc1/Tlg1) recycling at the late-Golgi/TGN under ER stress
   - statement: SFT2D3 nominated in pancreatic cancer TWAS
-    supporting_text: A 2020 TWAS implicating pancreatic cancer risk identified 13
+    supporting_text: A TWAS implicating pancreatic cancer risk identified 13
       genes at FDR ≤ 0.05, including SFT2D3 listed among vesicle-fusion–related genes
   - statement: Localization inferred to late-Golgi/TGN based on orthologs
     supporting_text: Localization is inferred to late-Golgi/TGN and endosome-to-Golgi
@@ -428,7 +428,7 @@ knowledge_gaps:
     roles.
   provenance:
   - reference_id: file:human/SFT2D3/SFT2D3-deep-research-falcon.md
-    supporting_text: A 2020 TWAS implicating pancreatic cancer risk identified 13 genes at FDR ≤ 0.05, including SFT2D3 listed among vesicle-fusion–related genes
+    supporting_text: A TWAS implicating pancreatic cancer risk identified 13 genes at FDR ≤ 0.05, including SFT2D3 listed among vesicle-fusion–related genes
   - reference_id: file:human/SFT2D3/SFT2D3-deep-research-falcon.md
     supporting_text: this nominates SFT2D3 for functional follow-up in pancreatic cancer biology.
   - reference_id: file:human/SFT2D3/SFT2D3-deep-research-falcon.md


### PR DESCRIPTION
## Summary
- Add three top-level knowledge gaps for human SFT2D3: direct molecular mechanism/SNARE partners, endogenous localization, and physiological/disease-relevant role.
- Re-render the SFT2D3 review HTML.

## Validation
- `just validate human SFT2D3` passed with 1 warning: core function term GO:0000149 (SNARE binding) is not reflected in the `existing_annotations` block as `NEW`.
- `just render human SFT2D3`
- `git diff --check`