### PR TITLE
Add UMAD1 knowledge gaps

### DIFF
--- a/genes/human/UMAD1/UMAD1-ai-review.html
+++ b/genes/human/UMAD1/UMAD1-ai-review.html
@@ -1311,6 +1311,108 @@
 
 
 
+    <div class="section">
+        <h2 class="section-title">Knowledge Gaps</h2>
+        <p style="color: #555; font-size: 0.92rem; margin-top: -0.3rem;">
+            What is <em>not</em> known — curated, literature-grounded statements of the open
+            unknowns (the inverse of core functions).
+        </p>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> It is unresolved whether endogenous UMAD1 assembles into a stable human ESCRT-I complex, and if so which TSG101/VPS28/VPS37-containing complex it joins and what molecular role its UMA domain performs.</p>
+            <p style="margin-top: 0.4rem;">
+                <span class="badge">OPEN</span>
+                <span class="badge">BIOLOGY</span><span class="badge">CURATION</span>
+                <span class="badge">MF_DARK</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> UMAD1 has a predicted UMA domain and is listed by Flower et al. 2020 among possible UMA-domain fourth subunits of human ESCRT-I. Local evidence does not verify a UMAD1-containing ESCRT-I complex, and the only GOA evidence is broad HuRI protein binding to GABARAPL1 and TH isoform 3.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Significance:</strong> ESCRT-I complex membership would be the key molecular anchor for all more specific UMAD1 process annotations. Without direct assembly evidence, adding ESCRT-I, membrane-fission, ubiquitin-binding, or adaptor-function terms would overstate the local evidence.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>What would resolve it:</strong> Endogenous UMAD1 tagging or validated-antibody immunoprecipitation with TSG101, VPS28, VPS37 paralogs, MVB12A/B, UBAP1, and ALIX, plus purified UMA-domain binding assays and motif mutants, would establish whether UMAD1 is an ESCRT-I subunit and define its molecular partners.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Provenance (the field's own admissions):</strong></p>
+            <ul style="margin-top: 0.2rem;">
+
+                <li><em>"UMAD1 should be treated as a poorly characterized UMA-domain protein rather than as an experimentally established ESCRT-I subunit in this review."</em> — file:human/UMAD1/UMAD1-notes.md</li>
+
+                <li><em>"The name and domain architecture make ESCRT-I membership plausible, and the proteostasis network entry is useful search context, but the local evidence does not show UMAD1 incorporation into an ESCRT-I complex"</em> — file:human/UMAD1/UMAD1-notes.md</li>
+
+                <li><em>"No core GO function is assigned in this review."</em> — file:human/UMAD1/UMAD1-notes.md</li>
+
+            </ul>
+
+
+        </div>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> The biological process in which UMAD1 acts is unresolved. Cytokinetic abscission is proposed by an uncached 2023 primary study summarized in Falcon deep research, while endosomal sorting, autophagosome closure, membrane repair, and viral budding remain family-level ESCRT inferences rather than locally verified UMAD1 functions.</p>
+            <p style="margin-top: 0.4rem;">
+                <span class="badge">OPEN</span>
+                <span class="badge">BIOLOGY</span><span class="badge">CURATION</span>
+                <span class="badge">BP_DARK</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> The Falcon report identifies a potentially decisive Glover et al. 2023 cytokinesis paper, but that paper is not in the local cache and was not read for this review. The locally cached Flower et al. paper supports UMA-domain ESCRT-I architectural context but does not establish a UMAD1-specific process.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Significance:</strong> UMAD1 currently cannot be assigned a defensible biological-process term beyond treating protein-binding evidence as over-annotated. Resolving this gap would determine whether UMAD1 belongs in cytokinesis, endosomal MVB sorting, autophagy, membrane repair, or no currently supported ESCRT-dependent process.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>What would resolve it:</strong> Cache and review the Glover et al. 2023 article, verify its UMAD1-specific supporting text, then test UMAD1 perturbation in cytokinetic abscission, endosomal cargo sorting, autophagosome closure, and membrane repair assays with rescue by wild-type and ESCRT-binding-defective UMAD1.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Provenance (the field's own admissions):</strong></p>
+            <ul style="margin-top: 0.2rem;">
+
+                <li><em>"though direct experimental demonstration of UMAD1-specific roles in endosomal cargo sorting, autophagosome closure, or membrane repair remains an important area for future investigation."</em> — file:human/UMAD1/UMAD1-deep-research-falcon.md</li>
+
+                <li><em>"As an ESCRT-I component, UMAD1 is positioned to contribute to these processes, though specific roles beyond cytokinesis remain to be experimentally demonstrated."</em> — file:human/UMAD1/UMAD1-deep-research-falcon.md</li>
+
+                <li><em>"Adding ESCRT-I complex membership, MVB sorting, ubiquitin binding, phospholipid binding, membrane fission, or macroautophagy terms would overstate the available evidence."</em> — file:human/UMAD1/UMAD1-notes.md</li>
+
+            </ul>
+
+
+        </div>
+
+        <div class="question-card">
+            <p><strong>Gap:</strong> The compartment where UMAD1 acts is unresolved. Midbody localization is asserted in the unverified cytokinesis model, while endosomal localization is inferred from ESCRT-I family context; neither compartment is established from locally reviewed endogenous UMAD1 evidence.</p>
+            <p style="margin-top: 0.4rem;">
+                <span class="badge">OPEN</span>
+                <span class="badge">BIOLOGY</span><span class="badge">CURATION</span>
+                <span class="badge">CC_DARK</span>
+            </p>
+
+            <p style="margin-top: 0.5rem;"><strong>What is known:</strong> UMAD1&#39;s domain architecture places it among UMA-domain ESCRT-I-associated proteins, and the Falcon report describes context-dependent midbody and expected endosomal localization. The local review does not accept those locations as established cellular-component annotations.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Significance:</strong> Distinguishing midbody, endosomal, autophagosome-associated, or other pools is essential for deciding whether UMAD1 should receive ESCRT-I complex, midbody, endosome, or autophagy-related location annotations.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>What would resolve it:</strong> Use endogenous tagging or validated antibodies for UMAD1 localization through the cell cycle and during ESCRT-dependent endosomal/autophagy perturbations, paired with CEP55, TSG101, VPS37, ALIX, endosome, and autophagosome markers.</p>
+
+
+            <p style="margin-top: 0.5rem;"><strong>Provenance (the field's own admissions):</strong></p>
+            <ul style="margin-top: 0.2rem;">
+
+                <li><em>"While direct endosomal localization of UMAD1 has not been extensively documented in the available literature"</em> — file:human/UMAD1/UMAD1-deep-research-falcon.md</li>
+
+                <li><em>"the local evidence does not show UMAD1 incorporation into an ESCRT-I complex, endosomal cargo sorting, membrane fission, autophagy, or viral budding."</em> — file:human/UMAD1/UMAD1-notes.md</li>
+
+                <li><em>"UMAD1 exhibits context-dependent subcellular localization."</em> — file:human/UMAD1/UMAD1-deep-research-falcon.md</li>
+
+            </ul>
+
+
+        </div>
+
+    </div>
+
 
 
 
@@ -1879,6 +1981,100 @@ suggested_experiments:
   hypothesis: &gt;-
     The binary-interactome partners may be reproducible physical interactors, but
     they do not yet define UMAD1 molecular function.
+knowledge_gaps:
+- gap_statement: &gt;-
+    It is unresolved whether endogenous UMAD1 assembles into a stable human ESCRT-I
+    complex, and if so which TSG101/VPS28/VPS37-containing complex it joins and what
+    molecular role its UMA domain performs.
+  boundary: &gt;-
+    UMAD1 has a predicted UMA domain and is listed by Flower et al. 2020 among possible
+    UMA-domain fourth subunits of human ESCRT-I. Local evidence does not verify a
+    UMAD1-containing ESCRT-I complex, and the only GOA evidence is broad HuRI protein
+    binding to GABARAPL1 and TH isoform 3.
+  gap_kind:
+  - BIOLOGY
+  - CURATION
+  dark_aspect: MF_DARK
+  status: OPEN
+  significance: &gt;-
+    ESCRT-I complex membership would be the key molecular anchor for all more specific
+    UMAD1 process annotations. Without direct assembly evidence, adding ESCRT-I,
+    membrane-fission, ubiquitin-binding, or adaptor-function terms would overstate
+    the local evidence.
+  resolution: &gt;-
+    Endogenous UMAD1 tagging or validated-antibody immunoprecipitation with TSG101,
+    VPS28, VPS37 paralogs, MVB12A/B, UBAP1, and ALIX, plus purified UMA-domain binding
+    assays and motif mutants, would establish whether UMAD1 is an ESCRT-I subunit and
+    define its molecular partners.
+  provenance:
+  - reference_id: file:human/UMAD1/UMAD1-notes.md
+    supporting_text: UMAD1 should be treated as a poorly characterized UMA-domain protein rather than as an experimentally established ESCRT-I subunit in this review.
+  - reference_id: file:human/UMAD1/UMAD1-notes.md
+    supporting_text: The name and domain architecture make ESCRT-I membership plausible, and the proteostasis network entry is useful search context, but the local evidence does not show UMAD1 incorporation into an ESCRT-I complex
+  - reference_id: file:human/UMAD1/UMAD1-notes.md
+    supporting_text: No core GO function is assigned in this review.
+- gap_statement: &gt;-
+    The biological process in which UMAD1 acts is unresolved. Cytokinetic abscission
+    is proposed by an uncached 2023 primary study summarized in Falcon deep research,
+    while endosomal sorting, autophagosome closure, membrane repair, and viral budding
+    remain family-level ESCRT inferences rather than locally verified UMAD1 functions.
+  boundary: &gt;-
+    The Falcon report identifies a potentially decisive Glover et al. 2023 cytokinesis
+    paper, but that paper is not in the local cache and was not read for this review.
+    The locally cached Flower et al. paper supports UMA-domain ESCRT-I architectural
+    context but does not establish a UMAD1-specific process.
+  gap_kind:
+  - BIOLOGY
+  - CURATION
+  dark_aspect: BP_DARK
+  status: OPEN
+  significance: &gt;-
+    UMAD1 currently cannot be assigned a defensible biological-process term beyond
+    treating protein-binding evidence as over-annotated. Resolving this gap would
+    determine whether UMAD1 belongs in cytokinesis, endosomal MVB sorting, autophagy,
+    membrane repair, or no currently supported ESCRT-dependent process.
+  resolution: &gt;-
+    Cache and review the Glover et al. 2023 article, verify its UMAD1-specific
+    supporting text, then test UMAD1 perturbation in cytokinetic abscission, endosomal
+    cargo sorting, autophagosome closure, and membrane repair assays with rescue by
+    wild-type and ESCRT-binding-defective UMAD1.
+  provenance:
+  - reference_id: file:human/UMAD1/UMAD1-deep-research-falcon.md
+    supporting_text: though direct experimental demonstration of UMAD1-specific roles in endosomal cargo sorting, autophagosome closure, or membrane repair remains an important area for future investigation.
+  - reference_id: file:human/UMAD1/UMAD1-deep-research-falcon.md
+    supporting_text: As an ESCRT-I component, UMAD1 is positioned to contribute to these processes, though specific roles beyond cytokinesis remain to be experimentally demonstrated.
+  - reference_id: file:human/UMAD1/UMAD1-notes.md
+    supporting_text: Adding ESCRT-I complex membership, MVB sorting, ubiquitin binding, phospholipid binding, membrane fission, or macroautophagy terms would overstate the available evidence.
+- gap_statement: &gt;-
+    The compartment where UMAD1 acts is unresolved. Midbody localization is asserted
+    in the unverified cytokinesis model, while endosomal localization is inferred from
+    ESCRT-I family context; neither compartment is established from locally reviewed
+    endogenous UMAD1 evidence.
+  boundary: &gt;-
+    UMAD1&#39;s domain architecture places it among UMA-domain ESCRT-I-associated proteins,
+    and the Falcon report describes context-dependent midbody and expected endosomal
+    localization. The local review does not accept those locations as established
+    cellular-component annotations.
+  gap_kind:
+  - BIOLOGY
+  - CURATION
+  dark_aspect: CC_DARK
+  status: OPEN
+  significance: &gt;-
+    Distinguishing midbody, endosomal, autophagosome-associated, or other pools is
+    essential for deciding whether UMAD1 should receive ESCRT-I complex, midbody,
+    endosome, or autophagy-related location annotations.
+  resolution: &gt;-
+    Use endogenous tagging or validated antibodies for UMAD1 localization through the
+    cell cycle and during ESCRT-dependent endosomal/autophagy perturbations, paired
+    with CEP55, TSG101, VPS37, ALIX, endosome, and autophagosome markers.
+  provenance:
+  - reference_id: file:human/UMAD1/UMAD1-deep-research-falcon.md
+    supporting_text: While direct endosomal localization of UMAD1 has not been extensively documented in the available literature
+  - reference_id: file:human/UMAD1/UMAD1-notes.md
+    supporting_text: the local evidence does not show UMAD1 incorporation into an ESCRT-I complex, endosomal cargo sorting, membrane fission, autophagy, or viral budding.
+  - reference_id: file:human/UMAD1/UMAD1-deep-research-falcon.md
+    supporting_text: UMAD1 exhibits context-dependent subcellular localization.
 </code></pre>
             </div>
         </details>

--- a/genes/human/UMAD1/UMAD1-ai-review.yaml
+++ b/genes/human/UMAD1/UMAD1-ai-review.yaml
@@ -170,3 +170,97 @@ suggested_experiments:
   hypothesis: >-
     The binary-interactome partners may be reproducible physical interactors, but
     they do not yet define UMAD1 molecular function.
+knowledge_gaps:
+- gap_statement: >-
+    It is unresolved whether endogenous UMAD1 assembles into a stable human ESCRT-I
+    complex, and if so which TSG101/VPS28/VPS37-containing complex it joins and what
+    molecular role its UMA domain performs.
+  boundary: >-
+    UMAD1 has a predicted UMA domain and is listed by Flower et al. 2020 among possible
+    UMA-domain fourth subunits of human ESCRT-I. Local evidence does not verify a
+    UMAD1-containing ESCRT-I complex, and the only GOA evidence is broad HuRI protein
+    binding to GABARAPL1 and TH isoform 3.
+  gap_kind:
+  - BIOLOGY
+  - CURATION
+  dark_aspect: MF_DARK
+  status: OPEN
+  significance: >-
+    ESCRT-I complex membership would be the key molecular anchor for all more specific
+    UMAD1 process annotations. Without direct assembly evidence, adding ESCRT-I,
+    membrane-fission, ubiquitin-binding, or adaptor-function terms would overstate
+    the local evidence.
+  resolution: >-
+    Endogenous UMAD1 tagging or validated-antibody immunoprecipitation with TSG101,
+    VPS28, VPS37 paralogs, MVB12A/B, UBAP1, and ALIX, plus purified UMA-domain binding
+    assays and motif mutants, would establish whether UMAD1 is an ESCRT-I subunit and
+    define its molecular partners.
+  provenance:
+  - reference_id: file:human/UMAD1/UMAD1-notes.md
+    supporting_text: UMAD1 should be treated as a poorly characterized UMA-domain protein rather than as an experimentally established ESCRT-I subunit in this review.
+  - reference_id: file:human/UMAD1/UMAD1-notes.md
+    supporting_text: The name and domain architecture make ESCRT-I membership plausible, and the proteostasis network entry is useful search context, but the local evidence does not show UMAD1 incorporation into an ESCRT-I complex
+  - reference_id: file:human/UMAD1/UMAD1-notes.md
+    supporting_text: No core GO function is assigned in this review.
+- gap_statement: >-
+    The biological process in which UMAD1 acts is unresolved. Cytokinetic abscission
+    is proposed by an uncached 2023 primary study summarized in Falcon deep research,
+    while endosomal sorting, autophagosome closure, membrane repair, and viral budding
+    remain family-level ESCRT inferences rather than locally verified UMAD1 functions.
+  boundary: >-
+    The Falcon report identifies a potentially decisive Glover et al. 2023 cytokinesis
+    paper, but that paper is not in the local cache and was not read for this review.
+    The locally cached Flower et al. paper supports UMA-domain ESCRT-I architectural
+    context but does not establish a UMAD1-specific process.
+  gap_kind:
+  - BIOLOGY
+  - CURATION
+  dark_aspect: BP_DARK
+  status: OPEN
+  significance: >-
+    UMAD1 currently cannot be assigned a defensible biological-process term beyond
+    treating protein-binding evidence as over-annotated. Resolving this gap would
+    determine whether UMAD1 belongs in cytokinesis, endosomal MVB sorting, autophagy,
+    membrane repair, or no currently supported ESCRT-dependent process.
+  resolution: >-
+    Cache and review the Glover et al. 2023 article, verify its UMAD1-specific
+    supporting text, then test UMAD1 perturbation in cytokinetic abscission, endosomal
+    cargo sorting, autophagosome closure, and membrane repair assays with rescue by
+    wild-type and ESCRT-binding-defective UMAD1.
+  provenance:
+  - reference_id: file:human/UMAD1/UMAD1-deep-research-falcon.md
+    supporting_text: though direct experimental demonstration of UMAD1-specific roles in endosomal cargo sorting, autophagosome closure, or membrane repair remains an important area for future investigation.
+  - reference_id: file:human/UMAD1/UMAD1-deep-research-falcon.md
+    supporting_text: As an ESCRT-I component, UMAD1 is positioned to contribute to these processes, though specific roles beyond cytokinesis remain to be experimentally demonstrated.
+  - reference_id: file:human/UMAD1/UMAD1-notes.md
+    supporting_text: Adding ESCRT-I complex membership, MVB sorting, ubiquitin binding, phospholipid binding, membrane fission, or macroautophagy terms would overstate the available evidence.
+- gap_statement: >-
+    The compartment where UMAD1 acts is unresolved. Midbody localization is asserted
+    in the unverified cytokinesis model, while endosomal localization is inferred from
+    ESCRT-I family context; neither compartment is established from locally reviewed
+    endogenous UMAD1 evidence.
+  boundary: >-
+    UMAD1's domain architecture places it among UMA-domain ESCRT-I-associated proteins,
+    and the Falcon report describes context-dependent midbody and expected endosomal
+    localization. The local review does not accept those locations as established
+    cellular-component annotations.
+  gap_kind:
+  - BIOLOGY
+  - CURATION
+  dark_aspect: CC_DARK
+  status: OPEN
+  significance: >-
+    Distinguishing midbody, endosomal, autophagosome-associated, or other pools is
+    essential for deciding whether UMAD1 should receive ESCRT-I complex, midbody,
+    endosome, or autophagy-related location annotations.
+  resolution: >-
+    Use endogenous tagging or validated antibodies for UMAD1 localization through the
+    cell cycle and during ESCRT-dependent endosomal/autophagy perturbations, paired
+    with CEP55, TSG101, VPS37, ALIX, endosome, and autophagosome markers.
+  provenance:
+  - reference_id: file:human/UMAD1/UMAD1-deep-research-falcon.md
+    supporting_text: While direct endosomal localization of UMAD1 has not been extensively documented in the available literature
+  - reference_id: file:human/UMAD1/UMAD1-notes.md
+    supporting_text: the local evidence does not show UMAD1 incorporation into an ESCRT-I complex, endosomal cargo sorting, membrane fission, autophagy, or viral budding.
+  - reference_id: file:human/UMAD1/UMAD1-deep-research-falcon.md
+    supporting_text: UMAD1 exhibits context-dependent subcellular localization.


### PR DESCRIPTION
## Summary
- Add three top-level knowledge gaps for UMAD1: unverified ESCRT-I assembly/molecular role, unresolved biological process assignment, and underdetermined compartment of action.
- Keep the gaps aligned with the current review's cautious treatment of uncached Glover 2023 claims and over-annotated protein-binding evidence.
- Re-render the UMAD1 review HTML.

## Validation
- `just validate human UMAD1`
- `just render human UMAD1`
- `git diff --check`