### PR TITLE
Add KCTD18 knowledge gaps

### DIFF
--- a/genes/human/KCTD18/KCTD18-ai-review.html
+++ b/genes/human/KCTD18/KCTD18-ai-review.html
@@ -1228,6 +1228,31 @@
 
             </div>
 
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        file:human/KCTD18/KCTD18-notes.md
+
+                    </span>
+                </div>
+
+                <div class="reference-title">KCTD18 curation notes</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">KCTD18 should not receive automatic Cul3 substrate-receptor molecular-function propagation until direct CUL3 binding and substrate-adaptor activity are experimentally supported.</div>
+
+                        <div class="finding-text">"Curation conclusion: keep KCTD18 in the PN taxonomy as a possible/provisional Cul3-related KCTD-family member, but exclude it from automatic propagation to `GO:1990756` until direct CUL3 binding and substrate-adaptor activity are experimentally supported."</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
         </div>
     </div>
 
@@ -1371,6 +1396,108 @@
     </div>
 
 
+
+    <div class="section">
+        <h2 class="section-title">Knowledge Gaps</h2>
+        <p style="color: #555; font-size: 0.92rem; margin-top: -0.3rem;">
+            What is <em>not</em> known — curated, literature-grounded statements of the open
+            unknowns (the inverse of core functions).
+        </p>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> It is unresolved whether KCTD18 is a bona fide CUL3-dependent ubiquitin-ligase substrate adaptor, and no KCTD18-specific ubiquitination substrate has been experimentally established.</p>
+            <p style="margin-top: 0.4rem;">
+                <span class="badge">OPEN</span>
+                <span class="badge">BIOLOGY</span><span class="badge">CURATION</span>
+                <span class="badge">MF_DARK</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> KCTD18 has an N-terminal BTB/POZ domain and a KCTD18-specific C-terminal domain. AlphaFold2 modeling predicts a possible 1:1 BTB-CUL3 interaction, and many KCTD family members use BTB domains to recruit CUL3 while their C-terminal regions recognize substrates. For KCTD18 specifically, this remains a structural and family-level hypothesis rather than a demonstrated molecular function.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Significance:</strong> This is the central curation decision for KCTD18. If direct CUL3 binding and substrate-adaptor activity are confirmed, GO:1990756 could become an informative molecular-function annotation; without that evidence, propagating the term would overstate a prediction.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>What would resolve it:</strong> Validate KCTD18-CUL3 binding by co-immunoprecipitation and purified-protein binding assays, test BTB-interface mutants, identify candidate substrates by proximity/affinity proteomics, and demonstrate CUL3/RBX1-dependent ubiquitination of a KCTD18 substrate in cells or reconstituted reactions.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Provenance (the field's own admissions):</strong></p>
+            <ul style="margin-top: 0.2rem;">
+
+                <li><em>"AlphaFold2 modeling predicts possible 1:1 BTB-CUL3 binding, but the review explicitly finds no experimentally validated KCTD18 substrates, no validated CUL3 complex membership, no cellular localization data, and no established molecular function."</em> — file:human/KCTD18/KCTD18-notes.md</li>
+
+                <li><em>"exclude it from automatic propagation to `GO:1990756` until direct CUL3 binding and substrate-adaptor activity are experimentally supported."</em> — file:human/KCTD18/KCTD18-notes.md</li>
+
+                <li><em>"No experimentally validated substrates reported for KCTD18 to date"</em> — file:human/KCTD18/KCTD18-deep-research-falcon.md</li>
+
+            </ul>
+
+
+        </div>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> The subcellular localization of endogenous KCTD18 is unknown. It is not clear whether KCTD18 acts in cytosol, nucleus, mitochondria, another organelle-associated pool, or in a context-dependent complex with CUL3 or other KCTD proteins.</p>
+            <p style="margin-top: 0.4rem;">
+                <span class="badge">OPEN</span>
+                <span class="badge">BIOLOGY</span><span class="badge">CURATION</span>
+                <span class="badge">CC_DARK</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> KCTD18 lacks predicted secretion and transmembrane features and is expected to be intracellular. Family members occupy diverse compartments, and one deep research source reports predicted or high-throughput mitochondrial/cytoplasmic/ nuclear signals, but these do not establish the compartment where endogenous KCTD18 performs its function.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Significance:</strong> Cellular-component annotation is currently absent because the compartment of action is not known. Resolving localization would also constrain the possible substrate pool and the biological process in which KCTD18 acts.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>What would resolve it:</strong> Use validated antibodies or endogenous tagging, subcellular fractionation, proximity labeling, and CUL3/substrate perturbations across relevant cell types to define KCTD18 localization and whether it changes with complex assembly or cellular state.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Provenance (the field's own admissions):</strong></p>
+            <ul style="margin-top: 0.2rem;">
+
+                <li><em>"Not established experimentally for KCTD18 in the gathered literature"</em> — file:human/KCTD18/KCTD18-deep-research-falcon.md</li>
+
+                <li><em>"KCTD family members localize to cytosol, nucleus, and, in some cases, associate with organelles; KCTD13 mitochondrial co-localization is an example of family diversity but should not be generalized to KCTD18"</em> — file:human/KCTD18/KCTD18-deep-research-falcon.md</li>
+
+                <li><em>"no cellular localization data"</em> — file:human/KCTD18/KCTD18-notes.md</li>
+
+            </ul>
+
+
+        </div>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> The biological role of KCTD18 is not defined. Existing genetic and cell-based clues point to adipocyte progenitor proliferation, restless-legs-syndrome locus biology, neurodevelopmental dosage observations, and cancer associations, but no pathway connects these observations to a KCTD18-dependent substrate or CUL3 complex.</p>
+            <p style="margin-top: 0.4rem;">
+                <span class="badge">OPEN</span>
+                <span class="badge">BIOLOGY</span><span class="badge">CURATION</span>
+                <span class="badge">BP_DARK</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> KCTD18 is broadly expressed, has preliminary disease/trait associations, and cyberian deep research reports a KCTD18 knockdown effect on proliferating human adipose-derived stem cells. These observations support biological follow-up but are not yet a coherent GO biological-process annotation.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Significance:</strong> Without a defined pathway or substrate, KCTD18 cannot be curated beyond root molecular function and avoided generic binding terms. Establishing the relevant biological process would determine whether KCTD18 belongs in metabolism, neurobiology, cell-proliferation, cancer, or a narrower protein-homeostasis pathway.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>What would resolve it:</strong> Combine KCTD18 loss- and gain-of-function experiments with substrate proteomics, cell-cycle/proliferation readouts, adipocyte progenitor differentiation assays, and genetic follow-up of RLS/metabolic loci to connect KCTD18 molecular activity to a specific biological process.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Provenance (the field's own admissions):</strong></p>
+            <ul style="margin-top: 0.2rem;">
+
+                <li><em>"reduced KCTD18 expression decreases the number of proliferating cells in human adipose-derived stem cells"</em> — file:human/KCTD18/KCTD18-deep-research-cyberian.md</li>
+
+                <li><em>"the causative variant and whether KCTD18 or SPATS2L (or both) contribute to disease pathogenesis remains undetermined."</em> — file:human/KCTD18/KCTD18-deep-research-cyberian.md</li>
+
+                <li><em>"The identification of physiological KCTD18 interaction partners and potential ubiquitination substrates represents a critical gap in understanding this protein&#39;s biological function."</em> — file:human/KCTD18/KCTD18-deep-research-cyberian.md</li>
+
+            </ul>
+
+
+        </div>
+
+    </div>
 
 
 
@@ -2116,6 +2243,18 @@ references:
   - id: file:human/KCTD18/KCTD18-deep-research-cyberian.md
     title: Cyberian deep research on KCTD18 function
     findings: []
+  - id: file:human/KCTD18/KCTD18-notes.md
+    title: KCTD18 curation notes
+    findings:
+      - statement: &gt;-
+          KCTD18 should not receive automatic Cul3 substrate-receptor molecular-function
+          propagation until direct CUL3 binding and substrate-adaptor activity are
+          experimentally supported.
+        supporting_text: &gt;-
+          Curation conclusion: keep KCTD18 in the PN taxonomy as a possible/provisional
+          Cul3-related KCTD-family member, but exclude it from automatic propagation
+          to `GO:1990756` until direct CUL3 binding and substrate-adaptor activity
+          are experimentally supported.
 core_functions:
   - description: Molecular function unknown for this uncharacterized BTB/POZ domain
       protein.
@@ -2143,6 +2282,110 @@ suggested_experiments:
   - description: Subcellular fractionation and immunofluorescence to determine localization
     hypothesis: KCTD18 localizes to a specific cellular compartment where it exerts
       its function
+knowledge_gaps:
+  - gap_statement: &gt;-
+      It is unresolved whether KCTD18 is a bona fide CUL3-dependent ubiquitin-ligase
+      substrate adaptor, and no KCTD18-specific ubiquitination substrate has been
+      experimentally established.
+    boundary: &gt;-
+      KCTD18 has an N-terminal BTB/POZ domain and a KCTD18-specific C-terminal domain.
+      AlphaFold2 modeling predicts a possible 1:1 BTB-CUL3 interaction, and many KCTD
+      family members use BTB domains to recruit CUL3 while their C-terminal regions
+      recognize substrates. For KCTD18 specifically, this remains a structural and
+      family-level hypothesis rather than a demonstrated molecular function.
+    gap_kind:
+      - BIOLOGY
+      - CURATION
+    dark_aspect: MF_DARK
+    status: OPEN
+    significance: &gt;-
+      This is the central curation decision for KCTD18. If direct CUL3 binding and
+      substrate-adaptor activity are confirmed, GO:1990756 could become an informative
+      molecular-function annotation; without that evidence, propagating the term would
+      overstate a prediction.
+    resolution: &gt;-
+      Validate KCTD18-CUL3 binding by co-immunoprecipitation and purified-protein
+      binding assays, test BTB-interface mutants, identify candidate substrates by
+      proximity/affinity proteomics, and demonstrate CUL3/RBX1-dependent ubiquitination
+      of a KCTD18 substrate in cells or reconstituted reactions.
+    provenance:
+      - reference_id: file:human/KCTD18/KCTD18-notes.md
+        supporting_text: &gt;-
+          AlphaFold2 modeling predicts possible 1:1 BTB-CUL3 binding, but the review
+          explicitly finds no experimentally validated KCTD18 substrates, no validated
+          CUL3 complex membership, no cellular localization data, and no established
+          molecular function.
+      - reference_id: file:human/KCTD18/KCTD18-notes.md
+        supporting_text: &gt;-
+          exclude it from automatic propagation to `GO:1990756` until direct CUL3
+          binding and substrate-adaptor activity are experimentally supported.
+      - reference_id: file:human/KCTD18/KCTD18-deep-research-falcon.md
+        supporting_text: No experimentally validated substrates reported for KCTD18 to date
+  - gap_statement: &gt;-
+      The subcellular localization of endogenous KCTD18 is unknown. It is not clear
+      whether KCTD18 acts in cytosol, nucleus, mitochondria, another organelle-associated
+      pool, or in a context-dependent complex with CUL3 or other KCTD proteins.
+    boundary: &gt;-
+      KCTD18 lacks predicted secretion and transmembrane features and is expected to
+      be intracellular. Family members occupy diverse compartments, and one deep
+      research source reports predicted or high-throughput mitochondrial/cytoplasmic/
+      nuclear signals, but these do not establish the compartment where endogenous
+      KCTD18 performs its function.
+    gap_kind:
+      - BIOLOGY
+      - CURATION
+    dark_aspect: CC_DARK
+    status: OPEN
+    significance: &gt;-
+      Cellular-component annotation is currently absent because the compartment of
+      action is not known. Resolving localization would also constrain the possible
+      substrate pool and the biological process in which KCTD18 acts.
+    resolution: &gt;-
+      Use validated antibodies or endogenous tagging, subcellular fractionation,
+      proximity labeling, and CUL3/substrate perturbations across relevant cell types
+      to define KCTD18 localization and whether it changes with complex assembly or
+      cellular state.
+    provenance:
+      - reference_id: file:human/KCTD18/KCTD18-deep-research-falcon.md
+        supporting_text: Not established experimentally for KCTD18 in the gathered literature
+      - reference_id: file:human/KCTD18/KCTD18-deep-research-falcon.md
+        supporting_text: KCTD family members localize to cytosol, nucleus, and, in some cases, associate with organelles; KCTD13 mitochondrial co-localization is an example of family diversity but should not be generalized to KCTD18
+      - reference_id: file:human/KCTD18/KCTD18-notes.md
+        supporting_text: no cellular localization data
+  - gap_statement: &gt;-
+      The biological role of KCTD18 is not defined. Existing genetic and cell-based
+      clues point to adipocyte progenitor proliferation, restless-legs-syndrome locus
+      biology, neurodevelopmental dosage observations, and cancer associations, but
+      no pathway connects these observations to a KCTD18-dependent substrate or CUL3
+      complex.
+    boundary: &gt;-
+      KCTD18 is broadly expressed, has preliminary disease/trait associations, and
+      cyberian deep research reports a KCTD18 knockdown effect on proliferating human
+      adipose-derived stem cells. These observations support biological follow-up but
+      are not yet a coherent GO biological-process annotation.
+    gap_kind:
+      - BIOLOGY
+      - CURATION
+    dark_aspect: BP_DARK
+    status: OPEN
+    significance: &gt;-
+      Without a defined pathway or substrate, KCTD18 cannot be curated beyond root
+      molecular function and avoided generic binding terms. Establishing the relevant
+      biological process would determine whether KCTD18 belongs in metabolism,
+      neurobiology, cell-proliferation, cancer, or a narrower protein-homeostasis
+      pathway.
+    resolution: &gt;-
+      Combine KCTD18 loss- and gain-of-function experiments with substrate proteomics,
+      cell-cycle/proliferation readouts, adipocyte progenitor differentiation assays,
+      and genetic follow-up of RLS/metabolic loci to connect KCTD18 molecular activity
+      to a specific biological process.
+    provenance:
+      - reference_id: file:human/KCTD18/KCTD18-deep-research-cyberian.md
+        supporting_text: reduced KCTD18 expression decreases the number of proliferating cells in human adipose-derived stem cells
+      - reference_id: file:human/KCTD18/KCTD18-deep-research-cyberian.md
+        supporting_text: the causative variant and whether KCTD18 or SPATS2L (or both) contribute to disease pathogenesis remains undetermined.
+      - reference_id: file:human/KCTD18/KCTD18-deep-research-cyberian.md
+        supporting_text: The identification of physiological KCTD18 interaction partners and potential ubiquitination substrates represents a critical gap in understanding this protein&#39;s biological function.
 </code></pre>
             </div>
         </details>

--- a/genes/human/KCTD18/KCTD18-ai-review.yaml
+++ b/genes/human/KCTD18/KCTD18-ai-review.yaml
@@ -125,6 +125,18 @@ references:
   - id: file:human/KCTD18/KCTD18-deep-research-cyberian.md
     title: Cyberian deep research on KCTD18 function
     findings: []
+  - id: file:human/KCTD18/KCTD18-notes.md
+    title: KCTD18 curation notes
+    findings:
+      - statement: >-
+          KCTD18 should not receive automatic Cul3 substrate-receptor molecular-function
+          propagation until direct CUL3 binding and substrate-adaptor activity are
+          experimentally supported.
+        supporting_text: >-
+          Curation conclusion: keep KCTD18 in the PN taxonomy as a possible/provisional
+          Cul3-related KCTD-family member, but exclude it from automatic propagation
+          to `GO:1990756` until direct CUL3 binding and substrate-adaptor activity
+          are experimentally supported.
 core_functions:
   - description: Molecular function unknown for this uncharacterized BTB/POZ domain
       protein.
@@ -152,3 +164,107 @@ suggested_experiments:
   - description: Subcellular fractionation and immunofluorescence to determine localization
     hypothesis: KCTD18 localizes to a specific cellular compartment where it exerts
       its function
+knowledge_gaps:
+  - gap_statement: >-
+      It is unresolved whether KCTD18 is a bona fide CUL3-dependent ubiquitin-ligase
+      substrate adaptor, and no KCTD18-specific ubiquitination substrate has been
+      experimentally established.
+    boundary: >-
+      KCTD18 has an N-terminal BTB/POZ domain and a KCTD18-specific C-terminal domain.
+      AlphaFold2 modeling predicts a possible 1:1 BTB-CUL3 interaction, and many KCTD
+      family members use BTB domains to recruit CUL3 while their C-terminal regions
+      recognize substrates. For KCTD18 specifically, this remains a structural and
+      family-level hypothesis rather than a demonstrated molecular function.
+    gap_kind:
+      - BIOLOGY
+      - CURATION
+    dark_aspect: MF_DARK
+    status: OPEN
+    significance: >-
+      This is the central curation decision for KCTD18. If direct CUL3 binding and
+      substrate-adaptor activity are confirmed, GO:1990756 could become an informative
+      molecular-function annotation; without that evidence, propagating the term would
+      overstate a prediction.
+    resolution: >-
+      Validate KCTD18-CUL3 binding by co-immunoprecipitation and purified-protein
+      binding assays, test BTB-interface mutants, identify candidate substrates by
+      proximity/affinity proteomics, and demonstrate CUL3/RBX1-dependent ubiquitination
+      of a KCTD18 substrate in cells or reconstituted reactions.
+    provenance:
+      - reference_id: file:human/KCTD18/KCTD18-notes.md
+        supporting_text: >-
+          AlphaFold2 modeling predicts possible 1:1 BTB-CUL3 binding, but the review
+          explicitly finds no experimentally validated KCTD18 substrates, no validated
+          CUL3 complex membership, no cellular localization data, and no established
+          molecular function.
+      - reference_id: file:human/KCTD18/KCTD18-notes.md
+        supporting_text: >-
+          exclude it from automatic propagation to `GO:1990756` until direct CUL3
+          binding and substrate-adaptor activity are experimentally supported.
+      - reference_id: file:human/KCTD18/KCTD18-deep-research-falcon.md
+        supporting_text: No experimentally validated substrates reported for KCTD18 to date
+  - gap_statement: >-
+      The subcellular localization of endogenous KCTD18 is unknown. It is not clear
+      whether KCTD18 acts in cytosol, nucleus, mitochondria, another organelle-associated
+      pool, or in a context-dependent complex with CUL3 or other KCTD proteins.
+    boundary: >-
+      KCTD18 lacks predicted secretion and transmembrane features and is expected to
+      be intracellular. Family members occupy diverse compartments, and one deep
+      research source reports predicted or high-throughput mitochondrial/cytoplasmic/
+      nuclear signals, but these do not establish the compartment where endogenous
+      KCTD18 performs its function.
+    gap_kind:
+      - BIOLOGY
+      - CURATION
+    dark_aspect: CC_DARK
+    status: OPEN
+    significance: >-
+      Cellular-component annotation is currently absent because the compartment of
+      action is not known. Resolving localization would also constrain the possible
+      substrate pool and the biological process in which KCTD18 acts.
+    resolution: >-
+      Use validated antibodies or endogenous tagging, subcellular fractionation,
+      proximity labeling, and CUL3/substrate perturbations across relevant cell types
+      to define KCTD18 localization and whether it changes with complex assembly or
+      cellular state.
+    provenance:
+      - reference_id: file:human/KCTD18/KCTD18-deep-research-falcon.md
+        supporting_text: Not established experimentally for KCTD18 in the gathered literature
+      - reference_id: file:human/KCTD18/KCTD18-deep-research-falcon.md
+        supporting_text: KCTD family members localize to cytosol, nucleus, and, in some cases, associate with organelles; KCTD13 mitochondrial co-localization is an example of family diversity but should not be generalized to KCTD18
+      - reference_id: file:human/KCTD18/KCTD18-notes.md
+        supporting_text: no cellular localization data
+  - gap_statement: >-
+      The biological role of KCTD18 is not defined. Existing genetic and cell-based
+      clues point to adipocyte progenitor proliferation, restless-legs-syndrome locus
+      biology, neurodevelopmental dosage observations, and cancer associations, but
+      no pathway connects these observations to a KCTD18-dependent substrate or CUL3
+      complex.
+    boundary: >-
+      KCTD18 is broadly expressed, has preliminary disease/trait associations, and
+      cyberian deep research reports a KCTD18 knockdown effect on proliferating human
+      adipose-derived stem cells. These observations support biological follow-up but
+      are not yet a coherent GO biological-process annotation.
+    gap_kind:
+      - BIOLOGY
+      - CURATION
+    dark_aspect: BP_DARK
+    status: OPEN
+    significance: >-
+      Without a defined pathway or substrate, KCTD18 cannot be curated beyond root
+      molecular function and avoided generic binding terms. Establishing the relevant
+      biological process would determine whether KCTD18 belongs in metabolism,
+      neurobiology, cell-proliferation, cancer, or a narrower protein-homeostasis
+      pathway.
+    resolution: >-
+      Combine KCTD18 loss- and gain-of-function experiments with substrate proteomics,
+      cell-cycle/proliferation readouts, adipocyte progenitor differentiation assays,
+      and genetic follow-up of RLS/metabolic loci to connect KCTD18 molecular activity
+      to a specific biological process.
+    provenance:
+      - reference_id: file:human/KCTD18/KCTD18-deep-research-cyberian.md
+        supporting_text: reduced KCTD18 expression decreases the number of proliferating cells in human adipose-derived stem cells
+      - reference_id: file:human/KCTD18/KCTD18-deep-research-cyberian.md
+        supporting_text: the causative variant and whether KCTD18 or SPATS2L (or both) contribute to disease pathogenesis remains undetermined.
+      - reference_id: file:human/KCTD18/KCTD18-deep-research-cyberian.md
+        supporting_text: The identification of physiological KCTD18 interaction partners and potential ubiquitination substrates represents a critical gap in understanding this protein's biological function.


### PR DESCRIPTION
## Summary
- Add a top-level reference for the KCTD18 curation notes documenting why GO:1990756 should not be propagated yet.
- Add three top-level knowledge gaps for KCTD18: CUL3/substrate-adaptor activity and substrates, endogenous localization, and biological/disease pathway context.
- Re-render the KCTD18 review HTML.

## Validation
- `just validate human KCTD18`
- `just render human KCTD18`
- `git diff --check`